### PR TITLE
Update data directory defaults to include namespace, network

### DIFF
--- a/beacon_chain/buildinfo.nim
+++ b/beacon_chain/buildinfo.nim
@@ -1,0 +1,85 @@
+# beacon_chain
+# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [].}
+
+## This module implements the version tagging details of all binaries included
+## in the Nimbus release process (i.e. beacon_node, validator_client, etc)
+
+import std/[os, strutils], metrics
+
+const sourcePath = currentSourcePath.rsplit({DirSep, AltSep}, 1)[0]
+
+proc gitFolderExists(path: string): bool {.compileTime.} =
+  # walk up parent folder to find `.git` folder
+  var currPath = sourcePath
+  while true:
+    if dirExists(currPath & "/.git"):
+      return true
+    let parts = splitPath(currPath)
+    if parts.tail.len == 0:
+      break
+    currPath = parts.head
+  false
+
+const
+  compileYear = CompileDate[0 ..< 4] # YYYY-MM-DD (UTC)
+  copyrights* =
+    "Copyright (c) 2019-" & compileYear & " Status Research & Development GmbH"
+
+  GitRevisionOverride {.strdefine.} = ""
+
+  # strip: remove spaces
+  # --short=8: ensure we get 8 chars of commit hash
+  # -C sourcePath: get the correct git hash no matter where the current dir is.
+  GitRevision* =
+    when GitRevisionOverride.len > 0:
+      static:
+        doAssert(
+          GitRevisionOverride.len == 8,
+          "GitRevisionOverride must consist of 8 characters",
+        )
+        doAssert(
+          GitRevisionOverride.allIt(it in HexDigits),
+          "GitRevisionOverride should contains only hex chars",
+        )
+
+      GitRevisionOverride
+    else:
+      if gitFolderExists(sourcePath):
+        # only using git if the parent dir is a git repo.
+        strip(
+          staticExec(
+            "git -C " & strutils.escape(sourcePath) & " rev-parse --short=8 HEAD"
+          )
+        )
+      else:
+        # otherwise we use revision number given by build system.
+        # e.g. user download from release tarball, or Github zip download.
+        "00000000"
+
+  nimFullBanner* = staticExec("nim --version")
+
+func getNimGitHash(): string =
+  const gitPrefix = "git hash: "
+  let tmp = splitLines(nimFullBanner)
+  if tmp.len == 0:
+    return
+  for line in tmp:
+    if line.startsWith(gitPrefix) and line.len > 8 + gitPrefix.len:
+      result = line[gitPrefix.len ..< gitPrefix.len + 8]
+
+func nimBanner*(): string =
+  let gitHash = getNimGitHash()
+  let tmp = splitLines(nimFullBanner)
+  if gitHash.len > 0:
+    tmp[0] & " (" & gitHash & ")"
+  else:
+    tmp[0]
+
+declareGauge nimVersionGauge, "Nim version info", ["version", "nim_commit"], name = "nim_version"
+nimVersionGauge.set(1, labelValues=[NimVersion, getNimGitHash()])

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -151,7 +151,6 @@ type
 
     dataDirFlag* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValueDesc: defaultDataDir("", "<network>")
       abbr: "d"
       name: "data-dir" .}: Option[OutDir]
 
@@ -913,7 +912,6 @@ type
 
     dataDirFlag* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValueDesc: defaultDataDir("vc", "")
       abbr: "d"
       name: "data-dir" .}: Option[OutDir]
 
@@ -1098,7 +1096,6 @@ type
 
     dataDirFlag* {.
       desc: "The directory where nimbus will store validator's keys"
-      defaultValueDesc: defaultDataDir("sn", "<network>")
       abbr: "d"
       name: "data-dir" .}: Option[OutDir]
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -8,9 +8,9 @@
 {.push raises: [].}
 
 import
-  std/[options, unicode, uri],
+  std/[options, os, unicode, uri],
   metrics,
-
+  results,
   chronicles, chronicles/options as chroniclesOptions,
   confutils, confutils/defs, confutils/std/net,
   confutils/toml/defs as confTomlDefs,
@@ -28,9 +28,8 @@ import
   ./networking/network_metadata,
   ./validators/slashing_protection_common,
   ./el/el_conf,
-  ./filepath
+  ./[filepath, nimbus_binary_common]
 
-from std/os import getHomeDir, parentDir, `/`
 from std/strutils import parseBiggestUInt, replace
 from consensus_object_pools/block_pools_types_light_client
   import LightClientDataImportMode
@@ -84,7 +83,7 @@ type
     # status   = "Displays status information about all deposits"
     exit     = "Submits a validator voluntary exit"
 
-  SNStartUpCmd* = enum
+  SNStartUpCmd* {.pure.} = enum
     SNNoCommand
 
   RecordCmd* {.pure.} = enum
@@ -99,22 +98,13 @@ type
     v2
     both
 
-  StdoutLogKind* {.pure.} = enum
-    Auto = "auto"
-    Colors = "colors"
-    NoColors = "nocolors"
-    Json = "json"
-    None = "none"
-
   HistoryMode* {.pure.} = enum
     Archive = "archive"
     Prune = "prune"
 
-  SlashProtCmd* = enum
+  SlashProtCmd* {.pure.} = enum
     `import` = "Import a EIP-3076 slashing protection interchange file"
     `export` = "Export a EIP-3076 slashing protection interchange file"
-    # migrateAll = "Export and remove the whole validator slashing protection DB."
-    # migrate = "Export and remove specified validators from Nimbus."
 
   ImportMethod* {.pure.} = enum
     Normal = "normal"
