### PR TITLE
rm redundant PeerDAS helper functions

### DIFF
--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/json,
@@ -779,7 +779,7 @@ proc sendGetBlobsV2*(
     let requests = m.elConnections.mapIt(
       sendGetBlobsV2toSingleEl(it,
         mapIt(blck.message.body.blob_kzg_commitments,
-              engine_api.VersionedHash(kzg_commitment_to_versioned_hash(it)))
+              kzg_commitment_to_versioned_hash(it))
       )
     )
 
@@ -853,7 +853,7 @@ proc sendNewPayload*(
               let
                 versioned_hashes = mapIt(
                   blck.body.blob_kzg_commitments,
-                  engine_api.VersionedHash(kzg_commitment_to_versioned_hash(it)))
+                  kzg_commitment_to_versioned_hash(it))
                 # https://github.com/ethereum/execution-apis/blob/7c9772f95c2472ccfc6f6128dc2e1b568284a2da/src/engine/prague.md#request
                 # "Each list element is a `requests` byte array as defined by
                 # EIP-7685. The first byte of each element is the `request_type`
@@ -880,7 +880,7 @@ proc sendNewPayload*(
               # [Modified in Deneb] Pass `versioned_hashes` to Execution Engine
               let versioned_hashes = mapIt(
                 blck.body.blob_kzg_commitments,
-                engine_api.VersionedHash(kzg_commitment_to_versioned_hash(it)))
+                kzg_commitment_to_versioned_hash(it))
               sendNewPayloadToSingleEL(
                 it, payload, versioned_hashes,
                 FixedBytes[32] blck.parent_root.data)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -421,10 +421,11 @@ proc initFullNode(
         dag.cfg.NUMBER_OF_CUSTODY_GROUPS
       else:
         dag.cfg.CUSTODY_REQUIREMENT
-    custodyColumns = resolve_columns_from_custody_groups(
-      node.network.nodeId,
-      max(dag.cfg.SAMPLES_PER_SLOT.uint64,
-          localCustodyGroups))
+    custodyColumns =
+      dag.cfg.resolve_columns_from_custody_groups(
+        node.network.nodeId,
+        max(dag.cfg.SAMPLES_PER_SLOT.uint64,
+            localCustodyGroups))
 
   var sortedColumns = custodyColumns.toSeq()
   sort(sortedColumns)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -421,11 +421,10 @@ proc initFullNode(
         dag.cfg.NUMBER_OF_CUSTODY_GROUPS
       else:
         dag.cfg.CUSTODY_REQUIREMENT
-    custodyColumns =
-      dag.cfg.resolve_columns_from_custody_groups(
-        node.network.nodeId,
-        max(dag.cfg.SAMPLES_PER_SLOT.uint64,
-            localCustodyGroups))
+    custodyColumns = resolve_columns_from_custody_groups(
+      node.network.nodeId,
+      max(dag.cfg.SAMPLES_PER_SLOT.uint64,
+          localCustodyGroups))
 
   var sortedColumns = custodyColumns.toSeq()
   sort(sortedColumns)

--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -61,7 +61,6 @@ const
   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/das-core.md#custody-setting
   SAMPLES_PER_SLOT* = 8
   CUSTODY_REQUIREMENT* = 4
-  NUMBER_OF_CUSTODY_GROUPS* = 128
 
   # Minimum number of custody groups an honest node with
   # validators attached custodies and serves samples from
@@ -70,9 +69,6 @@ const
   # Balance increment corresponding to one additional group to custody
   # 2**5 * 10**9 (= 32,000,000,000) Gwei
   BALANCE_PER_ADDITIONAL_CUSTODY_GROUP*: uint64 = 32000000000'u64
-
-  # Number of columns in the network per custody group
-  COLUMNS_PER_GROUP* = NUMBER_OF_COLUMNS div NUMBER_OF_CUSTODY_GROUPS
 
 type
   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/polynomial-commitments-sampling.md#custom-types

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -26,13 +26,15 @@ type
   CellBytes = array[fulu.CELLS_PER_EXT_BLOB, Cell]
   ProofBytes = array[fulu.CELLS_PER_EXT_BLOB, KzgProof]
 
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/das-core.md#compute_columns_for_custody_group
-iterator compute_columns_for_custody_group*(custody_group: CustodyIndex):
+# https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/das-core.md#compute_columns_for_custody_group
+iterator compute_columns_for_custody_group*(cfg: RuntimeConfig,
+                                            custody_group: CustodyIndex):
                                             ColumnIndex =
-  for i in 0'u64 ..< COLUMNS_PER_GROUP:
-    yield ColumnIndex(NUMBER_OF_CUSTODY_GROUPS * i + custody_group)
+  let columns_per_group = NUMBER_OF_COLUMNS div cfg.NUMBER_OF_CUSTODY_GROUPS
+  for i in 0'u64 ..< columns_per_group:
+    yield ColumnIndex(cfg.NUMBER_OF_CUSTODY_GROUPS * i + custody_group)
 
-func handle_custody_groups(node_id: NodeId,
+func handle_custody_groups(cfg: RuntimeConfig, node_id: NodeId,
                            custody_group_count: CustodyIndex):
                            HashSet[CustodyIndex] =
   # Decouples the custody group computation from
@@ -52,7 +54,7 @@ func handle_custody_groups(node_id: NodeId,
 
     hashed_bytes[0..7] = hashed_current_id.data.toOpenArray(0,7)
     let custody_group = bytes_to_uint64(hashed_bytes) mod
-      NUMBER_OF_CUSTODY_GROUPS
+      cfg.NUMBER_OF_CUSTODY_GROUPS
 
     custody_groups.incl custody_group
 
@@ -61,24 +63,24 @@ func handle_custody_groups(node_id: NodeId,
   custody_groups
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/das-core.md#get_custody_groups
-func get_custody_groups*(node_id: NodeId,
+func get_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
                          custody_group_count: CustodyIndex):
                          seq[CustodyIndex] =
   let custody_groups =
-    node_id.handle_custody_groups(custody_group_count)
+    cfg.handle_custody_groups(node_id, custody_group_count)
 
   var groups = custody_groups.toSeq()
   groups.sort()
   groups
 
-func resolve_columns_from_custody_groups*(node_id: NodeId,
+func resolve_columns_from_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
                                           custody_group_count: CustodyIndex):
                                           HashSet[ColumnIndex] =
   ## Returns a set of unique columns for the custody groups of a node.
-  let custody_groups = node_id.get_custody_groups(custody_group_count)
+  let custody_groups = cfg.get_custody_groups(node_id, custody_group_count)
   var columns: HashSet[ColumnIndex]
   for group in custody_groups:
-    for index in compute_columns_for_custody_group(group):
+    for index in compute_columns_for_custody_group(cfg, group):
       columns.incl index
   columns
 
@@ -187,7 +189,7 @@ proc recover_cells_and_proofs*(
   ok(recovered_cps)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/das-core.md#get_data_column_sidecars
-proc get_data_column_sidecars*(signed_beacon_block: electra.TrustedSignedBeaconBlock,
+func get_data_column_sidecars*(signed_beacon_block: electra.TrustedSignedBeaconBlock,
                                cellsAndProofs: seq[CellsAndProofs]):
                                seq[DataColumnSidecar] =
   ## Given a trusted signed beacon block and the cells/proofs associated
@@ -241,7 +243,7 @@ proc get_data_column_sidecars*(signed_beacon_block: electra.TrustedSignedBeaconB
 
 # Additional overload to perform reconstruction at the time of gossip
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/validator.md#get_data_column_sidecars
-proc get_data_column_sidecars*(signed_beacon_block: fulu.SignedBeaconBlock,
+func get_data_column_sidecars*(signed_beacon_block: fulu.SignedBeaconBlock,
                                cellsAndProofs: seq[CellsAndProofs]):
                                seq[DataColumnSidecar] =
   ## Given a signed beacon block and the blobs corresponding to the block,
@@ -385,7 +387,7 @@ func get_extended_sample_count*(samples_per_slot: int,
   NUMBER_OF_COLUMNS
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/p2p-interface.md#verify_data_column_sidecar
-proc verify_data_column_sidecar*(sidecar: DataColumnSidecar):
+func verify_data_column_sidecar*(sidecar: DataColumnSidecar):
                                  Result[void, cstring] =
   ## Verify if the data column sidecar is valid.
 
@@ -402,7 +404,7 @@ proc verify_data_column_sidecar*(sidecar: DataColumnSidecar):
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/p2p-interface.md#verify_data_column_sidecar_inclusion_proof
-proc verify_data_column_sidecar_inclusion_proof*(sidecar: DataColumnSidecar):
+func verify_data_column_sidecar_inclusion_proof*(sidecar: DataColumnSidecar):
                                                  Result[void, cstring] =
   ## Verify if the given KZG commitments included in the given beacon block.
   let gindex =
@@ -438,12 +440,10 @@ proc verify_data_column_sidecar_kzg_proofs*(sidecar: DataColumnSidecar):
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.3/specs/fulu/das-core.md#validator-custody
-func get_validators_custody_requirement*(state: fulu.BeaconState,
-                                         validator_indices: openArray[ValidatorIndex]):
+# https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/validator.md#validator-custody
+func get_validators_custody_requirement*(cfg: RuntimeConfig,
+                                         total_node_balance: Gwei):
                                          uint64 =
-  var total_node_balance: Gwei
-  for index in validator_indices:
-    total_node_balance += state.balances[index]
-  let count = total_node_balance div BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
-  min(max(count.uint64, VALIDATOR_CUSTODY_REQUIREMENT.uint64), NUMBER_OF_CUSTODY_GROUPS.uint64)
+  let count = total_node_balance div cfg.BALANCE_PER_ADDITIONAL_CUSTODY_GROUP
+  min(max(count.uint64, cfg.VALIDATOR_CUSTODY_REQUIREMENT),
+      cfg.NUMBER_OF_CUSTODY_GROUPS.uint64)

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -1,15 +1,14 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 # Uncategorized helper functions from the spec
 import
-  std/[algorithm, sequtils],
   chronicles, results,
   eth/p2p/discoveryv5/[node],
   kzg4844/[kzg],
@@ -18,7 +17,10 @@ import
     types],
   ./crypto,
   ./[helpers, digest],
-  ./datatypes/[fulu]
+  ./datatypes/fulu
+
+from std/algorithm import sort
+from std/sequtils import toSeq
 
 type
   CellBytes = array[fulu.CELLS_PER_EXT_BLOB, Cell]
@@ -30,41 +32,7 @@ iterator compute_columns_for_custody_group*(custody_group: CustodyIndex):
   for i in 0'u64 ..< COLUMNS_PER_GROUP:
     yield ColumnIndex(NUMBER_OF_CUSTODY_GROUPS * i + custody_group)
 
-iterator compute_columns_for_custody_group*(cfg: RuntimeConfig,
-                                            custody_group: CustodyIndex):
-                                            ColumnIndex =
-  for i in 0'u64 ..< COLUMNS_PER_GROUP:
-    yield ColumnIndex(cfg.NUMBER_OF_CUSTODY_GROUPS * i + custody_group)
-
 func handle_custody_groups(node_id: NodeId,
-                           custody_group_count: CustodyIndex):
-                           HashSet[CustodyIndex] =
-  # Decouples the custody group computation from
-  # `get_custody_groups`, in order to later use this custody
-  # group list across various types of output types
-
-  var
-    custody_groups: HashSet[CustodyIndex]
-    current_id = node_id
-
-  while custody_groups.lenu64 < custody_group_count:
-    var hashed_bytes: array[8, byte]
-
-    let
-      current_id_bytes = current_id.toBytesLE()
-      hashed_current_id = eth2digest(current_id_bytes)
-
-    hashed_bytes[0..7] = hashed_current_id.data.toOpenArray(0,7)
-    let custody_group = bytes_to_uint64(hashed_bytes) mod
-      NUMBER_OF_CUSTODY_GROUPS
-
-    custody_groups.incl custody_group
-
-    inc current_id
-
-  custody_groups
-
-func handle_custody_groups(cfg: RuntimeConfig, node_id: NodeId,
                            custody_group_count: CustodyIndex):
                            HashSet[CustodyIndex] =
   # Decouples the custody group computation from
@@ -103,24 +71,14 @@ func get_custody_groups*(node_id: NodeId,
   groups.sort()
   groups
 
-func get_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
-                         custody_group_count: CustodyIndex):
-                         seq[CustodyIndex] =
-  let custody_groups =
-    cfg.handle_custody_groups(node_id, custody_group_count)
-
-  var groups = custody_groups.toSeq()
-  groups.sort()
-  groups
-
-func resolve_columns_from_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
+func resolve_columns_from_custody_groups*(node_id: NodeId,
                                           custody_group_count: CustodyIndex):
                                           HashSet[ColumnIndex] =
   ## Returns a set of unique columns for the custody groups of a node.
   let custody_groups = node_id.get_custody_groups(custody_group_count)
   var columns: HashSet[ColumnIndex]
   for group in custody_groups:
-    for index in compute_columns_for_custody_group(cfg, group):
+    for index in compute_columns_for_custody_group(group):
       columns.incl index
   columns
 

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import std/[sets, sequtils], chronos, chronicles
 import ssz_serialization/types
@@ -337,11 +337,10 @@ proc checkPeerCustody(rman: RequestManager,
       # Fetch custody columns from remote peer
       let
         remoteNodeId = fetchNodeIdFromPeerId(peer)
-        remoteCustodyColumns =
-          rman.network.cfg.resolve_columns_from_custody_groups(
-            remoteNodeId,
-            max(rman.network.cfg.SAMPLES_PER_SLOT.uint64,
-                remoteCustodyGroupCount))
+        remoteCustodyColumns = resolve_columns_from_custody_groups(
+          remoteNodeId,
+          max(rman.network.cfg.SAMPLES_PER_SLOT.uint64,
+              remoteCustodyGroupCount))
 
       for local_column in rman.custody_columns_set:
         if local_column notin remoteCustodyColumns:

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -318,12 +318,12 @@ proc checkPeerCustody(rman: RequestManager,
     # too many full nodes that have a subset of the custody
     # columns
     if peer.lookupCgcFromPeer() ==
-        NUMBER_OF_CUSTODY_GROUPS.uint64:
+        rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS.uint64:
       return true
 
   else:
     if peer.lookupCgcFromPeer() ==
-        NUMBER_OF_CUSTODY_GROUPS.uint64:
+        rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS.uint64:
       return true
 
     elif peer.lookupCgcFromPeer() ==
@@ -337,10 +337,11 @@ proc checkPeerCustody(rman: RequestManager,
       # Fetch custody columns from remote peer
       let
         remoteNodeId = fetchNodeIdFromPeerId(peer)
-        remoteCustodyColumns = resolve_columns_from_custody_groups(
-          remoteNodeId,
-          max(rman.network.cfg.SAMPLES_PER_SLOT.uint64,
-              remoteCustodyGroupCount))
+        remoteCustodyColumns =
+          rman.network.cfg.resolve_columns_from_custody_groups(
+            remoteNodeId,
+            max(rman.network.cfg.SAMPLES_PER_SLOT.uint64,
+                remoteCustodyGroupCount))
 
       for local_column in rman.custody_columns_set:
         if local_column notin remoteCustodyColumns:
@@ -663,7 +664,8 @@ proc requestManagerDataColumnLoop(
       debug "Requesting detected missing data columns", columns = shortLog(columnIds)
       let start = SyncMoment.now(0)
       let workerCount =
-        if rman.custody_columns_set.lenu64 > NUMBER_OF_CUSTODY_GROUPS.uint64:
+        if rman.custody_columns_set.lenu64 >
+            rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS.uint64:
           PARALLEL_REQUESTS
         else:
           PARALLEL_REQUESTS_DATA_COLUMNS

--- a/config.nims
+++ b/config.nims
@@ -180,6 +180,7 @@ if canEnableDebuggingSymbols:
 switch("warningAsError", "BareExcept:on")
 switch("warningAsError", "CStringConv:on")
 switch("warningAsError", "UnusedImport:on")
+switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")

--- a/tests/consensus_spec/test_fixture_networking.nim
+++ b/tests/consensus_spec/test_fixture_networking.nim
@@ -35,7 +35,8 @@ proc runComputeForCustodyGroup(suiteName, path: string) =
       custody_group = meta.custody_group
 
     var counter = 0
-    for column in compute_columns_for_custody_group(custody_group):
+    for column in compute_columns_for_custody_group(
+        defaultRuntimeConfig, custody_group):
       check column == meta.result[counter]
       inc counter
 
@@ -56,7 +57,8 @@ proc runGetCustodyGroups(suiteName, path: string) =
       node_id = UInt256.fromDecimal(meta.node_id)
       custody_group_count = meta.custody_group_count
 
-    let columns = get_custody_groups(node_id, custody_group_count)
+    let columns = defaultRuntimeConfig.get_custody_groups(
+      node_id, custody_group_count)
 
     for i in 0..<columns.lenu64:
       check columns[i] == meta.result[i]


### PR DESCRIPTION
The `el_manager` changes are to address:
```
/github-runner/github-runner-node-01/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/el/el_manager.nim(782, 39) Hint: conversion from Hash32 to itself is pointless [ConvFromXtoItselfNotNeeded]
/github-runner/github-runner-node-01/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/el/el_manager.nim(856, 43) Hint: conversion from Hash32 to itself is pointless [ConvFromXtoItselfNotNeeded]
/github-runner/github-runner-node-01/workspace/nimbus-eth2/nimbus-eth2/beacon_chain/el/el_manager.nim(883, 41) Hint: conversion from Hash32 to itself is pointless [ConvFromXtoItselfNotNeeded]
```

As far as the rest:
https://github.com/status-im/nimbus-eth2/blob/ca3a6d6cbc1baa5b4a7fbef383f944dca138129e/beacon_chain/spec/peerdas_helpers.nim#L28-L37

The two `compute_columns_for_custody_group` are identical except for the useless/unused `cfg` parameter. Similarly for `handle_custody_groups`, and also the case for `get_custody_groups`:
https://github.com/status-im/nimbus-eth2/blob/ca3a6d6cbc1baa5b4a7fbef383f944dca138129e/beacon_chain/spec/peerdas_helpers.nim#L96-L114