### PR TITLE
builder: use GENESIS_FORK_VERSION throughout, fix web3signer registration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
         if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
           excluded_files="config.yaml|config.nims|beacon_chain.nimble"
-          excluded_extensions="ans|bin|cfg|yml|json|json\\.template|md|png|service|ssz|tpl|txt|lock|nix|gitignore|envrc"
+          excluded_extensions="ans|bin|cfg|yml|json|json\\.template|md|png|service|ssz|tpl|txt|lock|nix|gitignore|envrc|sh"
 
           current_year=$(date +"%Y")
           problematic_files=()

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1099,6 +1099,11 @@ type
       desc: "Specifies a path for the written JSON log file"
       name: "log-file" .}: Option[OutFile]
 
+    eth2Network* {.
+      desc: "The Eth2 network to join"
+      defaultValueDesc: "mainnet"
+      name: "network" .}: Option[string]
+
     nonInteractive* {.
       desc: "Do not display interactive prompts. Quit on missing configuration"
       name: "non-interactive" .}: bool

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -42,6 +42,7 @@ type
     runKeystoreCachePruningLoopFut: Future[void]
     sigintHandleFut: Future[void]
     sigtermHandleFut: Future[void]
+    genesis_fork_version: Version
 
   SigningNodeRef* = ref SigningNode
 
@@ -114,19 +115,24 @@ proc loadTLSKey(pathName: InputFile): Result[TLSPrivateKey, cstring] =
   ok(key)
 
 proc new(t: typedesc[SigningNodeRef], config: SigningNodeConf): SigningNodeRef =
+  let
+    genesis_fork_version = loadEth2Network(config.eth2Network).cfg.GENESIS_FORK_VERSION
+
   when declared(waitSignal):
     SigningNodeRef(
       config: config,
       sigintHandleFut: waitSignal(SIGINT),
       sigtermHandleFut: waitSignal(SIGTERM),
-      keystoreCache: KeystoreCacheRef.init()
+      keystoreCache: KeystoreCacheRef.init(),
+      genesis_fork_version: genesis_fork_version,
     )
   else:
     SigningNodeRef(
       config: config,
       sigintHandleFut: newFuture[void]("sigint_placeholder"),
       sigtermHandleFut: newFuture[void]("sigterm_placeholder"),
-      keystoreCache: KeystoreCacheRef.init()
+      keystoreCache: KeystoreCacheRef.init(),
+      genesis_fork_version: genesis_fork_version,
     )
 
 template errorResponse(code: HttpCode, message: string): RestApiResponse =