@@ -159,12 +149,11 @@ type
       defaultValueDesc: "mainnet"
       name: "network" .}: Option[string]
 
-    dataDir* {.
+    dataDirFlag* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir()
-      defaultValueDesc: ""
+      defaultValueDesc: defaultDataDir("", "<network>")
       abbr: "d"
-      name: "data-dir" .}: OutDir
+      name: "data-dir" .}: Option[OutDir]
 
     validatorsDirFlag* {.
       desc: "A directory containing validator keystores"
@@ -658,7 +647,7 @@ type
       # https://github.com/prysmaticlabs/prysm/pull/10312
       suggestedFeeRecipient* {.
         desc: "Suggested fee recipient"
-        name: "suggested-fee-recipient" .}: Option[Address]
+        name: "suggested-fee-recipient" .}: Option[Eth1Address]
 
       suggestedGasLimit* {.
         desc: "Suggested gas limit"
@@ -922,12 +911,11 @@ type
       desc: "Specifies a path for the written JSON log file (deprecated)"
       name: "log-file" .}: Option[OutFile]
 
-    dataDir* {.
+    dataDirFlag* {.
       desc: "The directory where nimbus will store all blockchain data"
-      defaultValue: config.defaultDataDir()
-      defaultValueDesc: ""
+      defaultValueDesc: defaultDataDir("vc", "")
       abbr: "d"
-      name: "data-dir" .}: OutDir
+      name: "data-dir" .}: Option[OutDir]
 
     doppelgangerDetection* {.
       # TODO This description is shared between the BN and the VC.
@@ -991,7 +979,7 @@ type
     # https://github.com/prysmaticlabs/prysm/pull/10312
     suggestedFeeRecipient* {.
       desc: "Suggested fee recipient"
-      name: "suggested-fee-recipient" .}: Option[Address]
+      name: "suggested-fee-recipient" .}: Option[Eth1Address]
 
     suggestedGasLimit* {.
       desc: "Suggested gas limit"
@@ -1108,12 +1096,11 @@ type
       desc: "Do not display interactive prompts. Quit on missing configuration"
       name: "non-interactive" .}: bool
 
