### PR TITLE
Block production revamp, part 2

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -791,9 +791,13 @@ func check_attestation_compatible*(
     return err("Incompatible shuffling")
   ok()
 
-proc getAttestationsForBlock*(pool: var AttestationPool,
-                              state: ForkyHashedBeaconState,
-                              cache: var StateCache): seq[phase0.Attestation] =
+proc getAttestationsForBlock*(
+    pool: var AttestationPool,
+    state:
+      phase0.HashedBeaconState | altair.HashedBeaconState | bellatrix.HashedBeaconState |
+      capella.HashedBeaconState | deneb.HashedBeaconState,
+    cache: var StateCache,
+): seq[phase0.Attestation] =
   ## Retrieve attestations that may be added to a new block at the slot of the
   ## given state
   ## https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/validator.md#attestations
@@ -929,10 +933,11 @@ proc getAttestationsForBlock*(pool: var AttestationPool,
     else:
       default(seq[phase0.Attestation])
 
-proc getElectraAttestationsForBlock*(
+proc getAttestationsForBlock*(
     pool: var AttestationPool,
     state: electra.HashedBeaconState | fulu.HashedBeaconState,
-    cache: var StateCache): seq[electra.Attestation] =
+    cache: var StateCache,
+): seq[electra.Attestation] =
   let newBlockSlot = state.data.slot.uint64
 
   if newBlockSlot < MIN_ATTESTATION_INCLUSION_DELAY:
@@ -1092,7 +1097,7 @@ proc getElectraAttestationsForBlock*(
     cache: var StateCache): seq[electra.Attestation] =
   withState(state):
     when consensusFork >= ConsensusFork.Electra:
-      pool.getElectraAttestationsForBlock(forkyState, cache)
+      pool.getAttestationsForBlock(forkyState, cache)
     else:
       default(seq[electra.Attestation])
 

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -489,7 +489,8 @@ proc getPayload*(
     withdrawals: seq[capella.Withdrawal]
 ): Future[Opt[PayloadType]] {.async: (raises: [CancelledError]).} =
   if m.elConnections.len == 0:
-    return err()
+    notice "No engine configured, using empty payload"
+    return Opt.none(PayloadType)
 
   let
     engineApiWithdrawals = toEngineWithdrawals withdrawals

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -94,6 +94,9 @@ type
     electra.ExecutionPayloadHeader |
     fulu.ExecutionPayloadHeader
 
+  ForkyExecutionPayloadOrHeader* =
+    ForkyExecutionPayload | ForkyExecutionPayloadHeader
+
   ForkyBeaconBlockBody* =
     phase0.BeaconBlockBody |
     altair.BeaconBlockBody |
@@ -168,6 +171,17 @@ type
   ForkyBlindedBeaconBlock* =
     electra_mev.BlindedBeaconBlock |
     fulu_mev.BlindedBeaconBlock
+
+  SomeForkyBlindedBeaconBlock* =
+    ForkyBlindedBeaconBlock |
+    electra_mev.SigVerifiedBlindedBeaconBlock |
+    fulu_mev.SigVerifiedBlindedBeaconBlock
+
+  SomeForkyBlindedBeaconBlockBody* =
+    electra_mev.BlindedBeaconBlockBody |
+    fulu_mev.BlindedBeaconBlockBody |
+    electra_mev.SigVerifiedBlindedBeaconBlockBody |
+    fulu_mev.SigVerifiedBlindedBeaconBlockBody
 
   ForkyBuilderBid* =
     electra_mev.BuilderBid |
@@ -1921,3 +1935,9 @@ template init*(T: type ForkedAggregateAndProof,
     ForkedAggregateAndProof(kind: ConsensusFork.Electra, electraData: proof)
   of ConsensusFork.Fulu:
     ForkedAggregateAndProof(kind: ConsensusFork.Fulu, fuluData: proof)
+
+proc kzg_commitments*(eps: ForkyExecutionPayloadForSigning): KzgCommitments =
+  when typeof(eps).kind >= ConsensusFork.Deneb:
+    eps.blobsBundle.commitments
+  else:
+    default(KzgCommitments)

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -408,34 +408,23 @@ func is_execution_block*(blck: SomeForkyBeaconBlock): bool =
 func is_merge_transition_block(
     state: bellatrix.BeaconState | capella.BeaconState | deneb.BeaconState |
            electra.BeaconState | fulu.BeaconState,
-    body: bellatrix.BeaconBlockBody | bellatrix.TrustedBeaconBlockBody |
-          bellatrix.SigVerifiedBeaconBlockBody |
-          capella.BeaconBlockBody | capella.TrustedBeaconBlockBody |
-          capella.SigVerifiedBeaconBlockBody |
-          deneb.BeaconBlockBody | deneb.TrustedBeaconBlockBody |
-          deneb.SigVerifiedBeaconBlockBody |
-          electra.BeaconBlockBody | electra.TrustedBeaconBlockBody |
-          electra.SigVerifiedBeaconBlockBody |
-          fulu.BeaconBlockBody | fulu.TrustedBeaconBlockBody |
-          fulu.SigVerifiedBeaconBlockBody): bool =
-  const defaultExecutionPayload = default(typeof(body.execution_payload))
-  not is_merge_transition_complete(state) and
-    body.execution_payload != defaultExecutionPayload
+    body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody): bool =
+  when body is SomeForkyBlindedBeaconBlockBody:
+    const defaultExecutionPayload = default(typeof(body.execution_payload_header))
+    not is_merge_transition_complete(state) and
+      body.execution_payload_header != defaultExecutionPayload
+  elif typeof(body).kind >= ConsensusFork.Bellatrix:
+    const defaultExecutionPayload = default(typeof(body.execution_payload))
+    not is_merge_transition_complete(state) and
+      body.execution_payload != defaultExecutionPayload
+  else:
+    false
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/bellatrix/beacon-chain.md#is_execution_enabled
 func is_execution_enabled*(
     state: bellatrix.BeaconState | capella.BeaconState | deneb.BeaconState |
            electra.BeaconState | fulu.BeaconState,
-    body: bellatrix.BeaconBlockBody | bellatrix.TrustedBeaconBlockBody |
-          bellatrix.SigVerifiedBeaconBlockBody |
-          capella.BeaconBlockBody | capella.TrustedBeaconBlockBody |
-          capella.SigVerifiedBeaconBlockBody |
-          deneb.BeaconBlockBody | deneb.TrustedBeaconBlockBody |
-          deneb.SigVerifiedBeaconBlockBody |
-          electra.BeaconBlockBody | electra.TrustedBeaconBlockBody |
-          electra.SigVerifiedBeaconBlockBody |
-          fulu.BeaconBlockBody | fulu.TrustedBeaconBlockBody |
-          fulu.SigVerifiedBeaconBlockBody): bool =
+    body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody): bool =
   is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot

--- a/beacon_chain/spec/mev/electra_mev.nim
+++ b/beacon_chain/spec/mev/electra_mev.nim
@@ -60,6 +60,24 @@ type
     blob_kzg_commitments*: KzgCommitments
     execution_requests*: ExecutionRequests # [New in Electra]
 
+  SigVerifiedBlindedBeaconBlockBody* = object
+    randao_reveal*: TrustedSig
+    eth1_data*: Eth1Data
+    graffiti*: GraffitiBytes
+    proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*:
+      List[electra.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
+    attestations*: List[electra.TrustedAttestation, Limit MAX_ATTESTATIONS_ELECTRA]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+    sync_aggregate*: TrustedSyncAggregate
+    execution_payload_header*: electra.ExecutionPayloadHeader
+    bls_to_execution_changes*:
+      List[SignedBLSToExecutionChange,
+        Limit MAX_BLS_TO_EXECUTION_CHANGES]
+    blob_kzg_commitments*: KzgCommitments
+    execution_requests*: ExecutionRequests # [New in Electra]
+
   # https://github.com/ethereum/builder-specs/blob/v0.5.0/specs/bellatrix/builder.md#blindedbeaconblock
   BlindedBeaconBlock* = object
     slot*: Slot
@@ -67,6 +85,14 @@ type
     parent_root*: Eth2Digest
     state_root*: Eth2Digest
     body*: BlindedBeaconBlockBody # [Modified in Deneb]
+
+  # https://github.com/ethereum/builder-specs/blob/v0.5.0/specs/bellatrix/builder.md#blindedbeaconblock
+  SigVerifiedBlindedBeaconBlock* = object
+    slot*: Slot
+    proposer_index*: uint64
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
+    body*: SigVerifiedBlindedBeaconBlockBody # [Modified in Deneb]
 
   MaybeBlindedBeaconBlock* = object
     case isBlinded*: bool
@@ -173,3 +199,7 @@ func toSignedBlindedBeaconBlock*(blck: electra.SignedBeaconBlock):
         blob_kzg_commitments: blck.message.body.blob_kzg_commitments,
         execution_requests: blck.message.body.execution_requests)),
     signature: blck.signature)
+
+template asSigVerified*(
+    x: BlindedBeaconBlock): SigVerifiedBlindedBeaconBlock =
+  isomorphicCast[SigVerifiedBlindedBeaconBlock](x)

--- a/beacon_chain/spec/mev/fulu_mev.nim
+++ b/beacon_chain/spec/mev/fulu_mev.nim
@@ -48,13 +48,38 @@ type
     blob_kzg_commitments*: KzgCommitments # [New in Deneb]
     execution_requests*: ExecutionRequests # [New in Electra]
 
+  SigVerifiedBlindedBeaconBlockBody* = object
+    randao_reveal*: TrustedSig
+    eth1_data*: Eth1Data
+    graffiti*: GraffitiBytes
+    proposer_slashings*: List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*:
+      List[electra.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
+    attestations*: List[electra.TrustedAttestation, Limit MAX_ATTESTATIONS_ELECTRA]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+    sync_aggregate*: TrustedSyncAggregate
+    execution_payload_header*: fulu.ExecutionPayloadHeader
+    bls_to_execution_changes*:
+      List[SignedBLSToExecutionChange,
+        Limit MAX_BLS_TO_EXECUTION_CHANGES]
+    blob_kzg_commitments*: KzgCommitments # [New in Deneb]
+    execution_requests*: ExecutionRequests # [New in Electra]
+
   # https://github.com/ethereum/builder-specs/blob/v0.5.0/specs/bellatrix/builder.md#blindedbeaconblock
   BlindedBeaconBlock* = object
     slot*: Slot
     proposer_index*: uint64
     parent_root*: Eth2Digest
     state_root*: Eth2Digest
-    body*: BlindedBeaconBlockBody # [Modified in Deneb]
+    body*: BlindedBeaconBlockBody
+
+  SigVerifiedBlindedBeaconBlock* = object
+    slot*: Slot
+    proposer_index*: uint64
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
+    body*: SigVerifiedBlindedBeaconBlockBody
 
   MaybeBlindedBeaconBlock* = object
     case isBlinded*: bool
@@ -146,3 +171,7 @@ func toSignedBlindedBeaconBlock*(blck: fulu.SignedBeaconBlock):
         blob_kzg_commitments: blck.message.body.blob_kzg_commitments,
         execution_requests: blck.message.body.execution_requests)),
     signature: blck.signature)
