### PR TITLE
refactor storeBackfillBlock

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles, chronos, web3/[primitives, engine_api_types],
@@ -373,7 +373,6 @@ proc runProposalForkchoiceUpdated*(
       debug "Fork-choice updated for proposal", status
 
     static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
-    debugFuluComment "Will Fulu need fcuV4? Or there shall be a new fcuV introduced in Fulu? We don't know"
     when consensusFork >= ConsensusFork.Deneb:
       # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
       # does not define any new forkchoiceUpdated, so reuse V3 from Dencun

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles, chronos, metrics,
@@ -185,54 +185,12 @@ from ../consensus_object_pools/block_clearance import
 
 proc storeBackfillBlock(
     self: var BlockProcessor,
-    signedBlock: ForkySignedBeaconBlock,
-    blobsOpt: Opt[BlobSidecars],
-    dataColumnsOpt: Opt[DataColumnSidecars]): Result[void, VerifierError] =
-
+    signedBlock: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+                 bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
+                 deneb.SignedBeaconBlock | electra.SignedBeaconBlock,
+    blobsOpt: Opt[BlobSidecars]): Result[void, VerifierError] =
   # The block is certainly not missing any more
   self.consensusManager.quarantine[].missing.del(signedBlock.root)
-
-  var columnsOk = true
-  when typeof(signedBlock).kind >= ConsensusFork.Fulu:
-    var malformed_cols: seq[int]
-    if dataColumnsOpt.isSome:
-      let columns = dataColumnsOpt.get()
-      let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
-      if columns.len > 0 and kzgCommits.len > 0:
-        for i in 0..<columns.len:
-          let r =
-            verify_data_column_sidecar_kzg_proofs(columns[i][])
-          if r.isErr:
-            malformed_cols.add(i)
-            debug "backfill data column validation failed",
-              blockRoot = shortLog(signedBlock.root),
-              column_sidecar = shortLog(columns[i][]),
-              blck = shortLog(signedBlock.message),
-              signature = shortLog(signedBlock.signature),
-              msg = r.error()
-          columnsOk = r.isOk()
-
-      # DataColumnSidecar repairing strategy attempt in case of
-      # malformed columns where 50%+ columns are legit. Note that
-      # this repairing will almost never happen unless these malformed
-      # columns coming via req/resp.
-      if dataColumnsOpt.get.lenu64 >
-          (self.consensusManager.dag.cfg.NUMBER_OF_COLUMNS div 2) and
-           not columnsOk:
-        let
-          recovered_cps =
-            recover_cells_and_proofs(columns)
-          recovered_columns =
-            signedBlock.get_data_column_sidecars(recovered_cps.get)
-
-        for mc in malformed_cols:
-          # copy the healed columns only into the
-          # sidecar spaces
-          columns[mc][] = recovered_columns[mc]
-        columnsOk = true
-
-  if not columnsOk:
-    return err(VerifierError.Invalid)
 
   # Establish blob viability before calling addbackfillBlock to avoid
   # writing the block in case of blob error.