-    dataDir* {.
+    dataDirFlag* {.
       desc: "The directory where nimbus will store validator's keys"
-      defaultValue: config.defaultDataDir()
-      defaultValueDesc: ""
+      defaultValueDesc: defaultDataDir("sn", "<network>")
       abbr: "d"
-      name: "data-dir" .}: OutDir
+      name: "data-dir" .}: Option[OutDir]
 
     validatorsDirFlag* {.
       desc: "A directory containing validator keystores"
@@ -1126,7 +1113,7 @@ type
     expectedFeeRecipient* {.
       desc: "Signatures for blocks will require proofs of the specified " &
             "fee recipient"
-      name: "expected-fee-recipient".}: Option[Address]
+      name: "expected-fee-recipient".}: Option[Eth1Address]
 
     serverIdent* {.
       desc: "Server identifier which will be used in HTTP Host header"
@@ -1165,26 +1152,66 @@ type
 
   AnyConf* = BeaconNodeConf | ValidatorClientConf | SigningNodeConf
 
-proc defaultDataDir*[Conf](config: Conf): string =
-  let dataDir = when defined(windows):
-    "AppData" / "Roaming" / "Nimbus"
-  elif defined(macosx):
-    "Library" / "Application Support" / "Nimbus"
+proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
+  let metadata =
+    if eth2Network.isSome:
+      getMetadataForNetwork(eth2Network.get)
+    else:
+      when const_preset == "gnosis":
+        getMetadataForNetwork("gnosis")
+      elif const_preset == "mainnet":
+        getMetadataForNetwork("mainnet")
+      else:
+        # Presumably other configurations can have other defaults, but for now
+        # this simplifies the flow
+        fatal "Must specify network on non-mainnet node"
+        quit 1
+
+  network_name.set(2, labelValues = [metadata.cfg.name()])
+
+  metadata
+
+template loadEth2Network*(config: BeaconNodeConf|SigningNodeConf): Eth2NetworkMetadata =
+  loadEth2Network(config.eth2Network)
+
+proc legacyDataDir*(): Opt[string] =
+  let dir =
+    getHomeDir() / (
+      when defined(windows):
+        "AppData" / "Roaming" / "Nimbus" / "BeaconNode"
+      elif defined(macosx):
+        "Library" / "Application Support" / "Nimbus" / "BeaconNode"
+      else:
+        ".cache" / "nimbus" / "BeaconNode"
+    )
+
+  if dirExists(dir):
+    Opt.some(dir)
   else:
-    ".cache" / "nimbus"
+    Opt.none(string)
 
-  getHomeDir() / dataDir / "BeaconNode"
+proc defaultDataDir*(config: BeaconNodeConf): string =
+  defaultDataDir("", config.loadEth2Network().cfg.name())
 
-func dumpDir(config: AnyConf): string =
+proc defaultDataDir*(_: ValidatorClientConf): string =
+  defaultDataDir("vc", "")
+
+proc defaultDataDir*(config: SigningNodeConf): string =
+  defaultDataDir("sn", config.loadEth2Network().cfg.name())
+
+proc dataDir*(config: AnyConf): OutDir =
+  config.dataDirFlag.get(OutDir legacyDataDir().valueOr(defaultDataDir(config)))
+
+proc dumpDir(config: AnyConf): string =
   config.dataDir / "dump"
 
-func dumpDirInvalid*(config: AnyConf): string =
+proc dumpDirInvalid*(config: AnyConf): string =
   config.dumpDir / "invalid" # things that failed validation
 
-func dumpDirIncoming*(config: AnyConf): string =
+proc dumpDirIncoming*(config: AnyConf): string =
   config.dumpDir / "incoming" # things that couldn't be validated (missingparent etc)
 
-func dumpDirOutgoing*(config: AnyConf): string =
+proc dumpDirOutgoing*(config: AnyConf): string =
   config.dumpDir / "outgoing" # things we produced
 
 proc createDumpDirs*(config: BeaconNodeConf) =
@@ -1303,16 +1330,16 @@ proc parseCmdArg*(T: type enr.Record, p: string): T {.raises: [ValueError].} =
 func completeCmdArg*(T: type enr.Record, val: string): seq[string] =
   return @[]
 
-func validatorsDir*[Conf](config: Conf): string =
+proc validatorsDir*[Conf](config: Conf): string =
   string config.validatorsDirFlag.get(InputDir(config.dataDir / "validators"))
 
-func secretsDir*[Conf](config: Conf): string =
+proc secretsDir*[Conf](config: Conf): string =
   string config.secretsDirFlag.get(InputDir(config.dataDir / "secrets"))
 
-func walletsDir*(config: BeaconNodeConf): string =
+proc walletsDir*(config: BeaconNodeConf): string =
   string config.walletsDirFlag.get(InputDir(config.dataDir / "wallets"))
 
-func eraDir*(config: BeaconNodeConf): string =
+proc eraDir*(config: BeaconNodeConf): string =
   # The era directory should be shared between networks of the same type..
   string config.eraDirFlag.get(InputDir(config.dataDir / "era"))
 
@@ -1437,38 +1464,12 @@ proc readValue*(r: var TomlReader, a: var WalletName)
   except CatchableError:
     r.raiseUnexpectedValue("string expected")
 
-proc readValue*(r: var TomlReader, a: var Address)
+proc readValue*(r: var TomlReader, a: var Eth1Address)
                {.raises: [SerializationError].} =
   try:
-    a = parseCmdArg(Address, r.readValue(string))
+    a = parseCmdArg(Eth1Address, r.readValue(string))
   except CatchableError:
     r.raiseUnexpectedValue("string expected")
-
-proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
-  const defaultName =
-    when const_preset == "gnosis":
-      "gnosis"
-    elif const_preset == "mainnet":
-      "mainnet"
-    else:
-      "(unspecified)"
-  network_name.set(2, labelValues = [eth2Network.get(otherwise = defaultName)])
-
-  if eth2Network.isSome:
-    getMetadataForNetwork(eth2Network.get)
-  else:
-    when const_preset == "gnosis":
-      getMetadataForNetwork("gnosis")
-    elif const_preset == "mainnet":
-      getMetadataForNetwork("mainnet")
-    else:
-      # Presumably other configurations can have other defaults, but for now
-      # this simplifies the flow
-      fatal "Must specify network on non-mainnet node"
-      quit 1
-
-template loadEth2Network*(config: BeaconNodeConf): Eth2NetworkMetadata =
-  loadEth2Network(config.eth2Network)
 
 func defaultFeeRecipient*(conf: AnyConf): Opt[Eth1Address] =
   if conf.suggestedFeeRecipient.isSome:
@@ -1509,12 +1510,12 @@ func configJwtSecretOpt*(jwtSecret: Option[InputFile]): Opt[InputFile] =
 
 proc loadJwtSecret*(
     rng: var HmacDrbgContext,
-    config: BeaconNodeConf,
+    config: auto,
     allowCreate: bool): Opt[seq[byte]] =
   rng.loadJwtSecret(
     string(config.dataDir), config.jwtSecret.configJwtSecretOpt, allowCreate)
 
-proc engineApiUrls*(config: BeaconNodeConf): seq[EngineApiUrl] =
+proc engineApiUrls*(config: auto): seq[EngineApiUrl] =
   let elUrls = if config.noEl:
     return newSeq[EngineApiUrl]()
   elif config.elUrls.len == 0 and config.web3Urls.len == 0:

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1171,6 +1171,16 @@ proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
 template loadEth2Network*(config: BeaconNodeConf|SigningNodeConf): Eth2NetworkMetadata =
   loadEth2Network(config.eth2Network)
 
+proc shortNetworkName*(eth2Network: Option[string]) =
+  # Given an eth2Network configuration, figure out a good canonical name for the
+  # network that can be used for directories etc.
+  if eth2Network.isSome() and
+      config.eth2Network.get() in
+      ["mainnet", "minimal", "gnosis", "chiado", "hoodi", "holesky", "sepolia"]:
+    eth2Network.get()
+  else:
+    config.loadEth2Network().cfg.name()
+
 proc legacyDataDir*(): Opt[string] =
   let dir =
     getHomeDir() / (
@@ -1188,13 +1198,13 @@ proc legacyDataDir*(): Opt[string] =
     Opt.none(string)
 
 proc defaultDataDir*(config: BeaconNodeConf): string =
-  defaultDataDir("", config.loadEth2Network().cfg.name())
+  defaultDataDir("", config.eth2Network.shortNetworkName())
 
 proc defaultDataDir*(_: ValidatorClientConf): string =
   defaultDataDir("vc", "")
 
 proc defaultDataDir*(config: SigningNodeConf): string =
-  defaultDataDir("sn", config.loadEth2Network().cfg.name())
+  defaultDataDir("sn", config.eth2Network.shortNetworkName())
 
 proc dataDir*(config: AnyConf): OutDir =
   config.dataDirFlag.get(OutDir legacyDataDir().valueOr(defaultDataDir(config)))

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -40,7 +40,7 @@ export
   defs, parseCmdArg, completeCmdArg, network_metadata,
   el_conf, network, BlockHashOrNumber,
   confTomlDefs, confTomlNet, confTomlUri, jsnet,
-  LightClientDataImportMode, slashing_protection_common
+  LightClientDataImportMode, slashing_protection_common, nimbus_binary_common
 
 declareGauge network_name, "network name", ["name"]
 

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1171,15 +1171,15 @@ proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
 template loadEth2Network*(config: BeaconNodeConf|SigningNodeConf): Eth2NetworkMetadata =
   loadEth2Network(config.eth2Network)
 
-proc shortNetworkName*(eth2Network: Option[string]) =
+proc shortNetworkName*(eth2Network: Option[string]): string =
   # Given an eth2Network configuration, figure out a good canonical name for the
   # network that can be used for directories etc.
   if eth2Network.isSome() and
-      config.eth2Network.get() in
+      eth2Network.get() in
       ["mainnet", "minimal", "gnosis", "chiado", "hoodi", "holesky", "sepolia"]:
     eth2Network.get()
   else:
-    config.loadEth2Network().cfg.name()
+    eth2Network.loadEth2Network().cfg.name()
 
 proc legacyDataDir*(): Opt[string] =
   let dir =

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -148,7 +148,7 @@ type LightClientConf* = object
     name: "debug-stop-at-epoch" .}: uint64
 
 proc defaultDataDir*(config: LightClientConf): string =
-  defaultDataDir("", config.eth2Network.loadEth2Network().cfg.name())
+  defaultDataDir("", config.eth2Network.shortNetworkName())
 
 proc dataDir*(config: LightClientConf): OutDir =
   config.dataDirFlag.get(OutDir legacyDataDir().valueOr(defaultDataDir(config)))

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -9,7 +9,7 @@
 
 import
   json_serialization/std/net,
-  ./conf
+  ./conf, ./nimbus_binary_common
 
 export net, conf
 
@@ -37,12 +37,11 @@ type LightClientConf* = object
     name: "log-file" .}: Option[OutFile]
 
   # Storage