+
+template asSigVerified*(
+    x: BlindedBeaconBlock): SigVerifiedBlindedBeaconBlock =
+  isomorphicCast[SigVerifiedBlindedBeaconBlock](x)

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -283,7 +283,7 @@ proc process_slots*(
 proc state_transition_block_aux(
     cfg: RuntimeConfig,
     state: var ForkyHashedBeaconState,
-    signedBlock: SomeForkySignedBeaconBlock,
+    signedBlock: SomeForkySignedBeaconBlock | ForkySignedBlindedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags): Result[BlockRewards, cstring] =
   # Block updates - these happen when there's a new block being suggested
   # by the block proposer. Every actor in the network will update its state
@@ -316,7 +316,7 @@ func noRollback*(state: var ForkedHashedBeaconState) =
 proc state_transition_block*(
     cfg: RuntimeConfig,
     state: var ForkedHashedBeaconState,
-    signedBlock: SomeForkySignedBeaconBlock,
+    signedBlock: SomeForkySignedBeaconBlock | ForkySignedBlindedBeaconBlock,
     cache: var StateCache, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): Result[BlockRewards, cstring] =
   ## `rollback` is called if the transition fails and the given state has been
@@ -340,7 +340,7 @@ proc state_transition_block*(
 proc state_transition*(
     cfg: RuntimeConfig,
     state: var ForkedHashedBeaconState,
-    signedBlock: SomeForkySignedBeaconBlock,
+    signedBlock: SomeForkySignedBeaconBlock | ForkySignedBlindedBeaconBlock,
     cache: var StateCache, info: var ForkedEpochInfo, flags: UpdateFlags,
     rollback: RollbackForkedHashedProc): Result[BlockRewards, cstring] =
   ## Apply a block to the state, advancing the slot counter as necessary. The
@@ -365,97 +365,31 @@ proc state_transition*(
   state_transition_block(
     cfg, state, signedBlock, cache, flags, rollback)
 
-func partialBeaconBlock*(
-    cfg: RuntimeConfig,
-    state: var (phase0.HashedBeaconState | altair.HashedBeaconState |
-                bellatrix.HashedBeaconState | capella.HashedBeaconState |
-                deneb.HashedBeaconState),
-    proposer_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    eth1_data: Eth1Data,
-    graffiti: GraffitiBytes,
-    attestations: seq[phase0.Attestation],
-    deposits: seq[Deposit],
-    validator_changes: BeaconBlockValidatorChanges,
-    sync_aggregate: SyncAggregate,
-    execution_payload: ForkyExecutionPayloadForSigning,
-    _: ExecutionRequests): auto =
-  const consensusFork = typeof(state).kind
+template toList[A](attestations: seq[A]): auto =
+  when A is phase0.Attestation:
+    List[phase0.Attestation, Limit MAX_ATTESTATIONS](attestations)
+  elif A is electra.Attestation:
+    List[electra.Attestation, Limit MAX_ATTESTATIONS_ELECTRA](attestations)
+  else:
+    {.error: "Unknown attestation type".}
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/validator.md#preparing-for-a-beaconblock
-  var res = consensusFork.BeaconBlock(
-    slot: state.data.slot,
-    proposer_index: proposer_index.uint64,
-    parent_root: state.latest_block_root,
-    body: consensusFork.BeaconBlockBody(
-      randao_reveal: randao_reveal,
-      eth1_data: eth1_data,
-      graffiti: graffiti,
-      proposer_slashings: validator_changes.proposer_slashings,
-      attester_slashings: validator_changes.phase0_attester_slashings,
-      attestations:
-        List[phase0.Attestation, Limit MAX_ATTESTATIONS](attestations),
-      deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: validator_changes.voluntary_exits))
+template attester_slashings(changes: BeaconBlockValidatorChanges, consensusFork): auto =
+  when consensusFork >= ConsensusFork.Electra:
+    changes.electra_attester_slashings
+  else:
+    changes.phase0_attester_slashings
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/altair/validator.md#preparing-a-beaconblock
-  when consensusFork >= ConsensusFork.Altair:
-    res.body.sync_aggregate = sync_aggregate
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/bellatrix/validator.md#block-proposal
-  when consensusFork >= ConsensusFork.Bellatrix:
-    res.body.execution_payload = execution_payload.executionPayload
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/capella/validator.md#block-proposal
-  when consensusFork >= ConsensusFork.Capella:
-    res.body.bls_to_execution_changes =
-      validator_changes.bls_to_execution_changes
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/validator.md#constructing-the-beaconblockbody
-  when consensusFork >= ConsensusFork.Deneb:
-    res.body.blob_kzg_commitments = execution_payload.blobsBundle.commitments
-
-  res
-
-func partialBeaconBlock*(
-    cfg: RuntimeConfig,
-    state: var (electra.HashedBeaconState | fulu.HashedBeaconState),
-    proposer_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    eth1_data: Eth1Data,
-    graffiti: GraffitiBytes,
-    attestations: seq[electra.Attestation],
-    deposits: seq[Deposit],
-    validator_changes: BeaconBlockValidatorChanges,
-    sync_aggregate: SyncAggregate,
-    execution_payload: ForkyExecutionPayloadForSigning,
-    execution_requests: ExecutionRequests): auto =
-  const consensusFork = typeof(state).kind
-
-  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/validator.md#preparing-for-a-beaconblock
-  consensusFork.BeaconBlock(
-    slot: state.data.slot,
-    proposer_index: proposer_index.uint64,
-    parent_root: state.latest_block_root,
-    body: consensusFork.BeaconBlockBody(
-      randao_reveal: randao_reveal,
-      eth1_data: eth1_data,
-      graffiti: graffiti,
-      proposer_slashings: validator_changes.proposer_slashings,
-      attester_slashings: validator_changes.electra_attester_slashings,
-      attestations:
-        List[electra.Attestation, Limit MAX_ATTESTATIONS_ELECTRA](attestations),
-      deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
-      voluntary_exits: validator_changes.voluntary_exits,
-      sync_aggregate: sync_aggregate,
-      execution_payload: execution_payload.executionPayload,
-      bls_to_execution_changes: validator_changes.bls_to_execution_changes,
-      blob_kzg_commitments: execution_payload.blobsBundle.commitments,
-      execution_requests: execution_requests))
+template BeaconBlock(fork: ConsensusFork, EPOH: type): type =
+  when EPOH is ForkyExecutionPayloadHeader:
+    fork.BlindedBeaconBlock
+  else:
+    fork.BeaconBlock
 
 proc makeBeaconBlockWithRewards*(
     cfg: RuntimeConfig,
-    state: var ForkedHashedBeaconState,
+    consensusFork: static ConsensusFork,
+    state: var ForkyHashedBeaconState,
+    cache: var StateCache,
     proposer_index: ValidatorIndex,
     randao_reveal: ValidatorSig,
     eth1_data: Eth1Data,
@@ -464,197 +398,116 @@ proc makeBeaconBlockWithRewards*(
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    executionPayload: ForkyExecutionPayloadForSigning,
-    rollback: RollbackForkedHashedProc,
-    cache: var StateCache,
-    # TODO:
-    # `verificationFlags` is needed only in tests and can be
-    # removed if we don't use invalid signatures there
+    execution_payload: ForkyExecutionPayloadOrHeader,
     verificationFlags: UpdateFlags,
-    transactions_root: Opt[Eth2Digest],
-    execution_payload_root: Opt[Eth2Digest],
-    kzg_commitments: Opt[KzgCommitments],
-    execution_requests: ExecutionRequests):
-    Result[tuple[blck: ForkedBeaconBlock, rewards: BlockRewards], cstring] =
+    kzg_commitments: KzgCommitments,
+    execution_requests: ExecutionRequests,
+): Result[
+    tuple[
+      blck: consensusFork.BeaconBlock(typeof(execution_payload)), rewards: BlockRewards
+    ],
+    cstring,
+] =
   ## Create a block for the given state. The latest block applied to it will
   ## be used for the parent_root value, and the slot will be take from
   ## state.slot meaning process_slots must be called up to the slot for which
   ## the block is to be created.
+  type
+    MaybeBlindedBeaconBlock = consensusFork.BeaconBlock(type(execution_payload))
+    MaybeBlindedBlockBody = typeof(default(MaybeBlindedBeaconBlock).body)
 
-  template makeBeaconBlock(
-      kind: untyped
-  ): Result[tuple[blck: ForkedBeaconBlock, rewards: BlockRewards], cstring] =
-    # To create a block, we'll first apply a partial block to the state, skipping
-    # some validations.
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/validator.md#preparing-for-a-beaconblock
+  var blck = MaybeBlindedBeaconBlock(
+    slot: state.data.slot,
+    proposer_index: proposer_index.uint64,
+    parent_root: state.latest_block_root,
+    body: MaybeBlindedBlockBody(
+      randao_reveal: randao_reveal,
+      eth1_data: eth1_data,
+      graffiti: graffiti,
+      proposer_slashings: validator_changes.proposer_slashings,
+      attester_slashings: validator_changes.attester_slashings(consensusFork),
+      attestations: attestations.toList(),
+      deposits: List[Deposit, Limit MAX_DEPOSITS](deposits),
+      voluntary_exits: validator_changes.voluntary_exits,
+    ),
+  )
 
-    var blck =
-      ForkedBeaconBlock.init(
-        partialBeaconBlock(
-          cfg, state.`kind Data`, proposer_index, randao_reveal, eth1_data,
-          graffiti, attestations, deposits, validator_changes, sync_aggregate,
-          executionPayload, execution_requests))
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/altair/validator.md#preparing-a-beaconblock
+  when consensusFork >= ConsensusFork.Altair:
+    blck.body.sync_aggregate = sync_aggregate
 
-    let res = process_block(
-      cfg, state.`kind Data`.data, blck.`kind Data`.asSigVerified(),
-      verificationFlags, cache)
-    if res.isErr:
-      rollback(state)
-      return err(res.error())
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/bellatrix/validator.md#block-proposal
+  when consensusFork >= ConsensusFork.Bellatrix:
+    when execution_payload is ForkyExecutionPayloadHeader:
+      blck.body.execution_payload_header = execution_payload
+    else:
+      blck.body.execution_payload = execution_payload
 
-    # Override for Builder API
-    if transactions_root.isSome and execution_payload_root.isSome:
-      withState(state):
-        when consensusFork < ConsensusFork.Electra:
-          # Nimbus doesn't support pre-Electra builder API
-          discard
-        elif consensusFork == ConsensusFork.Electra:
-          forkyState.data.latest_execution_payload_header.transactions_root =
-            transactions_root.get
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/capella/validator.md#block-proposal
+  when consensusFork >= ConsensusFork.Capella:
+    blck.body.bls_to_execution_changes = validator_changes.bls_to_execution_changes
 
-          when executionPayload is electra.ExecutionPayloadForSigning:
-            # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#beaconblockbody
-            forkyState.data.latest_block_header.body_root = hash_tree_root(
-              [hash_tree_root(randao_reveal),
-               hash_tree_root(eth1_data),
-               hash_tree_root(graffiti),
-               hash_tree_root(validator_changes.proposer_slashings),
-               hash_tree_root(validator_changes.electra_attester_slashings),
-               hash_tree_root(
-                 List[electra.Attestation, Limit MAX_ATTESTATIONS_ELECTRA](
-                   attestations)),
-               hash_tree_root(List[Deposit, Limit MAX_DEPOSITS](deposits)),
-               hash_tree_root(validator_changes.voluntary_exits),
-               hash_tree_root(sync_aggregate),
-               execution_payload_root.get,
-               hash_tree_root(validator_changes.bls_to_execution_changes),
-               hash_tree_root(kzg_commitments.get),
-               hash_tree_root(execution_requests)
-            ])
-          else:
-            raiseAssert "Attempt to use non-Electra payload with post-Deneb state"
-        elif consensusFork == ConsensusFork.Fulu:
-          forkyState.data.latest_execution_payload_header.transactions_root =
-            transactions_root.get
+  # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/validator.md#constructing-the-beaconblockbody
+  when consensusFork >= ConsensusFork.Deneb:
+    blck.body.blob_kzg_commitments = kzg_commitments
 
-          debugFuluComment "verify (again) that this is what builder API needs"
-          when executionPayload is fulu.ExecutionPayloadForSigning:
-            # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#beaconblockbody
-            forkyState.data.latest_block_header.body_root = hash_tree_root(
-              [hash_tree_root(randao_reveal),
-               hash_tree_root(eth1_data),
-               hash_tree_root(graffiti),
-               hash_tree_root(validator_changes.proposer_slashings),
-               hash_tree_root(validator_changes.electra_attester_slashings),
-               hash_tree_root(
-                 List[electra.Attestation, Limit MAX_ATTESTATIONS](
-                   attestations)),
-               hash_tree_root(List[Deposit, Limit MAX_DEPOSITS](deposits)),
-               hash_tree_root(validator_changes.voluntary_exits),
-               hash_tree_root(sync_aggregate),
-               execution_payload_root.get,
-               hash_tree_root(validator_changes.bls_to_execution_changes),
-               hash_tree_root(kzg_commitments.get),
-               hash_tree_root(execution_requests)
-            ])
-          else:
-            raiseAssert "Attempt to use non-Fulu payload with post-Electra state"
-        else:
-          static: raiseAssert "Unreachable"
+  when consensusFork >= ConsensusFork.Electra:
+    blck.body.execution_requests = execution_requests
 
-    state.`kind Data`.root = hash_tree_root(state.`kind Data`.data)
-    blck.`kind Data`.state_root = state.`kind Data`.root
+  let rewards =
+    ?process_block(cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
 
-    ok((blck: blck, rewards: res.get))
+  state.root = hash_tree_root(state.data)
+  blck.state_root = state.root
 
-  const payloadFork = typeof(executionPayload).kind
-  when payloadFork == ConsensusFork.Bellatrix:
-    case state.kind
-    of ConsensusFork.Phase0:    makeBeaconBlock(phase0)
-    of ConsensusFork.Altair:    makeBeaconBlock(altair)
-    of ConsensusFork.Bellatrix: makeBeaconBlock(bellatrix)
-    else: raiseAssert "Attempt to use Bellatrix payload with post-Bellatrix state"
-  elif payloadFork == ConsensusFork.Capella:
-    case state.kind
-    of ConsensusFork.Capella:   makeBeaconBlock(capella)
-    else: raiseAssert "Attempt to use Capella payload with non-Capella state"
-  elif payloadFork == ConsensusFork.Deneb:
-    case state.kind
-    of ConsensusFork.Deneb:     makeBeaconBlock(deneb)
-    else: raiseAssert "Attempt to use Deneb payload with non-Deneb state"
-  elif payloadFork == ConsensusFork.Electra:
-    case state.kind
-    of ConsensusFork.Electra:   makeBeaconBlock(electra)
-    else: raiseAssert "Attempt to use Electra payload with non-Electra state"
-  elif payloadFork == ConsensusFork.Fulu:
-    case state.kind
-    of ConsensusFork.Fulu:   makeBeaconBlock(fulu)
-    else: raiseAssert "Attempt to use Electra payload with non-Fulu state"
-  else:
-    {.error: "Unsupported fork".}
+  ok((blck: blck, rewards: rewards))
 
-proc makeBeaconBlock*(
-    cfg: RuntimeConfig, state: var ForkedHashedBeaconState,
-    proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
-    eth1_data: Eth1Data, graffiti: GraffitiBytes,
+proc makeBeaconBlock*[EP: ForkyExecutionPayload | ForkyExecutionPayloadHeader](
+    cfg: RuntimeConfig,
+    consensusFork: static ConsensusFork,
+    state: var ForkyHashedBeaconState,
+    cache: var StateCache,
+    proposer_index: ValidatorIndex,
+    randao_reveal: ValidatorSig,
+    eth1_data: Eth1Data,
+    graffiti: GraffitiBytes,
     attestations: seq[phase0.Attestation] | seq[electra.Attestation],
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    executionPayload: ForkyExecutionPayloadForSigning,
-    rollback: RollbackForkedHashedProc, cache: var StateCache,
+    execution_payload: EP,
     verificationFlags: UpdateFlags,
-    transactions_root: Opt[Eth2Digest],
-    execution_payload_root: Opt[Eth2Digest],
-    kzg_commitments: Opt[KzgCommitments],
-    execution_requests: ExecutionRequests):
-    Result[ForkedBeaconBlock, cstring] =
-  let blockAndRewards =
-    ? makeBeaconBlockWithRewards(
-      cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-      attestations, deposits, validator_changes, sync_aggregate,
-      executionPayload, rollback, cache, verificationFlags,
-      transactions_root, execution_payload_root, kzg_commitments,
-      execution_requests)
-  ok(blockAndRewards.blck)
+    kzg_commitments: KzgCommitments,
+    execution_requests: ExecutionRequests,
+): Result[consensusFork.BeaconBlock, cstring] =
+  ok (
+    ?makeBeaconBlockWithRewards(
+      cfg, consensusFork, state, cache, proposer_index, randao_reveal, eth1_data,
+      graffiti, attestations, deposits, validator_changes, sync_aggregate,
+      execution_payload, verificationFlags, kzg_commitments, execution_requests,
+    )
+  ).blck
 
 proc makeBeaconBlock*(
-    cfg: RuntimeConfig, state: var ForkedHashedBeaconState,
-    proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
-    eth1_data: Eth1Data, graffiti: GraffitiBytes,
+    cfg: RuntimeConfig,
+    consensusFork: static ConsensusFork,
+    state: var ForkyHashedBeaconState,
+    cache: var StateCache,
+    proposer_index: ValidatorIndex,
+    randao_reveal: ValidatorSig,
+    eth1_data: Eth1Data,
+    graffiti: GraffitiBytes,
     attestations: seq[phase0.Attestation] | seq[electra.Attestation],
     deposits: seq[Deposit],
     validator_changes: BeaconBlockValidatorChanges,
     sync_aggregate: SyncAggregate,
-    executionPayload: ForkyExecutionPayloadForSigning,
-    rollback: RollbackForkedHashedProc, cache: var StateCache):
-    Result[ForkedBeaconBlock, cstring] =
+    eps: ForkyExecutionPayloadForSigning,
+    verificationFlags: UpdateFlags,
+    execution_requests: ExecutionRequests = default(ExecutionRequests),
+): Result[consensusFork.BeaconBlock, cstring] =
   makeBeaconBlock(
-    cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, validator_changes, sync_aggregate,
-    executionPayload, rollback, cache,
-    verificationFlags = {}, transactions_root = Opt.none Eth2Digest,
-    execution_payload_root = Opt.none Eth2Digest,
-    kzg_commitments = Opt.none KzgCommitments,
-    execution_requests = default(ExecutionRequests))
-
-proc makeBeaconBlock*(
-    cfg: RuntimeConfig, state: var ForkedHashedBeaconState,
-    proposer_index: ValidatorIndex, randao_reveal: ValidatorSig,
-    eth1_data: Eth1Data, graffiti: GraffitiBytes,
-    attestations: seq[phase0.Attestation] | seq[electra.Attestation],
-    deposits: seq[Deposit],
-    validator_changes: BeaconBlockValidatorChanges,
-    sync_aggregate: SyncAggregate,
-    executionPayload: ForkyExecutionPayloadForSigning,
-    rollback: RollbackForkedHashedProc,
-    cache: var StateCache, verificationFlags: UpdateFlags):
-    Result[ForkedBeaconBlock, cstring] =
-  makeBeaconBlock(
-    cfg, state, proposer_index, randao_reveal, eth1_data, graffiti,
-    attestations, deposits, validator_changes, sync_aggregate,
-    executionPayload, rollback, cache,
-    verificationFlags = verificationFlags,
-    transactions_root = Opt.none Eth2Digest,
-    execution_payload_root = Opt.none Eth2Digest,
-    kzg_commitments = Opt.none KzgCommitments,
-    execution_requests = static(default(ExecutionRequests)))
+    cfg, consensusFork, state, cache, proposer_index, randao_reveal, eth1_data,
+    graffiti, attestations, deposits, validator_changes, sync_aggregate,
+    eps.executionPayload, verificationFlags, eps.kzg_commitments, execution_requests,
+  )

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -27,8 +27,7 @@
 import
   chronicles, metrics,
   ../extras,
-  ./datatypes/[phase0, altair, bellatrix, deneb],
-  "."/[beaconstate, eth2_merkleization, helpers, validator, signatures],
+  ./[beaconstate, eth2_merkleization, forks, helpers, validator, signatures],
   kzg4844/kzg_abi, kzg4844/kzg
 
 from std/algorithm import fill, sorted
@@ -40,10 +39,19 @@ from ./datatypes/electra import PendingPartialWithdrawal
 
 export extras, phase0, altair
 
+template payload(body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody): auto =
+  # Blinded blocks contain a payload header instead of the full execution
+  # payload - where relevant, we assume the blinded parts are valid and just
+  # process the consensus-relevant parts.
+  when body is SomeForkyBlindedBeaconBlockBody:
+    body.execution_payload_header
+  else:
+    body.execution_payload
+
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/beacon-chain.md#block-header
 func process_block_header*(
     state: var ForkyBeaconState,
-    blck: SomeForkyBeaconBlock,
+    blck: SomeForkyBeaconBlock | SomeForkyBlindedBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[void, cstring] =
   # Verify that the slots match
   if not (blck.slot == state.slot):
@@ -84,7 +92,8 @@ func `xor`[T: array](a, b: T): T =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/beacon-chain.md#randao
 proc process_randao(
-    state: var ForkyBeaconState, body: SomeForkyBeaconBlockBody,
+    state: var ForkyBeaconState,
+    body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody,
     flags: UpdateFlags, cache: var StateCache): Result[void, cstring] =
   let
     proposer_index = get_beacon_proposer_index(state, cache).valueOr:
@@ -118,7 +127,8 @@ proc process_randao(
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#eth1-data
 func process_eth1_data(
     state: var ForkyBeaconState,
-    body: SomeForkyBeaconBlockBody): Result[void, cstring] =
+    body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody
+): Result[void, cstring] =
   if not state.eth1_data_votes.add body.eth1_data:
     # Count is reset  in process_final_updates, so this should never happen
     return err("process_eth1_data: no more room for eth1 data")
@@ -692,11 +702,14 @@ type
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/electra/beacon-chain.md#modified-process_operations
 proc process_operations(
     cfg: RuntimeConfig, state: var ForkyBeaconState,
-    body: SomeForkyBeaconBlockBody, base_reward_per_increment: Gwei,
+    body: SomeForkyBeaconBlockBody | SomeForkyBlindedBeaconBlockBody,
+    base_reward_per_increment: Gwei,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   # Verify that outstanding deposits are processed up to the maximum number of
   # deposits
-  when typeof(body).kind >= ConsensusFork.Electra:
+  const consensusFork = typeof(state).kind
+
+  when consensusFork >= ConsensusFork.Electra:
     # Disable former deposit mechanism once all prior deposits are processed
     let
       eth1_deposit_index_limit =
@@ -735,7 +748,7 @@ proc process_operations(
       else:
         default(ExitQueueInfo)  # not used
     bsv_use =
-      when typeof(body).kind >= ConsensusFork.Electra:
+      when consensusFork >= ConsensusFork.Electra:
         body.deposits.len + body.execution_requests.withdrawals.len +
           body.execution_requests.consolidations.len > 0
       else:
@@ -764,11 +777,12 @@ proc process_operations(
   for op in body.voluntary_exits:
     exit_queue_info = ? process_voluntary_exit(
       cfg, state, op, flags, exit_queue_info, cache)
-  when typeof(body).kind >= ConsensusFork.Capella:
+
+  when consensusFork >= ConsensusFork.Capella:
     for op in body.bls_to_execution_changes:
       ? process_bls_to_execution_change(cfg, state, op)
 
-  when typeof(body).kind >= ConsensusFork.Electra:
+  when consensusFork >= ConsensusFork.Electra:
     for op in body.execution_requests.deposits:
       ? process_deposit_request(cfg, state, op, {})
     for op in body.execution_requests.withdrawals:
@@ -1010,9 +1024,9 @@ type SomeElectraBeaconBlockBody =
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#modified-process_execution_payload
 proc process_execution_payload*(
     cfg: RuntimeConfig, state: var electra.BeaconState,
-    body: SomeElectraBeaconBlockBody,
+    body: SomeElectraBeaconBlockBody | electra_mev.SigVerifiedBlindedBeaconBlockBody,
     notify_new_payload: electra.ExecutePayload): Result[void, cstring] =
-  template payload: auto = body.execution_payload
+  template payload: auto = body.payload
 
   # Verify consistency of the parent hash with respect to the previous
   # execution payload header
@@ -1032,30 +1046,33 @@ proc process_execution_payload*(
   if not (lenu64(body.blob_kzg_commitments) <= cfg.MAX_BLOBS_PER_BLOCK_ELECTRA):
     return err("process_execution_payload: too many KZG commitments")
 
-  # Verify the execution payload is valid
-  if not notify_new_payload(payload):
-    return err("process_execution_payload: execution payload invalid")
+  when payload is ForkyExecutionPayloadHeader:
+    # Assume valid, when blinded
+    state.latest_execution_payload_header = payload
+  else:
+    # Verify the execution payload is valid
+    if not notify_new_payload(payload):
+      return err("process_execution_payload: execution payload invalid")
 
-  # Cache execution payload header
-  state.latest_execution_payload_header = electra.ExecutionPayloadHeader(
-    parent_hash: payload.parent_hash,
-    fee_recipient: payload.fee_recipient,
-    state_root: payload.state_root,
-    receipts_root: payload.receipts_root,
-    logs_bloom: payload.logs_bloom,
-    prev_randao: payload.prev_randao,
-    block_number: payload.block_number,
-    gas_limit: payload.gas_limit,
-    gas_used: payload.gas_used,
-    timestamp: payload.timestamp,
-    base_fee_per_gas: payload.base_fee_per_gas,
-    block_hash: payload.block_hash,
-    extra_data: payload.extra_data,
-    transactions_root: hash_tree_root(payload.transactions),
-    withdrawals_root: hash_tree_root(payload.withdrawals),
-    blob_gas_used: payload.blob_gas_used,
-    excess_blob_gas: payload.excess_blob_gas)
-
+    # Cache execution payload header
+    state.latest_execution_payload_header = electra.ExecutionPayloadHeader(
+      parent_hash: payload.parent_hash,
+      fee_recipient: payload.fee_recipient,
+      state_root: payload.state_root,
+      receipts_root: payload.receipts_root,
+      logs_bloom: payload.logs_bloom,
+      prev_randao: payload.prev_randao,
+      block_number: payload.block_number,
+      gas_limit: payload.gas_limit,
+      gas_used: payload.gas_used,
+      timestamp: payload.timestamp,
+      base_fee_per_gas: payload.base_fee_per_gas,
+      block_hash: payload.block_hash,
+      extra_data: payload.extra_data,
+      transactions_root: hash_tree_root(payload.transactions),
+      withdrawals_root: hash_tree_root(payload.withdrawals),
+      blob_gas_used: payload.blob_gas_used,
+      excess_blob_gas: payload.excess_blob_gas)
   ok()
 
 # copy of datatypes/fulu.nim
@@ -1066,9 +1083,9 @@ type SomeFuluBeaconBlockBody =
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/beacon-chain.md#modified-process_execution_payload
 proc process_execution_payload*(
     cfg: RuntimeConfig, state: var fulu.BeaconState,
-    body: SomeFuluBeaconBlockBody,
+    body: SomeFuluBeaconBlockBody | fulu_mev.SigVerifiedBlindedBeaconBlockBody,
     notify_new_payload: fulu.ExecutePayload): Result[void, cstring] =
-  template payload: auto = body.execution_payload
+  template payload: auto = body.payload()
 
   # Verify consistency of the parent hash with respect to the previous
   # execution payload header
@@ -1090,29 +1107,33 @@ proc process_execution_payload*(
   if not (lenu64(body.blob_kzg_commitments) <= blob_params.MAX_BLOBS_PER_BLOCK):
     return err("process_execution_payload: too many KZG commitments")
 
-  # Verify the execution payload is valid
-  if not notify_new_payload(payload):
-    return err("process_execution_payload: execution payload invalid")
+  when payload is ForkyExecutionPayloadHeader:
+    # Assume valid, when blinded
+    state.latest_execution_payload_header = payload
+  else:
+    # Verify the execution payload is valid
+    if not notify_new_payload(payload):
+      return err("process_execution_payload: execution payload invalid")
 
-  # Cache execution payload header
-  state.latest_execution_payload_header = fulu.ExecutionPayloadHeader(
-    parent_hash: payload.parent_hash,
-    fee_recipient: payload.fee_recipient,
-    state_root: payload.state_root,
-    receipts_root: payload.receipts_root,
-    logs_bloom: payload.logs_bloom,
-    prev_randao: payload.prev_randao,
-    block_number: payload.block_number,
-    gas_limit: payload.gas_limit,
-    gas_used: payload.gas_used,
-    timestamp: payload.timestamp,
-    base_fee_per_gas: payload.base_fee_per_gas,
-    block_hash: payload.block_hash,
-    extra_data: payload.extra_data,
-    transactions_root: hash_tree_root(payload.transactions),
-    withdrawals_root: hash_tree_root(payload.withdrawals),
-    blob_gas_used: payload.blob_gas_used,
-    excess_blob_gas: payload.excess_blob_gas)
+    # Cache execution payload header
+    state.latest_execution_payload_header = fulu.ExecutionPayloadHeader(
+      parent_hash: payload.parent_hash,
+      fee_recipient: payload.fee_recipient,
+      state_root: payload.state_root,
+      receipts_root: payload.receipts_root,
+      logs_bloom: payload.logs_bloom,
+      prev_randao: payload.prev_randao,
+      block_number: payload.block_number,
+      gas_limit: payload.gas_limit,
+      gas_used: payload.gas_used,
+      timestamp: payload.timestamp,
+      base_fee_per_gas: payload.base_fee_per_gas,
+      block_hash: payload.block_hash,
+      extra_data: payload.extra_data,
+      transactions_root: hash_tree_root(payload.transactions),
+      withdrawals_root: hash_tree_root(payload.withdrawals),
+      blob_gas_used: payload.blob_gas_used,
+      excess_blob_gas: payload.excess_blob_gas)
 
   ok()
 
@@ -1121,10 +1142,11 @@ proc process_execution_payload*(
 func process_withdrawals*(
     state: var (capella.BeaconState | deneb.BeaconState | electra.BeaconState |
     fulu.BeaconState),
-    payload: capella.ExecutionPayload | deneb.ExecutionPayload |
-             electra.ExecutionPayload | fulu.ExecutionPayload):
+    payload: ForkyExecutionPayloadOrHeader):
     Result[void, cstring] =
-  when typeof(state).kind >= ConsensusFork.Electra:
+  const consensusFork = typeof(state).kind
+
+  when consensusFork >= ConsensusFork.Electra:
     let (expected_withdrawals, partial_withdrawals_count) =
       get_expected_withdrawals_with_partial_count(state)
 
@@ -1136,17 +1158,18 @@ func process_withdrawals*(
   else:
     let expected_withdrawals = get_expected_withdrawals(state)
 
-  if not (len(payload.withdrawals) == len(expected_withdrawals)):
-    return err("process_withdrawals: different numbers of payload and expected withdrawals")
+  when payload is ForkyExecutionPayloadHeader:
+    if not (payload.withdrawals_root == hash_tree_root(expected_withdrawals)):
+      return err("process_withdrawals: withdrawals_root does not match expected withdrawals")
+  else:
+    if payload.withdrawals.asSeq() != expected_withdrawals:
+      return err("process_withdrawals: payload withdrawals don't match expected withdrawals")
 
-  for i in 0 ..< len(expected_withdrawals):
-    if expected_withdrawals[i] != payload.withdrawals[i]:
-      return err("process_withdrawals: mismatched expected and payload withdrawal")
-    let validator_index =
-      ValidatorIndex.init(expected_withdrawals[i].validator_index).valueOr:
+  for withdrawal in expected_withdrawals:
+    let validator_index = ValidatorIndex.init(withdrawal.validator_index).valueOr:
         return err("process_withdrawals: invalid validator index")
     decrease_balance(
-      state, validator_index, expected_withdrawals[i].amount)
+      state, validator_index, withdrawal.amount)
 
   # Update the next withdrawal index if this block contained withdrawals
   if len(expected_withdrawals) != 0:
@@ -1350,7 +1373,8 @@ type SomeElectraBlock =
   electra.BeaconBlock | electra.SigVerifiedBeaconBlock | electra.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var electra.BeaconState, blck: SomeElectraBlock,
+    state: var electra.BeaconState,
+    blck: SomeElectraBlock | electra_mev.SigVerifiedBlindedBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1361,7 +1385,7 @@ proc process_block*(
   # Consensus specs v1.4.0 unconditionally assume is_execution_enabled is
   # true, but intentionally keep such a check.
   if is_execution_enabled(state, blck.body):
-    ? process_withdrawals(state, blck.body.execution_payload)
+    ? process_withdrawals(state, blck.body.payload)
     ? process_execution_payload(
         cfg, state, blck.body,
         func(_: electra.ExecutionPayload): bool = true)
@@ -1383,7 +1407,8 @@ type SomeFuluBlock =
   fulu.BeaconBlock | fulu.SigVerifiedBeaconBlock | fulu.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var fulu.BeaconState, blck: SomeFuluBlock,
+    state: var fulu.BeaconState,
+    blck: SomeFuluBlock | fulu_mev.SigVerifiedBlindedBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1394,7 +1419,8 @@ proc process_block*(
   # Consensus specs v1.4.0 unconditionally assume is_execution_enabled is
   # true, but intentionally keep such a check.
   if is_execution_enabled(state, blck.body):
-    ? process_withdrawals(state, blck.body.execution_payload)
+    ? process_withdrawals(state, blck.body.payload)
+
     ? process_execution_payload(
         cfg, state, blck.body,
         func(_: fulu.ExecutionPayload): bool = true)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -404,7 +404,7 @@ proc proposeBlockAux(
     graffiti = node.getGraffitiBytes(validator)
     validator_index = validator.index.expect("index set for proposer")
 
-    enginePayload =
+    engineBid =
       when consensusFork >= ConsensusFork.Electra:
         # Fetch both builder and engine payloads then use the better one to
         # make a block
@@ -435,7 +435,7 @@ proc proposeBlockAux(
           doAssert bids.builderBid.isSome(), "Checked in useBuilderPayload"
           let builderBlockRes = node.makeBuilderBlock(
             consensusFork,
-            state[],
+            state[].forky(consensusFork),
             cache[],
             validator_index,
             randao_reveal,
@@ -522,21 +522,26 @@ proc proposeBlockAux(
 
         bids.engineBid
       else:
-        type EPS = consensusFork.ExecutionPayloadForSigning
         await node.getExecutionPayload(
-          EPS, head, state, validator_index, validator.pubkey
+          consensusFork, head, state, validator_index, validator.pubkey
         )
 
+  if engineBid.isNone():
+    beacon_block_production_errors.inc()
+    return head
+
+  let
     engineBlock = node.makeEngineBlock(
       consensusFork,
-      state[],
+      state[].forky(consensusFork),
       cache[],
       validator_index,
       randao_reveal,
       graffiti,
       head,
       slot,
-      enginePayload,
+      engineBid[].eps,
+      engineBid[].execution_requests,
     ).valueOr:
       beacon_block_production_errors.inc()
       return head

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -308,7 +308,7 @@ proc getExecutionPayload*(
       )
     ).valueOr:
       if not proposalState[].is_merge_transition_complete():
-        # Per-merge, an all-zeroes execution payload is used and there are no
+        # Pre-merge, an all-zeroes execution payload is used and there are no
         # requests, so default is fine here
         return Opt.some(static(default(EngineBid[PayloadType])))
       return Opt.none(EngineBid[PayloadType])

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -41,7 +41,7 @@ import
 from eth/async_utils import awaitWithTimeout
 from ../spec/beaconstate import get_expected_withdrawals
 
-export results, forks, get_expected_withdrawals
+export results
 
 type
   BuilderBidResult[BB: ForkyBuilderBid] = Result[BB, string]

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -301,11 +301,17 @@ proc getExecutionPayload*(
 
   type PayloadType = consensusFork.ExecutionPayloadForSigning
   let
-    eps =
-      ?await node.elManager.getPayload(
+    eps = (
+      await node.elManager.getPayload(
         PayloadType, beaconHead.blck.bid.root, executionHead, latestSafe,
         latestFinalized, timestamp, random, feeRecipient, withdrawals,
       )
+    ).valueOr:
+      if not proposalState[].is_merge_transition_complete():
+        # Per-merge, an all-zeroes execution payload is used and there are no
+        # requests, so default is fine here
+        return Opt.some(static(default(EngineBid[PayloadType])))
+      return Opt.none(EngineBid[PayloadType])
 
     requests = decodePayloadRequests(eps).valueOr:
       warn "Cannot decode payload requests from engine", slot, err = error

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -245,11 +245,11 @@ proc makeEngineBlock*(
 
   ok EngineBlock[consensusFork.BeaconBlock](
     blck: blockAndRewards.blck,
-    executionValue: payload.blockValue,
+    executionValue: eps.blockValue,
     consensusValue: blockAndRewards.rewards.blockConsensusValue(),
     blobsBundle:
       when consensusFork >= ConsensusFork.Deneb:
-        payload.blobsBundle
+        eps.blobsBundle
       else:
         default(deneb.BlobsBundle),
   )

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -20,10 +20,17 @@
 ## and then pass it back.
 ##
 ## Either way, signing is out of scope for this module.
+##
+
+# Implementation notes
+#
+# * Even though they are in theory redundant, we sometimes pass both
+#   `consensusFork` and fork-specific `Forky*` types - this makes spelling the
+#   return type slightly easier
+
 {.push raises: [], gcsafe.}
 
 import
-  stew/assign2,
   chronicles,
   results,
   ../consensus_object_pools/[attestation_pool, consensus_manager],
@@ -33,9 +40,8 @@ import
 
 from eth/async_utils import awaitWithTimeout
 from ../spec/beaconstate import get_expected_withdrawals
-from ./message_router_mev import copyFields, getFieldNames
 
-export results
+export results, forks, get_expected_withdrawals
 
 type
   BuilderBidResult[BB: ForkyBuilderBid] = Result[BB, string]
@@ -54,8 +60,12 @@ type
   EngineBlockResult[BB: ForkyBeaconBlock] = Result[EngineBlock[BB], string]
   BuilderBlockResult[BBB: ForkyBlindedBeaconBlock] = Result[BuilderBlock[BBB], string]
 
+  EngineBid*[EPS: ForkyExecutionPayloadForSigning] = object
+    eps*: EPS
+    execution_requests*: ExecutionRequests
+
   Bids[consensusFork: static ConsensusFork] = object
-    engineBid*: Opt[consensusFork.ExecutionPayloadForSigning]
+    engineBid*: Opt[EngineBid[consensusFork.ExecutionPayloadForSigning]]
     builderBid*: Opt[consensusFork.BuilderBid]
 
   BoostFactorKind {.pure.} = enum
@@ -135,112 +145,84 @@ func builderBetterBid(
   of BoostFactorKind.Builder:
     builderBetterBid(boostFactor.value64, builderValue, engineValue)
 
+func decodePayloadRequests(
+    _:
+      bellatrix.ExecutionPayloadForSigning | capella.ExecutionPayloadForSigning |
+      deneb.ExecutionPayloadForSigning
+): Result[ExecutionRequests, string] =
+  ok default(ExecutionRequests)
+
+func decodePayloadRequests(
+    eps: electra.ExecutionPayloadForSigning | fulu.ExecutionPayloadForSigning
+): Result[ExecutionRequests, string] =
+  try:
+    var
+      execution_requests_buffer: ExecutionRequests
+      prev_type: Opt[byte]
+
+    # TODO why aren't these decoded already?
+    for request_type_and_payload in eps.executionRequests:
+      if request_type_and_payload.len < 2:
+        return err("Execution layer request too short")
+
+      let request_type = request_type_and_payload[0]
+      if prev_type.isSome:
+        if request_type < prev_type.get:
+          return err("Execution layer request types not sorted")
+        if request_type == prev_type.get:
+          return err("Execution layer request types duplicated")
+      prev_type.ok request_type
+
+      template request_payload(): untyped =
+        request_type_and_payload.toOpenArray(1, request_type_and_payload.len - 1)
+
+      case request_type_and_payload[0]
+      of DEPOSIT_REQUEST_TYPE:
+        execution_requests_buffer.deposits = SSZ.decode(
+          request_payload, List[DepositRequest, Limit MAX_DEPOSIT_REQUESTS_PER_PAYLOAD]
+        )
+      of WITHDRAWAL_REQUEST_TYPE:
+        execution_requests_buffer.withdrawals = SSZ.decode(
+          request_payload,
+          List[WithdrawalRequest, Limit MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD],
+        )
+      of CONSOLIDATION_REQUEST_TYPE:
+        execution_requests_buffer.consolidations = SSZ.decode(
+          request_payload,
+          List[ConsolidationRequest, Limit MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD],
+        )
+      else:
+        return err("Execution layer invalid request type")
+
+    ok execution_requests_buffer
+  except SerializationError as exc:
+    err("Failed to deserialize execution requests")
+
 proc makeEngineBlock*(
     node: BeaconNode,
     consensusFork: static ConsensusFork,
-    state: var ForkedHashedBeaconState,
+    state: var ForkyHashedBeaconState,
     cache: var StateCache,
     validator_index: ValidatorIndex,
     randao_reveal: ValidatorSig,
     graffiti: GraffitiBytes,
     head: BlockRef,
     slot: Slot,
-    execution_payload: Opt[ForkyExecutionPayloadForSigning],
-
-    # These parameters are for the builder API
-    transactions_root = Opt.none(Eth2Digest),
-    execution_payload_root = Opt.none(Eth2Digest),
-    withdrawals_root = Opt.none(Eth2Digest),
-    kzg_commitments = Opt.none(KzgCommitments),
-    builder_execution_requests = Opt.none(ExecutionRequests),
+    eps: ForkyExecutionPayloadForSigning,
+    execution_requests: ExecutionRequests,
 ): EngineBlockResult[consensusFork.BeaconBlock] =
-  type BeaconBlockType = consensusFork.BeaconBlock
-
   let
-    payload =
-      if execution_payload.isNone():
-        if state.is_merge_transition_complete():
-          return err("Execution payload required post merge")
-        default(typeof(execution_payload[]))
-      elif withdrawals_root.isSome:
-        # Builder API
-
-        # In Capella, only get withdrawals root from relay.
-        # The execution payload will be small enough to be safe to copy because
-        # it won't have transactions (it's blinded)
-        var modified_execution_payload = execution_payload[]
-        when consensusFork >= ConsensusFork.Capella:
-          let withdrawals = List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
-            get_expected_withdrawals(state.forky(consensusFork).data)
-          )
-          if hash_tree_root(withdrawals) != withdrawals_root.get:
-            # If engine API returned a block, will use that
-            return err("Builder relay provided incorrect withdrawals root")
-          # Otherwise, the state transition function notices that there are
-          # too few withdrawals.
-          assign(modified_execution_payload.executionPayload.withdrawals, withdrawals)
-
-        modified_execution_payload
-      else:
-        execution_payload[]
-    attestations =
-      when consensusFork >= ConsensusFork.Electra:
-        node.attestationPool[].getElectraAttestationsForBlock(state, cache)
-      else:
-        node.attestationPool[].getAttestationsForBlock(state, cache)
+    attestations = node.attestationPool[].getAttestationsForBlock(state, cache)
     exits = node.validatorChangePool[].getBeaconBlockValidatorChanges(
-      node.dag.cfg, state.forky(consensusFork).data
+      node.dag.cfg, state.data
     )
-    execution_requests = builder_execution_requests.valueOr:
-      when consensusFork >= ConsensusFork.Electra:
-        # Don't want un-decoded SSZ going any further/deeper
-        var
-          execution_requests_buffer: ExecutionRequests
-          prev_type: Opt[byte]
-        try:
-          for request_type_and_payload in payload.executionRequests:
-            if request_type_and_payload.len < 2:
-              return err("Execution layer request too short")
-
-            let request_type = request_type_and_payload[0]
-            if prev_type.isSome:
-              if request_type < prev_type.get:
-                return err("Execution layer request types not sorted")
-              if request_type == prev_type.get:
-                return err("Execution layer request types duplicated")
-            prev_type.ok request_type
-
-            template request_payload(): untyped =
-              request_type_and_payload.toOpenArray(1, request_type_and_payload.len - 1)
-
-            case request_type_and_payload[0]
-            of DEPOSIT_REQUEST_TYPE:
-              execution_requests_buffer.deposits = SSZ.decode(
-                request_payload,
-                List[DepositRequest, Limit MAX_DEPOSIT_REQUESTS_PER_PAYLOAD],
-              )
-            of WITHDRAWAL_REQUEST_TYPE:
-              execution_requests_buffer.withdrawals = SSZ.decode(
-                request_payload,
-                List[WithdrawalRequest, Limit MAX_WITHDRAWAL_REQUESTS_PER_PAYLOAD],
-              )
-            of CONSOLIDATION_REQUEST_TYPE:
-              execution_requests_buffer.consolidations = SSZ.decode(
-                request_payload,
-                List[ConsolidationRequest, Limit MAX_CONSOLIDATION_REQUESTS_PER_PAYLOAD],
-              )
-            else:
-              return err("Execution layer invalid request type")
-        except CatchableError:
-          return err("Unable to deserialize execution layer requests")
-
-        execution_requests_buffer
-      else:
-        default(ExecutionRequests) # won't be used by block builder
+    sync_aggregate = node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot)
 
     blockAndRewards = makeBeaconBlockWithRewards(
       node.dag.cfg,
+      consensusFork,
       state,
+      cache,
       validator_index,
       randao_reveal,
       Eth1Data(),
@@ -248,15 +230,11 @@ proc makeEngineBlock*(
       attestations,
       @[],
       exits,
-      node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot),
-      payload,
-      noRollback, # Temporary state - no need for rollback
-      cache,
+      sync_aggregate,
+      eps.executionPayload,
       verificationFlags = {},
-      transactions_root = transactions_root,
-      execution_payload_root = execution_payload_root,
-      kzg_commitments = kzg_commitments,
-      execution_requests = execution_requests,
+      eps.kzg_commitments,
+      execution_requests,
     ).valueOr:
       # This is almost certainly a bug, but it's complex enough that there's a
       # small risk it might happen even when most proposals succeed - thus we
@@ -265,8 +243,8 @@ proc makeEngineBlock*(
         slot, head = shortLog(head), error = error
       return err($error)
 
-  ok EngineBlock[BeaconBlockType](
-    blck: blockAndRewards.blck.forky(consensusFork),
+  ok EngineBlock[consensusFork.BeaconBlock](
+    blck: blockAndRewards.blck,
     executionValue: payload.blockValue,
     consensusValue: blockAndRewards.rewards.blockConsensusValue(),
     blobsBundle:
@@ -278,14 +256,15 @@ proc makeEngineBlock*(
 
 proc getExecutionPayload*(
     node: BeaconNode,
-    PayloadType: type ForkyExecutionPayloadForSigning,
+    consensusFork: static ConsensusFork,
     head: BlockRef,
     proposalState: ref ForkedHashedBeaconState,
     validator_index: ValidatorIndex,
     validator_pubkey: ValidatorPubKey,
-): Future[Opt[PayloadType]] {.async: (raises: [CancelledError]).} =
+): Future[Opt[EngineBid[consensusFork.ExecutionPayloadForSigning]]] {.
+    async: (raises: [CancelledError])
+.} =
   # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/validator.md#executionpayload
-
   let
     slot = withState(proposalState[]):
       forkyState.data.slot
@@ -320,21 +299,25 @@ proc getExecutionPayload*(
     latestFinalized = shortLog(latestFinalized),
     feeRecipient = $feeRecipient
 
-  let payload = await node.elManager.getPayload(
-    PayloadType, beaconHead.blck.bid.root, executionHead, latestSafe, latestFinalized,
-    timestamp, random, feeRecipient, withdrawals,
-  )
+  type PayloadType = consensusFork.ExecutionPayloadForSigning
+  let
+    eps =
+      ?await node.elManager.getPayload(
+        PayloadType, beaconHead.blck.bid.root, executionHead, latestSafe,
+        latestFinalized, timestamp, random, feeRecipient, withdrawals,
+      )
 
-  if payload.isSome():
-    # TODO errors are logged in elmanager but unlike most other things, we want
-    #      success log here for getting the payload since they are so rare - it
-    #      would be nice to have a more structured approach to the logging here
-    info "Received engine payload",
-      slot,
-      value = shortLog(payload[].blockValue),
-      payload = shortLog(payload[].executionPayload)
+    requests = decodePayloadRequests(eps).valueOr:
+      warn "Cannot decode payload requests from engine", slot, err = error
+      return Opt.none(EngineBid[PayloadType])
 
-  payload
+  # TODO errors are logged in elmanager but unlike most other things, we want
+  #      success log here for getting the payload since they are so rare - it
+  #      would be nice to have a more structured approach to the logging here
+  info "Received engine payload",
+    slot, value = shortLog(eps.blockValue), payload = shortLog(eps.executionPayload)
+
+  ok EngineBid[PayloadType](eps: eps, execution_requests: requests)
 
 proc getSignedBuilderBid(
     payloadBuilderClient: RestClientRef,
@@ -375,6 +358,7 @@ proc getBuilderBid(
     slot: Slot,
     executionBlockHash: Eth2Digest,
     pubkey: ValidatorPubKey,
+    expected_withdrawals_root: Eth2Digest,
 ): Future[BuilderBidResult[consensusFork.BuilderBid]] {.
     async: (raises: [CancelledError])
 .} =
@@ -409,6 +393,7 @@ proc getBuilderBid(
     head: BlockRef,
     slot: Slot,
     pubkey: ValidatorPubKey,
+    expected_withdrawals_root: Eth2Digest,
 ): Future[BuilderBidResult[consensusFork.BuilderBid]] {.
     async: (raises: [CancelledError])
 .} =
@@ -421,32 +406,14 @@ proc getBuilderBid(
     return err("loadExecutionBlockHash failed")
 
   await node.getBuilderBid(
-    consensusFork, payloadBuilderClient, slot, executionBlockHash, pubkey
+    consensusFork, payloadBuilderClient, slot, executionBlockHash, pubkey,
+    expected_withdrawals_root,
   )
-
-func constructBlindedBeaconBlock(
-    blck: ForkyBeaconBlock, builderBid: ForkyBuilderBid
-): auto =
-  # Leaves signature field default, to be filled in by caller
-  const
-    blckFields = getFieldNames(typeof(blck))
-    blckBodyFields = getFieldNames(typeof(blck.body))
-
-  var blindedBlock: type(blck).kind.BlindedBeaconBlock
-
-  # https://github.com/ethereum/builder-specs/blob/v0.4.0/specs/bellatrix/validator.md#block-proposal
-  copyFields(blindedBlock, blck, blckFields)
-  copyFields(blindedBlock.body, blck.body, blckBodyFields)
-  assign(blindedBlock.body.execution_payload_header, builderBid.header)
-  assign(blindedBlock.body.blob_kzg_commitments, builderBid.blob_kzg_commitments)
-  assign(blindedBlock.body.execution_requests, builderBid.execution_requests)
-
-  blindedBlock
 
 proc makeBuilderBlock*(
     node: BeaconNode,
     consensusFork: static ConsensusFork,
-    state: var ForkedHashedBeaconState,
+    state: var ForkyHashedBeaconState,
     cache: var StateCache,
     validator_index: ValidatorIndex,
     randao_reveal: ValidatorSig,
@@ -455,45 +422,42 @@ proc makeBuilderBlock*(
     slot: Slot,
     builderBid: ForkyBuilderBid,
 ): BuilderBlockResult[consensusFork.BlindedBeaconBlock] =
-  # When creating this block, need to ensure it uses the MEV-provided execution
-  # payload, both to avoid repeated calls to network services and to ensure the
-  # consistency of this block (e.g., its state root being correct). Since block
-  # processing does not work directly using blinded blocks, fix up transactions
-  # root after running the state transition function on an otherwise equivalent
-  # non-blinded block without transactions.
-  #
-  # This doesn't have withdrawals, which each node has regardless of engine or
-  # builder API. makeEngineBlock fills it in later.
+  let
+    attestations = node.attestationPool[].getAttestationsForBlock(state, cache)
+    exits = node.validatorChangePool[].getBeaconBlockValidatorChanges(
+      node.dag.cfg, state.data
+    )
+    sync_aggregate = node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot)
 
-  var shimExecutionPayload: consensusFork.ExecutionPayloadForSigning
-  copyFields(
-    shimExecutionPayload.executionPayload,
-    builderBid.header,
-    getFieldNames(typeof(builderBid.header)),
-  )
-
-  let fakeBlock =
-    ?node.makeEngineBlock(
+    blockAndRewards = makeBeaconBlockWithRewards(
+      node.dag.cfg,
       consensusFork,
       state,
       cache,
       validator_index,
       randao_reveal,
+      Eth1Data(),
       graffiti,
-      head,
-      slot,
-      execution_payload = Opt.some shimExecutionPayload,
-      transactions_root = Opt.some builderBid.header.transactions_root,
-      execution_payload_root = Opt.some hash_tree_root(builderBid.header),
-      withdrawals_root = Opt.some builderBid.header.withdrawals_root,
-      kzg_commitments = Opt.some builderBid.blob_kzg_commitments,
-      builder_execution_requests = Opt.some builderBid.execution_requests,
-    )
+      attestations,
+      @[],
+      exits,
+      sync_aggregate,
+      builderBid.header,
+      verificationFlags = {},
+      builderBid.blob_kzg_commitments,
+      builderBid.execution_requests,
+    ).valueOr:
+      # This is almost certainly a bug, but it's complex enough that there's a
+      # small risk it might happen even when most proposals succeed - thus we
+      # log instead of asserting
+      warn "Cannot create block for proposal",
+        slot, head = shortLog(head), error = error
+      return err($error)
 
   ok BuilderBlock[consensusFork.BlindedBeaconBlock](
-    blck: constructBlindedBeaconBlock(fakeBlock.blck, builderBid),
-    executionValue: fakeBlock.executionValue,
-    consensusValue: fakeBlock.consensusValue,
+    blck: blockAndRewards.blck,
+    executionValue: builderBid.value,
+    consensusValue: blockAndRewards.rewards.blockConsensusValue(),
   )
 
 func isExcludedTestnet(cfg: RuntimeConfig): bool =
@@ -511,9 +475,7 @@ proc collectBids*(
     slot: Slot,
     proposalState: ref ForkedHashedBeaconState,
 ): Future[Bids[consensusFork]] {.async: (raises: [CancelledError]).} =
-  type
-    EPS = consensusFork.ExecutionPayloadForSigning
-    BB = consensusFork.BuilderBid
+  type BB = consensusFork.BuilderBid
 
   let
     usePayloadBuilder =
@@ -534,14 +496,20 @@ proc collectBids*(
 
     builderBidFut =
       if usePayloadBuilder:
+        let
+          withdrawals = List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](
+            get_expected_withdrawals(proposalState[].forky(consensusFork).data)
+          )
+          expected_withdrawals_root = hash_tree_root(withdrawals)
         node.getBuilderBid(
-          consensusFork, payloadBuilderClient, head, slot, validator_pubkey
+          consensusFork, payloadBuilderClient, head, slot, validator_pubkey,
+          expected_withdrawals_root,
         )
       else:
         nil
 
     enginePayloadFut = node.getExecutionPayload(
-      EPS, head, proposalState, validator_index, validator_pubkey
+      consensusFork, head, proposalState, validator_index, validator_pubkey
     )
 
   # getBuilderBid times out after BUILDER_PROPOSAL_DELAY_TOLERANCE, with 1 more
@@ -573,11 +541,11 @@ proc useBuilderPayload*(bids: Bids, boostFactor: BoostFactor): bool =
   bids.builderBid.isSome() and (
     bids.engineBid.isNone() or
     builderBetterBid(
-      boostFactor, bids.builderBid.value().value, bids.engineBid.value().blockValue
+      boostFactor, bids.builderBid.value().value, bids.engineBid.value().eps.blockValue
     )
   )
 
-proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
+proc makeMaybeBlindedBeaconBlockForHeadAndSlot*(
     node: BeaconNode,
     consensusFork: static ConsensusFork,
     validator_index: ValidatorIndex,
@@ -586,7 +554,16 @@ proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
     head: BlockRef,
     slot: Slot,
     builderBoostFactor: uint64,
-): Future[ResultType] {.async: (raises: [CancelledError]).} =
+): Future[
+    Result[
+      tuple[
+        blck: consensusFork.MaybeBlindedBeaconBlock,
+        executionValue: UInt256,
+        consensusValue: UInt256,
+      ],
+      string,
+    ]
+] {.async: (raises: [CancelledError]).} =
   let
     proposerKey = node.dag.validatorKey(validator_index).get().toPubKey()
 
@@ -595,7 +572,7 @@ proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
 
     cache = new StateCache
     state = node.dag.getProposalState(head, slot, cache[]).valueOr:
-      return ResultType.err("Proposal state is not available")
+      return err("Proposal state is not available")
 
     bids = await node.collectBids(
       consensusFork, payloadBuilderClient, proposerKey, validator_index, head, slot,
@@ -614,7 +591,7 @@ proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
   if useBuilderPayload:
     let builderBlock = node.makeBuilderBlock(
       consensusFork,
-      state[],
+      state[].forky(consensusFork),
       cache[],
       validator_index,
       randao_reveal,
@@ -623,9 +600,9 @@ proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
       slot,
       bids.builderBid.value(),
     ).valueOr:
-      return ResultType.err("Failed to create builder block")
+      return err("Failed to create builder block")
 
-    return ResultType.ok(
+    return ok(
       (
         blck: consensusFork.MaybeBlindedBeaconBlock(
           isBlinded: true, blindedData: builderBlock.blck
@@ -635,89 +612,28 @@ proc makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
       )
     )
 
+  if bids.engineBid.isNone:
+    return err("Engine payload is not available")
+
   let engineBlock =
     ?node.makeEngineBlock(
       consensusFork,
-      state[],
+      state[].forky(consensusFork),
       cache[],
       validator_index,
       randao_reveal,
       graffiti,
       head,
       slot,
-      bids.engineBid,
+      bids.engineBid[].eps,
+      bids.engineBid[].execution_requests,
     )
 
-  ResultType.ok(
+  ok(
     (
       blck: consensusFork.MaybeBlindedBeaconBlock(
         isBlinded: false, data: engineBlock.toBlockContents(consensusFork)
       ),
-      executionValue: engineBlock.executionValue,
-      consensusValue: engineBlock.consensusValue,
-    )
-  )
-
-proc makeMaybeBlindedBeaconBlockForHeadAndSlot*(
-    node: BeaconNode,
-    consensusFork: static ConsensusFork,
-    validator_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    graffiti: GraffitiBytes,
-    head: BlockRef,
-    slot: Slot,
-    builderBoostFactor: uint64,
-): auto =
-  type ResultType = Result[
-    tuple[
-      blck: consensusFork.MaybeBlindedBeaconBlock,
-      executionValue: UInt256,
-      consensusValue: UInt256,
-    ],
-    string,
-  ]
-
-  makeMaybeBlindedBeaconBlockForHeadAndSlotImpl[ResultType](
-    node, consensusFork, validator_index, randao_reveal, graffiti, head, slot,
-    builderBoostFactor,
-  )
-
-proc makeBeaconBlockForHeadAndSlotImpl[ResultType](
-    node: BeaconNode,
-    consensusFork: static ConsensusFork,
-    validator_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    graffiti: GraffitiBytes,
-    head: BlockRef,
-    slot: Slot,
-): Future[ResultType] {.async: (raises: [CancelledError]).} =
-  type EPS = consensusFork.ExecutionPayloadForSigning
-
-  let
-    proposerKey = node.dag.validatorKey(validator_index).get().toPubKey()
-    cache = new StateCache
-    # TODO move the creation of this proposal state away from the hot path
-    state = node.dag.getProposalState(head, slot, cache[]).valueOr:
-      return ResultType.err("Proposal state is not available")
-    enginePayload =
-      await node.getExecutionPayload(EPS, head, state, validator_index, proposerKey)
-
-    engineBlock =
-      ?node.makeEngineBlock(
-        consensusFork,
-        state[],
-        cache[],
-        validator_index,
-        randao_reveal,
-        graffiti,
-        head,
-        slot,
-        enginePayload,
-      )
-
-  ResultType.ok(
-    (
-      blck: engineBlock.toBlockContents(consensusFork),
       executionValue: engineBlock.executionValue,
       consensusValue: engineBlock.consensusValue,
     )
@@ -731,16 +647,47 @@ proc makeBeaconBlockForHeadAndSlot*(
     graffiti: GraffitiBytes,
     head: BlockRef,
     slot: Slot,
-): auto =
-  type ResultType = Result[
-    tuple[
-      blck: consensusFork.BlockContents,
-      executionValue: UInt256,
-      consensusValue: UInt256,
-    ],
-    string,
-  ]
+): Future[
+    Result[
+      tuple[
+        blck: consensusFork.BlockContents,
+        executionValue: UInt256,
+        consensusValue: UInt256,
+      ],
+      string,
+    ]
+] {.async: (raises: [CancelledError]).} =
+  let
+    proposerKey = node.dag.validatorKey(validator_index).get().toPubKey()
+    cache = new StateCache
+    # TODO move the creation of this proposal state away from the hot path
+    state = node.dag.getProposalState(head, slot, cache[]).valueOr:
+      return err("Proposal state is not available")
+    enginePayload = (
+      await node.getExecutionPayload(
+        consensusFork, head, state, validator_index, proposerKey
+      )
+    ).valueOr:
+      return err("Engine payload is not available")
 
-  makeBeaconBlockForHeadAndSlotImpl[ResultType](
-    node, consensusFork, validator_index, randao_reveal, graffiti, head, slot
+  let engineBlock =
+    ?node.makeEngineBlock(
+      consensusFork,
+      state[].forky(consensusFork),
+      cache[],
+      validator_index,
+      randao_reveal,
+      graffiti,
+      head,
+      slot,
+      enginePayload.eps,
+      enginePayload.execution_requests,
+    )
+
+  ok(
+    (
+      blck: engineBlock.toBlockContents(consensusFork),
+      executionValue: engineBlock.executionValue,
+      consensusValue: engineBlock.consensusValue,
+    )
   )

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -15,8 +15,12 @@
 # nodes, just like a set of `beacon_node` instances would.
 
 import
-  confutils, chronicles, eth/db/kvstore_sqlite3,
-  chronos, chronos/timer, taskpools,
+  confutils,
+  chronicles,
+  eth/db/kvstore_sqlite3,
+  chronos,
+  chronos/timer,
+  taskpools,
   ../beacon_chain/spec/[forks, state_transition],
   ../beacon_chain/beacon_chain_db,
   ../beacon_chain/gossip_processing/[batch_validation, gossip_validation],
@@ -26,16 +30,14 @@ import
 from std/random import initRand, rand
 from std/stats import RunningStat
 from ../beacon_chain/consensus_object_pools/attestation_pool import
-  AttestationPool, addAttestation, addForkChoice,
-  getElectraAttestationsForBlock, init, prune
-from ../beacon_chain/consensus_object_pools/block_quarantine import
-  Quarantine, init
+  AttestationPool, addAttestation, addForkChoice, getAttestationsForBlock, init, prune
+from ../beacon_chain/consensus_object_pools/block_quarantine import Quarantine, init
 from ../beacon_chain/consensus_object_pools/sync_committee_msg_pool import
   SyncCommitteeMsgPool, addContribution, addSyncCommitteeMessage, init,
   produceContribution, produceSyncAggregate, pruneData
 from ../beacon_chain/spec/beaconstate import
-  get_beacon_committee, get_beacon_proposer_index,
-  get_committee_count_per_slot, get_committee_indices
+  get_beacon_committee, get_beacon_proposer_index, get_committee_count_per_slot,
+  get_committee_indices
 from ../beacon_chain/spec/state_transition_block import process_block
 from ../tests/testbcutil import addHeadBlock
 from ../tests/testblockutil import makeAttestationData, MockPrivKeys, `[]`
@@ -49,102 +51,28 @@ type Timers = enum
   tSyncCommittees = "Produce sync committee actions"
   tReplay = "Replay all produced blocks"
 
-proc makeSimulationBlock(
-    cfg: RuntimeConfig,
-    state: var electra.HashedBeaconState,
-    proposer_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    attestations: seq[electra.Attestation],
-    exits: BeaconBlockValidatorChanges,
-    sync_aggregate: SyncAggregate,
-    execution_payload: electra.ExecutionPayloadForSigning,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,
-    rollback: RollbackHashedProc[electra.HashedBeaconState],
-    cache: var StateCache,
-    # TODO:
-    # `verificationFlags` is needed only in tests and can be
-    # removed if we don't use invalid signatures there
-    verificationFlags: UpdateFlags = {}): Result[electra.BeaconBlock, cstring] =
-  ## Create a block for the given state. The latest block applied to it will
-  ## be used for the parent_root value, and the slot will be take from
-  ## state.slot meaning process_slots must be called up to the slot for which
-  ## the block is to be created.
-
-  # To create a block, we'll first apply a partial block to the state, skipping
-  # some validations.
-
-  var blck = partialBeaconBlock(
-    cfg, state, proposer_index, randao_reveal, Eth1Data(),
-    default(GraffitiBytes), attestations, @[], exits, sync_aggregate,
-    execution_payload, ExecutionRequests())
-
-  let res = process_block(
-    cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
-
-  if res.isErr:
-    rollback(state)
-    return err(res.error())
-
-  state.root = hash_tree_root(state.data)
-  blck.state_root = state.root
-
-  ok(blck)
-
-proc makeSimulationBlock(
-    cfg: RuntimeConfig,
-    state: var fulu.HashedBeaconState,
-    proposer_index: ValidatorIndex,
-    randao_reveal: ValidatorSig,
-    attestations: seq[electra.Attestation],
-    exits: BeaconBlockValidatorChanges,
-    sync_aggregate: SyncAggregate,
-    execution_payload: fulu.ExecutionPayloadForSigning,
-    bls_to_execution_changes: SignedBLSToExecutionChangeList,
-    rollback: RollbackHashedProc[fulu.HashedBeaconState],
-    cache: var StateCache,
-    # TODO:
-    # `verificationFlags` is needed only in tests and can be
-    # removed if we don't use invalid signatures there
-    verificationFlags: UpdateFlags = {}): Result[fulu.BeaconBlock, cstring] =
-  ## Create a block for the given state. The latest block applied to it will
-  ## be used for the parent_root value, and the slot will be take from
-  ## state.slot meaning process_slots must be called up to the slot for which
-  ## the block is to be created.
-
-  # To create a block, we'll first apply a partial block to the state, skipping
-  # some validations.
-
-  var blck = partialBeaconBlock(
-    cfg, state, proposer_index, randao_reveal, Eth1Data(),
-    default(GraffitiBytes), attestations, @[], exits, sync_aggregate,
-    execution_payload, ExecutionRequests())
-
-  let res = process_block(
-    cfg, state.data, blck.asSigVerified(), verificationFlags, cache)
-
-  if res.isErr:
-    rollback(state)
-    return err(res.error())
-
-  state.root = hash_tree_root(state.data)
-  blck.state_root = state.root
-
-  ok(blck)
-
 # TODO confutils is an impenetrable black box. how can a help text be added here?
-cli do(slots = SLOTS_PER_EPOCH * 7,
-       validators = SLOTS_PER_EPOCH * 500,
-       attesterRatio {.desc: "ratio of validators that attest in each round"} = 0.82,
-       syncCommitteeRatio {.desc: "ratio of validators that perform sync committee actions in each round"} = 0.82,
-       blockRatio {.desc: "ratio of slots with blocks"} = 1.0,
-       replay = true):
+cli do(
+  slots = SLOTS_PER_EPOCH * 7,
+  validators = SLOTS_PER_EPOCH * 500,
+  attesterRatio {.desc: "ratio of validators that attest in each round".} = 0.82,
+  syncCommitteeRatio {.
+    desc: "ratio of validators that perform sync committee actions in each round"
+  .} = 0.82,
+  blockRatio {.desc: "ratio of slots with blocks".} = 1.0,
+  replay = true
+):
   let genesisState = loadGenesis(validators, false)
   const cfg = getSimulationConfig()
 
   echo "Starting simulation..."
 
   let db = BeaconChainDB.new("block_sim_db", cfg)
-  defer: db.close()
+  defer:
+    db.close()
+
+  proc eager(): bool =
+    true
 
   ChainDAGRef.preInit(db, genesisState[])
   let rng = HmacDrbgContext.new()
@@ -159,10 +87,9 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
     verifier = BatchVerifier.init(rng, taskpool)
     quarantine = newClone(Quarantine.init(cfg))
     attPool = AttestationPool.init(dag, quarantine)
-    batchCrypto = BatchCrypto.new(
-      rng, eager = func(): bool = true,
-      genesis_validators_root = dag.genesis_validators_root,
-      taskpool).expect("working batcher")
+    batchCrypto = BatchCrypto
+      .new(rng, eager, genesis_validators_root = dag.genesis_validators_root, taskpool)
+      .expect("working batcher")
     syncCommitteePool = newClone SyncCommitteeMsgPool.init(rng, cfg)
     timers: array[Timers, RunningStat]
     attesters: RunningStat
@@ -172,10 +99,9 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
   let replayState = assignClone(dag.headState)
 
   proc handleAttestations(slot: Slot) =
-    let
-      attestationHead = dag.head.atSlot(slot)
+    let attestationHead = dag.head.atSlot(slot)
 
-    dag.withUpdatedState(tmpState[], attestationHead.toBlockSlotId.expect("not nil")) do:
+    dag.withUpdatedState(tmpState[], attestationHead.toBlockSlotId.expect("not nil")):
       let
         fork = getStateField(updatedState, fork)
         genesis_validators_root = getStateField(updatedState, genesis_validators_root)
@@ -183,51 +109,65 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
           get_committee_count_per_slot(updatedState, slot.epoch, cache)
 
       for committee_index in get_committee_indices(committees_per_slot):
-        let committee = get_beacon_committee(
-          updatedState, slot, committee_index, cache)
+        let committee = get_beacon_committee(updatedState, slot, committee_index, cache)
 
         for index_in_committee, validator_index in committee:
           if rand(r, 1.0) <= attesterRatio:
             if tmpState.kind < ConsensusFork.Electra:
               let
-                data = makeAttestationData(
-                  updatedState, slot, committee_index, bid.root)
-                sig =
-                  get_attestation_signature(
-                    fork, genesis_validators_root, data,
-                    MockPrivKeys[validator_index])
-                attestation = phase0.Attestation.init(
-                  [uint64 index_in_committee], committee.len, data,
-                  sig.toValidatorSig()).expect("valid data")
+                data =
+                  makeAttestationData(updatedState, slot, committee_index, bid.root)
+                sig = get_attestation_signature(
+                  fork, genesis_validators_root, data, MockPrivKeys[validator_index]
+                )
+                attestation = phase0.Attestation
+                  .init(
+                    [uint64 index_in_committee],
+                    committee.len,
+                    data,
+                    sig.toValidatorSig(),
+                  )
+                  .expect("valid data")
 
               attPool.addAttestation(
-                attestation, [validator_index], attestation.aggregation_bits.len,
-                -1, sig, data.slot.start_beacon_time)
+                attestation,
+                [validator_index],
+                attestation.aggregation_bits.len,
+                -1,
+                sig,
+                data.slot.start_beacon_time,
+              )
             else:
-              var data = makeAttestationData(
-                updatedState, slot, committee_index, bid.root)
-              data.index = 0   # fix in makeAttestationData for Electra
+              var data =
+                makeAttestationData(updatedState, slot, committee_index, bid.root)
+              data.index = 0 # fix in makeAttestationData for Electra
               let
                 sig = get_attestation_signature(
-                  fork, genesis_validators_root, data,
-                  MockPrivKeys[validator_index])
+                  fork, genesis_validators_root, data, MockPrivKeys[validator_index]
+                )
                 attestation = SingleAttestation(
                   committee_index: committee_index.distinctBase,
-                  attester_index: validator_index.uint64, data: data,
-                  signature: sig.toValidatorSig())
+                  attester_index: validator_index.uint64,
+                  data: data,
+                  signature: sig.toValidatorSig(),
+                )
 
               attPool.addAttestation(
-                attestation, [validator_index], committee.len,
-                index_in_committee, sig, data.slot.start_beacon_time)
+                attestation,
+                [validator_index],
+                committee.len,
+                index_in_committee,
+                sig,
+                data.slot.start_beacon_time,
+              )
     do:
       raiseAssert "withUpdatedState failed"
 
   proc handleSyncCommitteeActions(slot: Slot) =
-    type
-      Aggregator = object
-        subcommitteeIdx: SyncSubcommitteeIndex
-        validatorIdx: ValidatorIndex
-        selectionProof: ValidatorSig
+    type Aggregator = object
+      subcommitteeIdx: SyncSubcommitteeIndex
+      validatorIdx: ValidatorIndex
+      selectionProof: ValidatorSig
 
     let
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
@@ -246,118 +186,110 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
         let
           validatorPrivKey = MockPrivKeys[validatorIdx]
           signature = get_sync_committee_message_signature(
-            fork, genesis_validators_root,
-            slot, dag.head.root, validatorPrivKey)
+            fork, genesis_validators_root, slot, dag.head.root, validatorPrivKey
+          )
           msg = SyncCommitteeMessage(
             slot: slot,
             beacon_block_root: dag.head.root,
             validator_index: uint64 validatorIdx,
-            signature: signature.toValidatorSig)
+            signature: signature.toValidatorSig,
+          )
 
         let res = waitFor noCancel dag.validateSyncCommitteeMessage(
-          quarantine,
-          batchCrypto,
-          syncCommitteePool,
-          msg,
-          subcommitteeIdx,
-          messagesTime,
-          false)
+          quarantine, batchCrypto, syncCommitteePool, msg, subcommitteeIdx,
+          messagesTime, false,
+        )
 
         doAssert res.isOk
 
         let (bid, cookedSig, positions) = res.get()
 
         syncCommitteePool[].addSyncCommitteeMessage(
-          msg.slot,
-          bid,
-          msg.validator_index,
-          cookedSig,
-          subcommitteeIdx,
-          positions)
+          msg.slot, bid, msg.validator_index, cookedSig, subcommitteeIdx, positions
+        )
 
-        let
-          selectionProofSig = get_sync_committee_selection_proof(
-            fork, genesis_validators_root, slot, subcommitteeIdx,
-            validatorPrivKey).toValidatorSig
+        let selectionProofSig = get_sync_committee_selection_proof(
+          fork, genesis_validators_root, slot, subcommitteeIdx, validatorPrivKey
+        ).toValidatorSig
 
         if is_sync_committee_aggregator(selectionProofSig):
           aggregators.add Aggregator(
             subcommitteeIdx: subcommitteeIdx,
             validatorIdx: validatorIdx,
-            selectionProof: selectionProofSig)
+            selectionProof: selectionProofSig,
+          )
 
     for aggregator in aggregators:
       var contribution: SyncCommitteeContribution
       let contributionWasProduced = syncCommitteePool[].produceContribution(
-        slot, dag.head.bid, aggregator.subcommitteeIdx, contribution)
+        slot, dag.head.bid, aggregator.subcommitteeIdx, contribution
+      )
 
       if contributionWasProduced:
         let
           contributionAndProof = ContributionAndProof(
             aggregator_index: uint64 aggregator.validatorIdx,
             contribution: contribution,
-            selection_proof: aggregator.selectionProof)
+            selection_proof: aggregator.selectionProof,
+          )
 
           validatorPrivKey = MockPrivKeys[aggregator.validatorIdx]
 
           signedContributionAndProof = SignedContributionAndProof(
             message: contributionAndProof,
             signature: get_contribution_and_proof_signature(
-              fork, genesis_validators_root, contributionAndProof,
-              validatorPrivKey).toValidatorSig)
+              fork, genesis_validators_root, contributionAndProof, validatorPrivKey
+            ).toValidatorSig,
+          )
 
           res = waitFor noCancel dag.validateContribution(
-            quarantine,
-            batchCrypto,
-            syncCommitteePool,
-            signedContributionAndProof,
-            contributionsTime,
-            false)
+            quarantine, batchCrypto, syncCommitteePool, signedContributionAndProof,
+            contributionsTime, false,
+          )
         if res.isOk():
           let (bid, sig, _) = res.get
-          syncCommitteePool[].addContribution(
-            signedContributionAndProof, bid, sig)
+          syncCommitteePool[].addContribution(signedContributionAndProof, bid, sig)
         else:
           # We ignore duplicates / already-covered contributions
           doAssert res.error()[0] == ValidationResult.Ignore
 
-  proc getNewBlock[T](
-      state: var ForkedHashedBeaconState, slot: Slot, cache: var StateCache): T =
-    let
-      proposerIdx = get_beacon_proposer_index(
-        state, cache, getStateField(state, slot)).get()
-      privKey = MockPrivKeys[proposerIdx]
-      sync_aggregate =
-        syncCommitteePool[].produceSyncAggregate(dag.head.bid, slot)
-      hashedState =
-        when T is electra.SignedBeaconBlock:
-          addr state.electraData
-        elif T is fulu.SignedBeaconBlock:
-          addr state.fuluData
-        else:
-          static: doAssert false
-      message = makeSimulationBlock(
-        cfg,
-        hashedState[],
-        proposerIdx,
-        get_epoch_signature(
-          getStateField(state, fork),
-          getStateField(state, genesis_validators_root),
-          slot.epoch, privKey).toValidatorSig(),
-        attPool.getElectraAttestationsForBlock(state, cache),
-        BeaconBlockValidatorChanges(),
-        sync_aggregate,
-        (when T is electra.SignedBeaconBlock:
-          default(electra.ExecutionPayloadForSigning)
-        elif T is fulu.SignedBeaconBlock:
-          default(fulu.ExecutionPayloadForSigning)
-        else:
-          static: doAssert false),
-        static(default(SignedBLSToExecutionChangeList)),
-        noRollback,
-        cache)
+  let blockRatio = blockRatio # can't find in proposeBlock otherwise (?)
+  proc proposeBlock(
+      consensusFork: static ConsensusFork,
+      state: var ForkyHashedBeaconState,
+      cache: var StateCache,
+  ) =
+    if rand(r, 1.0) > blockRatio:
+      return
 
-    var newBlock = T(message: message.get())
+    let
+      slot = state.data.slot
+      proposerIdx = get_beacon_proposer_index(state.data, cache, slot).get()
+      privKey = MockPrivKeys[proposerIdx]
+      randao_reveal = get_epoch_signature(
+        state.data.fork, state.data.genesis_validators_root, slot.epoch, privKey
+      )
+      sync_aggregate = syncCommitteePool[].produceSyncAggregate(dag.head.bid, slot)
+
+      message = makeBeaconBlock(
+          cfg,
+          consensusFork,
+          state,
+          cache,
+          proposerIdx,
+          randao_reveal.toValidatorSig(),
+          default(Eth1Data),
+          default(GraffitiBytes),
+          attPool.getAttestationsForBlock(state, cache),
+          default(seq[Deposit]),
+          default(BeaconBlockValidatorChanges),
+          sync_aggregate,
+          default(consensusFork.ExecutionPayloadForSigning),
+          {},
+        )
+        .expect("block")
+
+    var newBlock = consensusFork.SignedBeaconBlock(message: message)
 
     let blockRoot = withTimerRet(timers[tHashBlock]):
       hash_tree_root(newBlock.message)
@@ -365,75 +297,47 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
     # Careful, state no longer valid after here because of the await..
     newBlock.signature = withTimerRet(timers[tSignBlock]):
       get_block_signature(
-        getStateField(state, fork),
-        getStateField(state, genesis_validators_root),
-        newBlock.message.slot,
-        blockRoot, privKey).toValidatorSig()
+        state.data.fork, state.data.genesis_validators_root, newBlock.message.slot,
+        blockRoot, privKey,
+      )
+      .toValidatorSig()
 
-    newBlock
+    # TODO without the OnBlockAdded cast, Nim can't figure out the type (?)
+    let onAdded: OnBlockAdded[consensusFork.TrustedSignedBeaconBlock] = proc(
+        blckRef: BlockRef,
+        signedBlock: consensusFork.TrustedSignedBeaconBlock,
+        epochRef: EpochRef,
+        unrealized: FinalityCheckpoints,
+    ) =
+      # Callback add to fork choice if valid
+      attPool.addForkChoice(
+        epochRef, blckRef, unrealized, signedBlock.message,
+        blckRef.slot.start_beacon_time,
+      )
 
-  # TODO when withUpdatedState's state template doesn't conflict with chronos's
-  # HTTP server's state function, combine all proposeForkBlock functions into a
-  # single generic function. Until https://github.com/nim-lang/Nim/issues/20811
-  # is fixed, that generic function must take `blockRatio` as a parameter.
-  proc proposeElectraBlock(slot: Slot) =
-    if rand(r, 1.0) > blockRatio:
-      return
+    let added = dag.addHeadBlock(verifier, newBlock, onAdded)
 
-    dag.withUpdatedState(tmpState[], dag.getBlockIdAtSlot(slot).expect("block")) do:
-      let
-        newBlock = getNewBlock[electra.SignedBeaconBlock](updatedState, slot, cache)
-        added = dag.addHeadBlock(verifier, newBlock) do (
-            blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-            epochRef: EpochRef, unrealized: FinalityCheckpoints):
-          # Callback add to fork choice if valid
-          attPool.addForkChoice(
-            epochRef, blckRef, unrealized, signedBlock.message,
-            blckRef.slot.start_beacon_time)
+    dag.updateHead(added[], quarantine[], [])
+    if dag.needStateCachesAndForkChoicePruning():
+      dag.pruneStateCachesDAG()
+      attPool.prune()
 
-      dag.updateHead(added[], quarantine[], [])
-      if dag.needStateCachesAndForkChoicePruning():
-        dag.pruneStateCachesDAG()
-        attPool.prune()
-    do:
-      raiseAssert "withUpdatedState failed"
-
-  proc proposeFuluBlock(slot: Slot) =
-    if rand(r, 1.0) > blockRatio:
-      return
-
-    dag.withUpdatedState(tmpState[], dag.getBlockIdAtSlot(slot).expect("block")) do:
-      let
-        newBlock = getNewBlock[fulu.SignedBeaconBlock](updatedState, slot, cache)
-        added = dag.addHeadBlock(verifier, newBlock) do (
-            blckRef: BlockRef, signedBlock: fulu.TrustedSignedBeaconBlock,
-            epochRef: EpochRef, unrealized: FinalityCheckpoints):
-          # Callback add to fork choice if valid
-          attPool.addForkChoice(
-            epochRef, blckRef, unrealized, signedBlock.message,
-            blckRef.slot.start_beacon_time)
-
-      dag.updateHead(added[], quarantine[], [])
-      if dag.needStateCachesAndForkChoicePruning():
-        dag.pruneStateCachesDAG()
-        attPool.prune()
-    do:
-      raiseAssert "withUpdatedState failed"
-
-  for i in 0..<slots:
+  for i in 0 ..< slots:
     let
       slot = Slot(i + 1)
-      t =
-        if slot.is_epoch: tEpoch
-        else: tBlock
+      t = if slot.is_epoch: tEpoch else: tBlock
 
     if blockRatio > 0.0:
       withTimer(timers[t]):
-        case dag.cfg.consensusForkAtEpoch(slot.epoch)
-        of ConsensusFork.Fulu:    proposeFuluBlock(slot)
-        of ConsensusFork.Electra: proposeElectraBlock(slot)
-        of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
-          doAssert false
+        let bsi = dag.getBlockIdAtSlot(slot).expect("block")
+        var cache = StateCache()
+        doAssert dag.updateState(tmpState[], bsi, false, cache, dag.updateFlags)
+        withState(tmpState[]):
+          when consensusFork >= ConsensusFork.Bellatrix:
+            proposeBlock(consensusFork, forkyState, cache)
+          else:
+            raiseAssert "Unsupported fork " & $consensusFork
+
     if attesterRatio > 0.0:
       withTimer(timers[tAttest]):
         handleAttestations(slot)
@@ -460,8 +364,12 @@ cli do(slots = SLOTS_PER_EPOCH * 7,
     withTimer(timers[tReplay]):
       var cache = StateCache()
       doAssert dag.updateState(
-        replayState[], dag.getBlockIdAtSlot(Slot(slots)).expect("block"),
-        false, cache, dag.updateFlags)
+        replayState[],
+        dag.getBlockIdAtSlot(Slot(slots)).expect("block"),
+        false,
+        cache,
+        dag.updateFlags,
+      )
 
   echo "Done!"
 

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -274,12 +274,14 @@ cli do(validatorsDir: string, secretsDir: string,
               default(bellatrix.ExecutionPayloadForSigning)
           message = makeBeaconBlock(
             cfg,
-            state[],
+            consensusFork,
+            forkyState,
+            cache,
             proposer,
             randao_reveal,
             forkyState.data.eth1_data,
             graffitiValue,
-            when typeof(payload).kind >= ConsensusFork.Electra:
+            when consensusFork >= ConsensusFork.Electra:
               default(seq[electra.Attestation])
             else:
               blockAggregates,
@@ -287,10 +289,9 @@ cli do(validatorsDir: string, secretsDir: string,
             BeaconBlockValidatorChanges(),
             syncAggregate,
             payload,
-            noRollback,
-            cache).get()
+            {}).expect("block")
 
-        blockRoot = message.forky(consensusFork).hash_tree_root()
+        blockRoot = message.hash_tree_root()
         let
           proposerPrivkey =
             try:
@@ -298,7 +299,7 @@ cli do(validatorsDir: string, secretsDir: string,
             except KeyError as exc:
               raiseAssert "Proposer key not available: " & exc.msg
           signedBlock = consensusFork.SignedBeaconBlock(
-            message: message.forky(consensusFork),
+            message: message,
             root: blockRoot,
             signature: get_block_signature(
               fork, genesis_validators_root, slot, blockRoot,

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -72,18 +72,18 @@ proc makeInitialDeposits*(
     result.add makeDeposit(i, flags, cfg = cfg)
 
 func signBlock(
-    fork: Fork, genesis_validators_root: Eth2Digest, forked: ForkedBeaconBlock,
+    fork: Fork, genesis_validators_root: Eth2Digest, blck: ForkyBeaconBlock,
     privKey: ValidatorPrivKey, flags: UpdateFlags = {}): ForkedSignedBeaconBlock =
   let
-    slot = withBlck(forked): forkyBlck.slot
-    root = hash_tree_root(forked)
+    slot = blck.slot
+    root = hash_tree_root(blck)
     signature =
       if skipBlsValidation notin flags:
         get_block_signature(
           fork, genesis_validators_root, slot, root, privKey).toValidatorSig()
       else:
         ValidatorSig()
-  ForkedSignedBeaconBlock.init(forked, root, signature)
+  ForkedSignedBeaconBlock.init(ForkedBeaconBlock.init(blck), root, signature)
 
 from eth/eip1559 import EIP1559_INITIAL_BASE_FEE, calcEip1599BaseFee
 from eth/common/eth_types import EMPTY_ROOT_HASH, GasInt
@@ -186,7 +186,7 @@ proc addTestBlock*(
       else:
         ValidatorSig()
 
-  let message = withState(state):
+  withState(state):
     let execution_payload =
       when consensusFork > ConsensusFork.Bellatrix:
         default(consensusFork.ExecutionPayloadForSigning)
@@ -207,9 +207,11 @@ proc addTestBlock*(
       else:
         default(bellatrix.ExecutionPayloadForSigning)
 
-    makeBeaconBlock(
+    let message = makeBeaconBlock(
       cfg,
-      state,
+      consensusFork,
+      forkyState,
+      cache,
       proposer_index,
       randao_reveal,
       # Keep deposit counts internally consistent.
@@ -218,9 +220,7 @@ proc addTestBlock*(
         deposit_count: forkyState.data.eth1_deposit_index + deposits.lenu64,
         block_hash: eth1_data.block_hash),
       graffiti,
-      when consensusFork == ConsensusFork.Electra:
-        electraAttestations
-      elif consensusFork == ConsensusFork.Fulu:
+      when consensusFork >= ConsensusFork.Electra:
         electraAttestations
       else:
         attestations,
@@ -228,20 +228,11 @@ proc addTestBlock*(
       BeaconBlockValidatorChanges(),
       sync_aggregate,
       execution_payload,
-      noRollback,
-      cache,
-      verificationFlags = {skipBlsValidation})
+      verificationFlags = {skipBlsValidation}).expect("block")
 
-  if message.isErr:
-    raiseAssert "Failed to create a block: " & $message.error
 
-  let
-    new_block = signBlock(
-      getStateField(state, fork),
-      getStateField(state, genesis_validators_root), message.get(), privKey,
-      flags)
-
-  new_block
+    signBlock(
+        forkyState.data.fork, forkyState.data.genesis_validators_root, message, privKey, flags)
 
 proc makeTestBlock*(
     state: ForkedHashedBeaconState,


### PR DESCRIPTION
d74a9622009a538c29b92b2d1b3aa97b4f1d5b6b reorganised the block production flow to first compute the best payload and then create the full consensus block.

However, once we had a payload, the code was still creating a "fake" non-blinded execution payload to compute the new state root causing quite a bit of complexity in the blinded pipeline.

Therefore:

* refactor the state transition to also accept blinded blocks - the state transition does not really touch execution payloads except superficially meaning that most of it doesn't have to change - this same facility could be used for replay as well, if we start loading blocks without execution payloads
* use `Forky*` consistently in block production helpers - it had grown to a mix of both forked and forky which meant extra block copies and binary bloat without any benefit
* simplify block_sim to use more of the production block flow, thus removing fork-specific code
* parse execution requests earlier in the pipeline - this is still too late, but now we can at least fall back to a builder block if local EL gives invalid requests (it really should discard invalid encodings before selecting the best EL)