### PR TITLE
disallow accidental duplicate module imports

### DIFF
--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -74,12 +74,6 @@ proc detectTTY*(stdoutKind: StdoutLogKind): StdoutLogKind =
   else:
     stdoutKind
 
-when defaultChroniclesStream.outputs.type.arity == 2:
-  from std/os import splitFile
-  from "."/filepath import secureCreatePath
-
-  import stew/staticfor
-
 proc setupFileLimits*() =
   when not defined(windows):
     # In addition to databases and sockets, we need a file descriptor for every

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -11,7 +11,7 @@
 
 import
   # Standard library
-  std/[os, tables, strutils, terminal, typetraits],
+  std/[tables, terminal, typetraits],
 
   # Nimble packages
   chronos, confutils, presto, toml_serialization, metrics,
@@ -21,7 +21,15 @@ import
   # Local modules
   ./spec/[helpers, keystore],
   ./spec/datatypes/base,
-  "."/[beacon_clock, beacon_node_status, conf, version]
+  ./[beacon_clock, beacon_node_status, conf, version]
+
+when defaultChroniclesStream.outputs.type.arity == 2:
+  from std/os import commandLineParams, getEnv, splitFile
+  from ./filepath import secureCreatePath
+
+  import stew/staticfor
+else:
+  from std/os import commandLineParams, getEnv
 
 when defined(posix):
   import termios

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1306,4 +1306,3 @@ proc registerDuties*(node: BeaconNode, wallSlot: Slot) {.async: (raises: [Cancel
 
         node.consensusManager[].actionTracker.registerDuty(
           slot, subnet_id, validator_index, isAggregator)
-

--- a/config.nims
+++ b/config.nims
@@ -181,6 +181,7 @@ switch("warningAsError", "BareExcept:on")
 switch("warningAsError", "CStringConv:on")
 switch("warningAsError", "UnusedImport:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
+switch("hintAsError", "DuplicateModuleImport:on")
 
 # `switch("warning[CaseTransition]", "off")` fails with "Error: invalid command line option: '--warning[CaseTransition]'"
 switch("warning", "CaseTransition:off")


### PR DESCRIPTION
These happen from time to time, and don't necessarily get noticed, because they're hints buried in usually hidden compiler output which `make foo` doesn't display by default. Furthermore, they're trivial to fix when they are noticed. So rather than wait/hope for someone to read verbose compiler output, make it obvious.