-  dataDir* {.
+  dataDirFlag* {.
     desc: "The directory where nimbus will store all blockchain data"
-    defaultValue: config.defaultDataDir()
-    defaultValueDesc: ""
+    defaultValueDesc: defaultDataDir("", "<network>")
     abbr: "d"
-    name: "data-dir" .}: OutDir
+    name: "data-dir" .}: Option[OutDir]
 
   # Network
   eth2Network* {.
@@ -149,22 +148,11 @@ type LightClientConf* = object
     defaultValue: 0
     name: "debug-stop-at-epoch" .}: uint64
 
+proc defaultDataDir*(config: LightClientConf): string =
+  defaultDataDir("", config.eth2Network.loadEth2Network().cfg.name())
+
+proc dataDir*(config: LightClientConf): OutDir =
+  config.dataDirFlag.get(OutDir legacyDataDir().valueOr(defaultDataDir(config)))
+
 template databaseDir*(config: LightClientConf): string =
   config.dataDir.databaseDir
-
-template loadJwtSecret*(
-    rng: var HmacDrbgContext,
-    config: LightClientConf,
-    allowCreate: bool): Option[seq[byte]] =
-  rng.loadJwtSecret(string(config.dataDir), config.jwtSecret, allowCreate)
-
-proc engineApiUrls*(config: LightClientConf): seq[EngineApiUrl] =
-  let elUrls = if config.noEl:
-    return newSeq[EngineApiUrl]()
-  elif config.elUrls.len == 0 and config.web3Urls.len == 0:
-    @[getDefaultEngineApiUrl(config.jwtSecret)]
-  else:
-    config.elUrls
-
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(
-    config.jwtSecret.configJwtSecretOpt)

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -39,7 +39,6 @@ type LightClientConf* = object
   # Storage
   dataDirFlag* {.
     desc: "The directory where nimbus will store all blockchain data"
-    defaultValueDesc: defaultDataDir("", "<network>")
     abbr: "d"
     name: "data-dir" .}: Option[OutDir]
 

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -8,22 +8,17 @@
 {.push raises: [], gcsafe.}
 
 import
-  chronicles, chronos, web3/[primitives, engine_api_types],
+  chronicles, chronos,
   ../spec/datatypes/base,
   ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
   ../el/el_manager,
   ../beacon_clock,
   ./common_tools
 
-from ../el/engine_api_conversions import asBlockHash
 from ../spec/beaconstate import
-  get_expected_withdrawals, has_eth1_withdrawal_credential
-from ../spec/datatypes/capella import Withdrawal
+  get_expected_withdrawals
 from ../spec/eth2_apis/dynamic_fee_recipients import
   DynamicFeeRecipientsStore, getDynamicFeeRecipient
-from ../validators/keystore_management import
-  KeymanagerHost, getPerValidatorDefaultFeeRecipient, getSuggestedFeeRecipient,
-  getSuggestedGasLimit
 from ../validators/action_tracker import ActionTracker, getNextProposalSlot
 
 logScope: topics = "cman"

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -229,14 +229,14 @@ func get_attesting_indices_one*(shufflingRef: ShufflingRef,
                                 slot: Slot,
                                 committee_index: CommitteeIndex,
                                 bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits):