@@ -325,6 +331,7 @@ proc installApiHandlers*(node: SigningNodeRef) =
       of Web3SignerRequestKind.ValidatorRegistration:
         let
           signature = get_builder_signature(
+            node.genesis_fork_version,
             ValidatorRegistrationV1(
               fee_recipient: Eth1Address.fromHex(
                   request.validatorRegistration.feeRecipient),

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -116,7 +116,14 @@ proc loadTLSKey(pathName: InputFile): Result[TLSPrivateKey, cstring] =
 
 proc new(t: typedesc[SigningNodeRef], config: SigningNodeConf): SigningNodeRef =
   let
-    genesis_fork_version = loadEth2Network(config.eth2Network).cfg.GENESIS_FORK_VERSION
+    genesis_fork_version =
+      # With `mainnet` compile-time preset, these are not available
+      if config.eth2Network == some("minimal"):
+        Version [byte 0x00, 0x00, 0x00, 0x01]
+      elif config.eth2Network == some("gnosis"):
+        Version [byte 0x00, 0x00, 0x00, 0x64]
+      else:
+        loadEth2Network(config.eth2Network).cfg.GENESIS_FORK_VERSION
 
   when declared(waitSignal):
     SigningNodeRef(

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -324,8 +324,7 @@ proc installApiHandlers*(node: SigningNodeRef) =
         signatureResponse(Http200, signature)
       of Web3SignerRequestKind.ValidatorRegistration:
         let
-          forkInfo = request.forkInfo.get()
-          signature = get_builder_signature(forkInfo.fork,
+          signature = get_builder_signature(
             ValidatorRegistrationV1(
               fee_recipient: Eth1Address.fromHex(
                   request.validatorRegistration.feeRecipient),

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -2121,10 +2121,7 @@ proc writeValue*(
                       value.syncCommitteeContributionAndProof)
   of Web3SignerRequestKind.ValidatorRegistration:
     # https://consensys.github.io/web3signer/web3signer-eth2.html#operation/ETH2_SIGN
-    doAssert(value.forkInfo.isSome(),
-             "forkInfo should be set for this type of request")
     writer.writeField("type", "VALIDATOR_REGISTRATION")
-    writer.writeField("fork_info", value.forkInfo.get())
     if isSome(value.signingRoot):
       writer.writeField("signingRoot", value.signingRoot)
     writer.writeField("validator_registration", value.validatorRegistration)

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -961,16 +961,13 @@ func init*(t: typedesc[Web3SignerRequest], fork: Fork,
 
 from stew/byteutils import to0xHex
 
-func init*(t: typedesc[Web3SignerRequest], fork: Fork,
+func init*(t: typedesc[Web3SignerRequest],
            genesis_validators_root: Eth2Digest,
            data: ValidatorRegistrationV1,
            signingRoot: Opt[Eth2Digest] = Opt.none(Eth2Digest)
           ): Web3SignerRequest =
   Web3SignerRequest(
     kind: Web3SignerRequestKind.ValidatorRegistration,
-    forkInfo: Opt.some(Web3SignerForkInfo(
-      fork: fork, genesis_validators_root: genesis_validators_root
-    )),
     signingRoot: signingRoot,
     validatorRegistration: Web3SignerValidatorRegistration(
       feeRecipient: data.fee_recipient.data.to0xHex,

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -373,27 +373,24 @@ proc verify_contribution_and_proof_signature*(
 
 # https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/builder.md#signing
 func compute_builder_signing_root(
-    fork: Fork,
     msg: electra_mev.BuilderBid | fulu_mev.BuilderBid |
          ValidatorRegistrationV1): Eth2Digest =
-  # Uses genesis fork version regardless
-  doAssert fork.current_version == fork.previous_version
-
+  # Fork = none, per spec
   let domain = get_domain(
-    fork, DOMAIN_APPLICATION_BUILDER, GENESIS_EPOCH, ZERO_HASH)
+    Fork(), DOMAIN_APPLICATION_BUILDER, GENESIS_EPOCH, ZERO_HASH)
   compute_signing_root(msg, domain)
 
 proc get_builder_signature*(
-    fork: Fork, msg: ValidatorRegistrationV1, privkey: ValidatorPrivKey):
+    msg: ValidatorRegistrationV1, privkey: ValidatorPrivKey):
     CookedSig =
-  let signing_root = compute_builder_signing_root(fork, msg)
+  let signing_root = compute_builder_signing_root(msg)
   blsSign(privkey, signing_root.data)
 
 proc verify_builder_signature*(
-    fork: Fork, msg: electra_mev.BuilderBid |
+    msg: electra_mev.BuilderBid |
           fulu_mev.BuilderBid | ValidatorRegistrationV1,
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
-  let signing_root = compute_builder_signing_root(fork, msg)
+  let signing_root = compute_builder_signing_root(msg)
   blsVerify(pubkey, signing_root.data, signature)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/capella/beacon-chain.md#new-process_bls_to_execution_change

--- a/beacon_chain/spec/signatures.nim
+++ b/beacon_chain/spec/signatures.nim
@@ -373,24 +373,28 @@ proc verify_contribution_and_proof_signature*(
 
 # https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/builder.md#signing
 func compute_builder_signing_root(
-    msg: electra_mev.BuilderBid | fulu_mev.BuilderBid |
+    genesis_fork_version: Version,
+      msg: electra_mev.BuilderBid | fulu_mev.BuilderBid |
          ValidatorRegistrationV1): Eth2Digest =
-  # Fork = none, per spec
-  let domain = get_domain(
-    Fork(), DOMAIN_APPLICATION_BUILDER, GENESIS_EPOCH, ZERO_HASH)
+  # Fork = none in spec which means GENESIS_FORK_VERSION:
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/phase0/beacon-chain.md#compute_domain
+  let domain = compute_domain(
+    DOMAIN_APPLICATION_BUILDER, genesis_fork_version, ZERO_HASH)
   compute_signing_root(msg, domain)
 
 proc get_builder_signature*(
+    genesis_fork_version: Version,
     msg: ValidatorRegistrationV1, privkey: ValidatorPrivKey):
     CookedSig =
-  let signing_root = compute_builder_signing_root(msg)
+  let signing_root = compute_builder_signing_root(genesis_fork_version, msg)
   blsSign(privkey, signing_root.data)
 
 proc verify_builder_signature*(
+    genesis_fork_version: Version,
     msg: electra_mev.BuilderBid |
           fulu_mev.BuilderBid | ValidatorRegistrationV1,
     pubkey: ValidatorPubKey | CookedPubKey, signature: SomeSig): bool =
-  let signing_root = compute_builder_signing_root(msg)
+  let signing_root = compute_builder_signing_root(genesis_fork_version, msg)
   blsVerify(pubkey, signing_root.data, signature)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/capella/beacon-chain.md#new-process_bls_to_execution_change

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1067,6 +1067,7 @@ proc getValidatorRegistration(
     vc: ValidatorClientRef,
     validator: AttachedValidator,
     timestamp: Time,
+    genesis_fork_version: Version,
 ): Result[PendingValidatorRegistration, RegistrationKind] =
   if validator.index.isNone():
     debug "Validator registration missing validator index",
@@ -1103,7 +1104,7 @@ proc getValidatorRegistration(
       )
     )
 
-  let sigfut = validator.getBuilderSignature(registration.message)
+  let sigfut = validator.getBuilderSignature(genesis_fork_version, registration.message)
   if sigfut.finished():
     # This is short-path if we able to create signature locally.
     if not(sigfut.completed()):
@@ -1125,6 +1126,7 @@ proc getValidatorRegistration(
 proc prepareRegistrationList*(
     vc: ValidatorClientRef,
     timestamp: Time,
+    genesis_fork_version: Version,
 ): Future[seq[SignedValidatorRegistrationV1]] {.
   async: (raises: [CancelledError]).} =
 
@@ -1144,7 +1146,7 @@ proc prepareRegistrationList*(
     timed = 0
 
   for validator in vc.attachedValidators[].items():
-    let res = vc.getValidatorRegistration(validator, timestamp)
+    let res = vc.getValidatorRegistration(validator, timestamp, genesis_fork_version)
     if res.isOk():
       let preg = res.get()
       if preg.future.isNil():

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1067,7 +1067,6 @@ proc getValidatorRegistration(
     vc: ValidatorClientRef,
     validator: AttachedValidator,
     timestamp: Time,
-    fork: Fork
 ): Result[PendingValidatorRegistration, RegistrationKind] =
   if validator.index.isNone():
     debug "Validator registration missing validator index",
@@ -1104,7 +1103,7 @@ proc getValidatorRegistration(
       )
     )
 
-  let sigfut = validator.getBuilderSignature(fork, registration.message)
+  let sigfut = validator.getBuilderSignature(registration.message)
   if sigfut.finished():
     # This is short-path if we able to create signature locally.
     if not(sigfut.completed()):
@@ -1126,7 +1125,6 @@ proc getValidatorRegistration(
 proc prepareRegistrationList*(
     vc: ValidatorClientRef,
     timestamp: Time,
-    fork: Fork
 ): Future[seq[SignedValidatorRegistrationV1]] {.
   async: (raises: [CancelledError]).} =
 
@@ -1146,7 +1144,7 @@ proc prepareRegistrationList*(
     timed = 0
 
   for validator in vc.attachedValidators[].items():
-    let res = vc.getValidatorRegistration(validator, timestamp, fork)
+    let res = vc.getValidatorRegistration(validator, timestamp)
     if res.isOk():
       let preg = res.get()
       if preg.future.isNil():

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -561,9 +561,10 @@ proc registerValidators*(
   let vc = service.client
   let
     currentSlot = vc.getCurrentSlot().get(Slot(0))
+    genesis_fork_version = vc.forks[0].current_version
     registrations =
       try:
-        await vc.prepareRegistrationList(getTime())
+        await vc.prepareRegistrationList(getTime(), genesis_fork_version)
       except CancelledError as exc:
         debug "Validator registration preparation was interrupted",
               slot = currentSlot
@@ -575,11 +576,12 @@ proc registerValidators*(
           await registerValidator(vc, registrations)
         except ValidatorApiError as exc:
           warn "Unable to register validators", slot = currentSlot,
-                err_name = exc.name,
+                version = genesis_fork_version, err_name = exc.name,
                 err_msg = exc.msg, reason = exc.getFailureReason()
           0
         except CancelledError as exc:
-          debug "Validator registration was interrupted", slot = currentSlot
+          debug "Validator registration was interrupted", slot = currentSlot,
+                version = genesis_fork_version
           raise exc
       else:
         0

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -561,13 +561,12 @@ proc registerValidators*(
   let vc = service.client
   let
     currentSlot = vc.getCurrentSlot().get(Slot(0))
-    genesisFork = vc.forks[0]
     registrations =
       try:
-        await vc.prepareRegistrationList(getTime(), genesisFork)
+        await vc.prepareRegistrationList(getTime())
       except CancelledError as exc:
         debug "Validator registration preparation was interrupted",
-              slot = currentSlot, fork = genesisFork
+              slot = currentSlot
         raise exc
 
     count =
@@ -576,12 +575,11 @@ proc registerValidators*(
           await registerValidator(vc, registrations)
         except ValidatorApiError as exc:
           warn "Unable to register validators", slot = currentSlot,
-                fork = genesisFork, err_name = exc.name,
+                err_name = exc.name,
                 err_msg = exc.msg, reason = exc.getFailureReason()
           0
         except CancelledError as exc:
-          debug "Validator registration was interrupted", slot = currentSlot,
-                fork = genesisFork
+          debug "Validator registration was interrupted", slot = currentSlot
           raise exc
       else:
         0

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -666,7 +666,7 @@ proc getBlindedExecutionPayload[
     return err "getBlindedExecutionPayload: non-200 HTTP response"
   else:
     if not verify_builder_signature(
-        blindedHeader.data.message,
+        node.dag.cfg.GENESIS_FORK_VERSION, blindedHeader.data.message,
         blindedHeader.data.message.pubkey, blindedHeader.data.signature):
       return err "getBlindedExecutionPayload: signature verification failed"
 
@@ -1635,7 +1635,9 @@ proc getValidatorRegistration(
   debug "getValidatorRegistration: registering", validatorRegistration
 
   validatorRegistration.signature =
-    ?await validator.getBuilderSignature(validatorRegistration.message)
+    ?await validator.getBuilderSignature(
+      node.dag.cfg.GENESIS_FORK_VERSION, validatorRegistration.message
+    )
 
   ok validatorRegistration
 

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -666,7 +666,7 @@ proc getBlindedExecutionPayload[
     return err "getBlindedExecutionPayload: non-200 HTTP response"
   else:
     if not verify_builder_signature(
-        node.dag.cfg.genesisFork, blindedHeader.data.message,
+        blindedHeader.data.message,
         blindedHeader.data.message.pubkey, blindedHeader.data.signature):
       return err "getBlindedExecutionPayload: signature verification failed"
 
@@ -1635,9 +1635,7 @@ proc getValidatorRegistration(
   debug "getValidatorRegistration: registering", validatorRegistration
 
   validatorRegistration.signature =
-    ?await validator.getBuilderSignature(
-      node.dag.cfg.genesisFork, validatorRegistration.message
-    )
+    ?await validator.getBuilderSignature(validatorRegistration.message)
 
   ok validatorRegistration
 

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -802,14 +802,13 @@ proc getDepositMessageSignature*(v: AttachedValidator, version: Version,
     await v.signData(request)
 
 # https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/builder.md#signing
-proc getBuilderSignature*(v: AttachedValidator, fork: Fork,
+proc getBuilderSignature*(v: AttachedValidator,
     validatorRegistration: ValidatorRegistrationV1):
     Future[SignatureResult] {.async: (raises: [CancelledError]).} =
   case v.kind
   of ValidatorKind.Local:
     SignatureResult.ok(get_builder_signature(
-      fork, validatorRegistration, v.data.privateKey).toValidatorSig())
+      validatorRegistration, v.data.privateKey).toValidatorSig())
   of ValidatorKind.Remote:
-    let request = Web3SignerRequest.init(
-      fork, ZERO_HASH, validatorRegistration)
+    let request = Web3SignerRequest.init(ZERO_HASH, validatorRegistration)
     await v.signData(request)

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -802,13 +802,13 @@ proc getDepositMessageSignature*(v: AttachedValidator, version: Version,
     await v.signData(request)
 
 # https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/builder.md#signing
-proc getBuilderSignature*(v: AttachedValidator,
+proc getBuilderSignature*(v: AttachedValidator, genesis_fork_version: Version,
     validatorRegistration: ValidatorRegistrationV1):
     Future[SignatureResult] {.async: (raises: [CancelledError]).} =
   case v.kind
   of ValidatorKind.Local:
     SignatureResult.ok(get_builder_signature(
-      validatorRegistration, v.data.privateKey).toValidatorSig())
+      genesis_fork_version, validatorRegistration, v.data.privateKey).toValidatorSig())
   of ValidatorKind.Remote:
     let request = Web3SignerRequest.init(ZERO_HASH, validatorRegistration)
     await v.signData(request)

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1060,7 +1060,7 @@ if ((SIGNER_NODES > 0)); then
   for NUM_REMOTE in $(seq 0 $LAST_SIGNER_NODE_IDX); do
     # TODO find some way for this and other background-launched processes to
     # still participate in set -e, ideally
-    source "${SCRIPTS_DIR}/signers/${SIGNER_TYPE}.sh" $NUM_REMOTE
+    source "${SCRIPTS_DIR}/signers/${SIGNER_TYPE}.sh" $NUM_REMOTE $CONST_PRESET
   done
 fi
 

--- a/scripts/signers/nimbus.sh
+++ b/scripts/signers/nimbus.sh
@@ -11,6 +11,7 @@ SIGNING_NODE_IDX=$1
 
 ./build/nimbus_signing_node \
   --log-level=DEBUG \
+  --network=$2 \
   --validators-dir="${DATA_DIR}/validators_shares/$(( SIGNING_NODE_IDX + 1 ))" \
   --secrets-dir="${DATA_DIR}/secrets_shares/$(( SIGNING_NODE_IDX + 1 ))" \
   --bind-port=$(( BASE_REMOTE_SIGNER_PORT + SIGNING_NODE_IDX )) &> "${DATA_DIR}/logs/nimbus_signing_node.${SIGNING_NODE_IDX}.jsonl" &

--- a/tests/test_mev_calls.nim
+++ b/tests/test_mev_calls.nim
@@ -23,6 +23,7 @@ from std/times import Time, toUnix, fromUnix, getTime
 const
   ElectraSlot = Slot(64000)
   FuluSlot = Slot(96000)
+  emptyFork = Fork()
   emptyRoot = Eth2Digest()
 
 type
@@ -97,7 +98,7 @@ proc prepare(
     )))
     block_root = hash_tree_root(blindedBlock)
   T(message: blindedBlock,
-    signature: get_block_signature(emptyRoot, slot, block_root,
+    signature: get_block_signature(emptyFork, emptyRoot, slot, block_root,
                                    privateKey).toValidatorSig())
 
 proc jsonResponseSignedBuilderBid(

--- a/tests/test_mev_calls.nim
+++ b/tests/test_mev_calls.nim
@@ -23,7 +23,6 @@ from std/times import Time, toUnix, fromUnix, getTime
 const
   ElectraSlot = Slot(64000)
   FuluSlot = Slot(96000)
-  emptyFork = Fork()
   emptyRoot = Eth2Digest()
 
 type
@@ -49,7 +48,6 @@ func specifiedFeeRecipient(x: int): Eth1Address =
   copyMem(addr result, unsafeAddr x, sizeof x)
 
 proc prepareRegistration(
-    fork: Fork,
     key: ValidatorPrivKey,
     gas_limit: uint64 = 0'u64,
     timestamp: Time,
@@ -63,7 +61,7 @@ proc prepareRegistration(
         timestamp: uint64(timestamp.toUnix()),
         pubkey: key.toPubKey().toPubKey()
       ))
-  msg.signature = get_builder_signature(fork, msg.message, key).toValidatorSig()
+  msg.signature = get_builder_signature(msg.message, key).toValidatorSig()
   msg
 
 proc generateRegistrations(
@@ -77,7 +75,7 @@ proc generateRegistrations(
         raiseAssert "Unable to generate private key"
       feeRecipient = specifiedFeeRecipient(index)
     res.add(prepareRegistration(
-      emptyFork, privateKey, 30_000_000'u64, getTime(), feeRecipient))
+      privateKey, 30_000_000'u64, getTime(), feeRecipient))
   res
 
 proc prepare(
@@ -99,7 +97,7 @@ proc prepare(
     )))
     block_root = hash_tree_root(blindedBlock)
   T(message: blindedBlock,
-    signature: get_block_signature(emptyFork, emptyRoot, slot, block_root,
+    signature: get_block_signature(emptyRoot, slot, block_root,
                                    privateKey).toValidatorSig())
 
 proc jsonResponseSignedBuilderBid(
@@ -193,7 +191,7 @@ proc setupEngineAPI*(router: var RestRouter, node: TestNodeRef) =
       return RestApiResponse.jsonError(error)
 
     for item in registrations:
-      if not(verify_builder_signature(emptyFork, item.message,
+      if not(verify_builder_signature(item.message,
                                       item.message.pubkey, item.signature)):
         return RestApiResponse.jsonError(Http400,
                                          "Signature verification failed")

--- a/tests/test_mev_calls.nim
+++ b/tests/test_mev_calls.nim
@@ -24,6 +24,7 @@ const
   ElectraSlot = Slot(64000)
   FuluSlot = Slot(96000)
   emptyFork = Fork()
+  emptyVersion = emptyFork.current_version
   emptyRoot = Eth2Digest()
 
 type
@@ -49,6 +50,7 @@ func specifiedFeeRecipient(x: int): Eth1Address =
   copyMem(addr result, unsafeAddr x, sizeof x)
 
 proc prepareRegistration(
+    genesis_fork_version: Version,
     key: ValidatorPrivKey,
     gas_limit: uint64 = 0'u64,
     timestamp: Time,
@@ -62,7 +64,8 @@ proc prepareRegistration(
         timestamp: uint64(timestamp.toUnix()),
         pubkey: key.toPubKey().toPubKey()
       ))
-  msg.signature = get_builder_signature(msg.message, key).toValidatorSig()
+  msg.signature =
+    get_builder_signature(genesis_fork_version, msg.message, key).toValidatorSig()
   msg
 
 proc generateRegistrations(
@@ -76,7 +79,7 @@ proc generateRegistrations(
         raiseAssert "Unable to generate private key"
       feeRecipient = specifiedFeeRecipient(index)
     res.add(prepareRegistration(
-      privateKey, 30_000_000'u64, getTime(), feeRecipient))
+      emptyVersion, privateKey, 30_000_000'u64, getTime(), feeRecipient))
   res
 
 proc prepare(
@@ -192,7 +195,7 @@ proc setupEngineAPI*(router: var RestRouter, node: TestNodeRef) =
       return RestApiResponse.jsonError(error)
 
     for item in registrations:
-      if not(verify_builder_signature(item.message,
+      if not(verify_builder_signature(emptyVersion, item.message,
                                       item.message.pubkey, item.signature)):
         return RestApiResponse.jsonError(Http400,
                                          "Signature verification failed")

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -741,12 +741,12 @@ block:
     asyncTest "Signing validator registration (getBuilderSignature())":
       let
         vdata = default(ValidatorRegistrationV1)
-        sres1 = await validator1.getBuilderSignature(SigningFork, vdata)
-        sres2 = await validator2.getBuilderSignature(SigningFork, vdata)
-        sres3 = await validator3.getBuilderSignature(SigningFork, vdata)
-        rres1 = await validator4.getBuilderSignature(SigningFork, vdata)
-        rres2 = await validator5.getBuilderSignature(SigningFork, vdata)
-        rres3 = await validator6.getBuilderSignature(SigningFork, vdata)
+        sres1 = await validator1.getBuilderSignature(vdata)
+        sres2 = await validator2.getBuilderSignature(vdata)
+        sres3 = await validator3.getBuilderSignature(vdata)
+        rres1 = await validator4.getBuilderSignature(vdata)
+        rres2 = await validator5.getBuilderSignature(vdata)
+        rres3 = await validator6.getBuilderSignature(vdata)
 
       check:
         sres1.isOk()

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -54,6 +54,7 @@ const
     current_version: Version(hexToByteArray[4]("00001020")),
     epoch: Epoch(0'u64)
   )
+  SigningVersion = SigningFork.current_version
   SomeSignature =
     "0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9"
 
@@ -741,12 +742,12 @@ block:
     asyncTest "Signing validator registration (getBuilderSignature())":
       let
         vdata = default(ValidatorRegistrationV1)
-        sres1 = await validator1.getBuilderSignature(vdata)
-        sres2 = await validator2.getBuilderSignature(vdata)
-        sres3 = await validator3.getBuilderSignature(vdata)
-        rres1 = await validator4.getBuilderSignature(vdata)
-        rres2 = await validator5.getBuilderSignature(vdata)
-        rres3 = await validator6.getBuilderSignature(vdata)
+        sres1 = await validator1.getBuilderSignature(SigningVersion, vdata)
+        sres2 = await validator2.getBuilderSignature(SigningVersion, vdata)
+        sres3 = await validator3.getBuilderSignature(SigningVersion, vdata)
+        rres1 = await validator4.getBuilderSignature(SigningVersion, vdata)
+        rres2 = await validator5.getBuilderSignature(SigningVersion, vdata)
+        rres3 = await validator6.getBuilderSignature(SigningVersion, vdata)
 
       check:
         sres1.isOk()

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -54,7 +54,6 @@ const
     current_version: Version(hexToByteArray[4]("00001020")),
     epoch: Epoch(0'u64)
   )
-  SigningVersion = SigningFork.current_version
   SomeSignature =
     "0xb3baa751d0a9132cfe93e4e3d5ff9075111100e3789dca219ade5a24d27e19d16b3353149da1833e9b691bb38634e8dc04469be7032132906c927d7e1a49b414730612877bc6b2810c8f202daf793d1ab0d6b5cb21d52f9e52e883859887a5d9"
 
@@ -740,14 +739,15 @@ block:
         sres3.get() == rres3.get()
 
     asyncTest "Signing validator registration (getBuilderSignature())":
+      const genesis_fork_version = Version() # mainnet version used by default
       let
         vdata = default(ValidatorRegistrationV1)
-        sres1 = await validator1.getBuilderSignature(SigningVersion, vdata)
-        sres2 = await validator2.getBuilderSignature(SigningVersion, vdata)
-        sres3 = await validator3.getBuilderSignature(SigningVersion, vdata)
-        rres1 = await validator4.getBuilderSignature(SigningVersion, vdata)
-        rres2 = await validator5.getBuilderSignature(SigningVersion, vdata)
-        rres3 = await validator6.getBuilderSignature(SigningVersion, vdata)
+        sres1 = await validator1.getBuilderSignature(genesis_fork_version, vdata)
+        sres2 = await validator2.getBuilderSignature(genesis_fork_version, vdata)
+        sres3 = await validator3.getBuilderSignature(genesis_fork_version, vdata)
+        rres1 = await validator4.getBuilderSignature(genesis_fork_version, vdata)
+        rres2 = await validator5.getBuilderSignature(genesis_fork_version, vdata)
+        rres3 = await validator6.getBuilderSignature(genesis_fork_version, vdata)
 
       check:
         sres1.isOk()

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -12,7 +12,7 @@ import
   unittest2, chronicles, results,
   chronos/asyncproc,
   chronos/unittest2/asynctests,
-  ../beacon_chain/spec/crypto,
+  ../beacon_chain/spec/[crypto, presets],
   ../beacon_chain/spec/eth2_apis/rest_remote_signer_calls,
   ../beacon_chain/validators/validator_pool
 
@@ -739,7 +739,8 @@ block:
         sres3.get() == rres3.get()
 
     asyncTest "Signing validator registration (getBuilderSignature())":
-      const genesis_fork_version = Version() # mainnet version used by default
+      # mainnet version used by default in nimbus_signing_node
+      const genesis_fork_version = defaultRuntimeConfig.GENESIS_FORK_VERSION
       let
         vdata = default(ValidatorRegistrationV1)
         sres1 = await validator1.getBuilderSignature(genesis_fork_version, vdata)


### PR DESCRIPTION
https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/builder.md#signing

>  with domain given by compute_domain(DOMAIN_APPLICATION_BUILDER,
fork_version=None, genesis_validators_root=None)

Ditto web3signer, where we should not be sending a fork info according to spec:

https://github.com/ethereum/remote-signing-api/blob/87a392deb4e43209ca896dde6b4ec40bef7ee02c/signing/schemas.yaml#L312

Per https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/phase0/beacon-chain.md#compute_domain, we have to pass in the genesis fork version - since this is not available from the remote signing API, `nimbus_signing_node` gains a `--network` parameter from which the genesis fork version is read.