@@ -280,9 +238,77 @@ proc storeBackfillBlock(
   for b in blobs:
     self.consensusManager.dag.db.putBlobSidecar(b[])
 
+  res
+
+proc storeBackfillBlock(
+    self: var BlockProcessor,
+    signedBlock: fulu.SignedBeaconBlock,
+    dataColumnsOpt: Opt[DataColumnSidecars]): Result[void, VerifierError] =
+  # The block is certainly not missing any more
+  self.consensusManager.quarantine[].missing.del(signedBlock.root)
+
+  var
+    columnsOk = true
+    malformed_cols: seq[int]
+  if dataColumnsOpt.isSome:
+    let columns = dataColumnsOpt.get()
+    let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
+    if columns.len > 0 and kzgCommits.len > 0:
+      for i in 0..<columns.len:
+        let r =
+          verify_data_column_sidecar_kzg_proofs(columns[i][])
+        if r.isErr:
+          malformed_cols.add(i)
+          debug "backfill data column validation failed",
+            blockRoot = shortLog(signedBlock.root),
+            column_sidecar = shortLog(columns[i][]),
+            blck = shortLog(signedBlock.message),
+            signature = shortLog(signedBlock.signature),
+            msg = r.error()
+        columnsOk = r.isOk()
+
+    # DataColumnSidecar repairing strategy attempt in case of
+    # malformed columns where 50%+ columns are legit. Note that
+    # this repairing will almost never happen unless these malformed
+    # columns coming via req/resp.
+    if dataColumnsOpt.get.lenu64 >
+        (self.consensusManager.dag.cfg.NUMBER_OF_COLUMNS div 2) and
+         not columnsOk:
+      let
+        recovered_cps =
+          recover_cells_and_proofs(columns)
+        recovered_columns =
+          signedBlock.get_data_column_sidecars(recovered_cps.get)
+
+      for mc in malformed_cols:
+        # copy the healed columns only into the
+        # sidecar spaces
+        columns[mc][] = recovered_columns[mc]
+      columnsOk = true
+
+  if not columnsOk:
+    return err(VerifierError.Invalid)
+
+  let res = self.consensusManager.dag.addBackfillBlock(signedBlock)
+
+  if res.isErr():
+    case res.error
+    of VerifierError.MissingParent:
+      if signedBlock.message.parent_root in
+          self.consensusManager.quarantine[].unviable:
+        # DAG doesn't know about unviable ancestor blocks - we do! Translate
+        # this to the appropriate error so that sync etc doesn't retry the block
+        self.consensusManager.quarantine[].addUnviable(signedBlock.root)
+
+        return err(VerifierError.UnviableFork)
+    of VerifierError.UnviableFork:
+      # Track unviables so that descendants can be discarded properly
+      self.consensusManager.quarantine[].addUnviable(signedBlock.root)
+    else: discard
+    return res
+
   # Only store data columns after successfully establishing block viability.
-  let
-    columns = dataColumnsOpt.valueOr: DataColumnSidecars @[]
+  let columns = dataColumnsOpt.valueOr: DataColumnSidecars @[]
   for c in columns:
     self.consensusManager.dag.db.putDataColumnSidecar(c[])
 
@@ -465,8 +491,12 @@ proc enqueueBlock*(
     if forkyBlck.message.slot <= self.consensusManager.dag.finalizedHead.slot:
       # let backfill blocks skip the queue - these are always "fast" to process
       # because there are no state rewinds to deal with
-      let res = self.storeBackfillBlock(forkyBlck, blobs, Opt.none(DataColumnSidecars))
-      resfut.complete(res)
+      when consensusFork >= ConsensusFork.Fulu:
+        debugFuluComment "hook up data_columns to storeBackfillBlock"
+        resfut.complete(
+          self.storeBackfillBlock(forkyBlck, Opt.none(DataColumnSidecars)))
+      else:
+        resFut.complete(self.storeBackfillBlock(forkyBlck, blobs))
       return
 
   try:
@@ -897,7 +927,6 @@ proc storeBlock(
             deadlineObj = deadlineObj,
             maxRetriesCount = getRetriesCount())
 
-        debugFuluComment "We don't know yet if there'd be new PayloadAttributes version in Fulu."
         template callForkChoiceUpdated: auto =
           case self.consensusManager.dag.cfg.consensusForkAtEpoch(
               newHead.get.blck.bid.slot.epoch)

--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -16,7 +16,7 @@
 {.experimental: "notnil".}
 
 import
-  std/[sequtils, typetraits],
+  std/typetraits,
   "."/[phase0, base, bellatrix, electra],
   chronicles,
   json_serialization,
@@ -25,6 +25,7 @@ import
   ../digest,
   kzg4844/[kzg, kzg_abi]
 
+from std/sequtils import mapIt
 from std/strutils import join
 from stew/bitops2 import log2trunc
 from stew/byteutils import to0xHex
@@ -59,7 +60,6 @@ const
   DATA_COLUMN_SIDECAR_SUBNET_COUNT* = 128
 
   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/das-core.md#custody-setting
-  SAMPLES_PER_SLOT* = 8
   CUSTODY_REQUIREMENT* = 4
 
   # Minimum number of custody groups an honest node with

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -623,12 +623,6 @@ template SignedBlindedBeaconBlock*(kind: static ConsensusFork): typedesc =
     fulu_mev.SignedBlindedBeaconBlock
   elif kind == ConsensusFork.Electra:
     electra_mev.SignedBlindedBeaconBlock
-  elif kind == ConsensusFork.Deneb:
-    deneb_mev.SignedBlindedBeaconBlock
-  elif kind == ConsensusFork.Capella:
-    capella_mev.SignedBlindedBeaconBlock
-  elif kind == ConsensusFork.Bellatrix:
-    bellatrix_mev.SignedBlindedBeaconBlock
   else:
     {.error: "SignedBlindedBeaconBlock unsupported in " & $kind.}
 

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   # Standard library
@@ -729,7 +729,6 @@ template writeValue*(w: var JsonWriter,
 
 func parseProvenBlockProperty*(propertyPath: string): Result[ProvenProperty, string] =
   if propertyPath == ".execution_payload.fee_recipient":
-    debugFuluComment "We don't know yet if `GeneralizedIndex` will stay same in Fulu yet."
     ok ProvenProperty(
       path: propertyPath,
       denebIndex: GeneralizedIndex(801),

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -536,7 +536,6 @@ proc makeBeaconBlockWithRewards*(
           forkyState.data.latest_execution_payload_header.transactions_root =
             transactions_root.get
 
-          debugFuluComment "verify (again) that this is what builder API needs"
           when executionPayload is fulu.ExecutionPayloadForSigning:
             # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#beaconblockbody
             forkyState.data.latest_block_header.body_root = hash_tree_root(


### PR DESCRIPTION
Also mark all but one `debugFuluComment` as either resolved or in process of resolution with an active PR open. The `enqueueBlock` code this refactors also don't handle Fulu in any particular way, this just makes it more obvious.

Removing `SAMPLES_PER_SLOT` as a true constant ensures that any reference to it will have to go through `RuntimeConfig`, because indeed https://github.com/ethereum/consensus-specs/blob/6aa39fa589579e64a93005cada5265931462783b/configs/mainnet.yaml#L213
```yaml
SAMPLES_PER_SLOT: 8
# 2**2 (= 4) sidecars
```