-                                  Option[ValidatorIndex] =
+                                  Opt[ValidatorIndex] =
   # A variation on get_attesting_indices that returns the validator index only
   # if only one validator index is set
-  var res = none(ValidatorIndex)
+  var res = Opt.none(ValidatorIndex)
   for validator_index in get_attesting_indices(
       shufflingRef, slot, committee_index, bits):
-    if res.isSome(): return none(ValidatorIndex)
-    res = some(validator_index)
+    if res.isSome(): return Opt.none(ValidatorIndex)
+    res = Opt.some(validator_index)
   res
 
 func get_attesting_indices_one*(shufflingRef: ShufflingRef,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1960,6 +1960,76 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
 
   return false
 
+proc runSlotLoop(node: BeaconNode, startTime: BeaconTime) {.async.} =
+  var
+    curSlot = startTime.slotOrZero()
+    nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
+    timeToNextSlot = nextSlot.start_beacon_time() - startTime
+
+  info "Scheduling first slot action",
+    startTime = shortLog(startTime),
+    nextSlot = shortLog(nextSlot),
+    timeToNextSlot = shortLog(timeToNextSlot)
+
+  while true:
+    # Start by waiting for the time when the slot starts. Sleeping relinquishes
+    # control to other tasks which may or may not finish within the allotted
+    # time, so below, we need to be wary that the ship might have sailed
+    # already.
+    await sleepAsync(timeToNextSlot)
+
+    let
+      wallTime = node.beaconClock.now()
+      wallSlot = wallTime.slotOrZero() # Always > GENESIS!
+
+    if wallSlot < nextSlot:
+      # While we were sleeping, the system clock changed and time moved
+      # backwards!
+      if wallSlot + 1 < nextSlot:
+        # This is a critical condition where it's hard to reason about what
+        # to do next - we'll call the attention of the user here by shutting
+        # down.
+        fatal "System time adjusted backwards significantly - clock may be inaccurate - shutting down",
+          nextSlot = shortLog(nextSlot), wallSlot = shortLog(wallSlot)
+        ProcessState.scheduleStop("clock skew")
+        return
+
+      # Time moved back by a single slot - this could be a minor adjustment,
+      # for example when NTP does its thing after not working for a while
+      warn "System time adjusted backwards, rescheduling slot actions",
+        wallTime = shortLog(wallTime),
+        nextSlot = shortLog(nextSlot),
+        wallSlot = shortLog(wallSlot)
+
+      # cur & next slot remain the same
+      timeToNextSlot = nextSlot.start_beacon_time() - wallTime
+      continue
+
+    if wallSlot > nextSlot + SLOTS_PER_EPOCH:
+      # Time moved forwards by more than an epoch - either the clock was reset
+      # or we've been stuck in processing for a long time - either way, we will
+      # skip ahead so that we only process the events of the last
+      # SLOTS_PER_EPOCH slots
+      warn "Time moved forwards by more than an epoch, skipping ahead",
+        curSlot = shortLog(curSlot),
+        nextSlot = shortLog(nextSlot),
+        wallSlot = shortLog(wallSlot)
+
+      curSlot = wallSlot - SLOTS_PER_EPOCH
+    elif wallSlot > nextSlot:
+      notice "Missed expected slot start, catching up",
+        delay = shortLog(wallTime - nextSlot.start_beacon_time()),
+        curSlot = shortLog(curSlot),
+        nextSlot = shortLog(curSlot)
+
+    let breakLoop = await onSlotStart(node, wallTime, curSlot)
+    if breakLoop:
+      break
+
+    curSlot = wallSlot
+    nextSlot = wallSlot + 1
+    timeToNextSlot = nextSlot.start_beacon_time() - node.beaconClock.now()
+
 proc onSecond(node: BeaconNode, time: Moment) =
   # Nim GC metrics (for the main thread)
   updateThreadMetrics()
@@ -2251,7 +2321,7 @@ proc run(node: BeaconNode) {.raises: [CatchableError].} =
     asyncSpawn node.pollForDynamicValidators(
       web3signerUrl, node.config.web3signerUpdateInterval)
 
-  asyncSpawn runSlotLoop(node, wallTime, onSlotStart)
+  asyncSpawn runSlotLoop(node, wallTime)
   asyncSpawn runOnSecondLoop(node)
   asyncSpawn runQueueProcessingLoop(node.blockProcessor)
   asyncSpawn runKeystoreCachePruningLoop(node.keystoreCache)
@@ -2688,7 +2758,8 @@ proc main() {.noinline, raises: [CatchableError].} =
     if config.runAsService:
       proc exitService() =
         ProcessState.scheduleStop("exitService")
-      establishWindowsService(clientId, copyrights, nimBanner, SPEC_VERSION,
+      establishWindowsService(clientId,
+                              ["Ethereum consensus spec v" & SPEC_VERSION],
                               "nimbus_beacon_node", BeaconNodeConf,
                               handleStartUpCmd, exitService)
     else:

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -7,11 +7,11 @@
 
 {.push raises: [].}
 
-# Common routines for a BeaconNode and a ValidatorClient
+# Utilities common across several nimbus binaries (BN/VC/EC/Portal/etc)
 
 import
   # Standard library
-  std/[tables, terminal, typetraits],
+  std/[os, tables, terminal, typetraits],
 
   # Nimble packages
   chronos, confutils, presto, toml_serialization, metrics,
@@ -19,34 +19,27 @@ import
   stew/io2, metrics/chronos_httpserver,
 
   # Local modules
-  ./spec/[helpers, keystore],
-  ./spec/datatypes/base,
-  ./[beacon_clock, conf, process_state, version]
+  ./spec/keystore,
+  ./buildinfo
 
 when defaultChroniclesStream.outputs.type.arity == 2:
-  from std/os import commandLineParams, getEnv, splitFile
   from ./filepath import secureCreatePath
 
   import stew/staticfor
-else:
-  from std/os import commandLineParams, getEnv
 
 when defined(posix):
   import termios
 
-declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version", "commit"], name = "version"
-versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])
-
-declareGauge nimVersionGauge, "Nim version info", ["version", "nim_commit"], name = "nim_version"
-nimVersionGauge.set(1, labelValues=[NimVersion, getNimGitHash()])
-
 export
