### PR TITLE
move Nim cache location to Jenkins workspace tmp

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -59,6 +59,7 @@ pipeline {
   environment {
     NPROC = Runtime.getRuntime().availableProcessors()
     MAKEFLAGS = "V=${params.VERBOSITY} NIM_COMMIT=${params.NIM_COMMIT} -j${env.NPROC}"
+    XDG_CACHE_HOME = "${env.WORKSPACE_TMP}/.cache"
   }
 
   stages {


### PR DESCRIPTION
To avoid bizzare errors when parallel jobs share the same cache folder.