### PR TITLE
fix(docs, scripts, tests): correct typos and improve consistency across codebase

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -6,9 +6,9 @@ AllTests-mainnet
 ```
 ## Attestation pool electra processing [Preset: mainnet]
 ```diff
-+ Aggregated attestations with disjoint comittee bits into a single on-chain aggregate [Pres OK
++ Aggregated attestations with disjoint committee bits into a single on-chain aggregate [Pres OK
 + Aggregating across committees [Preset: mainnet]                                            OK
-+ Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Pr OK
++ Attestations with disjoint committee bits and equal data into single on-chain aggregate [Pr OK
 + Cache coherence on chain aggregates [Preset: mainnet]                                      OK
 + Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
 + Simple add and get with electra nonzero committee [Preset: mainnet]                        OK
@@ -464,7 +464,7 @@ AllTests-mainnet
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_invalid_proof_1       OK
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_invalid_proof_2       OK
 + KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_invalid_proof_3       OK
-+ KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_proof_length_differen OK
++ KZG - Verify blob KZG proof batch - verify_blob_kzg_proof_batch_case_proof_length_different OK
 ```
 ## EF - KZG - PeerDAS
 ```diff
@@ -696,7 +696,7 @@ AllTests-mainnet
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK
 ```
-## Key spliting
+## Key splitting
 ```diff
 + k < n                                                                                      OK
 + k == n                                                                                     OK
@@ -856,7 +856,7 @@ AllTests-mainnet
 + Single remote                                                                              OK
 + Verifying Signer / Many remotes                                                            OK
 + Verifying Signer / Single remote                                                           OK
-+ vesion 1                                                                                   OK
++ version 1                                                                                  OK
 ```
 ## Serialization/deserialization [Beacon Node] [Preset: mainnet]
 ```diff

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1825,7 +1825,7 @@ A shout out to our great community for reporting and helping diagnose the issues
 * Improve Bellatrix block processing performance
   [#4085](https://github.com/status-im/nimbus-eth2/pull/4085) and [#4082](https://github.com/status-im/nimbus-eth2/pull/4082)
 
-* Optimize execution layer calls when not producing blocks, improving Besu performance and compatiblity
+* Optimize execution layer calls when not producing blocks, improving Besu performance and compatibility
   [#4055](https://github.com/status-im/nimbus-eth2/pull/4055)
 
 * Revise timing of execution layer configuration call, resolving warnings that no consensus client is present on Geth and Besu
@@ -2389,7 +2389,7 @@ Of particular note: the [Keymanager API](https://nimbus.guide/keymanager-api.htm
 ### We've fixed:
 
 * Unnecessary CPU and bandwidth usage: https://github.com/status-im/nimbus-eth2/pull/3308
-  * The result of staying subsribed to sync committee topics even when there were no validators in the committee.
+  * The result of staying subscribed to sync committee topics even when there were no validators in the committee.
 * Excessive logging on beacon nodes with large numbers of validators (in particular, those with `--validator-monitor-totals` enabled): https://github.com/status-im/nimbus-eth2/pull/3332
 * Deviations from the spec in the REST API; this led to sub-optimal performance when Nimbus was paired with Vouch.
 * Naming inconsistencies in the "totals" metrics (this was produced by the [validator monitor](https://nimbus.guide/validator-monitor.html)).
@@ -2598,7 +2598,7 @@ It's a rare occurrence, since it requires a validator to be scheduled to attest 
 
 As a fix, we are using a larger send delay: [#2705](https://github.com/status-im/nimbus-eth2/pull/2705).
 
-Fo those Nimbus `v1.4.0` users who are concerned about reaching optimal attestation effectiveness, we encourage you to upgrade as soon as possible.
+For those Nimbus `v1.4.0` users who are concerned about reaching optimal attestation effectiveness, we encourage you to upgrade as soon as possible.
 
 Other changes include log flushing and metrics fixes.
 
@@ -2961,7 +2961,7 @@ and further performance improvements across the board.
 
 * A bug that had the potential to completely halt all syncing activity.
 
-* Inefficient processing of blocks with Eth1 deposits which occassionally
+* Inefficient processing of blocks with Eth1 deposits which occasionally
   led to increased latencies when delivering attestations.
 
 * Outdated records in our bootstrap nodes list.
@@ -3097,7 +3097,7 @@ So it's important you update at your earliest convenience.
 * A deposit merkle proofs generation issue occasionally resulting in missed
   block proposals shortly after a new Eth1 head was selected.
 
-* Slow status bar updates in the absense of logging messages.
+* Slow status bar updates in the absence of logging messages.
 
 
 2020-12-02 v1.0.1
@@ -3301,7 +3301,7 @@ A bugfix release addressing issues discovered in the Toledo network.
 * Incorrectly set message-ids in gossip message causing other clients
   to penalise and potentially disconnect our nodes from the network.
 
-* An issue occuring when Nimbus is paired with a Geth node
+* An issue occurring when Nimbus is paired with a Geth node
   that is not fully synced.
 
 

--- a/Makefile
+++ b/Makefile
@@ -481,7 +481,7 @@ endif
 force_build_alone_tools: | $(FORCE_BUILD_ALONE_TOOLS_DEPS)
 
 # https://www.gnu.org/software/make/manual/html_node/Multiple-Rules.html#Multiple-Rules
-# Already defined as a reult
+# Already defined as a result
 nimbus_beacon_node: force_build_alone_tools
 
 GOERLI_TESTNETS_PARAMS := \

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -65,7 +65,7 @@ const
   GETPAYLOAD_TIMEOUT = 1.seconds
 
   connectionStateChangeHysteresisThreshold = 15
-    ## How many unsuccesful/successful requests we must see
+    ## How many unsuccessful/successful requests we must see
     ## before declaring the connection as degraded/restored
 
 type
@@ -101,7 +101,7 @@ type
 
     web3: Opt[Web3]
       ## This will be `none` before connecting and while we are
-      ## reconnecting after a lost connetion. You can wait on
+      ## reconnecting after a lost connection. You can wait on
       ## the future below for the moment the connection is active.
 
     connectingFut: Future[Result[Web3, string]].Raising([CancelledError])
@@ -121,7 +121,7 @@ declareCounter engine_api_responses,
   labels = ["url", "request", "status"]
 
 declareHistogram engine_api_request_duration_seconds,
-  "Time(s) used to generate signature usign remote signer",
+  "Time(s) used to generate signature using remote signer",
    buckets = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
    labels = ["url", "request"]
 
@@ -172,7 +172,7 @@ func increaseCounterTowardsStateChange(connection: ELConnection): bool =
 
 func decreaseCounterTowardsStateChange(connection: ELConnection) =
   if connection.hysteresisCounter > 0:
-    # While we increase the counter by 1, we decreate it by 20% in order
+    # While we increase the counter by 1, we decrease it by 20% in order
     # to require a steady and affirmative change instead of allowing
     # the counter to drift very slowly in one direction when the ratio
     # between success and failure is roughly 50:50%
@@ -546,7 +546,7 @@ proc getPayload*(
             # address: ..., amount: ...), (index: ..., validatorIndex: ...,
             # address: ..., amount: ...)]"
             # TODO (cheatfate): should we have `continue` statement at the
-            # end of this branch. If no such payload could be choosen as
+            # end of this branch. If no such payload could be chosen as
             # best one.
             warn "Execution client did not return correct withdrawals",
               withdrawals_from_cl_len = engineApiWithdrawals.len,
@@ -878,7 +878,7 @@ proc sendNewPayload*(
           if retriesCount == maxRetriesCount:
             return PayloadExecutionStatus.syncing
 
-          # To avoid continous spam of requests when EL node is offline we
+          # To avoid continuous spam of requests when EL node is offline we
           # going to sleep until next attempt.
           await variedSleep(sleepCounter, SleepDurations)
           break mainLoop
@@ -1069,7 +1069,7 @@ proc forkchoiceUpdated*(
           if retriesCount == maxRetriesCount:
             return (PayloadExecutionStatus.syncing, Opt.none Hash32)
 
-          # To avoid continous spam of requests when EL node is offline we
+          # To avoid continuous spam of requests when EL node is offline we
           # going to sleep until next attempt.
           await variedSleep(sleepCounter, SleepDurations)
           break mainLoop

--- a/docs/the_nimbus_book/src/voluntary-exit.md
+++ b/docs/the_nimbus_book/src/voluntary-exit.md
@@ -3,7 +3,7 @@
 Voluntary exits allow validators to permanently stop performing their duties, and eventually recover the deposit.
 
 Exits are subject to a wait period that depends on the length of the exit queue.
-While a validator is exiting, it still must perform its duties in order not to lose funds to inactivity penalities.
+While a validator is exiting, it still must perform its duties in order not to lose funds to inactivity penalties.
 
 !!! warning
     Voluntary exits are **irreversible**.

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -16,7 +16,7 @@
   ],
 }:
 
-# The 'or' is to handle src fallback to ../. which lack submodules attribue.
+# The 'or' is to handle src fallback to ../. which lack submodules attribute.
 assert pkgs.lib.assertMsg ((src.submodules or true) == true)
   "Unable to build without submodules. Append '?submodules=1#' to the URI.";
 
@@ -40,7 +40,7 @@ in stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  # Disable CPU optmizations that make binary not portable.
+  # Disable CPU optimizations that make binary not portable.
   NIMFLAGS = "-d:disableMarchNative -d:git_revision_override=${revision}";
   # Avoid Nim cache permission errors.
   XDG_CACHE_HOME = "/tmp";

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -710,7 +710,7 @@ cleanup() {
 
   echo "Cleaning up"
 
-  # Avoid the trap enterring an infinite loop
+  # Avoid the trap entering an infinite loop
   trap - SIGINT SIGTERM EXIT
 
   PKILL_ECHO_FLAG='-e'
@@ -1077,7 +1077,7 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
     # removed by switching to a fully-connected topology.
     BOOTSTRAP_ARG="--netkey-file=${CONTAINER_BOOTSTRAP_NETWORK_KEYFILE} --insecure-netkey-password=true --subscribe-all-subnets --direct-peer=$DIRECTPEER_ENR"
   elif [[ ${NUM_NODE} == "${DIRECTPEER_NODE}" ]]; then
-    # Start a node using the Direct Peer functionality instead of regular bootstraping
+    # Start a node using the Direct Peer functionality instead of regular bootstrapping
     BOOTSTRAP_ARG="--netkey-file=${DIRECTPEER_NETWORK_KEYFILE} --direct-peer=$(cat $CONTAINER_BOOTSTRAP_ENR) --insecure-netkey-password=true"
   else
     BOOTSTRAP_ARG="--bootstrap-file=${CONTAINER_BOOTSTRAP_ENR}"

--- a/scripts/mainnet-non-overriden-config.yaml
+++ b/scripts/mainnet-non-overriden-config.yaml
@@ -1,5 +1,5 @@
 # This file should contain the origin run-time config for the mainnet
-# network [1] without all properties overriden in the local network
+# network [1] without all properties overridden in the local network
 # simulation. We use to generate a full run-time config as required
 # by third-party binaries, such as Lighthouse and Web3Signer.
 #
@@ -8,7 +8,7 @@
 # Mainnet config
 
 # Extends the mainnet preset
-# (overriden in launch_local_testnet.sh) PRESET_BASE: 'mainnet'
+# (overridden in launch_local_testnet.sh) PRESET_BASE: 'mainnet'
 
 # Free-form short name of the network that this configuration applies to - known
 # canonical network names include:
@@ -20,7 +20,7 @@ CONFIG_NAME: 'mainnet'
 # Transition
 # ---------------------------------------------------------------
 # Estimated on Sept 15, 2022
-# (overriden in launch_local_testnet.sh) TERMINAL_TOTAL_DIFFICULTY: 58750000000000000000000
+# (overridden in launch_local_testnet.sh) TERMINAL_TOTAL_DIFFICULTY: 58750000000000000000000
 # By default, don't use these params
 TERMINAL_BLOCK_HASH: 0x0000000000000000000000000000000000000000000000000000000000000000
 TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
@@ -30,13 +30,13 @@ TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
 # Genesis
 # ---------------------------------------------------------------
 # `2**14` (= 16,384)
-# (overriden in launch_local_testnet.sh) MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
+# (overridden in launch_local_testnet.sh) MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 16384
 # Dec 1, 2020, 12pm UTC
-# (overriden in launch_local_testnet.sh) MIN_GENESIS_TIME: 1606824000
+# (overridden in launch_local_testnet.sh) MIN_GENESIS_TIME: 1606824000
 # Mainnet initial fork version, recommend altering for testnets
 GENESIS_FORK_VERSION: 0x00000000
 # 604800 seconds (7 days)
-# (overriden in launch_local_testnet.sh) GENESIS_DELAY: 604800
+# (overridden in launch_local_testnet.sh) GENESIS_DELAY: 604800
 
 
 # Forking
@@ -47,22 +47,22 @@ GENESIS_FORK_VERSION: 0x00000000
 
 # Altair
 ALTAIR_FORK_VERSION: 0x01000000
-# (overriden in launch_local_testnet.sh) ALTAIR_FORK_EPOCH: 74240  # Oct 27, 2021, 10:56:23am UTC
+# (overridden in launch_local_testnet.sh) ALTAIR_FORK_EPOCH: 74240  # Oct 27, 2021, 10:56:23am UTC
 # Bellatrix
 BELLATRIX_FORK_VERSION: 0x02000000
-# (overriden in launch_local_testnet.sh) BELLATRIX_FORK_EPOCH: 144896  # Sept 6, 2022, 11:34:47am UTC
+# (overridden in launch_local_testnet.sh) BELLATRIX_FORK_EPOCH: 144896  # Sept 6, 2022, 11:34:47am UTC
 # Capella
 CAPELLA_FORK_VERSION: 0x03000000
-# (overriden in launch_local_testnet.sh) CAPELLA_FORK_EPOCH: 194048  # April 12, 2023, 10:27:35pm UTC
+# (overridden in launch_local_testnet.sh) CAPELLA_FORK_EPOCH: 194048  # April 12, 2023, 10:27:35pm UTC
 # Deneb
 DENEB_FORK_VERSION: 0x04000000
-# (overriden in launch_local_testnet.sh) DENEB_FORK_EPOCH: 269568  # March 13, 2024, 01:55:35pm UTC
+# (overridden in launch_local_testnet.sh) DENEB_FORK_EPOCH: 269568  # March 13, 2024, 01:55:35pm UTC
 # Electra
 ELECTRA_FORK_VERSION: 0x05000000
-# (overriden in launch_local_testnet.sh) ELECTRA_FORK_EPOCH: 18446744073709551615  # temporary stub
+# (overridden in launch_local_testnet.sh) ELECTRA_FORK_EPOCH: 18446744073709551615  # temporary stub
 # Fulu
 FULU_FORK_VERSION: 0x06000000
-# (overriden in launch_local_testnet.sh) FULU_FORK_EPOCH: 18446744073709551615  # temporary stub
+# (overridden in launch_local_testnet.sh) FULU_FORK_EPOCH: 18446744073709551615  # temporary stub
 
 # Time parameters
 # ---------------------------------------------------------------
@@ -75,7 +75,7 @@ MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
 # 2**8 (= 256) epochs ~27 hours
 SHARD_COMMITTEE_PERIOD: 256
 # 2**11 (= 2,048) Eth1 blocks ~8 hours
-# (overriden in launch_local_testnet.sh) ETH1_FOLLOW_DISTANCE: 2048
+# (overridden in launch_local_testnet.sh) ETH1_FOLLOW_DISTANCE: 2048
 
 
 # Validator cycle
@@ -110,7 +110,7 @@ REORG_MAX_EPOCHS_SINCE_FINALIZATION: 2
 # Ethereum PoW Mainnet
 DEPOSIT_CHAIN_ID: 1
 DEPOSIT_NETWORK_ID: 1
-# (overriden in launch_local_testnet.sh) DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cBB839Cbe05303d7705Fa
+# (overridden in launch_local_testnet.sh) DEPOSIT_CONTRACT_ADDRESS: 0x00000000219ab540356cBB839Cbe05303d7705Fa
 
 
 # Networking

--- a/scripts/minimal-non-overriden-config.yaml
+++ b/scripts/minimal-non-overriden-config.yaml
@@ -1,5 +1,5 @@
 # This file should contain the origin run-time config for the minimal
-# network [1] without all properties overriden in the local network
+# network [1] without all properties overridden in the local network
 # simulation. We use to generate a full run-time config as required
 # by third-party binaries, such as Lighthouse and Web3Signer.
 #
@@ -8,7 +8,7 @@
 # Minimal config
 
 # Extends the minimal preset
-# (overriden in launch_local_testnet.sh) PRESET_BASE: 'minimal'
+# (overridden in launch_local_testnet.sh) PRESET_BASE: 'minimal'
 
 # Free-form short name of the network that this configuration applies to - known
 # canonical network names include:
@@ -20,7 +20,7 @@ CONFIG_NAME: 'minimal'
 # Transition
 # ---------------------------------------------------------------
 # 2**256-2**10 for testing minimal network
-# (overriden in launch_local_testnet.sh) TERMINAL_TOTAL_DIFFICULTY: 115792089237316195423570985008687907853269984665640564039457584007913129638912
+# (overridden in launch_local_testnet.sh) TERMINAL_TOTAL_DIFFICULTY: 115792089237316195423570985008687907853269984665640564039457584007913129638912
 # By default, don't use these params
 TERMINAL_BLOCK_HASH: 0x0000000000000000000000000000000000000000000000000000000000000000
 TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
@@ -30,13 +30,13 @@ TERMINAL_BLOCK_HASH_ACTIVATION_EPOCH: 18446744073709551615
 # Genesis
 # ---------------------------------------------------------------
 # [customized]
-# (overriden in launch_local_testnet.sh) MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64
+# (overridden in launch_local_testnet.sh) MIN_GENESIS_ACTIVE_VALIDATOR_COUNT: 64
 # Jan 3, 2020
-# (overriden in launch_local_testnet.sh) MIN_GENESIS_TIME: 1578009600
+# (overridden in launch_local_testnet.sh) MIN_GENESIS_TIME: 1578009600
 # Highest byte set to 0x01 to avoid collisions with mainnet versioning
 GENESIS_FORK_VERSION: 0x00000001
 # [customized] Faster to spin up testnets, but does not give validator reasonable warning time for genesis
-# (overriden in launch_local_testnet.sh) GENESIS_DELAY: 300
+# (overridden in launch_local_testnet.sh) GENESIS_DELAY: 300
 
 
 # Forking
@@ -46,22 +46,22 @@ GENESIS_FORK_VERSION: 0x00000001
 
 # Altair
 ALTAIR_FORK_VERSION: 0x01000001
-# (overriden in launch_local_testnet.sh) ALTAIR_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) ALTAIR_FORK_EPOCH: 18446744073709551615
 # Bellatrix
 BELLATRIX_FORK_VERSION: 0x02000001
-# (overriden in launch_local_testnet.sh) BELLATRIX_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) BELLATRIX_FORK_EPOCH: 18446744073709551615
 # Capella
 CAPELLA_FORK_VERSION: 0x03000001
-# (overriden in launch_local_testnet.sh) CAPELLA_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) CAPELLA_FORK_EPOCH: 18446744073709551615
 # Deneb
 DENEB_FORK_VERSION: 0x04000001
-# (overriden in launch_local_testnet.sh) DENEB_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) DENEB_FORK_EPOCH: 18446744073709551615
 # Electra
 ELECTRA_FORK_VERSION: 0x05000001
-# (overriden in launch_local_testnet.sh) ELECTRA_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) ELECTRA_FORK_EPOCH: 18446744073709551615
 # Fulu
 FULU_FORK_VERSION: 0x06000001
-# (overriden in launch_local_testnet.sh) FULU_FORK_EPOCH: 18446744073709551615
+# (overridden in launch_local_testnet.sh) FULU_FORK_EPOCH: 18446744073709551615
 
 # Time parameters
 # ---------------------------------------------------------------
@@ -74,7 +74,7 @@ MIN_VALIDATOR_WITHDRAWABILITY_DELAY: 256
 # [customized] higher frequency of committee turnover and faster time to acceptable voluntary exit
 SHARD_COMMITTEE_PERIOD: 64
 # [customized] process deposits more quickly, but insecure
-# (overriden in launch_local_testnet.sh) ETH1_FOLLOW_DISTANCE: 16
+# (overridden in launch_local_testnet.sh) ETH1_FOLLOW_DISTANCE: 16
 
 
 # Validator cycle
@@ -111,7 +111,7 @@ REORG_MAX_EPOCHS_SINCE_FINALIZATION: 2
 DEPOSIT_CHAIN_ID: 5
 DEPOSIT_NETWORK_ID: 5
 # Configured on a per testnet basis
-# (overriden in launch_local_testnet.sh) DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
+# (overridden in launch_local_testnet.sh) DEPOSIT_CONTRACT_ADDRESS: 0x1234567890123456789012345678901234567890
 
 
 # Networking

--- a/tests/slashing_protection/test_fixtures.nim
+++ b/tests/slashing_protection/test_fixtures.nim
@@ -14,7 +14,7 @@ import
   # Internal
   ../../beacon_chain/validators/[slashing_protection, slashing_protection_v2],
   ../../beacon_chain/spec/datatypes/base,
-  # Test utilies
+  # Test utilities
   ../testutil, ../testdbutil,
   ../consensus_spec/fixtures_utils
 
@@ -198,7 +198,7 @@ proc runTest(identifier: string) =
           "    for " & $toHexLogs(blck)
 
         # https://github.com/eth-clients/slashing-protection-interchange-tests/pull/14
-        # Successful blocks are to be incoporated in the DB
+        # Successful blocks are to be incorporated in the DB
         if status.isOk(): # Skip duplicates
           let status = db.db_v2.registerBlock(
             Opt.none(ValidatorIndex),
@@ -229,7 +229,7 @@ proc runTest(identifier: string) =
           "    for " & $toHexLogs(att)
 
         # https://github.com/eth-clients/slashing-protection-interchange-tests/pull/14
-        # Successful attestations are to be incoporated in the DB
+        # Successful attestations are to be incorporated in the DB
         if status.isOk(): # Skip duplicates
           let status = db.db_v2.registerAttestation(
             Opt.none(ValidatorIndex),

--- a/tests/slashing_protection/test_slashing_protection_db.nim
+++ b/tests/slashing_protection/test_slashing_protection_db.nim
@@ -18,7 +18,7 @@ import
   ../../beacon_chain/validators/slashing_protection,
   ../../beacon_chain/spec/[helpers],
   ../../beacon_chain/spec/datatypes/base,
-  # Test utilies
+  # Test utilities
   ../testutil
 
 func fakeRoot(index: SomeInteger): Eth2Digest =

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -876,7 +876,7 @@ suite "Attestation pool electra processing" & preset():
       pool[].getElectraAggregatedAttestation(
         2.Slot, hash_tree_root(combined[0].data), 1.CommitteeIndex).isNone()
 
-  test "Attestations with disjoint comittee bits and equal data into single on-chain aggregate" & preset():
+  test "Attestations with disjoint committee bits and equal data into single on-chain aggregate" & preset():
     let
       bc0 = get_beacon_committee(
         state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
@@ -916,7 +916,7 @@ suite "Attestation pool electra processing" & preset():
       attestations[0].aggregation_bits.countOnes() == 2
       attestations[0].committee_bits.countOnes() == 2
 
-  test "Aggregated attestations with disjoint comittee bits into a single on-chain aggregate" & preset():
+  test "Aggregated attestations with disjoint committee bits into a single on-chain aggregate" & preset():
     proc verifyAttestationSignature(attestation: electra.Attestation): bool =
       withState(state[]):
         when consensusFork == ConsensusFork.Electra:

--- a/tests/test_honest_validator.nim
+++ b/tests/test_honest_validator.nim
@@ -277,7 +277,7 @@ suite "Honest validator":
     for i in
         FAULT_INSPECTION_WINDOW * 7 ..
         FAULT_INSPECTION_WINDOW * 9 + MAX_MISSING_WINDOW * 2 - 1:
-      # i.e. two fullly covered epochs then get into MAX_MISSING_WINDOW * 2 - 1
+      # i.e. two fully covered epochs then get into MAX_MISSING_WINDOW * 2 - 1
       # of the every-other-block is present. Because only MAX_MISSING_WINDOW of
       # these can exist, it's the ones at (FIW*9 base of 0): 1, 3, 5, 7, 9 that
       # are missing. Can get up to 9 here, i.e. by 2 * MAX_MISSING_WINDOW, as a

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -22,8 +22,8 @@ template parse(keystore: string): auto =
     checkpoint "Serialization Error: " & err.formatMsg("<keystore>")
     raise err
 
-suite "Remove keystore testing suite":
-  test "vesion 1" :
+suite "Remote keystore testing suite":
+  test "version 1" :
     for version in [1, 2]:
       let remoteKeyStores = """{
         "version": """ & $version & """,

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -1050,7 +1050,7 @@ block:
         sres1.isOk()
         sres2.isOk()
         sres3.isOk()
-        # Remote requests with proper Merkle proof of proper FeeRecipent field
+        # Remote requests with proper Merkle proof of proper FeeRecipient field
         rres1.isOk()
         rres2.isOk()
         rres3.isOk()


### PR DESCRIPTION
This PR fixes multiple typos, spelling mistakes, and wording inconsistencies across documentation, scripts, changelog entries, Nim source code, and test files. No functional or consensus-impacting logic is changed.

## Changes
- **Docs/Markdown**
  - Fixed misspellings in `CHANGELOG.md`, `AllTests-mainnet.md`, `voluntary-exit.md`.
  - Corrected wording in `the_nimbus_book` and test descriptions.
- **Scripts**
  - Fixed typos in `launch_local_testnet.sh`, `Makefile`, YAML configs (`overriden` → `overridden`).
  - Corrected comments in shell scripts to avoid confusion.
- **Source (Nim)**
  - Corrected variable names, comments, and messages in `beacon_chain/el/el_manager.nim`.
- **Tests**
  - Fixed spelling in test names and comments (`comittee` → `committee`, `vesion` → `version`, `utilies` → `utilities`, etc.).
  - Updated strings for clarity (`FeeRecipent` → `FeeRecipient`).
- **Nix**
  - Corrected attribute naming in `default.nix`.