-  confutils, toml_serialization, beacon_clock, conf
-
+  confutils, toml_serialization
 
 type
-  SlotStartProc*[T] = proc(node: T, wallTime: BeaconTime,
-                           lastSlot: Slot): Future[bool] {.gcsafe, raises: [].}
+  StdoutLogKind* {.pure.} = enum
+    Auto = "auto"
+    Colors = "colors"
+    NoColors = "nocolors"
+    Json = "json"
+    None = "none"
 
 proc updateLogLevel*(logLevel: string) {.raises: [ValueError].} =
   # Updates log levels (without clearing old ones)
@@ -166,13 +159,13 @@ proc setupLogging*(
     quit 1
 
 proc makeBannerAndConfig*(
-    clientId, copyright, banner, specVersion: string,
+    helpBanner: string, versions: openArray[string],
     environment: openArray[string],
     ConfType: type,
 ): Result[ConfType, string] =
   let
-    spec = "eth2 specification v" & specVersion
-    version = clientId & "\p" & copyright & "\p\p" & spec & "\p\p" & banner
+    version = helpBanner & "\p" & copyrights & "\p\p" & (@versions & @[nimBanner()]).join("\p")
+
     cmdLine =
       if len(environment) == 0:
         commandLineParams()
@@ -183,8 +176,8 @@ proc makeBannerAndConfig*(
   let config =
     try:
       ConfType.load(
-        version = version, # but a short version string makes more sense...
-        copyrightBanner = clientId,
+        version = version, # what --version outputs
+        copyrightBanner = helpBanner, # what is shown on top of --help
         cmdLine = cmdLine,
         secondarySources = proc(
             config: ConfType, sources: ref SecondarySources
@@ -212,8 +205,10 @@ proc makeBannerAndConfig*(
   {.pop.}
   ok(config)
 
-template makeBannerAndConfig*(clientId: string, ConfType: type): auto =
-  makeBannerAndConfig(clientId, copyrights, nimbanner, SPEC_VERSION, [], ConfType).valueOr:
+template makeBannerAndConfig*(helpBanner: string, ConfType: type): auto =
+  makeBannerAndConfig(
+    helpBanner, ["Ethereum consensus spec v" & SPEC_VERSION], [], ConfType
+  ).valueOr:
     try:
       stderr.write(error)
     except IOError:
@@ -254,87 +249,10 @@ proc runKeystoreCachePruningLoop*(cache: KeystoreCacheRef) {.async.} =
     if exitLoop: break
     cache.pruneExpiredKeys()
 
-proc sleepAsync*(t: TimeDiff): Future[void] =
-  sleepAsync(nanoseconds(
-    if t.nanoseconds < 0: 0'i64 else: t.nanoseconds))
-
-proc sleepAsync2*(t: TimeDiff): Future[void] {.
+proc sleepAsync*(t: TimeDiff): Future[void] {.
      async: (raises: [CancelledError], raw: true).} =
   sleepAsync(nanoseconds(
     if t.nanoseconds < 0: 0'i64 else: t.nanoseconds))
-
-proc runSlotLoop*[T](node: T, startTime: BeaconTime,
-                     slotProc: SlotStartProc[T]) {.async.} =
-  var
-    curSlot = startTime.slotOrZero()
-    nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
-    timeToNextSlot = nextSlot.start_beacon_time() - startTime
-
-  info "Scheduling first slot action",
-    startTime = shortLog(startTime),
-    nextSlot = shortLog(nextSlot),
-    timeToNextSlot = shortLog(timeToNextSlot)
-
-  while true:
-    # Start by waiting for the time when the slot starts. Sleeping relinquishes
-    # control to other tasks which may or may not finish within the allotted
-    # time, so below, we need to be wary that the ship might have sailed
-    # already.
-    await sleepAsync(timeToNextSlot)
-
-    let
-      wallTime = node.beaconClock.now()
-      wallSlot = wallTime.slotOrZero() # Always > GENESIS!
-
-    if wallSlot < nextSlot:
-      # While we were sleeping, the system clock changed and time moved
-      # backwards!
-      if wallSlot + 1 < nextSlot:
-        # This is a critical condition where it's hard to reason about what
-        # to do next - we'll call the attention of the user here by shutting
-        # down.
-        fatal "System time adjusted backwards significantly - clock may be inaccurate - shutting down",
-          nextSlot = shortLog(nextSlot),
-          wallSlot = shortLog(wallSlot)
-        ProcessState.scheduleStop("clock skew")
-        return
-
-      # Time moved back by a single slot - this could be a minor adjustment,
-      # for example when NTP does its thing after not working for a while
-      warn "System time adjusted backwards, rescheduling slot actions",
-        wallTime = shortLog(wallTime),
-        nextSlot = shortLog(nextSlot),
-        wallSlot = shortLog(wallSlot)
-
-      # cur & next slot remain the same
-      timeToNextSlot = nextSlot.start_beacon_time() - wallTime
-      continue
-
-    if wallSlot > nextSlot + SLOTS_PER_EPOCH:
-      # Time moved forwards by more than an epoch - either the clock was reset
-      # or we've been stuck in processing for a long time - either way, we will
-      # skip ahead so that we only process the events of the last
-      # SLOTS_PER_EPOCH slots
-      warn "Time moved forwards by more than an epoch, skipping ahead",
-        curSlot = shortLog(curSlot),
-        nextSlot = shortLog(nextSlot),
-        wallSlot = shortLog(wallSlot)
-
-      curSlot = wallSlot - SLOTS_PER_EPOCH
-
-    elif wallSlot > nextSlot:
-        notice "Missed expected slot start, catching up",
-          delay = shortLog(wallTime - nextSlot.start_beacon_time()),
-          curSlot = shortLog(curSlot),
-          nextSlot = shortLog(curSlot)
-
-    let breakLoop = await slotProc(node, wallTime, curSlot)
-    if breakLoop:
-      break
-
-    curSlot = wallSlot
-    nextSlot = wallSlot + 1
-    timeToNextSlot = nextSlot.start_beacon_time() - node.beaconClock.now()
 
 proc init*(T: type RestServerRef,
            ip: IpAddress,
@@ -342,7 +260,7 @@ proc init*(T: type RestServerRef,
            allowedOrigin: Option[string],
            validateFn: PatternCallback,
            ident: string,
-           config: AnyConf): T =
+           config: auto): T =
   let
     address = initTAddress(ip, port)
     serverFlags = {HttpServerFlags.QueryCommaSeparatedArray,
@@ -380,7 +298,7 @@ type
     token*: string
 
 proc initKeymanagerServer*(
-    config: AnyConf,
+    config: auto,
     existingRestServer: RestServerRef = nil): KeymanagerInitResult
     {.raises: [].} =
 
@@ -405,7 +323,7 @@ proc initKeymanagerServer*(
       fatal "The keymanager token should not be empty", tokenFilePath
       quit 1
 
-    when config is BeaconNodeConf:
+    when compiles(config.restPort):
       if existingRestServer != nil and
          config.restAddress == config.keymanagerAddress and
         config.restPort == config.keymanagerPort:
@@ -428,7 +346,7 @@ proc initKeymanagerServer*(
   KeymanagerInitResult(server: keymanagerServer, token: token)
 
 proc initMetricsServer*(
-    config: AnyConf
+    config: auto
 ): Future[Result[Opt[MetricsHttpServerRef], string]] {.
   async: (raises: [CancelledError]).} =
   if config.metricsEnabled:
@@ -478,3 +396,41 @@ proc quitSlashing*() =
 
   const QuitSlashing = 198
   quit QuitSlashing
+
+proc defaultDataDir*(namespace, network: string): string =
+  ## Return the location to use by default for the given network - since
+  ## each network has its own blocks and configuration, separate the data
+  ## directories by chain to keep things simple.
+  ##
+  ## Namespace is for separating applications by namespace, ie when they don't
+  ## support sharing data directory - in particular, the validator client,
+  ## signing node and beacon node must use separate folders or they risk loading
+  ## the same keys!
+  ##
+  ## In theory, things like private keys could be shared between testnets and
+  ## mainnet, but this amounts to reusing the same keys for both environments
+  ## which seems dubious at best, security-wise.
+
+  let
+    base =
+      when defined(windows):
+        # Avoid roaming profile since DB is large
+        os.getEnv("LOCALAPPDATA", os.getEnv("APPDATA"))
+      elif defined(macos) or defined(macosx):
+        # Everything goes in here on mac
+        os.getHomeDir() / "Library/Application Support"
+      else:
+        # https://specifications.freedesktop.org/basedir-spec/0.8/#variables
+        os.getEnv("XDG_STATE_HOME", os.getEnv("HOME") / ".local/state")
+
+    nimbus = when defined(linux): "nimbus" else: "Nimbus"
+
+  var dir = base / nimbus
+
+  if namespace.len > 0:
+    dir = dir / namespace
+
+  if network.len > 0:
+    dir = dir / network
+
+  dir

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -16,7 +16,10 @@ import
   ./networking/[topic_params, network_metadata_downloads],
   ./spec/beaconstate,
   ./spec/datatypes/[phase0, altair, bellatrix, capella, deneb],
-  ./[filepath, light_client, light_client_db, nimbus_binary_common, process_state, version]
+  ./[
+    beacon_clock, buildinfo, filepath, light_client, light_client_db,
+    nimbus_binary_common, process_state, version,
+  ]
 
 from ./gossip_processing/block_processor import newExecutionPayload
 from ./gossip_processing/eth2_processor import toValidationResult

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -123,7 +123,7 @@ proc new(t: typedesc[SigningNodeRef], config: SigningNodeConf): SigningNodeRef =
       elif config.eth2Network == some("gnosis"):
         Version [byte 0x00, 0x00, 0x00, 0x64]
       else:
-        loadEth2Network(config.eth2Network).cfg.GENESIS_FORK_VERSION
+        config.loadEth2Network().cfg.GENESIS_FORK_VERSION
 
   when declared(waitSignal):
     SigningNodeRef(

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1241,7 +1241,7 @@ proc checkedWaitForSlot*(vc: ValidatorClientRef, destinationSlot: Slot,
     time_to_slot = shortLog(timeToSlot)
 
   while true:
-    await sleepAsync2(timeToSlot)
+    await sleepAsync(timeToSlot)
 
     let
       wallTime = vc.beaconClock.now()

--- a/beacon_chain/version.nim
+++ b/beacon_chain/version.nim
@@ -10,41 +10,16 @@
 ## This module implements the version tagging details of all binaries included
 ## in the Nimbus release process (i.e. beacon_node, validator_client, etc)
 
-import std/[strutils, compilesettings]
+import std/strutils, metrics, ./buildinfo
 
 const
-  compileYear = CompileDate[0 ..< 4]  # YYYY-MM-DD (UTC)
-  copyrights* =
-    "Copyright (c) 2019-" & compileYear & " Status Research & Development GmbH"
-
   versionMajor* = 25
   versionMinor* = 7
   versionBuild* = 1
 
   versionBlob* = "stateofus" # Single word - ends up in the default graffiti
 
-  ## You can override this if you are building the
-  ## sources outside the git tree of Nimbus:
-  git_revision_override* {.strdefine.} =
-    when querySetting(SingleValueSetting.command) == "check":
-      # The staticExec call below returns an empty string
-      # when `nim check` is used and this leads to a faux
-      # compile-time error.
-      # We work-around the problem with this override and
-      # save some time in executing the external command.
-      "123456"
-    else:
-      ""
-
-  gitRevisionLong* = when git_revision_override.len == 0:
-    staticExec "git rev-parse --short HEAD"
-  else:
-    git_revision_override
-
-  gitRevision* = strip(gitRevisionLong)[0..5]
-
-  nimFullBanner* = staticExec("nim --version")
-  nimBanner* = staticExec("nim --version | grep Version")
+  gitRevision* = strip(buildinfo.GitRevision)[0..5]
 
   versionAsStr* =
     $versionMajor & "." & $versionMinor & "." & $versionBuild
@@ -53,19 +28,5 @@ const
 
   nimbusAgentStr* = "Nimbus/" & fullVersionStr
 
-func getNimGitHash*(): string =
-  const gitPrefix = "git hash: "
-  let tmp = splitLines(nimFullBanner)
-  if tmp.len == 0:
-    return
-  for line in tmp:
-    if line.startsWith(gitPrefix) and line.len > 8 + gitPrefix.len:
-      result = line[gitPrefix.len..<gitPrefix.len + 8]
-
-func shortNimBanner*(): string =
-  let gitHash = getNimGitHash()
-  let tmp = splitLines(nimFullBanner)
-  if gitHash.len > 0:
-    tmp[0] & " (" & gitHash & ")"
-  else:
-    tmp[0]
+declareGauge versionGauge, "Nimbus version info (as metric labels)", ["version", "commit"], name = "version"
+versionGauge.set(1, labelValues=[fullVersionStr, gitRevision])

--- a/beacon_chain/winservice.nim
+++ b/beacon_chain/winservice.nim
@@ -106,10 +106,8 @@ when defined(windows):
   proc reportServiceStatusSuccess*() =
     reportServiceStatus(SERVICE_RUNNING, NO_ERROR, 0)
 
-  template establishWindowsService*(argClientId,
-                                    argCopyrights,
-                                    argNimBanner,
-                                    argSpecVersion,
+  template establishWindowsService*(argHelpBanner: string,
+                                    argVersions: openArray[string],
                                     argServiceName: string,
                                     argConfigType: untyped,
                                     argEntryPoint: untyped,
@@ -150,8 +148,7 @@ when defined(windows):
         reportServiceStatus(SERVICE_STOPPED, ERROR_INVALID_PARAMETER, 0)
         quit QuitFailure
 
-      var config = makeBannerAndConfig(argClientId, argCopyrights,
-                                       argNimBanner, argSpecVersion,
+      var config = makeBannerAndConfig(argHelpBanner, argVersions,
                                        environment, argConfigType).valueOr:
         reportServiceStatus(SERVICE_STOPPED, ERROR_BAD_CONFIGURATION, 0)
         quit QuitFailure

--- a/ncli/ncli_split_keystore.nim
+++ b/ncli/ncli_split_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -25,9 +25,7 @@ type
       name: "remote-signer" }: seq[string]
 
     dataDir {.
-      defaultValue: config.defaultDataDir()
-      defaultValueDesc: ""
-      desc: "A Nimbus data directory"
+      desc: "A directory containing validators and secrets"
       name: "data-dir" }: InputDir
 
     validatorsDirFlag* {.


### PR DESCRIPTION
Running `nimbus_xxx` without `--data-dir` currently results in the data directories colliding, for several reaons:

* Beacon node, validator client and signing node all use the same validator folders derived from the data directory - this means that when running either of those processes together based on defaults, the processes will attempt to load the same keys which is a bad idea - separating the folders by namespace gives an extra layer of safety
* Running with `--network` and without `--data-dir` fails due to incompatible databases - adding the network name helps keep each network separate

This change only affects the defaults - an explicit `--data-dir` continues to work as it did before. Also, if the legacy folder exists, it will be used in preference over the new structure.

While we're here, we also take the opportunity to:

* use `LocalAppData` on Windows, to avoid roaming the blockchain database
* use `XDG_STATE_HOME` on linux, in line with XDG spec 0.8 (2021)
* rework `nimbus_binary_common` to reduce eth2-specific quirks such that it can be reused in non-eth2 binaries
* clean up after VC stopped using `runSlotLoop`
* improve compatibilty for out-of-git builds when fetching git revision