### PR TITLE
initial Gloas fork infrastructure

### DIFF
--- a/ConsensusSpecPreset-mainnet.md
+++ b/ConsensusSpecPreset-mainnet.md
@@ -3432,7 +3432,6 @@ ConsensusSpecPreset-mainnet
 ## EF - Merkle proof [Preset: mainnet]
 ```diff
   Merkle proof - Single merkle proof - eip7805                                               Skip
-  Merkle proof - Single merkle proof - gloas                                                 Skip
 + Merkle proof - Single merkle proof - mainnet/deneb/merkle_proof/single_merkle_proof/Beacon OK
 + Merkle proof - Single merkle proof - mainnet/deneb/merkle_proof/single_merkle_proof/Beacon OK
 + Merkle proof - Single merkle proof - mainnet/deneb/merkle_proof/single_merkle_proof/Beacon OK

--- a/ConsensusSpecPreset-minimal.md
+++ b/ConsensusSpecPreset-minimal.md
@@ -3695,7 +3695,6 @@ ConsensusSpecPreset-minimal
 ## EF - Merkle proof [Preset: minimal]
 ```diff
   Merkle proof - Single merkle proof - eip7805                                               Skip
-  Merkle proof - Single merkle proof - gloas                                                 Skip
 + Merkle proof - Single merkle proof - minimal/deneb/merkle_proof/single_merkle_proof/Beacon OK
 + Merkle proof - Single merkle proof - minimal/deneb/merkle_proof/single_merkle_proof/Beacon OK
 + Merkle proof - Single merkle proof - minimal/deneb/merkle_proof/single_merkle_proof/Beacon OK

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -519,6 +519,8 @@ proc new*(T: type BeaconChainDB,
     if db.exec("DROP TABLE IF EXISTS ``;").isErr:
       debug "Failed to drop the `` table"
 
+  debugGloasComment "use actual names when closer"
+
   var
     genesisDepositsSeq =
       DbSeq[DepositData].init(db, "genesis_deposits").expectDb()
@@ -537,6 +539,10 @@ proc new*(T: type BeaconChainDB,
       if cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
         kvStore db.openKvStore("fulu_blocks").expectDb()
       else:
+        nil,
+      if cfg.GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        kvStore db.openKvStore("foobar_not_real_name").expectDb()
+      else:
         nil
     ]
 
@@ -551,6 +557,10 @@ proc new*(T: type BeaconChainDB,
       kvStore db.openKvStore("electra_state_no_validator_pubkeys").expectDb(),
       if cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
         kvStore db.openKvStore("fulu_state_no_validator_pubkeys").expectDb()
+      else:
+        nil,
+      if cfg.GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        kvStore db.openKvStore("more_intentional_gibberish___").expectDb()
       else:
         nil
     ]
@@ -866,7 +876,9 @@ proc updateImmutableValidators*(
     db.immutableValidators.add immutableValidator
 
 template BeaconStateNoImmutableValidators(kind: static ConsensusFork): auto =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    typedesc[GloasBeaconStateNoImmutableValidators]
+  elif kind == ConsensusFork.Fulu:
     typedesc[FuluBeaconStateNoImmutableValidators]
   elif kind == ConsensusFork.Electra:
     typedesc[ElectraBeaconStateNoImmutableValidators]

--- a/beacon_chain/beacon_chain_db_immutable.nim
+++ b/beacon_chain/beacon_chain_db_immutable.nim
@@ -506,3 +506,91 @@ type
     # [New in Fulu:EIP7917]
     proposer_lookahead*:
         HashArray[Limit ((MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH), uint64]
+
+  # Memory-representation-equivalent to a Fulu BeaconState for in-place SSZ
+  # reading and writing
+  GloasBeaconStateNoImmutableValidators* = object
+    # Versioning
+    genesis_time*: uint64
+    genesis_validators_root*: Eth2Digest
+    slot*: Slot
+    fork*: Fork
+
+    # History
+    latest_block_header*: BeaconBlockHeader
+      ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
+
+    state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+      ## Frozen in Capella, replaced by historical_summaries
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*:
+      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_deposit_index*: uint64
+
+    # Registry
+    validators*:
+      HashList[ValidatorStatusCapella, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Randomness
+    randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
+
+    # Slashings
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]
+      ## Per-epoch sums of slashed effective balances
+
+    # Participation
+    previous_epoch_participation*: EpochParticipationFlags
+    current_epoch_participation*: EpochParticipationFlags
+
+    # Finality
+    justification_bits*: JustificationBits
+      ## Bit set for every recent justified epoch
+
+    previous_justified_checkpoint*: Checkpoint
+    current_justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
+    # Inactivity
+    inactivity_scores*: HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Light client sync committees
+    current_sync_committee*: SyncCommittee
+    next_sync_committee*: SyncCommittee
+
+    # Execution
+    latest_execution_payload_header*: fulu.ExecutionPayloadHeader
+
+    # Withdrawals
+    next_withdrawal_index*: WithdrawalIndex
+    next_withdrawal_validator_index*: uint64
+
+    # Deep history valid from Capella onwards
+    historical_summaries*:
+      HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT]
+
+    deposit_requests_start_index*: uint64  # [New in Electra:EIP6110]
+    deposit_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    exit_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    earliest_exit_epoch*: Epoch  # [New in Electra:EIP7251]
+    consolidation_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    earliest_consolidation_epoch*: Epoch  # [New in Electra:EIP7251]
+    pending_deposits*: HashList[PendingDeposit, Limit PENDING_DEPOSITS_LIMIT]
+      ## [New in Electra:EIP7251]
+
+    # [New in Electra:EIP7251]
+    pending_partial_withdrawals*:
+      HashList[PendingPartialWithdrawal, Limit PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+    pending_consolidations*:
+      HashList[PendingConsolidation, Limit PENDING_CONSOLIDATIONS_LIMIT]
+      ## [New in Electra:EIP7251]
+
+    # [New in Fulu:EIP7917]
+    proposer_lookahead*:
+        HashArray[Limit ((MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH), uint64]

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -42,7 +42,9 @@ proc initLightClient*(
         signedBlock: ForkedSignedBeaconBlock
     ): Future[void] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Bellatrix:
+        when consensusFork == ConsensusFork.Gloas:
+          debugGloasComment ""
+        elif consensusFork >= ConsensusFork.Bellatrix:
           if forkyBlck.message.is_execution_block:
             template payload(): auto = forkyBlck.message.body.execution_payload
             if not payload.block_hash.isZero:
@@ -181,11 +183,13 @@ proc updateLightClientFromDag*(node: BeaconNode) =
     return
   var header: ForkedLightClientHeader
   withBlck(bdata):
-    const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
-    when lcDataFork > LightClientDataFork.None:
-      header = ForkedLightClientHeader.init(
-        forkyBlck.toLightClientHeader(lcDataFork))
-    else: raiseAssert "Unreachable"
+    debugGloasComment ""
+    when consensusFork != ConsensusFork.Gloas:
+      const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
+      when lcDataFork > LightClientDataFork.None:
+        header = ForkedLightClientHeader.init(
+          forkyBlck.toLightClientHeader(lcDataFork))
+      else: raiseAssert "Unreachable"
   let current_sync_committee = block:
     let tmpState = assignClone(node.dag.headState)
     node.dag.currentSyncCommitteeForPeriod(tmpState[], dagPeriod).valueOr:

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -18,6 +18,9 @@ import
   ../fork_choice/fork_choice,
   ../beacon_clock
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 from std/algorithm import sort
 from std/sequtils import keepItIf, maxIndex
 
@@ -169,7 +172,10 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
             unrealized =
               if blckRef == dag.head:
                 withState(dag.headState):
-                  when consensusFork >= ConsensusFork.Altair:
+                  debugGloasComment ""
+                  when consensusFork == ConsensusFork.Gloas:
+                    default(FinalityCheckpoints)
+                  elif consensusFork >= ConsensusFork.Altair:
                     forkyState.data.compute_unrealized_finality()
                   else:
                     var cache: StateCache
@@ -1096,7 +1102,8 @@ proc getElectraAttestationsForBlock*(
     pool: var AttestationPool, state: ForkedHashedBeaconState,
     cache: var StateCache): seq[electra.Attestation] =
   withState(state):
-    when consensusFork >= ConsensusFork.Electra:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Electra and consensusFork != ConsensusFork.Gloas:
       pool.getAttestationsForBlock(forkyState, cache)
     else:
       default(seq[electra.Attestation])

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -16,6 +16,9 @@ import
   "."/[block_pools_types, block_dag, blockchain_dag,
        blockchain_dag_light_client]
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 export results, signatures_batch, block_dag, blockchain_dag
 
 # Clearance
@@ -100,7 +103,10 @@ proc addResolvedHeadBlock(
   # notifications for parents happens before those of the children
   if onBlockAdded != nil:
     let unrealized = withState(state):
-      when consensusFork >= ConsensusFork.Altair:
+      when consensusFork == ConsensusFork.Gloas:
+        debugGloasComment ""
+        default(FinalityCheckpoints)
+      elif consensusFork >= ConsensusFork.Altair:
         forkyState.data.compute_unrealized_finality()
       else:
         forkyState.data.compute_unrealized_finality(cache)
@@ -453,7 +459,9 @@ proc addBackfillBlock*(
   ok()
 
 template BlockAdded(kind: static ConsensusFork): untyped =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    OnGloasBlockAdded
+  elif kind == ConsensusFork.Fulu:
     OnFuluBlockAdded
   elif kind == ConsensusFork.Electra:
     OnElectraBlockAdded

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -11,6 +11,9 @@ import
   chronicles,
   ../spec/forks
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 export chronicles, forks
 
 type
@@ -71,7 +74,8 @@ func init*(
           capella.SomeBeaconBlock | capella.TrustedBeaconBlock |
           deneb.SomeBeaconBlock | deneb.TrustedBeaconBlock |
           electra.SomeBeaconBlock | electra.TrustedBeaconBlock |
-          fulu.SomeBeaconBlock | fulu.TrustedBeaconBlock): BlockRef =
+          fulu.SomeBeaconBlock | fulu.TrustedBeaconBlock |
+          gloas.SomeBeaconBlock | gloas.TrustedBeaconBlock): BlockRef =
   BlockRef.init(
     root, Opt.some blck.body.execution_payload.block_hash,
     executionValid =

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -19,8 +19,8 @@ import
   ../validators/validator_monitor,
   ./block_dag, block_pools_types_light_client
 
-from ../spec/datatypes/capella import TrustedSignedBeaconBlock
-from ../spec/datatypes/deneb import TrustedSignedBeaconBlock
+debugGloasComment ""
+import ../spec/datatypes/gloas
 
 from "."/vanity_logs/vanity_logs import LogProc, VanityLogs
 
@@ -312,11 +312,12 @@ type
   OnDenebBlockAdded* = OnBlockAdded[deneb.TrustedSignedBeaconBlock]
   OnElectraBlockAdded* = OnBlockAdded[electra.TrustedSignedBeaconBlock]
   OnFuluBlockAdded* = OnBlockAdded[fulu.TrustedSignedBeaconBlock]
+  OnGloasBlockAdded* = OnBlockAdded[gloas.TrustedSignedBeaconBlock]
 
   OnForkyBlockAdded* =
     OnPhase0BlockAdded | OnAltairBlockAdded | OnBellatrixBlockAdded |
     OnCapellaBlockAdded | OnDenebBlockAdded | OnElectraBlockAdded |
-    OnFuluBlockAdded
+    OnFuluBlockAdded | OnGloasBlockAdded
 
   OnForkedBlockAdded* = proc(
     blckRef: BlockRef, blck: ForkedTrustedSignedBeaconBlock, epochRef: EpochRef,
@@ -359,7 +360,9 @@ type
     block_root* {.serializedFieldName: "block".}: Eth2Digest
 
 template OnBlockAddedCallback*(kind: static ConsensusFork): auto =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    typedesc[OnGloasBlockAdded]
+  elif kind == ConsensusFork.Fulu:
     typedesc[OnFuluBlockAdded]
   elif kind == ConsensusFork.Electra:
     typedesc[OnElectraBlockAdded]

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -17,6 +17,9 @@ import
   ".."/[beacon_chain_db, beacon_clock, era_db],
   "."/[block_pools_types, block_quarantine]
 
+debugGloasComment "..."
+import ../spec/datatypes/gloas
+
 export
   eth2_merkleization, eth2_ssz_serialization,
   block_pools_types, results, beacon_chain_db
@@ -266,8 +269,11 @@ proc getForkedBlock*(db: BeaconChainDB, root: Eth2Digest):
     Opt[ForkedTrustedSignedBeaconBlock] =
   # When we only have a digest, we don't know which fork it's from so we try
   # them one by one - this should be used sparingly
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
-  if (let blck = db.getBlock(root, fulu.TrustedSignedBeaconBlock);
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  if   (let blck = db.getBlock(root, gloas.TrustedSignedBeaconBlock);
+      blck.isSome()):
+    ok(ForkedTrustedSignedBeaconBlock.init(blck.get()))
+  elif (let blck = db.getBlock(root, fulu.TrustedSignedBeaconBlock);
       blck.isSome()):
     ok(ForkedTrustedSignedBeaconBlock.init(blck.get()))
   elif (let blck = db.getBlock(root, electra.TrustedSignedBeaconBlock);
@@ -1019,6 +1025,9 @@ proc applyBlock(
     ? state_transition(
       dag.cfg, state, data, cache, info,
       updateFlags + {slotProcessed}, noRollback)
+  of ConsensusFork.Gloas:
+    debugGloasComment ""
+    return ok()
 
   ok()
 
@@ -1158,7 +1167,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     dag.heads = @[headRef]
 
     withState(dag.headState):
-      when consensusFork >= ConsensusFork.Altair:
+      debugGloasComment ""
+      when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
         dag.headSyncCommittees = forkyState.data.get_sync_committee_cache(cache)
 
     assign(dag.clearanceState, dag.headState)
@@ -1181,6 +1191,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of ConsensusFork.Deneb:     denebFork(cfg)
       of ConsensusFork.Electra:   electraFork(cfg)
       of ConsensusFork.Fulu:      fuluFork(cfg)
+      of ConsensusFork.Gloas:     gloasFork(cfg)
     stateFork = getStateField(dag.headState, fork)
 
   # Here, we check only the `current_version` field because the spec
@@ -2479,7 +2490,8 @@ proc updateHead*(
   updateBeaconMetrics(dag.headState, dag.head.bid, cache)
 
   withState(dag.headState):
-    when consensusFork >= ConsensusFork.Altair:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
       dag.headSyncCommittees = forkyState.data.get_sync_committee_cache(cache)
 
   let

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -118,7 +118,11 @@ func lightClientHeader(
     blck: ForkyTrustedSignedBeaconBlock): ForkedLightClientHeader =
   const lcDataFork = max(
     lcDataForkAtConsensusFork(typeof(blck).kind), LightClientDataFork.Altair)
-  ForkedLightClientHeader.init(blck.toLightClientHeader(lcDataFork))
+  debugGloasComment "..."
+  when kind(typeof(blck)) == ConsensusFork.Gloas:
+    default(ForkedLightClientHeader)
+  else:
+    ForkedLightClientHeader.init(blck.toLightClientHeader(lcDataFork))
 
 func sync_aggregate(
     blck: ForkyTrustedSignedBeaconBlock): SyncAggregate =
@@ -134,7 +138,12 @@ proc getExistingLightClientHeader(
   if bdata.isNone:
     return res
 
-  res = withBlck(bdata.get): forkyBlck.lightClientHeader()
+  res = withBlck(bdata.get):
+    debugGloasComment "..."
+    when consensusFork != ConsensusFork.Gloas:
+      forkyBlck.lightClientHeader()
+    else:
+      default(ForkedLightClientHeader)
   dag.cacheRecentLightClientHeader(bid, res)
   res
 
@@ -148,7 +157,10 @@ proc getExistingSyncAggregate(
     return Opt.none(SyncAggregate)
 
   let res = withBlck(bdata.get):
-    when consensusFork >= ConsensusFork.Altair:
+    debugGloasComment "..."
+    when consensusFork >= ConsensusFork.Fulu:
+      return Opt.none(SyncAggregate)
+    elif consensusFork >= ConsensusFork.Altair:
       Opt.some forkyBlck.sync_aggregate()
     else:
       return Opt.none(SyncAggregate)
@@ -246,7 +258,9 @@ proc initLightClientBootstrapForPeriod(
         res.err()
         continue
       withStateAndBlck(tmpState[], bdata):
-        when consensusFork >= ConsensusFork.Altair:
+        when consensusFork == ConsensusFork.Gloas:
+          debugGloasComment "..."
+        elif consensusFork >= ConsensusFork.Altair:
           const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
           if not dag.lcDataStore.db.hasSyncCommittee(period):
             dag.lcDataStore.db.putSyncCommittee(
@@ -397,7 +411,9 @@ proc initLightClientUpdateForPeriod(
       dag.handleUnexpectedLightClientError(bid.slot)
       return err()
     withStateAndBlck(updatedState, bdata):
-      when consensusFork >= ConsensusFork.Altair:
+      when consensusFork >= ConsensusFork.Gloas:
+        debugGloasComment ""
+      elif consensusFork >= ConsensusFork.Altair:
         const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
         update = ForkedLightClientUpdate.init(lcDataFork.LightClientUpdate(
           attested_header: forkyBlck.toLightClientHeader(lcDataFork),
@@ -418,17 +434,20 @@ proc initLightClientUpdateForPeriod(
       dag.handleUnexpectedLightClientError(finalizedBid.slot)
       return err()
     withBlck(bdata):
-      withForkyUpdate(update):
-        when lcDataFork > LightClientDataFork.None:
-          when lcDataFork >= lcDataForkAtConsensusFork(consensusFork):
-            forkyUpdate.finalized_header =
-              forkyBlck.toLightClientHeader(lcDataFork)
-          else: raiseAssert "Unreachable"
+      debugGloasComment ""
+      when consensusFork != ConsensusFork.Gloas:
+        withForkyUpdate(update):
+          when lcDataFork > LightClientDataFork.None:
+            when lcDataFork >= lcDataForkAtConsensusFork(consensusFork):
+              forkyUpdate.finalized_header =
+                forkyBlck.toLightClientHeader(lcDataFork)
+            else: raiseAssert "Unreachable"
   let bdata = dag.getExistingForkedBlock(signatureBid).valueOr:
     dag.handleUnexpectedLightClientError(signatureBid.slot)
     return err()
   withBlck(bdata):
-    when consensusFork >= ConsensusFork.Altair:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
       withForkyUpdate(update):
         when lcDataFork > LightClientDataFork.None:
           forkyUpdate.sync_aggregate =
@@ -719,7 +738,8 @@ proc createLightClientBootstrap(
           tmpState[], period)
       dag.lcDataStore.db.putSyncCommittee(period, syncCommittee)
   withBlck(bdata):
-    when consensusFork >= ConsensusFork.Altair:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
       const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
       dag.lcDataStore.db.putHeader(
         forkyBlck.toLightClientHeader(lcDataFork))
@@ -823,7 +843,8 @@ proc initLightClientDataCache*(dag: ChainDAGRef) =
       res.err()
       continue
     withStateAndBlck(dag.headState, bdata):
-      when consensusFork >= ConsensusFork.Altair:
+      debugGloasComment ""
+      when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
         if i == blocks.high:
           let
             period = bid.slot.sync_committee_period
@@ -1099,7 +1120,8 @@ proc getLightClientBootstrap*(
     debug "LC bootstrap unavailable: Block not found", blockRoot
     return default(ForkedLightClientBootstrap)
   withBlck(bdata):
-    when consensusFork >= ConsensusFork.Altair:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
       const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
       let
         header = forkyBlck.toLightClientHeader(lcDataFork)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -367,8 +367,10 @@ proc runProposalForkchoiceUpdated*(
         payloadAttributes = Opt.some fcPayloadAttributes)
       debug "Fork-choice updated for proposal", status
 
-    static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
-    when consensusFork >= ConsensusFork.Deneb:
+    static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+    when consensusFork >= ConsensusFork.Gloas:
+      debugGloasComment "well, likely can't keep reusing V3 much longer"
+    elif consensusFork >= ConsensusFork.Deneb:
       # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
       # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
       callForkchoiceUpdated(PayloadAttributesV3(

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -27,7 +27,8 @@ type
     of ValidatorStorageKind.Identifier:
       ident: ValidatorIdent
 
-static: doAssert(high(ConsensusFork) == ConsensusFork.Fulu,
+debugGloasComment " yeah do it "
+static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
           "Update OptionalForks constant!")
 const
   OptionalForks* = {ConsensusFork.Fulu}

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -27,11 +27,10 @@ type
     of ValidatorStorageKind.Identifier:
       ident: ValidatorIdent
 
-debugGloasComment " yeah do it "
 static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
           "Update OptionalForks constant!")
 const
-  OptionalForks* = {ConsensusFork.Fulu}
+  OptionalForks* = {ConsensusFork.Fulu, ConsensusFork.Gloas}
     ## When a new ConsensusFork is added and before this fork is activated on
     ## `mainnet`, it should be part of `OptionalForks`.
     ## In this case, the client will ignore missing <FORKNAME>_VERSION

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -446,6 +446,8 @@ iterator getBlockIds*(
       if not getPartialState(
           db, historical_roots, historical_summaries, stateSlot, state[]):
         state = nil # No `return` in iterators
+    of ConsensusFork.Gloas:
+      debugGloasComment "probably trivial"
 
     if state == nil:
       break

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -37,6 +37,9 @@ from ../beacon_chain_db import getBlobSidecar, putBlobSidecar,
   getDataColumnSidecar, putDataColumnSidecar
 from ../spec/state_transition_block import validate_blobs
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 export sszdump, signatures_batch
 
 logScope: topics = "gossip_blocks"
@@ -491,7 +494,9 @@ proc enqueueBlock*(
     if forkyBlck.message.slot <= self.consensusManager.dag.finalizedHead.slot:
       # let backfill blocks skip the queue - these are always "fast" to process
       # because there are no state rewinds to deal with
-      when consensusFork >= ConsensusFork.Fulu:
+      when consensusFork >= ConsensusFork.Gloas:
+        debugGloasComment ""
+      elif consensusFork >= ConsensusFork.Fulu:
         resfut.complete(
           self.storeBackfillBlock(forkyBlck, data_columns))
       else:
@@ -928,6 +933,8 @@ proc storeBlock(
         template callForkChoiceUpdated: auto =
           case self.consensusManager.dag.cfg.consensusForkAtEpoch(
               newHead.get.blck.bid.slot.epoch)
+          of ConsensusFork.Gloas:
+            debugGloasComment ""
           of ConsensusFork.Deneb, ConsensusFork.Electra, ConsensusFork.Fulu:
             # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
             # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
@@ -980,7 +987,12 @@ proc storeBlock(
       quarantined = shortLog(quarantined.root)
 
     withBlck(quarantined):
-      when typeof(forkyBlck).kind < ConsensusFork.Deneb:
+      when typeof(forkyBlck).kind == ConsensusFork.Gloas:
+        debugGloasComment ""
+        self[].enqueueBlock(
+          MsgSource.gossip, quarantined, Opt.none(BlobSidecars),
+          Opt.none(DataColumnSidecars))
+      elif typeof(forkyBlck).kind < ConsensusFork.Deneb:
         self[].enqueueBlock(
           MsgSource.gossip, quarantined, Opt.none(BlobSidecars),
           Opt.none(DataColumnSidecars))
@@ -1109,9 +1121,13 @@ proc processBlock(
     quit 1
 
   let res = withBlck(entry.blck):
-    await self.storeBlock(
-      entry.src, wallTime, forkyBlck, entry.blobs, Opt.none(DataColumnSidecars),
-      entry.maybeFinalized, entry.queueTick, entry.validationDur)
+    debugGloasComment ""
+    when consensusFork != ConsensusFork.Gloas:
+      await self.storeBlock(
+        entry.src, wallTime, forkyBlck, entry.blobs, Opt.none(DataColumnSidecars),
+        entry.maybeFinalized, entry.queueTick, entry.validationDur)
+    else:
+      default(Result[BlockRef, (VerifierError, ProcessingStatus)])
 
   if res.isErr and res.error[1] == ProcessingStatus.notCompleted:
     # When an execution engine returns an error or fails to respond to a

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -356,7 +356,10 @@ proc validateDataColumnSidecarFromEL*(
   if (let o = self.quarantine[].getColumnless(block_root); o.isSome):
     let columnless = o.unsafeGet()
     withBlck(columnless):
-      when consensusFork >= ConsensusFork.Fulu:
+      debugGloasComment ""
+      when consensusFork >= ConsensusFork.Gloas:
+        discard
+      elif consensusFork >= ConsensusFork.Fulu:
         let
           blobsFromElOpt =
             await elManager.sendGetBlobsV2(forkyBlck)
@@ -412,7 +415,9 @@ proc processDataColumnSidecar*(
   if (let o = self.quarantine[].popColumnless(block_root); o.isSome):
     let columnless = o.unsafeGet()
     withBlck(columnless):
-      when consensusFork >= ConsensusFork.Fulu:
+      when consensusFork >= ConsensusFork.Gloas:
+        debugGloasComment ""
+      elif consensusFork >= ConsensusFork.Fulu:
         let cres =
           self.dataColumnQuarantine[].popSidecars(block_root, forkyBlck)
         if cres.isSome():

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -23,6 +23,9 @@ import
   ".."/[beacon_clock],
   ./batch_validation
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 from libp2p/protocols/pubsub/errors import ValidationResult
 
 export results, ValidationResult
@@ -301,8 +304,9 @@ func getMaxBlobsPerBlock(cfg: RuntimeConfig, slot: Slot): uint64 =
   else:
     cfg.MAX_BLOBS_PER_BLOCK
 
+debugGloasComment ""
 template validateBeaconBlockBellatrix(
-    _: phase0.SignedBeaconBlock | altair.SignedBeaconBlock,
+    _: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | gloas.SignedBeaconBlock,
     _: BlockRef): untyped =
   discard
 
@@ -360,11 +364,12 @@ template validateBeaconBlockBellatrix(
   # cannot occur here, because Nimbus's optimistic sync waits for either
   # `ACCEPTED` or `SYNCING` from the EL to get this far.
 
+debugGloasComment ""
 template validateBeaconBlockDeneb(
     _: ChainDAGRef,
     _:
       phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-      bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock,
+      bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock | gloas.SignedBeaconBlock,
     _: BeaconTime): untyped =
   discard
 
@@ -1498,7 +1503,8 @@ proc validateBlsToExecutionChange*(
   # [REJECT] All of the conditions within `process_bls_to_execution_change`
   # pass validation.
   withState(pool.dag.headState):
-    when consensusFork < ConsensusFork.Capella:
+    debugGloasComment ""
+    when consensusFork < ConsensusFork.Capella or consensusFork == ConsensusFork.Gloas:
       return errIgnore(
         "SignedBLSToExecutionChange: can't validate against pre-Capella state")
     else:

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -249,8 +249,8 @@ when const_preset == "gnosis":
       checkForkConsistency(network.cfg)
       doAssert network.cfg.ELECTRA_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.FULU_FORK_EPOCH == FAR_FUTURE_EPOCH
-      doAssert ConsensusFork.high == ConsensusFork.Fulu
-
+      doAssert network.cfg.GLOAS_FORK_EPOCH == FAR_FUTURE_EPOCH
+      doAssert ConsensusFork.high == ConsensusFork.Gloas
 
 elif const_preset == "mainnet":
   when incbinEnabled:

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -334,7 +334,8 @@ elif const_preset == "mainnet":
       checkForkConsistency(network.cfg)
       doAssert network.cfg.ELECTRA_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.FULU_FORK_EPOCH == FAR_FUTURE_EPOCH
-      doAssert ConsensusFork.high == ConsensusFork.Fulu
+      doAssert network.cfg.GLOAS_FORK_EPOCH == FAR_FUTURE_EPOCH
+      doAssert ConsensusFork.high == ConsensusFork.Gloas
 
 proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
   template loadRuntimeMetadata(): auto =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -172,7 +172,10 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
         (proc() = notice "🐅 Blob parameters updated 🐅"))
 
 func getVanityMascot(consensusFork: ConsensusFork): string =
+  debugGloasComment ""
   case consensusFork
+  of ConsensusFork.Gloas:
+    "?"
   of ConsensusFork.Fulu:
     "🐅"
   of ConsensusFork.Electra:
@@ -463,7 +466,10 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Fulu:
+        when consensusFork == ConsensusFork.Gloas:
+          debugGloasComment ""
+          return err(VerifierError.UnviableFork) # sure why not
+        elif consensusFork >= ConsensusFork.Fulu:
           let cres = dataColumnQuarantine[].popSidecars(forkyBlck.root, forkyBlck)
           if cres.isSome():
             await blockProcessor[].addBlock(MsgSource.gossip, signedBlock,
@@ -1549,7 +1555,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     TOPIC_SUBSCRIBE_THRESHOLD_SLOTS = 64
     HYSTERESIS_BUFFER = 16
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
 
   let
     head = node.dag.head
@@ -1597,14 +1603,16 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
 
     # We "know" the actions for the current and the next epoch
     withState(node.dag.headState):
-      if node.consensusManager[].actionTracker.needsUpdate(
-          forkyState, slot.epoch):
-        let epochRef = node.dag.getEpochRef(head, slot.epoch, false).expect(
-          "Getting head EpochRef should never fail")
-        node.consensusManager[].actionTracker.updateActions(
-          epochRef.shufflingRef, epochRef.beacon_proposers)
+      debugGloasComment ""
+      when consensusFork != ConsensusFork.Gloas:
+        if node.consensusManager[].actionTracker.needsUpdate(
+            forkyState, slot.epoch):
+          let epochRef = node.dag.getEpochRef(head, slot.epoch, false).expect(
+            "Getting head EpochRef should never fail")
+          node.consensusManager[].actionTracker.updateActions(
+            epochRef.shufflingRef, epochRef.beacon_proposers)
 
-      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
+        node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   if node.gossipState.len > 0 and targetGossipState.len == 0:
     debug "Disabling topic subscriptions",
@@ -1614,6 +1622,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
 
     node.processor[].clearDoppelgangerProtection()
 
+  debugGloasComment ""
   const removeMessageHandlers: array[ConsensusFork, auto] = [
     removePhase0MessageHandlers,
     removeAltairMessageHandlers,
@@ -1621,7 +1630,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     removeCapellaMessageHandlers,
     removeDenebMessageHandlers,
     removeElectraMessageHandlers,
-    removeFuluMessageHandlers
+    removeFuluMessageHandlers,
+    removeFuluMessageHandlers    # nope, will be different
   ]
 
   for gossipEpoch in oldGossipEpochs:
@@ -1629,6 +1639,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     removeMessageHandlers[gossipFork](
       node, node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg))
 
+  debugGloasComment ""
   const addMessageHandlers: array[ConsensusFork, auto] = [
     addPhase0MessageHandlers,
     addAltairMessageHandlers,
@@ -1636,7 +1647,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     addCapellaMessageHandlers,
     addDenebMessageHandlers,
     addElectraMessageHandlers,
-    addFuluMessageHandlers
+    addFuluMessageHandlers,
+    addFuluMessageHandlers   # nope, will be different
   ]
 
   for gossipEpoch in newGossipEpochs:
@@ -1764,19 +1776,21 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let head = node.dag.head
   if node.isSynced(head) and head.executionValid:
     withState(node.dag.headState):
-      # maybeUpdateActionTrackerNextEpoch might not account for balance changes
-      # from the process_rewards_and_penalties() epoch transition but only from
-      # process_block() and other per-slot sources. This mainly matters insofar
-      # as it might trigger process_effective_balance_updates() changes in that
-      # same epoch transition, which function is therefore potentially blind to
-      # but which might then affect beacon proposers.
-      #
-      # Because this runs every slot, it can account naturally for slashings,
-      # which affect balances via slash_validator() when they happen, and any
-      # missed sync committee participation via process_sync_aggregate(), but
-      # attestation penalties for example, need, specific handling.
-      # checked by maybeUpdateActionTrackerNextEpoch.
-      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
+      debugGloasComment ""
+      when consensusFork != ConsensusFork.Gloas:
+        # maybeUpdateActionTrackerNextEpoch might not account for balance changes
+        # from the process_rewards_and_penalties() epoch transition but only from
+        # process_block() and other per-slot sources. This mainly matters insofar
+        # as it might trigger process_effective_balance_updates() changes in that
+        # same epoch transition, which function is therefore potentially blind to
+        # but which might then affect beacon proposers.
+        #
+        # Because this runs every slot, it can account naturally for slashings,
+        # which affect balances via slash_validator() when they happen, and any
+        # missed sync committee participation via process_sync_aggregate(), but
+        # attestation penalties for example, need, specific handling.
+        # checked by maybeUpdateActionTrackerNextEpoch.
+        node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   let
     nextAttestationSlot =
@@ -2112,190 +2126,191 @@ proc installMessageValidators(node: BeaconNode) =
 
   for fork in ConsensusFork:
     withConsensusFork(fork):
-      for digest in @[forkDigests[].atConsensusFork(consensusFork)] &
-          forkDigests[].bpos.filterIt(it[1] == consensusFork).mapIt(it[2]):
-        let digest = digest # lent
-        # beacon_block
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#beacon_block
-        node.network.addValidator(
-          getBeaconBlocksTopic(digest), proc (
-            signedBlock: consensusFork.SignedBeaconBlock,
-            src: PeerId,
-          ): ValidationResult =
-            if node.shouldSyncOptimistically(node.currentSlot):
-              toValidationResult(
-                node.optimisticProcessor.processSignedBeaconBlock(
-                  signedBlock))
-            else:
-              toValidationResult(
-                node.processor[].processSignedBeaconBlock(
-                  MsgSource.gossip, signedBlock)))
-
-        # beacon_attestation_{subnet_id}
-        # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
-        when consensusFork >= ConsensusFork.Electra:
-          for it in SubnetId:
-            closureScope:  # Needed for inner `proc`; don't lift it out of loop.
-              let subnet_id = it
-              node.network.addAsyncValidator(
-                getAttestationTopic(digest, subnet_id), proc (
-                  attestation: SingleAttestation, src: PeerId
-                ): Future[ValidationResult] {.
-                    async: (raises: [CancelledError]).} =
-                  return toValidationResult(
-                    await node.processor.processAttestation(
-                      MsgSource.gossip, attestation, subnet_id,
-                      checkSignature = true, checkValidator = false)))
-        else:
-          for it in SubnetId:
-            closureScope:  # Needed for inner `proc`; don't lift it out of loop.
-              let subnet_id = it
-              node.network.addAsyncValidator(
-                getAttestationTopic(digest, subnet_id), proc (
-                  attestation: phase0.Attestation, src: PeerId
-                ): Future[ValidationResult] {.
-                    async: (raises: [CancelledError]).} =
-                  return toValidationResult(
-                    await node.processor.processAttestation(
-                      MsgSource.gossip, attestation, subnet_id,
-                      checkSignature = true, checkValidator = false)))
-
-        # beacon_aggregate_and_proof
-        # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
-        when consensusFork >= ConsensusFork.Electra:
-          node.network.addAsyncValidator(
-            getAggregateAndProofsTopic(digest), proc (
-              signedAggregateAndProof: electra.SignedAggregateAndProof,
-              src: PeerId
-            ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-              return toValidationResult(
-                await node.processor.processSignedAggregateAndProof(
-                  MsgSource.gossip, signedAggregateAndProof)))
-        else:
-          node.network.addAsyncValidator(
-            getAggregateAndProofsTopic(digest), proc (
-              signedAggregateAndProof: phase0.SignedAggregateAndProof,
-              src: PeerId
-            ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-              return toValidationResult(
-                await node.processor.processSignedAggregateAndProof(
-                  MsgSource.gossip, signedAggregateAndProof)))
-
-        # attester_slashing
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/p2p-interface.md#attester_slashing
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.6/specs/electra/p2p-interface.md#modifications-in-electra
-        when consensusFork >= ConsensusFork.Electra:
+      when consensusFork != ConsensusFork.Gloas:
+        for digest in @[forkDigests[].atConsensusFork(consensusFork)] &
+            forkDigests[].bpos.filterIt(it[1] == consensusFork).mapIt(it[2]):
+          let digest = digest # lent
+          # beacon_block
+          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#beacon_block
           node.network.addValidator(
-            getAttesterSlashingsTopic(digest), proc (
-              attesterSlashing: electra.AttesterSlashing,
+            getBeaconBlocksTopic(digest), proc (
+              signedBlock: consensusFork.SignedBeaconBlock,
+              src: PeerId,
+            ): ValidationResult =
+              if node.shouldSyncOptimistically(node.currentSlot):
+                toValidationResult(
+                  node.optimisticProcessor.processSignedBeaconBlock(
+                    signedBlock))
+              else:
+                toValidationResult(
+                  node.processor[].processSignedBeaconBlock(
+                    MsgSource.gossip, signedBlock)))
+
+          # beacon_attestation_{subnet_id}
+          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
+          when consensusFork >= ConsensusFork.Electra:
+            for it in SubnetId:
+              closureScope:  # Needed for inner `proc`; don't lift it out of loop.
+                let subnet_id = it
+                node.network.addAsyncValidator(
+                  getAttestationTopic(digest, subnet_id), proc (
+                    attestation: SingleAttestation, src: PeerId
+                  ): Future[ValidationResult] {.
+                      async: (raises: [CancelledError]).} =
+                    return toValidationResult(
+                      await node.processor.processAttestation(
+                        MsgSource.gossip, attestation, subnet_id,
+                        checkSignature = true, checkValidator = false)))
+          else:
+            for it in SubnetId:
+              closureScope:  # Needed for inner `proc`; don't lift it out of loop.
+                let subnet_id = it
+                node.network.addAsyncValidator(
+                  getAttestationTopic(digest, subnet_id), proc (
+                    attestation: phase0.Attestation, src: PeerId
+                  ): Future[ValidationResult] {.
+                      async: (raises: [CancelledError]).} =
+                    return toValidationResult(
+                      await node.processor.processAttestation(
+                        MsgSource.gossip, attestation, subnet_id,
+                        checkSignature = true, checkValidator = false)))
+
+          # beacon_aggregate_and_proof
+          # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/p2p-interface.md#beacon_aggregate_and_proof
+          when consensusFork >= ConsensusFork.Electra:
+            node.network.addAsyncValidator(
+              getAggregateAndProofsTopic(digest), proc (
+                signedAggregateAndProof: electra.SignedAggregateAndProof,
+                src: PeerId
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processSignedAggregateAndProof(
+                    MsgSource.gossip, signedAggregateAndProof)))
+          else:
+            node.network.addAsyncValidator(
+              getAggregateAndProofsTopic(digest), proc (
+                signedAggregateAndProof: phase0.SignedAggregateAndProof,
+                src: PeerId
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processSignedAggregateAndProof(
+                    MsgSource.gossip, signedAggregateAndProof)))
+
+          # attester_slashing
+          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/p2p-interface.md#attester_slashing
+          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.6/specs/electra/p2p-interface.md#modifications-in-electra
+          when consensusFork >= ConsensusFork.Electra:
+            node.network.addValidator(
+              getAttesterSlashingsTopic(digest), proc (
+                attesterSlashing: electra.AttesterSlashing,
+                src: PeerId
+              ): ValidationResult =
+                toValidationResult(
+                  node.processor[].processAttesterSlashing(
+                    MsgSource.gossip, attesterSlashing)))
+          else:
+            node.network.addValidator(
+              getAttesterSlashingsTopic(digest), proc (
+                attesterSlashing: phase0.AttesterSlashing,
+                src: PeerId
+              ): ValidationResult =
+                toValidationResult(
+                  node.processor[].processAttesterSlashing(
+                    MsgSource.gossip, attesterSlashing)))
+
+          # proposer_slashing
+          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#proposer_slashing
+          node.network.addValidator(
+            getProposerSlashingsTopic(digest), proc (
+              proposerSlashing: ProposerSlashing,
               src: PeerId
             ): ValidationResult =
               toValidationResult(
-                node.processor[].processAttesterSlashing(
-                  MsgSource.gossip, attesterSlashing)))
-        else:
+                node.processor[].processProposerSlashing(
+                  MsgSource.gossip, proposerSlashing)))
+
+          # voluntary_exit
+          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#voluntary_exit
           node.network.addValidator(
-            getAttesterSlashingsTopic(digest), proc (
-              attesterSlashing: phase0.AttesterSlashing,
+            getVoluntaryExitsTopic(digest), proc (
+              signedVoluntaryExit: SignedVoluntaryExit,
               src: PeerId
             ): ValidationResult =
               toValidationResult(
-                node.processor[].processAttesterSlashing(
-                  MsgSource.gossip, attesterSlashing)))
+                node.processor[].processSignedVoluntaryExit(
+                  MsgSource.gossip, signedVoluntaryExit)))
 
-        # proposer_slashing
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/p2p-interface.md#proposer_slashing
-        node.network.addValidator(
-          getProposerSlashingsTopic(digest), proc (
-            proposerSlashing: ProposerSlashing,
-            src: PeerId
-          ): ValidationResult =
-            toValidationResult(
-              node.processor[].processProposerSlashing(
-                MsgSource.gossip, proposerSlashing)))
+          when consensusFork >= ConsensusFork.Altair:
+            # sync_committee_{subnet_id}
+            # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/p2p-interface.md#sync_committee_subnet_id
+            for subcommitteeIdx in SyncSubcommitteeIndex:
+              closureScope:  # Needed for inner `proc`; don't lift it out of loop.
+                let idx = subcommitteeIdx
+                node.network.addAsyncValidator(
+                  getSyncCommitteeTopic(digest, idx), proc (
+                    msg: SyncCommitteeMessage,
+                    src: PeerId
+                  ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                    return toValidationResult(
+                      await node.processor.processSyncCommitteeMessage(
+                        MsgSource.gossip, msg, idx)))
 
-        # voluntary_exit
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#voluntary_exit
-        node.network.addValidator(
-          getVoluntaryExitsTopic(digest), proc (
-            signedVoluntaryExit: SignedVoluntaryExit,
-            src: PeerId
-          ): ValidationResult =
-            toValidationResult(
-              node.processor[].processSignedVoluntaryExit(
-                MsgSource.gossip, signedVoluntaryExit)))
+            # sync_committee_contribution_and_proof
+            # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/altair/p2p-interface.md#sync_committee_contribution_and_proof
+            node.network.addAsyncValidator(
+              getSyncCommitteeContributionAndProofTopic(digest), proc (
+                msg: SignedContributionAndProof,
+                src: PeerId
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processSignedContributionAndProof(
+                    MsgSource.gossip, msg)))
 
-        when consensusFork >= ConsensusFork.Altair:
-          # sync_committee_{subnet_id}
-          # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/p2p-interface.md#sync_committee_subnet_id
-          for subcommitteeIdx in SyncSubcommitteeIndex:
-            closureScope:  # Needed for inner `proc`; don't lift it out of loop.
-              let idx = subcommitteeIdx
-              node.network.addAsyncValidator(
-                getSyncCommitteeTopic(digest, idx), proc (
-                  msg: SyncCommitteeMessage,
-                  src: PeerId
-                ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-                  return toValidationResult(
-                    await node.processor.processSyncCommitteeMessage(
-                      MsgSource.gossip, msg, idx)))
+          when consensusFork >= ConsensusFork.Capella:
+            # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/capella/p2p-interface.md#bls_to_execution_change
+            node.network.addAsyncValidator(
+              getBlsToExecutionChangeTopic(digest), proc (
+                msg: SignedBLSToExecutionChange,
+                src: PeerId
+              ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                return toValidationResult(
+                  await node.processor.processBlsToExecutionChange(
+                    MsgSource.gossip, msg)))
 
-          # sync_committee_contribution_and_proof
-          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/altair/p2p-interface.md#sync_committee_contribution_and_proof
-          node.network.addAsyncValidator(
-            getSyncCommitteeContributionAndProofTopic(digest), proc (
-              msg: SignedContributionAndProof,
-              src: PeerId
-            ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-              return toValidationResult(
-                await node.processor.processSignedContributionAndProof(
-                  MsgSource.gossip, msg)))
-
-        when consensusFork >= ConsensusFork.Capella:
-          # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/capella/p2p-interface.md#bls_to_execution_change
-          node.network.addAsyncValidator(
-            getBlsToExecutionChangeTopic(digest), proc (
-              msg: SignedBLSToExecutionChange,
-              src: PeerId
-            ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-              return toValidationResult(
-                await node.processor.processBlsToExecutionChange(
-                  MsgSource.gossip, msg)))
-
-        # data_column_sidecar_{subnet_id}
-        when consensusFork >= ConsensusFork.Fulu:
           # data_column_sidecar_{subnet_id}
-          for it in 0'u64..<node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
-            closureScope:
-              let subnet_id = it
-              node.network.addAsyncValidator(
-                getDataColumnSidecarTopic(digest, subnet_id), proc (
-                  dataColumnSidecar: fulu.DataColumnSidecar,
-                  src: PeerId
-                ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
-                  toValidationResult(
-                    await node.processor.processDataColumnSidecar(
-                      MsgSource.gossip, dataColumnSidecar, subnet_id)))
+          when consensusFork >= ConsensusFork.Fulu:
+            # data_column_sidecar_{subnet_id}
+            for it in 0'u64..<node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
+              closureScope:
+                let subnet_id = it
+                node.network.addAsyncValidator(
+                  getDataColumnSidecarTopic(digest, subnet_id), proc (
+                    dataColumnSidecar: fulu.DataColumnSidecar,
+                    src: PeerId
+                  ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+                    toValidationResult(
+                      await node.processor.processDataColumnSidecar(
+                        MsgSource.gossip, dataColumnSidecar, subnet_id)))
 
-        when consensusFork in [ConsensusFork.Deneb, ConsensusFork.Electra]:
-          # blob_sidecar_{subnet_id}
-          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
-          let subnetCount =
-            when consensusFork >= ConsensusFork.Electra:
-              node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
-            else:
-              node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT
-          for it in 0.BlobId ..< subnetCount.BlobId:
-            closureScope:  # Needed for inner `proc`; don't lift it out of loop.
-              let subnet_id = it
-              node.network.addValidator(
-                getBlobSidecarTopic(digest, subnet_id), proc (
-                  blobSidecar: deneb.BlobSidecar,
-                  src: PeerId
-                ): ValidationResult =
-                  toValidationResult(
-                    node.processor[].processBlobSidecar(
-                      MsgSource.gossip, blobSidecar, subnet_id)))
+          when consensusFork in [ConsensusFork.Deneb, ConsensusFork.Electra]:
+            # blob_sidecar_{subnet_id}
+            # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/deneb/p2p-interface.md#blob_sidecar_subnet_id
+            let subnetCount =
+              when consensusFork >= ConsensusFork.Electra:
+                node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA
+              else:
+                node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT
+            for it in 0.BlobId ..< subnetCount.BlobId:
+              closureScope:  # Needed for inner `proc`; don't lift it out of loop.
+                let subnet_id = it
+                node.network.addValidator(
+                  getBlobSidecarTopic(digest, subnet_id), proc (
+                    blobSidecar: deneb.BlobSidecar,
+                    src: PeerId
+                  ): ValidationResult =
+                    toValidationResult(
+                      node.processor[].processBlobSidecar(
+                        MsgSource.gossip, blobSidecar, subnet_id)))
 
   node.installLightClientMessageValidators()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1603,16 +1603,14 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
 
     # We "know" the actions for the current and the next epoch
     withState(node.dag.headState):
-      debugGloasComment ""
-      when consensusFork != ConsensusFork.Gloas:
-        if node.consensusManager[].actionTracker.needsUpdate(
-            forkyState, slot.epoch):
-          let epochRef = node.dag.getEpochRef(head, slot.epoch, false).expect(
-            "Getting head EpochRef should never fail")
-          node.consensusManager[].actionTracker.updateActions(
-            epochRef.shufflingRef, epochRef.beacon_proposers)
+      if node.consensusManager[].actionTracker.needsUpdate(
+          forkyState, slot.epoch):
+        let epochRef = node.dag.getEpochRef(head, slot.epoch, false).expect(
+          "Getting head EpochRef should never fail")
+        node.consensusManager[].actionTracker.updateActions(
+          epochRef.shufflingRef, epochRef.beacon_proposers)
 
-        node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
+      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   if node.gossipState.len > 0 and targetGossipState.len == 0:
     debug "Disabling topic subscriptions",
@@ -1776,21 +1774,19 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   let head = node.dag.head
   if node.isSynced(head) and head.executionValid:
     withState(node.dag.headState):
-      debugGloasComment ""
-      when consensusFork != ConsensusFork.Gloas:
-        # maybeUpdateActionTrackerNextEpoch might not account for balance changes
-        # from the process_rewards_and_penalties() epoch transition but only from
-        # process_block() and other per-slot sources. This mainly matters insofar
-        # as it might trigger process_effective_balance_updates() changes in that
-        # same epoch transition, which function is therefore potentially blind to
-        # but which might then affect beacon proposers.
-        #
-        # Because this runs every slot, it can account naturally for slashings,
-        # which affect balances via slash_validator() when they happen, and any
-        # missed sync committee participation via process_sync_aggregate(), but
-        # attestation penalties for example, need, specific handling.
-        # checked by maybeUpdateActionTrackerNextEpoch.
-        node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
+      # maybeUpdateActionTrackerNextEpoch might not account for balance changes
+      # from the process_rewards_and_penalties() epoch transition but only from
+      # process_block() and other per-slot sources. This mainly matters insofar
+      # as it might trigger process_effective_balance_updates() changes in that
+      # same epoch transition, which function is therefore potentially blind to
+      # but which might then affect beacon proposers.
+      #
+      # Because this runs every slot, it can account naturally for slashings,
+      # which affect balances via slash_validator() when they happen, and any
+      # missed sync committee participation via process_sync_aggregate(), but
+      # attestation penalties for example, need, specific handling.
+      # checked by maybeUpdateActionTrackerNextEpoch.
+      node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
   let
     nextAttestationSlot =

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -94,7 +94,8 @@ proc main() {.noinline, raises: [CatchableError].} =
         signedBlock: ForkedSignedBeaconBlock
     ): Future[void] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Bellatrix:
+        debugGloasComment ""
+        when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
           if forkyBlck.message.is_execution_block:
             template payload(): auto = forkyBlck.message.body.execution_payload
             if elManager != nil and not payload.block_hash.isZero:

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -259,6 +259,9 @@ proc installApiHandlers*(node: SigningNodeRef) =
             (GeneralizedIndex(801), request.beaconBlockHeader.data)
           of ConsensusFork.Fulu:
             (GeneralizedIndex(801), request.beaconBlockHeader.data)
+          of ConsensusFork.Gloas:
+            debugGloasComment "do not this"
+            return errorResponse(Http400, BlockIncorrectFork)
 
         if request.proofs.isNone() or len(request.proofs.get()) == 0:
           return errorResponse(Http400, MissingMerkleProofError)

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1107,7 +1107,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                 forkyBlck.create_blob_sidecars(kzg_proofs, blobs)),
               Opt.none(seq[DataColumnSidecar]),
               checkValidator = true)
-          elif consensusFork >= ConsensusFork.Fulu:
+          elif consensusFork >= ConsensusFork.Fulu and consensusFork != ConsensusFork.Gloas:
+            debugGloasComment ""
             let data_columns =
               assemble_data_column_sidecars(
                 forkyBlck, blobs.mapIt(kzg.KzgBlob(bytes: it)),
@@ -1167,7 +1168,10 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
     withBlck(bdata.asSigned()):
-      when consensusFork <= ConsensusFork.Altair:
+      when consensusFork == ConsensusFork.Gloas:
+        debugGloasComment ""
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
+      elif consensusFork <= ConsensusFork.Altair:
         respondSszOrJson(forkyBlck, consensusFork)
       else:
         respondSszOrJson(toSignedBlindedBeaconBlock(forkyBlck), consensusFork)
@@ -1208,7 +1212,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http400, BlockIncorrectFork)
 
     withConsensusFork(currentEpochFork):
-      when consensusFork >= ConsensusFork.Electra:
+      when consensusFork == ConsensusFork.Gloas:
+        debugGloasComment ""
+        return RestApiResponse.jsonError(
+          Http400, $consensusFork & " builder API unsupported")
+      elif consensusFork >= ConsensusFork.Electra:
         let
           restBlock = decodeBodyJsonOrSsz(
               consensusFork.SignedBlindedBeaconBlock, body).valueOr:
@@ -1291,7 +1299,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     withConsensusFork(currentEpochFork):
       # TODO (cheatfate): handle broadcast_validation flag
-      when consensusFork >= ConsensusFork.Electra:
+      when consensusFork >= ConsensusFork.Gloas:
+        debugGloasComment ""
+        return RestApiResponse.jsonError(
+          Http400, $consensusFork & " builder API unsupported")
+      elif consensusFork >= ConsensusFork.Electra:
         let
           restBlock = decodeBodyJsonOrSsz(
               consensusFork.SignedBlindedBeaconBlock, body).valueOr:
@@ -1585,7 +1597,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     case consensusVersion.get():
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
         decodeAttestations(phase0.Attestation)
-      of ConsensusFork.Electra .. ConsensusFork.Fulu:
+      of ConsensusFork.Electra .. ConsensusFork.Gloas:
         decodeAttestations(electra.SingleAttestation)
 
     let failures =
@@ -1685,7 +1697,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     case consensusVersion.get():
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
         decodeAttesterSlashing(phase0.AttesterSlashing)
-      of ConsensusFork.Electra .. ConsensusFork.Fulu:
+      of ConsensusFork.Electra .. ConsensusFork.Gloas:
         decodeAttesterSlashing(electra.AttesterSlashing)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolProposerSlashings

--- a/beacon_chain/rpc/rest_builder_api.nim
+++ b/beacon_chain/rpc/rest_builder_api.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
 
 import
   ./rest_utils,

--- a/beacon_chain/rpc/rest_builder_api.nim
+++ b/beacon_chain/rpc/rest_builder_api.nim
@@ -34,7 +34,11 @@ proc installBuilderApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     node.withStateForBlockSlotId(bslot):
       withState(state):
-        when consensusFork >= ConsensusFork.Capella:
+        when consensusFork == ConsensusFork.Gloas:
+          debugGloasComment ""
+          return RestApiResponse.jsonError(
+            Http400, "The specified state is not a capella state")
+        elif consensusFork >= ConsensusFork.Capella:
           return RestApiResponse.jsonResponseWOpt(
             get_expected_withdrawals(forkyState.data),
             node.getStateOptimistic(state))

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -426,7 +426,11 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http400, InvalidRandaoRevealValue)
 
     withConsensusFork(node.dag.cfg.consensusForkAtEpoch(qslot.epoch)):
-      when consensusFork >= ConsensusFork.Electra:
+      when consensusFork == ConsensusFork.Gloas:
+        debugGloasComment ""
+        return RestApiResponse.jsonError(
+          Http500, "Unsupported fork for block production: " & $consensusFork)
+      elif consensusFork >= ConsensusFork.Electra:
         let
           message = (await node.makeMaybeBlindedBeaconBlockForHeadAndSlot(
               consensusFork, proposer, qrandao, qgraffiti, qhead, qslot,
@@ -700,7 +704,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     case consensusVersion.get():
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
         addDecodedProofs(phase0.SignedAggregateAndProof)
-      of ConsensusFork.Electra .. ConsensusFork.Fulu:
+      of ConsensusFork.Electra .. ConsensusFork.Gloas:
         addDecodedProofs(electra.SignedAggregateAndProof)
 
     await allFutures(proofs)

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -16,6 +16,9 @@ import
 from std/algorithm import fill, sort
 from std/sequtils import anyIt, mapIt, toSeq
 
+debugFuluComment "right now, be cautious about exporting gloas module where it doesn't yet need to be, or anything in it"
+import ./datatypes/gloas
+
 export extras, forks, validator, chronicles
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#increase_balance
@@ -86,7 +89,7 @@ func get_validator_from_deposit*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/electra/beacon-chain.md#deposits
 func get_validator_from_deposit*(
-    _: electra.BeaconState | fulu.BeaconState,
+    _: electra.BeaconState | fulu.BeaconState | gloas.BeaconState,
     pubkey: ValidatorPubKey,
     withdrawal_credentials: Eth2Digest, amount: Gwei): Validator =
   var validator = Validator(
@@ -530,6 +533,17 @@ func get_initial_beacon_block*(state: fulu.HashedBeaconState):
   fulu.TrustedSignedBeaconBlock(
     message: message, root: hash_tree_root(message))
 
+func get_initial_beacon_block*(state: gloas.HashedBeaconState):
+    gloas.TrustedSignedBeaconBlock =
+  # The genesis block is implicitly trusted
+  let message = gloas.TrustedBeaconBlock(
+    slot: state.data.slot,
+    state_root: state.root)
+    # parent_root, randao_reveal, eth1_data, signature, and body automatically
+    # initialized to default values.
+  gloas.TrustedSignedBeaconBlock(
+    message: message, root: hash_tree_root(message))
+
 func get_initial_beacon_block*(state: ForkedHashedBeaconState):
     ForkedTrustedSignedBeaconBlock =
   withState(state):
@@ -720,7 +734,8 @@ func get_attesting_indices*(state: ForkedHashedBeaconState;
 
   var idxBuf: seq[ValidatorIndex]
   withState(state):
-    when consensusFork >= ConsensusFork.Electra:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Electra and consensusFork != ConsensusFork.Gloas:
       for vidx in forkyState.data.get_attesting_indices(data, aggregation_bits, committee_bits, cache):
         idxBuf.add vidx
   idxBuf

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -979,5 +979,5 @@ func ofLen*[T, N](ListType: type List[T, N], n: int): ListType =
   else:
     raise newException(SszSizeMismatchError)
 
-# Specifically has the `Fulu` naming, for easy debugging.
-template debugFuluComment* (s: string) = discard
+template debugFuluComment*(s: string) = discard
+template debugGloasComment*(s: string) = discard

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -950,7 +950,7 @@ func checkForkConsistency*(cfg: RuntimeConfig) =
     [cfg.GENESIS_FORK_VERSION, cfg.ALTAIR_FORK_VERSION,
      cfg.BELLATRIX_FORK_VERSION, cfg.CAPELLA_FORK_VERSION,
      cfg.DENEB_FORK_VERSION, cfg.ELECTRA_FORK_VERSION,
-     cfg.FULU_FORK_VERSION]
+     cfg.FULU_FORK_VERSION, cfg.GLOAS_FORK_VERSION]
 
   for i in 0 ..< forkVersions.len:
     for j in i+1 ..< forkVersions.len:
@@ -970,6 +970,7 @@ func checkForkConsistency*(cfg: RuntimeConfig) =
   assertForkEpochOrder(cfg.CAPELLA_FORK_EPOCH, cfg.DENEB_FORK_EPOCH)
   assertForkEpochOrder(cfg.DENEB_FORK_EPOCH, cfg.ELECTRA_FORK_EPOCH)
   assertForkEpochOrder(cfg.ELECTRA_FORK_EPOCH, cfg.FULU_FORK_EPOCH)
+  assertForkEpochOrder(cfg.FULU_FORK_EPOCH, cfg.GLOAS_FORK_EPOCH)
 
   doAssert isSorted(cfg.BLOB_SCHEDULE, cmp = cmpBlobParameters)
 

--- a/beacon_chain/spec/datatypes/gloas.nim
+++ b/beacon_chain/spec/datatypes/gloas.nim
@@ -1,0 +1,646 @@
+# beacon_chain
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+# Types specific to Fulu (i.e. known to have changed across hard forks) - see
+# `base` for types and guidelines common across forks
+
+# TODO Careful, not nil analysis is broken / incomplete and the semantics will
+#      likely change in future versions of the language:
+#      https://github.com/nim-lang/RFCs/issues/250
+{.experimental: "notnil".}
+
+import
+  std/typetraits,
+  "."/[phase0, base, bellatrix, electra, fulu],
+  chronicles,
+  json_serialization,
+  ssz_serialization/[merkleization, proofs],
+  ssz_serialization/types as sszTypes,
+  ../digest,
+  kzg4844/[kzg, kzg_abi]
+
+from stew/bitops2 import log2trunc
+from stew/byteutils import to0xHex
+from ./altair import
+  EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
+  TrustedSyncAggregate, SyncnetBits, num_active_participants
+from ./capella import
+  ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
+  SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX
+from ./deneb import Blobs, KzgCommitments, KzgProofs
+
+export json_serialization, base
+
+const
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/fulu/polynomial-commitments-sampling.md#cells
+  FIELD_ELEMENTS_PER_EXT_BLOB* = 2 * kzg_abi.FIELD_ELEMENTS_PER_BLOB
+  # Number of field elements in a Reed-Solomon extended blob |
+  FIELD_ELEMENTS_PER_CELL* = 64 # Number of field elements in a cell |
+  BYTES_PER_CELL* = FIELD_ELEMENTS_PER_CELL * kzg_abi.BYTES_PER_FIELD_ELEMENT
+  # The number of bytes in a cell |
+  CELLS_PER_EXT_BLOB* = FIELD_ELEMENTS_PER_EXT_BLOB div FIELD_ELEMENTS_PER_CELL
+  # The number of cells in an extended blob |
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/p2p-interface.md#preset
+  KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH* = 4
+  KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX* = 27
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/fulu/das-core.md#data-size
+  NUMBER_OF_COLUMNS* = 128
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/p2p-interface.md#configuration
+  DATA_COLUMN_SIDECAR_SUBNET_COUNT* = 128
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/das-core.md#custody-setting
+  CUSTODY_REQUIREMENT* = 4
+
+  # Minimum number of custody groups an honest node with
+  # validators attached custodies and serves samples from
+  VALIDATOR_CUSTODY_REQUIREMENT* = 8
+
+  # Balance increment corresponding to one additional group to custody
+  # 2**5 * 10**9 (= 32,000,000,000) Gwei
+  BALANCE_PER_ADDITIONAL_CUSTODY_GROUP*: uint64 = 32000000000'u64
+
+type
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/deneb/beacon-chain.md#executionpayload
+  ExecutionPayload* = object
+    # Execution block header fields
+    parent_hash*: Eth2Digest
+    fee_recipient*: ExecutionAddress
+      ## 'beneficiary' in the yellow paper
+    state_root*: Eth2Digest
+    receipts_root*: Eth2Digest
+    logs_bloom*: BloomLogs
+    prev_randao*: Eth2Digest
+      ## 'difficulty' in the yellow paper
+    block_number*: uint64
+      ## 'number' in the yellow paper
+    gas_limit*: uint64
+    gas_used*: uint64
+    timestamp*: uint64
+    extra_data*: List[byte, MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas*: UInt256
+
+    # Extra payload fields
+    block_hash*: Eth2Digest # Hash of execution block
+    transactions*: List[Transaction, MAX_TRANSACTIONS_PER_PAYLOAD]
+    withdrawals*: List[Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD]
+    blob_gas_used*: uint64
+    excess_blob_gas*: uint64
+
+  ExecutionPayloadForSigning* = object
+    executionPayload*: ExecutionPayload
+    blockValue*: Wei
+    blobsBundle*: fulu.BlobsBundle # [New in Fulu]
+    executionRequests*: seq[seq[byte]]
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/deneb/beacon-chain.md#executionpayloadheader
+  ExecutionPayloadHeader* = object
+    # Execution block header fields
+    parent_hash*: Eth2Digest
+    fee_recipient*: ExecutionAddress
+    state_root*: Eth2Digest
+    receipts_root*: Eth2Digest
+    logs_bloom*: BloomLogs
+    prev_randao*: Eth2Digest
+    block_number*: uint64
+    gas_limit*: uint64
+    gas_used*: uint64
+    timestamp*: uint64
+    extra_data*: List[byte, MAX_EXTRA_DATA_BYTES]
+    base_fee_per_gas*: UInt256
+
+    # Extra payload fields
+    block_hash*: Eth2Digest
+      ## Hash of execution block
+    transactions_root*: Eth2Digest
+    withdrawals_root*: Eth2Digest
+    blob_gas_used*: uint64
+    excess_blob_gas*: uint64
+
+  ExecutePayload* = proc(
+    execution_payload: ExecutionPayload): bool {.gcsafe, raises: [].}
+
+  FinalityBranch* =
+    array[log2trunc(FINALIZED_ROOT_GINDEX_ELECTRA), Eth2Digest]
+
+  CurrentSyncCommitteeBranch* =
+    array[log2trunc(CURRENT_SYNC_COMMITTEE_GINDEX_ELECTRA), Eth2Digest]
+
+  NextSyncCommitteeBranch* =
+    array[log2trunc(NEXT_SYNC_COMMITTEE_GINDEX_ELECTRA), Eth2Digest]
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/capella/light-client/sync-protocol.md#modified-lightclientheader
+  LightClientHeader* = object
+    beacon*: BeaconBlockHeader
+      ## Beacon block header
+
+    execution*: ExecutionPayloadHeader
+      ## Execution payload header corresponding to `beacon.body_root` (from Capella onward)
+    execution_branch*: capella.ExecutionBranch
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/altair/light-client/sync-protocol.md#lightclientbootstrap
+  LightClientBootstrap* = object
+    header*: LightClientHeader
+      ## Header matching the requested beacon block root
+
+    current_sync_committee*: SyncCommittee
+      ## Current sync committee corresponding to `header.beacon.state_root`
+    current_sync_committee_branch*: CurrentSyncCommitteeBranch
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.5/specs/altair/light-client/sync-protocol.md#lightclientupdate
+  LightClientUpdate* = object
+    attested_header*: LightClientHeader
+      ## Header attested to by the sync committee
+
+    next_sync_committee*: SyncCommittee
+      ## Next sync committee corresponding to
+      ## `attested_header.beacon.state_root`
+    next_sync_committee_branch*: NextSyncCommitteeBranch
+
+    # Finalized header corresponding to `attested_header.beacon.state_root`
+    finalized_header*: LightClientHeader
+    finality_branch*: FinalityBranch
+
+    sync_aggregate*: SyncAggregate
+      ## Sync committee aggregate signature
+    signature_slot*: Slot
+      ## Slot at which the aggregate signature was created (untrusted)
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/altair/light-client/sync-protocol.md#lightclientfinalityupdate
+  LightClientFinalityUpdate* = object
+    # Header attested to by the sync committee
+    attested_header*: LightClientHeader
+
+    # Finalized header corresponding to `attested_header.beacon.state_root`
+    finalized_header*: LightClientHeader
+    finality_branch*: FinalityBranch
+
+    # Sync committee aggregate signature
+    sync_aggregate*: SyncAggregate
+    # Slot at which the aggregate signature was created (untrusted)
+    signature_slot*: Slot
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/sync-protocol.md#lightclientoptimisticupdate
+  LightClientOptimisticUpdate* = object
+    # Header attested to by the sync committee
+    attested_header*: LightClientHeader
+
+    # Sync committee aggregate signature
+    sync_aggregate*: SyncAggregate
+    # Slot at which the aggregate signature was created (untrusted)
+    signature_slot*: Slot
+
+  SomeLightClientUpdateWithSyncCommittee* =
+    LightClientUpdate
+
+  SomeLightClientUpdateWithFinality* =
+    LightClientUpdate |
+    LightClientFinalityUpdate
+
+  SomeLightClientUpdate* =
+    LightClientUpdate |
+    LightClientFinalityUpdate |
+    LightClientOptimisticUpdate
+
+  SomeLightClientObject* =
+    LightClientBootstrap |
+    SomeLightClientUpdate
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/altair/light-client/sync-protocol.md#lightclientstore
+  LightClientStore* = object
+    finalized_header*: LightClientHeader
+      ## Header that is finalized
+
+    current_sync_committee*: SyncCommittee
+      ## Sync committees corresponding to the finalized header
+    next_sync_committee*: SyncCommittee
+
+    best_valid_update*: Opt[LightClientUpdate]
+      ## Best available header to switch finalized head to
+      ## if we see nothing else
+
+    optimistic_header*: LightClientHeader
+      ## Most recent available reasonably-safe header
+
+    previous_max_active_participants*: uint64
+      ## Max number of active participants in a sync committee
+      ## (used to compute safety threshold)
+    current_max_active_participants*: uint64
+
+  # https://github.com/ethereum/consensus-specs/blob/82133085a1295e93394ebdf71df8f2f6e0962588/specs/electra/beacon-chain.md#beaconstate
+  BeaconState* = object
+    # Versioning
+    genesis_time*: uint64
+    genesis_validators_root*: Eth2Digest
+    slot*: Slot
+    fork*: Fork
+
+    # History
+    latest_block_header*: BeaconBlockHeader
+      ## `latest_block_header.state_root == ZERO_HASH` temporarily
+
+    block_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+      ## Needed to process attestations, older to newer
+
+    state_roots*: HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest]
+    historical_roots*: HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT]
+      ## Frozen in Capella, replaced by historical_summaries
+
+    # Eth1
+    eth1_data*: Eth1Data
+    eth1_data_votes*:
+      HashList[Eth1Data, Limit(EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH)]
+    eth1_deposit_index*: uint64
+
+    # Registry
+    validators*: HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT]
+    balances*: HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]
+
+    # Randomness
+    randao_mixes*: HashArray[Limit EPOCHS_PER_HISTORICAL_VECTOR, Eth2Digest]
+
+    # Slashings
+    slashings*: HashArray[Limit EPOCHS_PER_SLASHINGS_VECTOR, Gwei]
+      ## Per-epoch sums of slashed effective balances
+
+    # Participation
+    previous_epoch_participation*: EpochParticipationFlags
+    current_epoch_participation*: EpochParticipationFlags
+
+    # Finality
+    justification_bits*: JustificationBits
+      ## Bit set for every recent justified epoch
+
+    previous_justified_checkpoint*: Checkpoint
+    current_justified_checkpoint*: Checkpoint
+    finalized_checkpoint*: Checkpoint
+
+    # Inactivity
+    inactivity_scores*: InactivityScores
+
+    # Light client sync committees
+    current_sync_committee*: SyncCommittee
+    next_sync_committee*: SyncCommittee
+
+    # Execution
+    latest_execution_payload_header*: ExecutionPayloadHeader
+      ## [Modified in Electra:EIP6110:EIP7002]
+
+    # Withdrawals
+    next_withdrawal_index*: WithdrawalIndex
+    next_withdrawal_validator_index*: uint64
+
+    # Deep history valid from Capella onwards
+    historical_summaries*:
+      HashList[HistoricalSummary, Limit HISTORICAL_ROOTS_LIMIT]
+
+    deposit_requests_start_index*: uint64  # [New in Electra:EIP6110]
+    deposit_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    exit_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    earliest_exit_epoch*: Epoch  # [New in Electra:EIP7251]
+    consolidation_balance_to_consume*: Gwei  # [New in Electra:EIP7251]
+    earliest_consolidation_epoch*: Epoch  # [New in Electra:EIP7251]
+    pending_deposits*: HashList[PendingDeposit, Limit PENDING_DEPOSITS_LIMIT]
+      ## [New in Electra:EIP7251]
+
+    # [New in Electra:EIP7251]
+    pending_partial_withdrawals*:
+      HashList[PendingPartialWithdrawal, Limit PENDING_PARTIAL_WITHDRAWALS_LIMIT]
+    pending_consolidations*:
+      HashList[PendingConsolidation, Limit PENDING_CONSOLIDATIONS_LIMIT]
+
+    # [New in Fulu:EIP7917]
+    proposer_lookahead*:
+        HashArray[Limit ((MIN_SEED_LOOKAHEAD + 1) * SLOTS_PER_EPOCH), uint64]
+
+      ## [New in Electra:EIP7251]
+
+  # TODO Careful, not nil analysis is broken / incomplete and the semantics will
+  #      likely change in future versions of the language:
+  #      https://github.com/nim-lang/RFCs/issues/250
+  BeaconStateRef* = ref BeaconState not nil
+  NilableBeaconStateRef* = ref BeaconState
+
+  # TODO: There should be only a single generic HashedBeaconState definition
+  HashedBeaconState* = object
+    data*: BeaconState
+    root*: Eth2Digest # hash_tree_root(data)
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/beacon-chain.md#beaconblock
+  BeaconBlock* = object
+    ## For each slot, a proposer is chosen from the validator pool to propose
+    ## a new block. Once the block as been proposed, it is transmitted to
+    ## validators that will have a chance to vote on it through attestations.
+    ## Each block collects attestations, or votes, on past blocks, thus a chain
+    ## is formed.
+
+    slot*: Slot
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
+
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
+
+    body*: BeaconBlockBody
+
+  SigVerifiedBeaconBlock* = object
+    ## A BeaconBlock that contains verified signatures
+    ## but that has not been verified for state transition
+
+    slot*: Slot
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+
+    parent_root*: Eth2Digest
+      ## Root hash of the previous block
+
+    state_root*: Eth2Digest
+      ## The state root, _after_ this block has been processed
+
+    body*: SigVerifiedBeaconBlockBody
+
+  TrustedBeaconBlock* = object
+    ## When we receive blocks from outside sources, they are untrusted and go
+    ## through several layers of validation. Blocks that have gone through
+    ## validations can be trusted to be well-formed, with a correct signature,
+    ## having a parent and applying cleanly to the state that their parent
+    ## left them with.
+    ##
+    ## When loading such blocks from the database, to rewind states for example,
+    ## it is expensive to redo the validations (in particular, the signature
+    ## checks), thus `TrustedBlock` uses a `TrustedSig` type to mark that these
+    ## checks can be skipped.
+    ##
+    ## TODO this could probably be solved with some type trickery, but there
+    ##      too many bugs in nim around generics handling, and we've used up
+    ##      the trickery budget in the serialization library already. Until
+    ##      then, the type must be manually kept compatible with its untrusted
+    ##      cousin.
+    slot*: Slot
+    proposer_index*: uint64 # `ValidatorIndex` after validation
+    parent_root*: Eth2Digest
+    state_root*: Eth2Digest
+    body*: TrustedBeaconBlockBody
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/electra/beacon-chain.md#beaconblockbody
+  BeaconBlockBody* = object
+    randao_reveal*: ValidatorSig
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
+
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
+
+    # Operations
+    proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*:
+      List[electra.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    attestations*: List[electra.Attestation, Limit MAX_ATTESTATIONS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    sync_aggregate*: SyncAggregate
+
+    # Execution
+    execution_payload*: gloas.ExecutionPayload   # [Modified in Electra:EIP6110:EIP7002]
+    bls_to_execution_changes*: SignedBLSToExecutionChangeList
+    blob_kzg_commitments*: KzgCommitments
+    execution_requests*: ExecutionRequests  # [New in Electra]
+
+  SigVerifiedBeaconBlockBody* = object
+    ## A BeaconBlock body with signatures verified
+    ## including:
+    ## - Randao reveal
+    ## - Attestations
+    ## - ProposerSlashing (SignedBeaconBlockHeader)
+    ## - AttesterSlashing (IndexedAttestation)
+    ## - SignedVoluntaryExits
+    ## - SyncAggregate
+    ##
+    ## However:
+    ## - ETH1Data (Deposits) can contain invalid BLS signatures
+    ##
+    ## The block state transition has NOT been verified
+    randao_reveal*: TrustedSig
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
+
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
+
+    # Operations
+    proposer_slashings*:
+      List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*:
+      List[electra.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    attestations*: List[electra.TrustedAttestation, Limit MAX_ATTESTATIONS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    sync_aggregate*: TrustedSyncAggregate
+
+    # Execution
+    execution_payload*: ExecutionPayload   # [Modified in Electra:EIP6110:EIP7002]
+    bls_to_execution_changes*: SignedBLSToExecutionChangeList
+    blob_kzg_commitments*: KzgCommitments
+    execution_requests*: ExecutionRequests  # [New in Electra]
+
+  TrustedBeaconBlockBody* = object
+    ## A full verified block
+    randao_reveal*: TrustedSig
+    eth1_data*: Eth1Data
+      ## Eth1 data vote
+
+    graffiti*: GraffitiBytes
+      ## Arbitrary data
+
+    # Operations
+    proposer_slashings*:
+      List[TrustedProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
+    attester_slashings*:
+      List[electra.TrustedAttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    attestations*: List[electra.TrustedAttestation, Limit MAX_ATTESTATIONS_ELECTRA]
+      ## [Modified in Electra:EIP7549]
+    deposits*: List[Deposit, Limit MAX_DEPOSITS]
+    voluntary_exits*: List[TrustedSignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]
+
+    sync_aggregate*: TrustedSyncAggregate
+
+    # Execution
+    execution_payload*: ExecutionPayload   # [Modified in Electra:EIP6110:EIP7002]
+    bls_to_execution_changes*: SignedBLSToExecutionChangeList
+    blob_kzg_commitments*: KzgCommitments
+    execution_requests*: ExecutionRequests  # [New in Electra]
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/beacon-chain.md#signedbeaconblock
+  SignedBeaconBlock* = object
+    message*: BeaconBlock
+    signature*: ValidatorSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
+  SigVerifiedSignedBeaconBlock* = object
+    ## A SignedBeaconBlock with signatures verified
+    ## including:
+    ## - Block signature
+    ## - BeaconBlockBody
+    ##   - Randao reveal
+    ##   - Attestations
+    ##   - ProposerSlashing (SignedBeaconBlockHeader)
+    ##   - AttesterSlashing (IndexedAttestation)
+    ##   - SignedVoluntaryExits
+    ##
+    ##   - ETH1Data (Deposits) can contain invalid BLS signatures
+    ##
+    ## The block state transition has NOT been verified
+    message*: SigVerifiedBeaconBlock
+    signature*: TrustedSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
+  MsgTrustedSignedBeaconBlock* = object
+    message*: TrustedBeaconBlock
+    signature*: ValidatorSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
+  TrustedSignedBeaconBlock* = object
+    message*: TrustedBeaconBlock
+    signature*: TrustedSig
+
+    root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
+
+  SomeSignedBeaconBlock* =
+    SignedBeaconBlock |
+    SigVerifiedSignedBeaconBlock |
+    MsgTrustedSignedBeaconBlock |
+    TrustedSignedBeaconBlock
+  SomeBeaconBlock* =
+    BeaconBlock |
+    SigVerifiedBeaconBlock |
+    TrustedBeaconBlock
+  SomeBeaconBlockBody* =
+    BeaconBlockBody |
+    SigVerifiedBeaconBlockBody |
+    TrustedBeaconBlockBody
+
+  BlockContents* = object
+    `block`*: gloas.BeaconBlock
+    kzg_proofs*: fulu.KzgProofs
+    blobs*: Blobs
+
+# TODO: There should be only a single generic HashedBeaconState definition
+func initHashedBeaconState*(s: BeaconState): HashedBeaconState =
+  HashedBeaconState(data: s)
+
+func shortLog*(v: SomeBeaconBlock): auto =
+  (
+    slot: shortLog(v.slot),
+    proposer_index: v.proposer_index,
+    parent_root: shortLog(v.parent_root),
+    state_root: shortLog(v.state_root),
+    eth1data: v.body.eth1_data,
+    graffiti: $v.body.graffiti,
+    proposer_slashings_len: v.body.proposer_slashings.len(),
+    attester_slashings_len: v.body.attester_slashings.len(),
+    attestations_len: v.body.attestations.len(),
+    deposits_len: v.body.deposits.len(),
+    voluntary_exits_len: v.body.voluntary_exits.len(),
+    sync_committee_participants: v.body.sync_aggregate.num_active_participants,
+    block_number: v.body.execution_payload.block_number,
+    # TODO checksum hex? shortlog?
+    block_hash: to0xHex(v.body.execution_payload.block_hash.data),
+    parent_hash: to0xHex(v.body.execution_payload.parent_hash.data),
+    fee_recipient: to0xHex(v.body.execution_payload.fee_recipient.data),
+    bls_to_execution_changes_len: v.body.bls_to_execution_changes.len(),
+    blob_kzg_commitments_len: v.body.blob_kzg_commitments.len(),
+  )
+
+func shortLog*(v: SomeSignedBeaconBlock): auto =
+  (
+    blck: shortLog(v.message),
+    signature: shortLog(v.signature)
+  )
+
+func shortLog*(v: ExecutionPayload): auto =
+  (
+    parent_hash: shortLog(v.parent_hash),
+    fee_recipient: $v.fee_recipient,
+    state_root: shortLog(v.state_root),
+    receipts_root: shortLog(v.receipts_root),
+    prev_randao: shortLog(v.prev_randao),
+    block_number: v.block_number,
+    gas_limit: v.gas_limit,
+    gas_used: v.gas_used,
+    timestamp: v.timestamp,
+    extra_data: toPrettyString(distinctBase v.extra_data),
+    base_fee_per_gas: $(v.base_fee_per_gas),
+    block_hash: shortLog(v.block_hash),
+    num_transactions: len(v.transactions),
+    num_withdrawals: len(v.withdrawals),
+    blob_gas_used: $(v.blob_gas_used),
+    excess_blob_gas: $(v.excess_blob_gas)
+  )
+
+
+func shortLog*(v: ExecutionPayloadHeader): auto =
+  (
+    parent_hash: shortLog(v.parent_hash),
+    fee_recipient: $v.fee_recipient,
+    state_root: shortLog(v.state_root),
+    receipts_root: shortLog(v.receipts_root),
+    prev_randao: shortLog(v.prev_randao),
+    block_number: v.block_number,
+    gas_limit: v.gas_limit,
+    gas_used: v.gas_used,
+    timestamp: v.timestamp,
+    extra_data: toPrettyString(distinctBase v.extra_data),
+    base_fee_per_gas: $(v.base_fee_per_gas),
+    block_hash: shortLog(v.block_hash),
+    transactions_root: shortLog(v.transactions_root),
+    withdrawals_root: shortLog(v.withdrawals_root),
+    blob_gas_used: $(v.blob_gas_used),
+    excess_blob_gas: $(v.excess_blob_gas)
+  )
+
+template asSigned*(
+    x: SigVerifiedSignedBeaconBlock |
+       MsgTrustedSignedBeaconBlock |
+       TrustedSignedBeaconBlock): SignedBeaconBlock =
+  isomorphicCast[SignedBeaconBlock](x)
+
+template asSigVerified*(
+    x: SignedBeaconBlock |
+       MsgTrustedSignedBeaconBlock |
+       TrustedSignedBeaconBlock): SigVerifiedSignedBeaconBlock =
+  isomorphicCast[SigVerifiedSignedBeaconBlock](x)
+
+template asSigVerified*(
+    x: BeaconBlock | TrustedBeaconBlock): SigVerifiedBeaconBlock =
+  isomorphicCast[SigVerifiedBeaconBlock](x)
+
+template asMsgTrusted*(
+    x: SignedBeaconBlock |
+       SigVerifiedSignedBeaconBlock |
+       TrustedSignedBeaconBlock): MsgTrustedSignedBeaconBlock =
+  isomorphicCast[MsgTrustedSignedBeaconBlock](x)
+
+template asTrusted*(
+    x: SignedBeaconBlock |
+       SigVerifiedSignedBeaconBlock |
+       MsgTrustedSignedBeaconBlock): TrustedSignedBeaconBlock =
+  isomorphicCast[TrustedSignedBeaconBlock](x)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
@@ -19,6 +19,9 @@ import
   ../[forks, keystore],
   ./[rest_keymanager_types, rest_types]
 
+debugGloasComment "..."
+import ../datatypes/gloas
+
 export
   results, json_serialization, results, slashing_protection_common, block_pools_types,
   forks, keystore, rest_keymanager_types, rest_types
@@ -115,6 +118,7 @@ RestJson.useDefaultSerializationFor(
   GetStateValidatorResponse,
   GetStateValidatorsResponse,
   GetValidatorGasLimitResponse,
+  GloasSignedBlockContents,
   HeadChangeInfoObject,
   HistoricalSummary,
   ImportDistributedKeystoresBody,
@@ -289,6 +293,12 @@ RestJson.useDefaultSerializationFor(
   fulu_mev.BuilderBid,
   fulu_mev.SignedBlindedBeaconBlock,
   fulu_mev.SignedBuilderBid,
+  gloas.BeaconBlock,
+  gloas.BeaconBlockBody,
+  gloas.BeaconState,
+  gloas.BlockContents,
+  gloas.ExecutionPayload,
+  gloas.ExecutionPayloadHeader,
   phase0.AggregateAndProof,
   phase0.Attestation,
   phase0.AttesterSlashing,
@@ -655,6 +665,8 @@ proc readValue*(r: var RestJsonReader, value: var ForkedHashedBeaconState) {.rea
       toValue(electraData)
     of ConsensusFork.Fulu:
       toValue(fuluData)
+    of ConsensusFork.Gloas:
+      toValue(gloasData)
   except SerializationError:
     r.raiseUnexpectedValue(&"Incorrect {v.version} beacon state format")
 
@@ -1233,8 +1245,17 @@ proc readValue*(
   # `consensus_block_value`
 
   withConsensusFork(v.version):
+    debugGloasComment "re-add gloas mev"
     value =
-      when consensusFork >= ConsensusFork.Electra:
+      when consensusFork >= ConsensusFork.Gloas:
+        if v.execution_payload_blinded:
+          r.raiseUnexpectedValue(
+            &"`execution_payload_blinded` unsupported for {v.version}"
+          )
+        ForkedMaybeBlindedBeaconBlock.init(
+          RestJson.decode(string(v.data), consensusFork.BlockContents)
+        )
+      elif consensusFork >= ConsensusFork.Electra:
         if v.execution_payload_blinded:
           ForkedMaybeBlindedBeaconBlock.init(
             RestJson.decode(string(v.data), consensusFork.BlindedBlockContents),

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -847,7 +847,10 @@ proc decodeBytes*[T: ProduceBlockResponseV3](
           except ValueError:
             return err("Incorrect `Eth-Consensus-Block-Value` header value")
     withConsensusFork(fork):
-      when consensusFork >= ConsensusFork.Electra:
+      debugGloasComment ""
+      when consensusFork == ConsensusFork.Gloas:
+        return err("gloas produceblockv3 not available yet")
+      elif consensusFork >= ConsensusFork.Electra:
         if blinded:
           let contents =
             ? readSszResBytes(consensusFork.BlindedBlockContents, value)

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -19,6 +19,9 @@ import
   stew/base10, httputils, stew/bitops2,
   ../forks
 
+debugGloasComment ""
+import ../datatypes/gloas
+
 export forks, tables, httputils, results
 
 const
@@ -320,6 +323,11 @@ type
     kzg_proofs*: fulu.KzgProofs
     blobs*: deneb.Blobs
 
+  GloasSignedBlockContents* = object
+    signed_block*: gloas.SignedBeaconBlock
+    kzg_proofs*: fulu.KzgProofs
+    blobs*: deneb.Blobs
+
   RestPublishedSignedBlockContents* = object
     case kind*: ConsensusFork
     of ConsensusFork.Phase0:    phase0Data*:    phase0.SignedBeaconBlock
@@ -329,6 +337,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     DenebSignedBlockContents
     of ConsensusFork.Electra:   electraData*:   ElectraSignedBlockContents
     of ConsensusFork.Fulu:      fuluData*:      FuluSignedBlockContents
+    of ConsensusFork.Gloas:     gloasData*:     GloasSignedBlockContents
 
   ProduceBlockResponseV3* = ForkedMaybeBlindedBeaconBlock
 
@@ -612,6 +621,13 @@ func `==`*(a, b: RestValidatorIndex): bool {.borrow.}
 template withForkyBlck*(
     x: RestPublishedSignedBlockContents, body: untyped): untyped =
   case x.kind
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyData: untyped {.inject, used.} = x.gloasData
+    template forkyBlck: untyped {.inject, used.} = x.gloasData.signed_block
+    template kzg_proofs: untyped {.inject, used.} = x.gloasData.kzg_proofs
+    template blobs: untyped {.inject, used.} = x.gloasData.blobs
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyData: untyped {.inject, used.} = x.fuluData
@@ -672,6 +688,8 @@ func init*(T: type ForkedSignedBeaconBlock,
       ForkedSignedBeaconBlock.init(contents.electraData.signed_block)
     of ConsensusFork.Fulu:
       ForkedSignedBeaconBlock.init(contents.fuluData.signed_block)
+    of ConsensusFork.Gloas:
+      ForkedSignedBeaconBlock.init(contents.gloasData.signed_block)
 
 func init*(t: typedesc[RestPublishedSignedBlockContents],
            blck: phase0.BeaconBlock, root: Eth2Digest,
@@ -752,6 +770,22 @@ func init*(t: typedesc[RestPublishedSignedBlockContents],
     kind: ConsensusFork.Fulu,
     fuluData: FuluSignedBlockContents(
       signed_block: fulu.SignedBeaconBlock(
+        message: contents.`block`,
+        root: root,
+        signature: signature
+      ),
+      kzg_proofs: contents.kzg_proofs,
+      blobs: contents.blobs
+    )
+  )
+
+func init*(t: typedesc[RestPublishedSignedBlockContents],
+           contents: gloas.BlockContents, root: Eth2Digest,
+           signature: ValidatorSig): RestPublishedSignedBlockContents =
+  RestPublishedSignedBlockContents(
+    kind: ConsensusFork.Gloas,
+    gloasData: GloasSignedBlockContents(
+      signed_block: gloas.SignedBeaconBlock(
         message: contents.`block`,
         root: root,
         signature: signature

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -581,7 +581,7 @@ template BeaconState*(kind: static ConsensusFork): typedesc =
 
 template BeaconBlock*(kind: static ConsensusFork): typedesc =
   when kind == ConsensusFork.Gloas:
-    fulu.BeaconBlock
+    gloas.BeaconBlock
   elif kind == ConsensusFork.Fulu:
     fulu.BeaconBlock
   elif kind == ConsensusFork.Electra:

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -16,7 +16,7 @@ import
   "."/[
     block_id, eth2_merkleization, eth2_ssz_serialization,
     forks_light_client, presets],
-  ./datatypes/[phase0, altair, bellatrix, capella, deneb, electra, fulu],
+  ./datatypes/[phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas],
   ./mev/[bellatrix_mev, capella_mev, deneb_mev, electra_mev, fulu_mev]
 
 from std/sequtils import mapIt
@@ -53,6 +53,7 @@ type
     Deneb = "deneb"
     Electra = "electra"
     Fulu = "fulu"
+    Gloas = "gloas"
 
   ForkyBeaconState* =
     phase0.BeaconState |
@@ -61,7 +62,8 @@ type
     capella.BeaconState |
     deneb.BeaconState |
     electra.BeaconState |
-    fulu.BeaconState
+    fulu.BeaconState |
+    gloas.BeaconState
 
   ForkyHashedBeaconState* =
     phase0.HashedBeaconState |
@@ -70,7 +72,8 @@ type
     capella.HashedBeaconState |
     deneb.HashedBeaconState |
     electra.HashedBeaconState |
-    fulu.HashedBeaconState
+    fulu.HashedBeaconState |
+    gloas.HashedBeaconState
 
   ForkedHashedBeaconState* = object
     case kind*: ConsensusFork
@@ -81,20 +84,23 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb.HashedBeaconState
     of ConsensusFork.Electra:   electraData*:   electra.HashedBeaconState
     of ConsensusFork.Fulu:      fuluData*:      fulu.HashedBeaconState
+    of ConsensusFork.Gloas:     gloasData*:     gloas.HashedBeaconState
 
   ForkyExecutionPayload* =
     bellatrix.ExecutionPayload |
     capella.ExecutionPayload |
     deneb.ExecutionPayload |
     electra.ExecutionPayload |
-    fulu.ExecutionPayload
+    fulu.ExecutionPayload |
+    gloas.ExecutionPayload
 
   ForkyExecutionPayloadHeader* =
     bellatrix.ExecutionPayloadHeader |
     capella.ExecutionPayloadHeader |
     deneb.ExecutionPayloadHeader |
     electra.ExecutionPayloadHeader |
-    fulu.ExecutionPayloadHeader
+    fulu.ExecutionPayloadHeader |
+    gloas.ExecutionPayloadHeader
 
   ForkyExecutionPayloadOrHeader* =
     ForkyExecutionPayload | ForkyExecutionPayloadHeader
@@ -106,7 +112,8 @@ type
     capella.BeaconBlockBody |
     deneb.BeaconBlockBody |
     electra.BeaconBlockBody |
-    fulu.BeaconBlockBody
+    fulu.BeaconBlockBody |
+    gloas.BeaconBlockBody
 
   ForkySigVerifiedBeaconBlockBody* =
     phase0.SigVerifiedBeaconBlockBody |
@@ -115,7 +122,8 @@ type
     capella.SigVerifiedBeaconBlockBody |
     deneb.SigVerifiedBeaconBlockBody |
     electra.SigVerifiedBeaconBlockBody |
-    fulu.SigVerifiedBeaconBlockBody
+    fulu.SigVerifiedBeaconBlockBody |
+    gloas.SigVerifiedBeaconBlockBody
 
   ForkyTrustedBeaconBlockBody* =
     phase0.TrustedBeaconBlockBody |
@@ -124,7 +132,8 @@ type
     capella.TrustedBeaconBlockBody |
     deneb.TrustedBeaconBlockBody |
     electra.TrustedBeaconBlockBody |
-    fulu.TrustedBeaconBlockBody
+    fulu.TrustedBeaconBlockBody |
+    gloas.TrustedBeaconBlockBody
 
   SomeForkyBeaconBlockBody* =
     ForkyBeaconBlockBody |
@@ -138,7 +147,8 @@ type
     capella.BeaconBlock |
     deneb.BeaconBlock |
     electra.BeaconBlock |
-    fulu.BeaconBlock
+    fulu.BeaconBlock |
+    gloas.BeaconBlock
 
   ForkySigVerifiedBeaconBlock* =
     phase0.SigVerifiedBeaconBlock |
@@ -147,7 +157,8 @@ type
     capella.SigVerifiedBeaconBlock |
     deneb.SigVerifiedBeaconBlock |
     electra.SigVerifiedBeaconBlock |
-    fulu.SigVerifiedBeaconBlock
+    fulu.SigVerifiedBeaconBlock |
+    gloas.SigVerifiedBeaconBlock
 
   ForkyTrustedBeaconBlock* =
     phase0.TrustedBeaconBlock |
@@ -156,7 +167,8 @@ type
     capella.TrustedBeaconBlock |
     deneb.TrustedBeaconBlock |
     electra.TrustedBeaconBlock |
-    fulu.TrustedBeaconBlock
+    fulu.TrustedBeaconBlock |
+    gloas.TrustedBeaconBlock
 
   SomeForkyBeaconBlock* =
     ForkyBeaconBlock |
@@ -168,7 +180,8 @@ type
     capella.ExecutionPayloadForSigning |
     deneb.ExecutionPayloadForSigning |
     electra.ExecutionPayloadForSigning |
-    fulu.ExecutionPayloadForSigning
+    fulu.ExecutionPayloadForSigning |
+    gloas.ExecutionPayloadForSigning
 
   ForkyBlindedBeaconBlock* =
     electra_mev.BlindedBeaconBlock |
@@ -196,7 +209,8 @@ type
   ForkyBlockContents* =
     deneb.BlockContents |
     electra.BlockContents |
-    fulu.BlockContents
+    fulu.BlockContents |
+    gloas.BlockContents
 
   ForkyAggregateAndProof* =
     phase0.AggregateAndProof |
@@ -219,6 +233,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     phase0.Attestation
     of ConsensusFork.Electra:   electraData*:   electra.Attestation
     of ConsensusFork.Fulu:      fuluData*:      electra.Attestation
+    of ConsensusFork.Gloas:     gloasData*:     electra.Attestation
 
   ForkedAggregateAndProof* = object
     case kind*: ConsensusFork
@@ -229,6 +244,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     phase0.AggregateAndProof
     of ConsensusFork.Electra:   electraData*:   electra.AggregateAndProof
     of ConsensusFork.Fulu:      fuluData*:      electra.AggregateAndProof
+    of ConsensusFork.Gloas:     gloasData*:     electra.AggregateAndProof
 
   ForkedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -239,6 +255,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb.BeaconBlock
     of ConsensusFork.Electra:   electraData*:   electra.BeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.BeaconBlock
+    of ConsensusFork.Gloas:     gloasData*:     gloas.BeaconBlock
 
   ForkedMaybeBlindedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -256,6 +273,8 @@ type
       electraData*: electra_mev.MaybeBlindedBeaconBlock
     of ConsensusFork.Fulu:
       fuluData*: fulu_mev.MaybeBlindedBeaconBlock
+    of ConsensusFork.Gloas:
+      gloasData*: gloas.BlockContents
     consensusValue*: Opt[UInt256]
     executionValue*: Opt[UInt256]
 
@@ -271,7 +290,8 @@ type
     capella.SignedBeaconBlock |
     deneb.SignedBeaconBlock |
     electra.SignedBeaconBlock |
-    fulu.SignedBeaconBlock
+    fulu.SignedBeaconBlock |
+    gloas.SignedBeaconBlock
 
   ForkedSignedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -282,6 +302,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb.SignedBeaconBlock
     of ConsensusFork.Electra:   electraData*:   electra.SignedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.SignedBeaconBlock
+    of ConsensusFork.Gloas:     gloasData*:     gloas.SignedBeaconBlock
 
   ForkySignedBlindedBeaconBlock* =
     phase0.SignedBeaconBlock |
@@ -301,6 +322,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb_mev.SignedBlindedBeaconBlock
     of ConsensusFork.Electra:   electraData*:   electra_mev.SignedBlindedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu_mev.SignedBlindedBeaconBlock
+    of ConsensusFork.Gloas:     gloasData*:     fulu_mev.SignedBlindedBeaconBlock
 
   ForkySigVerifiedSignedBeaconBlock* =
     phase0.SigVerifiedSignedBeaconBlock |
@@ -309,7 +331,8 @@ type
     capella.SigVerifiedSignedBeaconBlock |
     deneb.SigVerifiedSignedBeaconBlock |
     electra.SigVerifiedSignedBeaconBlock |
-    fulu.SigVerifiedSignedBeaconBlock
+    fulu.SigVerifiedSignedBeaconBlock |
+    gloas.SigVerifiedSignedBeaconBlock
 
   ForkyMsgTrustedSignedBeaconBlock* =
     phase0.MsgTrustedSignedBeaconBlock |
@@ -318,7 +341,8 @@ type
     capella.MsgTrustedSignedBeaconBlock |
     deneb.MsgTrustedSignedBeaconBlock |
     electra.MsgTrustedSignedBeaconBlock |
-    fulu.MsgTrustedSignedBeaconBlock
+    fulu.MsgTrustedSignedBeaconBlock |
+    gloas.MsgTrustedSignedBeaconBlock
 
   ForkyTrustedSignedBeaconBlock* =
     phase0.TrustedSignedBeaconBlock |
@@ -327,7 +351,8 @@ type
     capella.TrustedSignedBeaconBlock |
     deneb.TrustedSignedBeaconBlock |
     electra.TrustedSignedBeaconBlock |
-    fulu.TrustedSignedBeaconBlock
+    fulu.TrustedSignedBeaconBlock |
+    gloas.TrustedSignedBeaconBlock
 
   ForkedMsgTrustedSignedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -338,6 +363,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb.MsgTrustedSignedBeaconBlock
     of ConsensusFork.Electra:   electraData*:   electra.MsgTrustedSignedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.MsgTrustedSignedBeaconBlock
+    of ConsensusFork.Gloas:     gloasData*:     gloas.MsgTrustedSignedBeaconBlock
 
   ForkedTrustedSignedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -348,6 +374,7 @@ type
     of ConsensusFork.Deneb:     denebData*:     deneb.TrustedSignedBeaconBlock
     of ConsensusFork.Electra:   electraData*:   electra.TrustedSignedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.TrustedSignedBeaconBlock
+    of ConsensusFork.Gloas:     gloasData*:     gloas.TrustedSignedBeaconBlock
 
   SomeForkySignedBeaconBlock* =
     ForkySignedBeaconBlock |
@@ -514,8 +541,28 @@ template kind*(
       fulu_mev.SignedBuilderBid]): ConsensusFork =
   ConsensusFork.Fulu
 
+template kind*(
+    x: typedesc[
+      gloas.BeaconState |
+      gloas.HashedBeaconState |
+      gloas.ExecutionPayload |
+      gloas.ExecutionPayloadForSigning |
+      gloas.ExecutionPayloadHeader |
+      gloas.BeaconBlock |
+      gloas.SignedBeaconBlock |
+      gloas.TrustedBeaconBlock |
+      gloas.BeaconBlockBody |
+      gloas.SigVerifiedBeaconBlockBody |
+      gloas.TrustedBeaconBlockBody |
+      gloas.SigVerifiedSignedBeaconBlock |
+      gloas.MsgTrustedSignedBeaconBlock |
+      gloas.TrustedSignedBeaconBlock]): ConsensusFork =
+  ConsensusFork.Gloas
+
 template BeaconState*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.BeaconState
+  elif kind == ConsensusFork.Fulu:
     fulu.BeaconState
   elif kind == ConsensusFork.Electra:
     electra.BeaconState
@@ -533,7 +580,9 @@ template BeaconState*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconState unsupported in " & $kind.}
 
 template BeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    fulu.BeaconBlock
+  elif kind == ConsensusFork.Fulu:
     fulu.BeaconBlock
   elif kind == ConsensusFork.Electra:
     electra.BeaconBlock
@@ -551,7 +600,9 @@ template BeaconBlock*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconBlock unsupported in " & $kind.}
 
 template BeaconBlockBody*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.BeaconBlockBody
+  elif kind == ConsensusFork.Fulu:
     fulu.BeaconBlockBody
   elif kind == ConsensusFork.Electra:
     electra.BeaconBlockBody
@@ -569,7 +620,9 @@ template BeaconBlockBody*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconBlockBody unsupported in " & $kind.}
 
 template SignedBeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.SignedBeaconBlock
+  elif kind == ConsensusFork.Fulu:
     fulu.SignedBeaconBlock
   elif kind == ConsensusFork.Electra:
     electra.SignedBeaconBlock
@@ -587,7 +640,9 @@ template SignedBeaconBlock*(kind: static ConsensusFork): typedesc =
     {.error: "SignedBeaconBlock unsupported in " & $kind.}
 
 template TrustedSignedBeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.TrustedSignedBeaconBlock
+  elif kind == ConsensusFork.Fulu:
     fulu.TrustedSignedBeaconBlock
   elif kind == ConsensusFork.Electra:
     electra.TrustedSignedBeaconBlock
@@ -605,7 +660,9 @@ template TrustedSignedBeaconBlock*(kind: static ConsensusFork): typedesc =
     {.error: "TrustedSignedBeaconBlock unsupported in " & $kind.}
 
 template ExecutionPayloadForSigning*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.ExecutionPayloadForSigning
+  elif kind == ConsensusFork.Fulu:
     fulu.ExecutionPayloadForSigning
   elif kind == ConsensusFork.Electra:
     electra.ExecutionPayloadForSigning
@@ -665,7 +722,8 @@ template Forky*(
 
 template withAll*(
     x: typedesc[ConsensusFork], body: untyped): untyped =
-  static: doAssert ConsensusFork.high == ConsensusFork.Fulu
+  debugGloasComment "don't add gloas here yet"
+  static: doAssert ConsensusFork.high == ConsensusFork.Gloas
   block:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     body
@@ -691,6 +749,9 @@ template withAll*(
 template withConsensusFork*(
     x: ConsensusFork, body: untyped): untyped =
   case x
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     body
@@ -714,7 +775,9 @@ template withConsensusFork*(
     body
 
 template BlockContents*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    gloas.BlockContents
+  elif kind == ConsensusFork.Fulu:
     fulu.BlockContents
   elif kind == ConsensusFork.Electra:
     electra.BlockContents
@@ -758,7 +821,8 @@ template PayloadAttributes*(
     {.error: "PayloadAttributes unsupported in " & $kind.}
 
 # `eth2_merkleization` cannot import `forks` (circular), so the check is here
-static: doAssert ConsensusFork.high == ConsensusFork.Fulu,
+debugGloasComment "actually verify this"
+static: doAssert ConsensusFork.high == ConsensusFork.Gloas,
   "eth2_merkleization has been checked and `hash_tree_root` is up to date"
 
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
@@ -806,6 +870,8 @@ template init*(T: type ForkedBeaconBlock, blck: electra.BeaconBlock): T =
   T(kind: ConsensusFork.Electra, electraData: blck)
 template init*(T: type ForkedBeaconBlock, blck: fulu.BeaconBlock): T =
   T(kind: ConsensusFork.Fulu, fuluData: blck)
+template init*(T: type ForkedBeaconBlock, blck: gloas.BeaconBlock): T =
+  T(kind: ConsensusFork.Gloas, gloasData: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, blck: phase0.SignedBeaconBlock): T =
   T(kind: ConsensusFork.Phase0, phase0Data: blck)
@@ -821,6 +887,8 @@ template init*(T: type ForkedSignedBeaconBlock, blck: electra.SignedBeaconBlock)
   T(kind: ConsensusFork.Electra, electraData: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: fulu.SignedBeaconBlock): T =
   T(kind: ConsensusFork.Fulu, fuluData: blck)
+template init*(T: type ForkedSignedBeaconBlock, blck: gloas.SignedBeaconBlock): T =
+  T(kind: ConsensusFork.Gloas, gloasData: blck)
 
 func init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
            blockRoot: Eth2Digest, signature: ValidatorSig): T =
@@ -858,6 +926,11 @@ func init*(T: type ForkedSignedBeaconBlock, forked: ForkedBeaconBlock,
   of ConsensusFork.Fulu:
     T(kind: ConsensusFork.Fulu,
       fuluData: fulu.SignedBeaconBlock(message: forked.fuluData,
+                                             root: blockRoot,
+                                             signature: signature))
+  of ConsensusFork.Gloas:
+    T(kind: ConsensusFork.Gloas,
+      gloasData: gloas.SignedBeaconBlock(message: forked.gloasData,
                                              root: blockRoot,
                                              signature: signature))
 
@@ -914,12 +987,16 @@ template init*(T: type ForkedTrustedSignedBeaconBlock, blck: electra.TrustedSign
   T(kind: ConsensusFork.Electra, electraData: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: fulu.TrustedSignedBeaconBlock): T =
   T(kind: ConsensusFork.Fulu, fuluData: blck)
+template init*(T: type ForkedTrustedSignedBeaconBlock, blck: gloas.TrustedSignedBeaconBlock): T =
+  T(kind: ConsensusFork.Gloas, gloasData: blck)
 
 template toString*(kind: ConsensusFork): string =
   $kind
 
 template init*(T: typedesc[ConsensusFork], value: string): Opt[ConsensusFork] =
   case value
+  of "gloas":
+    Opt.some ConsensusFork.Gloas
   of "fulu":
     Opt.some ConsensusFork.Fulu
   of "electra":
@@ -948,6 +1025,10 @@ template init*(T: type ForkedEpochInfo, info: altair.EpochInfo): T =
 
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyState: untyped {.inject, used.} = x.gloasData
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyState: untyped {.inject, used.} = x.fuluData
@@ -982,7 +1063,9 @@ template forky*(
       ForkedBeaconBlock |
       ForkedHashedBeaconState,
     kind: static ConsensusFork): untyped =
-  when kind == ConsensusFork.Fulu:
+  when kind == ConsensusFork.Gloas:
+    x.gloasData
+  elif kind == ConsensusFork.Fulu:
     x.fuluData
   elif kind == ConsensusFork.Electra:
     x.electraData
@@ -1020,7 +1103,8 @@ template withEpochInfo*(
 
 template withEpochInfo*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
-           deneb.BeaconState | electra.BeaconState | fulu.BeaconState,
+           deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
+           gloas.BeaconState,
     x: var ForkedEpochInfo, body: untyped): untyped =
   if x.kind != EpochInfoFork.Altair:
     # Rare, so efficiency not critical
@@ -1068,6 +1152,8 @@ func get_blob_parameters*(cfg: RuntimeConfig, epoch: Epoch): BlobParameters =
 func consensusForkEpoch*(
     cfg: RuntimeConfig, consensusFork: ConsensusFork): Epoch =
   case consensusFork
+  of ConsensusFork.Gloas:
+    cfg.GLOAS_FORK_EPOCH
   of ConsensusFork.Fulu:
     cfg.FULU_FORK_EPOCH
   of ConsensusFork.Electra:
@@ -1086,7 +1172,8 @@ func consensusForkEpoch*(
 func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
   ## Return the current fork for the given epoch.
   static:
-    doAssert high(ConsensusFork) == ConsensusFork.Fulu
+    doAssert high(ConsensusFork) == ConsensusFork.Gloas
+    doAssert ConsensusFork.Gloas     > ConsensusFork.Fulu
     doAssert ConsensusFork.Fulu      > ConsensusFork.Electra
     doAssert ConsensusFork.Electra   > ConsensusFork.Deneb
     doAssert ConsensusFork.Deneb     > ConsensusFork.Capella
@@ -1095,7 +1182,8 @@ func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
     doAssert ConsensusFork.Altair    > ConsensusFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.FULU_FORK_EPOCH:      ConsensusFork.Fulu
+  if   epoch >= cfg.GLOAS_FORK_EPOCH:     ConsensusFork.Gloas
+  elif epoch >= cfg.FULU_FORK_EPOCH:      ConsensusFork.Fulu
   elif epoch >= cfg.ELECTRA_FORK_EPOCH:   ConsensusFork.Electra
   elif epoch >= cfg.DENEB_FORK_EPOCH:     ConsensusFork.Deneb
   elif epoch >= cfg.CAPELLA_FORK_EPOCH:   ConsensusFork.Capella
@@ -1105,7 +1193,9 @@ func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
 
 func consensusForkForDigest*(
     forkDigests: ForkDigests, forkDigest: ForkDigest): Opt[ConsensusFork] =
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  # Past Fulu, this reverse lookup doesn't work anyway in a good way, needs to
+  # be refactored
   if   forkDigest == forkDigests.fuluInt:
     ok ConsensusFork.Fulu
   elif forkDigest == forkDigests.electra:
@@ -1128,7 +1218,10 @@ func consensusForkForDigest*(
 
 func atConsensusFork*(
     forkDigests: ForkDigests, consensusFork: ConsensusFork): ForkDigest {.deprecated.} =
+  debugGloasComment "atConsensusFork is deprecated anyway, should be gone before we need it for gloas, otherwise look at again"
   case consensusFork
+  of ConsensusFork.Gloas:
+    forkDigests.fuluInt
   of ConsensusFork.Fulu:
     forkDigests.fuluInt
   of ConsensusFork.Electra:
@@ -1228,6 +1321,10 @@ template withBlck*(
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyBlck: untyped {.inject, used.} = x.fuluData
     body
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyBlck: untyped {.inject, used.} = x.gloasData
+    body
 
 func proposer_index*(x: ForkedBeaconBlock): uint64 =
   withBlck(x): forkyBlck.proposer_index
@@ -1253,7 +1350,8 @@ template getForkedBlockField*(
   of ConsensusFork.Capella:   unsafeAddr x.capellaData.message.y
   of ConsensusFork.Deneb:     unsafeAddr x.denebData.message.y
   of ConsensusFork.Electra:   unsafeAddr x.electraData.message.y
-  of ConsensusFork.Fulu:      unsafeAddr x.fuluData.message.y)[]
+  of ConsensusFork.Fulu:      unsafeAddr x.fuluData.message.y
+  of ConsensusFork.Gloas:     unsafeAddr x.gloasData.message.y)[]
 
 template signature*(x: ForkedSignedBeaconBlock |
                        ForkedMsgTrustedSignedBeaconBlock |
@@ -1290,7 +1388,14 @@ chronicles.formatIt ForkedTrustedSignedBeaconBlock: it.shortLog
 template withForkyMaybeBlindedBlck*(
     b: ForkedMaybeBlindedBeaconBlock,
     body: untyped): untyped =
+  debugGloasComment "re-add mev to gloas"
   case b.kind
+  of ConsensusFork.Gloas:
+    const
+      consensusFork {.inject, used.} = ConsensusFork.Gloas
+      isBlinded {.inject, used.} = false
+    template forkyMaybeBlindedBlck: untyped {.inject, used.} = b.gloasData
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template d: untyped = b.fuluData
@@ -1363,6 +1468,11 @@ template withStateAndBlck*(
        ForkedTrustedSignedBeaconBlock,
     body: untyped): untyped =
   case s.kind
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyState: untyped {.inject.} = s.gloasData
+    template forkyBlck: untyped {.inject.} = b.gloasData
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyState: untyped {.inject.} = s.fuluData
@@ -1401,6 +1511,10 @@ template withStateAndBlck*(
 
 template withAttestation*(a: ForkedAttestation, body: untyped): untyped =
   case a.kind
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyAttestation: untyped {.inject.} = a.gloasData
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyAttestation: untyped {.inject.} = a.fuluData
@@ -1433,6 +1547,10 @@ template withAttestation*(a: ForkedAttestation, body: untyped): untyped =
 template withAggregateAndProof*(a: ForkedAggregateAndProof,
                                 body: untyped): untyped =
   case a.kind
+  of ConsensusFork.Gloas:
+    const consensusFork {.inject, used.} = ConsensusFork.Gloas
+    template forkyProof: untyped {.inject.} = a.gloasData
+    body
   of ConsensusFork.Fulu:
     const consensusFork {.inject, used.} = ConsensusFork.Fulu
     template forkyProof: untyped {.inject.} = a.fuluData
@@ -1534,8 +1652,15 @@ func fuluFork*(cfg: RuntimeConfig): Fork =
     current_version: cfg.FULU_FORK_VERSION,
     epoch: cfg.FULU_FORK_EPOCH)
 
+func gloasFork*(cfg: RuntimeConfig): Fork =
+  Fork(
+    previous_version: cfg.FULU_FORK_VERSION,
+    current_version: cfg.GLOAS_FORK_VERSION,
+    epoch: cfg.GLOAS_FORK_EPOCH)
+
 func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
   case cfg.consensusForkAtEpoch(epoch)
+  of ConsensusFork.Gloas:     cfg.gloasFork
   of ConsensusFork.Fulu:      cfg.fuluFork
   of ConsensusFork.Electra:   cfg.electraFork
   of ConsensusFork.Deneb:     cfg.denebFork
@@ -1546,6 +1671,7 @@ func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
 
 func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   case cfg.consensusForkAtEpoch(epoch)
+  of ConsensusFork.Gloas:     cfg.GLOAS_FORK_VERSION
   of ConsensusFork.Fulu:      cfg.FULU_FORK_VERSION
   of ConsensusFork.Electra:   cfg.ELECTRA_FORK_VERSION
   of ConsensusFork.Deneb:     cfg.DENEB_FORK_VERSION
@@ -1556,7 +1682,15 @@ func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
 
 func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
   ## Used to construct the eth2 field of ENRs
+  debugGloasComment "probably wrong, definitely look at again, and if right, refactor"
   case cfg.consensusForkAtEpoch(epoch)
+  of ConsensusFork.Gloas:
+    var res = FAR_FUTURE_EPOCH
+    for entry in cfg.BLOB_SCHEDULE:
+      if epoch >= entry.EPOCH:
+        break
+      res = entry.EPOCH
+    res
   of ConsensusFork.Fulu:
     var res = FAR_FUTURE_EPOCH
     for entry in cfg.BLOB_SCHEDULE:
@@ -1573,13 +1707,14 @@ func nextForkEpochAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Epoch =
 
 func forkVersion*(cfg: RuntimeConfig, consensusFork: ConsensusFork): Version =
   case consensusFork
-  of ConsensusFork.Phase0:      cfg.GENESIS_FORK_VERSION
-  of ConsensusFork.Altair:      cfg.ALTAIR_FORK_VERSION
-  of ConsensusFork.Bellatrix:   cfg.BELLATRIX_FORK_VERSION
-  of ConsensusFork.Capella:     cfg.CAPELLA_FORK_VERSION
-  of ConsensusFork.Deneb:       cfg.DENEB_FORK_VERSION
-  of ConsensusFork.Electra:     cfg.ELECTRA_FORK_VERSION
-  of ConsensusFork.Fulu:        cfg.FULU_FORK_VERSION
+  of ConsensusFork.Phase0:     cfg.GENESIS_FORK_VERSION
+  of ConsensusFork.Altair:     cfg.ALTAIR_FORK_VERSION
+  of ConsensusFork.Bellatrix:  cfg.BELLATRIX_FORK_VERSION
+  of ConsensusFork.Capella:    cfg.CAPELLA_FORK_VERSION
+  of ConsensusFork.Deneb:      cfg.DENEB_FORK_VERSION
+  of ConsensusFork.Electra:    cfg.ELECTRA_FORK_VERSION
+  of ConsensusFork.Fulu:       cfg.FULU_FORK_VERSION
+  of ConsensusFork.Gloas:      cfg.GLOAS_FORK_VERSION
 
 func lcDataForkAtConsensusFork*(
     consensusFork: ConsensusFork): LightClientDataFork =
@@ -1601,7 +1736,8 @@ func getForkSchedule*(cfg: RuntimeConfig): array[7, Fork] =
   ## This procedure is used by HTTP REST framework and validator client.
   ##
   ## NOTE: Update this procedure when new fork will be scheduled.
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  debugGloasComment "deliberately don't expose this to REST yet"
   [cfg.genesisFork(), cfg.altairFork(), cfg.bellatrixFork(), cfg.capellaFork(),
    cfg.denebFork(), cfg.electraFork(), cfg.fuluFork()]
 
@@ -1714,7 +1850,6 @@ func compute_fork_digest_fulu*(
 func init*(T: type ForkDigests,
            cfg: RuntimeConfig,
            genesis_validators_root: Eth2Digest): T =
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
   T(
     phase0:
       compute_fork_digest(cfg.GENESIS_FORK_VERSION, genesis_validators_root),
@@ -1831,6 +1966,12 @@ template init*(T: type ForkedMaybeBlindedBeaconBlock,
     executionValue: evalue)
 
 template init*(T: type ForkedMaybeBlindedBeaconBlock,
+               blck: gloas.BlockContents): T =
+  ForkedMaybeBlindedBeaconBlock(
+    kind: ConsensusFork.Gloas,
+    gloasData: blck)
+
+template init*(T: type ForkedMaybeBlindedBeaconBlock,
                blck: fulu_mev.BlindedBeaconBlock,
                evalue: Opt[UInt256], cvalue: Opt[UInt256]): T =
   ForkedMaybeBlindedBeaconBlock(
@@ -1869,9 +2010,7 @@ template init*(T: type ForkedAttestation,
     ForkedAttestation(kind: ConsensusFork.Capella, capellaData: attestation)
   of ConsensusFork.Deneb:
     ForkedAttestation(kind: ConsensusFork.Deneb, denebData: attestation)
-  of ConsensusFork.Electra:
-    raiseAssert $fork & " fork should not be used for this type of attestation"
-  of ConsensusFork.Fulu:
+  of ConsensusFork.Electra .. ConsensusFork.Gloas:
     raiseAssert $fork & " fork should not be used for this type of attestation"
 
 template init*(T: type ForkedAttestation,
@@ -1884,6 +2023,8 @@ template init*(T: type ForkedAttestation,
     ForkedAttestation(kind: ConsensusFork.Electra, electraData: attestation)
   of ConsensusFork.Fulu:
     ForkedAttestation(kind: ConsensusFork.Fulu, fuluData: attestation)
+  of ConsensusFork.Gloas:
+    ForkedAttestation(kind: ConsensusFork.Gloas, gloasData: attestation)
 
 template init*(T: type ForkedAggregateAndProof,
                proof: phase0.AggregateAndProof,
@@ -1899,10 +2040,7 @@ template init*(T: type ForkedAggregateAndProof,
     ForkedAggregateAndProof(kind: ConsensusFork.Capella, capellaData: proof)
   of ConsensusFork.Deneb:
     ForkedAggregateAndProof(kind: ConsensusFork.Deneb, denebData: proof)
-  of ConsensusFork.Electra:
-    raiseAssert $fork &
-      " fork should not be used for this type of aggregate and proof"
-  of ConsensusFork.Fulu:
+  of ConsensusFork.Electra .. ConsensusFork.Gloas:
     raiseAssert $fork &
       " fork should not be used for this type of aggregate and proof"
 
@@ -1917,6 +2055,8 @@ template init*(T: type ForkedAggregateAndProof,
     ForkedAggregateAndProof(kind: ConsensusFork.Electra, electraData: proof)
   of ConsensusFork.Fulu:
     ForkedAggregateAndProof(kind: ConsensusFork.Fulu, fuluData: proof)
+  of ConsensusFork.Gloas:
+    ForkedAggregateAndProof(kind: ConsensusFork.Gloas, gloasData: proof)
 
 proc kzg_commitments*(eps: ForkyExecutionPayloadForSigning): KzgCommitments =
   when typeof(eps).kind >= ConsensusFork.Deneb:

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -8,7 +8,8 @@
 {.push raises: [].}
 
 import
-  ./datatypes/[phase0, altair, bellatrix, capella, deneb, electra, fulu],
+  ./datatypes/[
+    phase0, altair, bellatrix, capella, deneb, electra, fulu, gloas],
   ./eth2_merkleization
 
 type

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -19,6 +19,9 @@ import
   # Internal
   "."/[eth2_merkleization, forks, ssz_codec]
 
+debugGloasComment ""
+import ./datatypes/gloas
+
 # TODO although eth2_merkleization already exports ssz_codec, *sometimes* code
 # fails to compile if the export is not done here also. Exporting rlp avoids a
 # generics sandwich where rlp/writer.append() is not seen, by a caller outside
@@ -386,7 +389,7 @@ func contextEpoch*(update: SomeForkyLightClientUpdate): Epoch =
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.3/specs/bellatrix/beacon-chain.md#is_merge_transition_complete
 func is_merge_transition_complete*(
     state: bellatrix.BeaconState | capella.BeaconState | deneb.BeaconState |
-           electra.BeaconState | fulu.BeaconState): bool =
+           electra.BeaconState | fulu.BeaconState | gloas.BeaconState): bool =
   const defaultExecutionPayloadHeader =
     default(typeof(state.latest_execution_payload_header))
   state.latest_execution_payload_header != defaultExecutionPayloadHeader
@@ -394,8 +397,7 @@ func is_merge_transition_complete*(
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/sync/optimistic.md#helpers
 func is_execution_block*(body: SomeForkyBeaconBlockBody): bool =
   when typeof(body).kind >= ConsensusFork.Bellatrix:
-    const defaultExecutionPayload =
-      default(typeof(body.execution_payload))
+    const defaultExecutionPayload = default(typeof(body.execution_payload))
     body.execution_payload != defaultExecutionPayload
   else:
     false

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -190,7 +190,7 @@ func getTargetGossipState*(epoch: Epoch, cfg: RuntimeConfig, isBehind: bool):
   if isBehind:
     return static(HashSet[Epoch]())
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
   var epochs = newSeqOfCap[Epoch](
     int(high(ConsensusFork)) + 1 + len(cfg.BLOB_SCHEDULE))
   for bpo in cfg.BLOB_SCHEDULE:
@@ -202,6 +202,7 @@ func getTargetGossipState*(epoch: Epoch, cfg: RuntimeConfig, isBehind: bool):
   epochs.add cfg.DENEB_FORK_EPOCH
   epochs.add cfg.ELECTRA_FORK_EPOCH
   epochs.add cfg.FULU_FORK_EPOCH
+  epochs.add cfg.GLOAS_FORK_EPOCH
 
   # Fusaka, Glamsterdam, and further forks' BPOs epochs interleave with fork
   # epochs; ensure they're treated uniformly.

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -76,6 +76,8 @@ type
     ELECTRA_FORK_EPOCH*: Epoch
     FULU_FORK_VERSION*: Version
     FULU_FORK_EPOCH*: Epoch
+    GLOAS_FORK_VERSION*: Version
+    GLOAS_FORK_EPOCH*: Epoch
 
     # Time parameters
     # TODO SECONDS_PER_SLOT*: uint64
@@ -235,6 +237,9 @@ when const_preset == "mainnet":
     # Fulu
     FULU_FORK_VERSION: Version [byte 0x06, 0x00, 0x00, 0x00],
     FULU_FORK_EPOCH: FAR_FUTURE_EPOCH,
+    # Gloas
+    GLOAS_FORK_VERSION: Version [byte 0x07, 0x00, 0x00, 0x00],
+    GLOAS_FORK_EPOCH: FAR_FUTURE_EPOCH,
 
     # Time parameters
     # ---------------------------------------------------------------
@@ -403,6 +408,9 @@ elif const_preset == "gnosis":
     # Fulu
     FULU_FORK_VERSION: Version [byte 0x06, 0x00, 0x00, 0x64],
     FULU_FORK_EPOCH: FAR_FUTURE_EPOCH,
+    # Gloas
+    GLOAS_FORK_VERSION: Version [byte 0x07, 0x00, 0x00, 0x64],
+    GLOAS_FORK_EPOCH: FAR_FUTURE_EPOCH,
 
     # Time parameters
     # ---------------------------------------------------------------
@@ -568,6 +576,9 @@ elif const_preset == "minimal":
     # Fulu
     FULU_FORK_VERSION: Version [byte 0x06, 0x00, 0x00, 0x01],
     FULU_FORK_EPOCH: Epoch(uint64.high),
+    # Gloas
+    GLOAS_FORK_VERSION: Version [byte 0x07, 0x00, 0x00, 0x01],
+    GLOAS_FORK_EPOCH: Epoch(uint64.high),
 
     # Time parameters
     # ---------------------------------------------------------------

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -450,7 +450,8 @@ proc collectSignatureSets*(
       # 7. SyncAggregate
       # ----------------------------------------------------
       withState(state):
-        when consensusFork >= ConsensusFork.Altair:
+        debugGloasComment ""
+        when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
           if signed_block.message.body.sync_aggregate.sync_committee_bits.isZeros:
             if signed_block.message.body.sync_aggregate.sync_committee_signature != ValidatorSig.infinity():
               return err("collectSignatureSets: empty sync aggregates need signature of point at infinity")
@@ -475,7 +476,8 @@ proc collectSignatureSets*(
     # 8. BLS to execution changes
     when typeof(signed_block).kind >= ConsensusFork.Capella:
       withState(state):
-        when consensusFork >= ConsensusFork.Capella:
+        debugGloasComment ""
+        when consensusFork >= ConsensusFork.Capella and consensusFork != ConsensusFork.Gloas:
           for bls_change in signed_block.message.body.bls_to_execution_changes:
             let sig = bls_change.signature.load.valueOr:
               return err("collectSignatureSets: cannot load BLS to execution change signature")

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -327,7 +327,10 @@ proc state_transition_block*(
   doAssert not rollback.isNil, "use noRollback if it's ok to mess up state"
 
   let res = withState(state):
-    when consensusFork == type(signedBlock).kind:
+    debugGloasComment ""
+    when consensusFork == type(signedBlock).kind and
+         consensusFork != ConsensusFork.Gloas and
+         typeof(signedBlock).kind != ConsensusFork.Gloas:
       state_transition_block_aux(cfg, forkyState, signedBlock, cache, flags)
     else:
       err("State/block fork mismatch")
@@ -362,8 +365,12 @@ proc state_transition*(
       cfg, state, signedBlock.message.slot, cache, info,
       flags + {skipLastStateRootCalculation})
 
-  state_transition_block(
-    cfg, state, signedBlock, cache, flags, rollback)
+  debugGloasComment ""
+  when typeof(signedBlock).kind == ConsensusFork.Gloas:
+    default(Result[BlockRewards, cstring])
+  else:
+    state_transition_block(
+      cfg, state, signedBlock, cache, flags, rollback)
 
 template toList[A](attestations: seq[A]): auto =
   when A is phase0.Attestation:

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -32,10 +32,9 @@ import
 
 from std/algorithm import fill, sorted
 from std/sequtils import count, foldl, filterIt, mapIt
-from ./datatypes/capella import
-  BeaconState, MAX_WITHDRAWALS_PER_PAYLOAD, SignedBLSToExecutionChange,
-  Withdrawal
-from ./datatypes/electra import PendingPartialWithdrawal
+
+debugGloasComment ""
+import ./datatypes/gloas
 
 export extras, phase0, altair
 
@@ -451,7 +450,11 @@ proc check_voluntary_exit*(
     signed_voluntary_exit: SomeSignedVoluntaryExit,
     flags: UpdateFlags): Result[ValidatorIndex, cstring] =
   withState(state):
-    check_voluntary_exit(cfg, forkyState.data, signed_voluntary_exit, flags)
+    debugGloasComment ""
+    when consensusFork == ConsensusFork.Gloas:
+      default(Result[ValidatorIndex, cstring])
+    else:
+      check_voluntary_exit(cfg, forkyState.data, signed_voluntary_exit, flags)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/beacon-chain.md#voluntary-exits
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.0/specs/electra/beacon-chain.md#updated-process_voluntary_exit
@@ -1437,3 +1440,12 @@ proc process_block*(
     state, blck.body.sync_aggregate, total_active_balance, flags, cache)
 
   ok(operations_rewards)
+
+debugGloasComment "readd gloas_mev block and, well the rest too"
+type SomeGloasBlock =
+  gloas.BeaconBlock | gloas.SigVerifiedBeaconBlock | gloas.TrustedBeaconBlock
+proc process_block*(
+    cfg: RuntimeConfig,
+    state: var gloas.BeaconState,
+    blck: SomeGloasBlock,
+    flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] = discard

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -27,6 +27,9 @@ import
   ../extras,
   "."/[beaconstate, eth2_merkleization, validator]
 
+debugGloasComment "forks will eventually export this"
+import ./datatypes/gloas
+
 from std/math import sum, `^`
 from stew/bitops2 import setBit
 from ./datatypes/capella import
@@ -1650,6 +1653,13 @@ proc process_epoch*(
   ? process_proposer_lookahead(state, cache) # [New in Fulu:EIP7917]
 
   ok()
+
+proc process_epoch*(
+    cfg: RuntimeConfig, state: var gloas.BeaconState,
+    flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
+    Result[void, cstring] =
+  debugGloasComment "do epoch transition"
+  discard
 
 proc get_validator_balance_after_epoch*(
     cfg: RuntimeConfig, state: electra.BeaconState | fulu.BeaconState,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -13,6 +13,9 @@ import
   "."/[crypto, helpers]
 export helpers
 
+debugGloasComment ""
+import ./datatypes/gloas
+
 const
   SEED_SIZE = sizeof(Eth2Digest)
   ROUND_SIZE = 1
@@ -391,7 +394,7 @@ template compute_proposer_index(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/electra/beacon-chain.md#modified-compute_proposer_index
 template compute_proposer_index(
-    state: electra.BeaconState | fulu.BeaconState,
+    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState,
     indices: openArray[ValidatorIndex], seed: Eth2Digest,
     unshuffleTransform: untyped): Opt[ValidatorIndex] =
   ## Return from ``indices`` a random index sampled by effective balance.

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -462,7 +462,9 @@ proc getMissingBlobs(rman: RequestManager): seq[BlobIdentifier] =
     ready: seq[Eth2Digest]
   for blobless in rman.quarantine[].peekSidecarless():
     withBlck(blobless):
-      when consensusFork >= ConsensusFork.Deneb:
+      when consensusFork >= ConsensusFork.Gloas:
+        debugGloasComment ""
+      elif consensusFork >= ConsensusFork.Deneb:
         # give blobs a chance to arrive over gossip
         if forkyBlck.message.slot == wallSlot and delay < waitDur:
           debug "Not handling missing blobs early in slot"
@@ -576,7 +578,8 @@ proc getMissingDataColumns(rman: RequestManager): seq[DataColumnsByRootIdentifie
 
   for columnless in rman.quarantine[].peekSidecarless():
     withBlck(columnless):
-      when consensusFork >= ConsensusFork.Fulu:
+      debugGloasComment ""
+      when consensusFork >= ConsensusFork.Fulu and consensusFork != ConsensusFork.Gloas:
         # granting data columns a chance to arrive over gossip
         if forkyBlck.message.slot == wallSlot and delay < waitDur:
           debug "Not handling missing data columns early in slot"

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -450,26 +450,28 @@ proc doTrustedNodeSync*(
           data = blck.get()
 
         withBlck(data[]):
-          let res =
-            case syncTarget.kind
-            of TrustedNodeSyncKind.TrustedBlockRoot:
-              # Trust-minimized sync: the server is only trusted for
-              # data availability, responses must be verified
-              dag.addBackfillBlock(forkyBlck)
-            of TrustedNodeSyncKind.StateId:
-              # The server is fully trusted to provide accurate data;
-              # it could have provided a malicious state
-              dag.addBackfillBlock(forkyBlck.asSigVerified())
-          if res.isErr():
-            case res.error()
-            of VerifierError.Invalid,
-                VerifierError.MissingParent,
-                VerifierError.UnviableFork:
-              error "Got invalid block from trusted node - is it on the right network?",
-                blck = shortLog(forkyBlck), err = res.error()
-              quit 1
-            of VerifierError.Duplicate:
-              discard
+          debugGloasComment ""
+          when consensusFork != ConsensusFork.Gloas:
+            let res =
+              case syncTarget.kind
+              of TrustedNodeSyncKind.TrustedBlockRoot:
+                # Trust-minimized sync: the server is only trusted for
+                # data availability, responses must be verified
+                dag.addBackfillBlock(forkyBlck)
+              of TrustedNodeSyncKind.StateId:
+                # The server is fully trusted to provide accurate data;
+                # it could have provided a malicious state
+                dag.addBackfillBlock(forkyBlck.asSigVerified())
+            if res.isErr():
+              case res.error()
+              of VerifierError.Invalid,
+                  VerifierError.MissingParent,
+                  VerifierError.UnviableFork:
+                error "Got invalid block from trusted node - is it on the right network?",
+                  blck = shortLog(forkyBlck), err = res.error()
+                quit 1
+              of VerifierError.Duplicate:
+                discard
 
     # Download blocks backwards from the backfill slot, ie the first slot for
     # which we don't have a block, when walking backwards from the head

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -2638,6 +2638,9 @@ proc publishBlockV2*(
           publishBlockV2(it, some(broadcast_validation), data.electraData)
         of ConsensusFork.Fulu:
           publishBlockV2(it, some(broadcast_validation), data.fuluData)
+        of ConsensusFork.Gloas:
+          debugGloasComment ""
+          return false
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2691,6 +2694,9 @@ proc publishBlockV2*(
         publishBlockV2(it, some(broadcast_validation), data.electraData)
       of ConsensusFork.Fulu:
         publishBlockV2(it, some(broadcast_validation), data.fuluData)
+      of ConsensusFork.Gloas:
+        debugGloasComment ""
+        return false
 
     do:
       if apiResponse.isErr():
@@ -2758,6 +2764,9 @@ proc publishBlock*(
           publishBlock(it, data.electraData)
         of ConsensusFork.Fulu:
           publishBlock(it, data.fuluData)
+        of ConsensusFork.Gloas:
+          debugGloasComment ""
+          return false
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2808,6 +2817,9 @@ proc publishBlock*(
         publishBlock(it, data.electraData)
       of ConsensusFork.Fulu:
         publishBlock(it, data.fuluData)
+      of ConsensusFork.Gloas:
+        debugGloasComment ""
+        return false
 
     do:
       if apiResponse.isErr():
@@ -2867,6 +2879,9 @@ proc publishBlindedBlockV2*(
         of ConsensusFork.Fulu:
           publishJsonBlindedBlockV2(it, some(broadcast_validation),
             data.fuluData)
+        of ConsensusFork.Gloas:
+          debugGloasComment ""
+          return false
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2913,6 +2928,9 @@ proc publishBlindedBlockV2*(
       of ConsensusFork.Fulu:
         publishJsonBlindedBlockV2(it, some(broadcast_validation),
           data.fuluData)
+      of ConsensusFork.Gloas:
+        debugGloasComment ""
+        return false
     do:
       if apiResponse.isErr():
         handleCommunicationError()
@@ -2978,6 +2996,9 @@ proc publishBlindedBlock*(
           publishBlindedBlock(it, data.electraData)
         of ConsensusFork.Fulu:
           publishBlindedBlock(it, data.fuluData)
+        of ConsensusFork.Gloas:
+          debugGloasComment ""
+          return false
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -3027,6 +3048,9 @@ proc publishBlindedBlock*(
         publishBlindedBlock(it, data.electraData)
       of ConsensusFork.Fulu:
         publishBlindedBlock(it, data.fuluData)
+      of ConsensusFork.Gloas:
+        debugGloasComment ""
+        return false
     do:
       if apiResponse.isErr():
         handleCommunicationError()

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -13,6 +13,9 @@ import
   ".."/spec/forks,
   "."/[common, api, fallback_service]
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 const
   ServiceName = "block_service"
   BlockPollInterval = attestationSlotOffset.nanoseconds div 4

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -46,11 +46,10 @@ const
 
   ZeroTimeDiff* = TimeDiff(nanoseconds: 0'i64)
 
-debugGloasComment "Update OptionalForks constant! (really)"
 static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
           "Update OptionalForks constant!")
 const
-  OptionalForks* = {ConsensusFork.Fulu}
+  OptionalForks* = {ConsensusFork.Fulu, ConsensusFork.Gloas}
     ## When a new ConsensusFork is added and before this fork is activated on
     ## `mainnet`, it should be part of `OptionalForks`.
     ## In this case, the client will ignore missing <FORKNAME>_VERSION

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -46,7 +46,8 @@ const
 
   ZeroTimeDiff* = TimeDiff(nanoseconds: 0'i64)
 
-static: doAssert(high(ConsensusFork) == ConsensusFork.Fulu,
+debugGloasComment "Update OptionalForks constant! (really)"
+static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
           "Update OptionalForks constant!")
 const
   OptionalForks* = {ConsensusFork.Fulu}

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -624,7 +624,10 @@ proc proposeBlock(
       return head
 
   withConsensusFork(node.dag.cfg.consensusForkAtEpoch(slot.epoch)):
-    when consensusFork >= ConsensusFork.Bellatrix:
+    when consensusFork == ConsensusFork.Gloas:
+      debugGloasComment "block proposals not yet supported for gloas"
+      head
+    elif consensusFork >= ConsensusFork.Bellatrix:
       await node.proposeBlockAux(consensusFork, validator, head, slot, randao_reveal)
     else:
       warn "Block proposals for fork no longer supported", consensusFork

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -297,7 +297,8 @@ proc getExecutionPayload*(
     random = withState(proposalState[]):
       get_randao_mix(forkyState.data, get_current_epoch(forkyState.data))
     withdrawals = withState(proposalState[]):
-      when consensusFork >= ConsensusFork.Capella:
+      debugGloasComment ""
+      when consensusFork >= ConsensusFork.Capella and consensusFork != ConsensusFork.Gloas:
         get_expected_withdrawals(forkyState.data)
       else:
         @[]

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -19,6 +19,9 @@ import
   ../spec/datatypes/deneb
 from  ../spec/state_transition_block import validate_blobs
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 export eth2_processor, eth2_network
 
 logScope:

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -13,6 +13,9 @@ import
   ../spec/[beaconstate, forks, helpers],
   ../beacon_clock
 
+debugGloasComment ""
+import ../spec/datatypes/gloas
+
 logScope: topics = "val_mon"
 
 # Validator monitoring based on the same feature in Lighthouse - using the same

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -547,6 +547,9 @@ proc forkIndex(prop: ProvenProperty, fork: static ConsensusFork): GeneralizedInd
     prop.electraIndex
   elif fork == ConsensusFork.Fulu:
     prop.fuluIndex
+  elif fork == ConsensusFork.Gloas:
+    debugGloasComment "this is obviously not correct, but it's the right type, which is fine for now"
+    prop.fuluIndex
   else:
     static: raiseAssert "Unknown fork " & $fork
 

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -100,6 +100,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
     of ConsensusFork.Deneb:     SSZ.saveFile(filename, value.denebData.data)
     of ConsensusFork.Electra:   SSZ.saveFile(filename, value.electraData.data)
     of ConsensusFork.Fulu:      SSZ.saveFile(filename, value.fuluData.data)
+    of ConsensusFork.Gloas:     SSZ.saveFile(filename, value.gloasData.data)
   except IOError:
     raiseAssert "error saving SSZ file"
 

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -346,28 +346,31 @@ func collectFromProposerSlashings(
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock) =
   withStateAndBlck(forkedState, forkedBlock):
-    for proposer_slashing in forkyBlck.message.body.proposer_slashings:
-      doAssert check_proposer_slashing(
-        forkyState.data, proposer_slashing, {}).isOk
-      let slashedIndex =
-        proposer_slashing.signed_header_1.message.proposer_index
-      rewardsAndPenalties.collectFromSlashedValidator(
-        forkyState.data, slashedIndex.ValidatorIndex,
-        forkyBlck.message.proposer_index.ValidatorIndex)
+    when consensusFork != ConsensusFork.Gloas:
+      for proposer_slashing in forkyBlck.message.body.proposer_slashings:
+        doAssert check_proposer_slashing(
+          forkyState.data, proposer_slashing, {}).isOk
+        let slashedIndex =
+          proposer_slashing.signed_header_1.message.proposer_index
+        rewardsAndPenalties.collectFromSlashedValidator(
+          forkyState.data, slashedIndex.ValidatorIndex,
+          forkyBlck.message.proposer_index.ValidatorIndex)
 
 func collectFromAttesterSlashings(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     forkedState: ForkedHashedBeaconState,
     forkedBlock: ForkedTrustedSignedBeaconBlock) =
   withStateAndBlck(forkedState, forkedBlock):
-    for attester_slashing in forkyBlck.message.body.attester_slashings:
-      let attester_slashing_validity = check_attester_slashing(
-        forkyState.data, attester_slashing, {})
-      doAssert attester_slashing_validity.isOk
-      for slashedIndex in attester_slashing_validity.value:
-        rewardsAndPenalties.collectFromSlashedValidator(
-          forkyState.data, slashedIndex,
-          forkyBlck.message.proposer_index.ValidatorIndex)
+    debugGloasComment ""
+    when consensusFork != ConsensusFork.Gloas:
+      for attester_slashing in forkyBlck.message.body.attester_slashings:
+        let attester_slashing_validity = check_attester_slashing(
+          forkyState.data, attester_slashing, {})
+        doAssert attester_slashing_validity.isOk
+        for slashedIndex in attester_slashing_validity.value:
+          rewardsAndPenalties.collectFromSlashedValidator(
+            forkyState.data, slashedIndex,
+            forkyBlck.message.proposer_index.ValidatorIndex)
 
 func collectFromAttestations(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
@@ -376,7 +379,8 @@ func collectFromAttestations(
     epochParticipationFlags: var ParticipationFlags,
     cache: var StateCache) =
   withStateAndBlck(forkedState, forkedBlock):
-    when consensusFork > ConsensusFork.Phase0:
+    debugGloasComment ""
+    when consensusFork > ConsensusFork.Phase0 and consensusFork != ConsensusFork.Gloas:
       let base_reward_per_increment = get_base_reward_per_increment(
         get_total_active_balance(forkyState.data, cache))
       doAssert base_reward_per_increment > 0.Gwei
@@ -447,7 +451,8 @@ func collectFromSyncAggregate(
     forkedBlock: ForkedTrustedSignedBeaconBlock,
     cache: var StateCache) =
   withStateAndBlck(forkedState, forkedBlock):
-    when consensusFork > ConsensusFork.Phase0:
+    debugGloasComment ""
+    when consensusFork > ConsensusFork.Phase0 and consensusFork != ConsensusFork.Gloas:
       let
         total_active_balance = get_total_active_balance(forkyState.data, cache)
         participant_reward = get_participant_reward(total_active_balance)

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -284,6 +284,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       of ConsensusFork.Fulu:
         blocks[6].add dag.db.getBlock(
           blck.root, fulu.TrustedSignedBeaconBlock).get()
+      of ConsensusFork.Gloas:
+        debugGloasComment ""
 
   let stateData = newClone(dag.headState)
 
@@ -364,7 +366,10 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
               of ConsensusFork.Fulu:
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[6][].data, noRollback)
+              of ConsensusFork.Gloas:
+                debugGloasComment ""
 
+            debugGloasComment ""
             if forkyState.data.slot.epoch mod 16 == 0:
               let loadedRoot = case consensusFork
                 of ConsensusFork.Phase0:    hash_tree_root(loadedState[0][].data)
@@ -374,6 +379,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 of ConsensusFork.Deneb:     hash_tree_root(loadedState[4][].data)
                 of ConsensusFork.Electra:   hash_tree_root(loadedState[5][].data)
                 of ConsensusFork.Fulu:      hash_tree_root(loadedState[6][].data)
+                of ConsensusFork.Gloas:     default(Digest)
               doAssert hash_tree_root(forkyState.data) == loadedRoot
 
   processBlocks(blocks[0])
@@ -1142,9 +1148,11 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
 
       if nextSlot.is_epoch:
         withState(tmpState[]):
-          var stateData = newClone(forkyState.data)
-          rewardsAndPenalties.collectEpochRewardsAndPenalties(
-            stateData[], cache, cfg, flags)
+          debugGloasComment ""
+          when consensusFork != ConsensusFork.Gloas:
+            var stateData = newClone(forkyState.data)
+            rewardsAndPenalties.collectEpochRewardsAndPenalties(
+              stateData[], cache, cfg, flags)
 
       let res = process_slots(cfg, tmpState[], nextSlot, cache, forkedInfo, flags)
       doAssert res.isOk, "Slot processing can't fail with correct inputs"

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -333,7 +333,8 @@ cli do(
         var cache = StateCache()
         doAssert dag.updateState(tmpState[], bsi, false, cache, dag.updateFlags)
         withState(tmpState[]):
-          when consensusFork >= ConsensusFork.Bellatrix:
+          debugGloasComment ""
+          when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
             proposeBlock(consensusFork, forkyState, cache)
           else:
             raiseAssert "Unsupported fork " & $consensusFork

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -113,7 +113,8 @@ cli do(validatorsDir: string, secretsDir: string,
   # The EL may otherwise refuse to produce new heads
   elManager.start(syncChain = false)
   withBlck(blck[]):
-    when consensusFork >= ConsensusFork.Bellatrix:
+    debugGloasComment ""
+    when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
       if forkyBlck.message.is_execution_block:
         template payload(): auto = forkyBlck.message.body.execution_payload
         if not payload.block_hash.isZero:
@@ -240,92 +241,95 @@ cli do(validatorsDir: string, secretsDir: string,
           validators.getOrDefault(
             proposer, default(ValidatorPrivKey))).toValidatorSig()
       withState(state[]):
-        let
-          payload =
-            when consensusFork >= ConsensusFork.Bellatrix:
-              let
-                executionHead =
-                  forkyState.data.latest_execution_payload_header.block_hash
-                withdrawals =
-                  when consensusFork >= ConsensusFork.Capella:
-                    get_expected_withdrawals(forkyState.data)
-                  else:
-                    newSeq[capella.Withdrawal]()
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          let
+            payload =
+              when consensusFork >= ConsensusFork.Bellatrix:
+                let
+                  executionHead =
+                    forkyState.data.latest_execution_payload_header.block_hash
+                  withdrawals =
+                    when consensusFork >= ConsensusFork.Capella and consensusFork != ConsensusFork.Gloas:
+                      debugGloasComment ""
+                      get_expected_withdrawals(forkyState.data)
+                    else:
+                      newSeq[capella.Withdrawal]()
 
-              var pl: consensusFork.ExecutionPayloadForSigning
-              while true:
-                pl = (waitFor noCancel elManager.getPayload(
-                    consensusFork.ExecutionPayloadForSigning,
-                    consensusHead = forkyState.latest_block_root,
-                    headBlock = executionHead,
-                    safeBlock = executionHead,
-                    finalizedBlock = ZERO_HASH,
-                    timestamp = compute_timestamp_at_slot(
-                      forkyState.data, forkyState.data.slot),
-                    randomData = get_randao_mix(
-                      forkyState.data, get_current_epoch(forkyState.data)),
-                    suggestedFeeRecipient = feeRecipient,
-                    withdrawals = withdrawals)).valueOr:
-                  waitFor noCancel sleepAsync(chronos.seconds(2))
-                  continue
-                break
-              pl
-            else:
-              default(bellatrix.ExecutionPayloadForSigning)
-          message = makeBeaconBlock(
-            cfg,
-            consensusFork,
-            forkyState,
-            cache,
-            proposer,
-            randao_reveal,
-            forkyState.data.eth1_data,
-            graffitiValue,
-            when consensusFork >= ConsensusFork.Electra:
-              default(seq[electra.Attestation])
-            else:
-              blockAggregates,
-            @[],
-            BeaconBlockValidatorChanges(),
-            syncAggregate,
-            payload,
-            {}).expect("block")
+                var pl: consensusFork.ExecutionPayloadForSigning
+                while true:
+                  pl = (waitFor noCancel elManager.getPayload(
+                      consensusFork.ExecutionPayloadForSigning,
+                      consensusHead = forkyState.latest_block_root,
+                      headBlock = executionHead,
+                      safeBlock = executionHead,
+                      finalizedBlock = ZERO_HASH,
+                      timestamp = compute_timestamp_at_slot(
+                        forkyState.data, forkyState.data.slot),
+                      randomData = get_randao_mix(
+                        forkyState.data, get_current_epoch(forkyState.data)),
+                      suggestedFeeRecipient = feeRecipient,
+                      withdrawals = withdrawals)).valueOr:
+                    waitFor noCancel sleepAsync(chronos.seconds(2))
+                    continue
+                  break
+                pl
+              else:
+                default(bellatrix.ExecutionPayloadForSigning)
+            message = makeBeaconBlock(
+              cfg,
+              consensusFork,
+              forkyState,
+              cache,
+              proposer,
+              randao_reveal,
+              forkyState.data.eth1_data,
+              graffitiValue,
+              when consensusFork >= ConsensusFork.Electra:
+                default(seq[electra.Attestation])
+              else:
+                blockAggregates,
+              @[],
+              BeaconBlockValidatorChanges(),
+              syncAggregate,
+              payload,
+              {}).expect("block")
 
-        blockRoot = message.hash_tree_root()
-        let
-          proposerPrivkey =
-            try:
-              validators[proposer]
-            except KeyError as exc:
-              raiseAssert "Proposer key not available: " & exc.msg
-          signedBlock = consensusFork.SignedBeaconBlock(
-            message: message,
-            root: blockRoot,
-            signature: get_block_signature(
-              fork, genesis_validators_root, slot, blockRoot,
-              proposerPrivkey).toValidatorSig())
+          blockRoot = message.hash_tree_root()
+          let
+            proposerPrivkey =
+              try:
+                validators[proposer]
+              except KeyError as exc:
+                raiseAssert "Proposer key not available: " & exc.msg
+            signedBlock = consensusFork.SignedBeaconBlock(
+              message: message,
+              root: blockRoot,
+              signature: get_block_signature(
+                fork, genesis_validators_root, slot, blockRoot,
+                proposerPrivkey).toValidatorSig())
 
-        dump(".", signedBlock)
-        when consensusFork in [ConsensusFork.Deneb, ConsensusFork.Electra]:
-          let blobs = signedBlock.create_blob_sidecars(
-            payload.blobsBundle.proofs, payload.blobsBundle.blobs)
-          for blob in blobs:
-            dump(".", blob)
+          dump(".", signedBlock)
+          when consensusFork in [ConsensusFork.Deneb, ConsensusFork.Electra]:
+            let blobs = signedBlock.create_blob_sidecars(
+              payload.blobsBundle.proofs, payload.blobsBundle.blobs)
+            for blob in blobs:
+              dump(".", blob)
 
-        notice "Block proposed", message, blockRoot
+          notice "Block proposed", message, blockRoot
 
-        when consensusFork >= ConsensusFork.Bellatrix:
-          while true:
-            let status = waitFor noCancel elManager
-              .newExecutionPayload(signedBlock.message)
-            if status.isNone:
-              waitFor noCancel sleepAsync(chronos.seconds(2))
-              continue
-            doAssert status.get in [
-              PayloadExecutionStatus.valid,
-              PayloadExecutionStatus.accepted,
-              PayloadExecutionStatus.syncing]
-            break
+          when consensusFork >= ConsensusFork.Bellatrix:
+            while true:
+              let status = waitFor noCancel elManager
+                .newExecutionPayload(signedBlock.message)
+              if status.isNone:
+                waitFor noCancel sleepAsync(chronos.seconds(2))
+                continue
+              doAssert status.get in [
+                PayloadExecutionStatus.valid,
+                PayloadExecutionStatus.accepted,
+                PayloadExecutionStatus.syncing]
+              break
 
       aggregates.setLen(0)
 

--- a/tests/consensus_spec/fixtures_utils.nim
+++ b/tests/consensus_spec/fixtures_utils.nim
@@ -47,6 +47,14 @@ func readValue*(r: var JsonReader, a: var seq[byte]) =
 func genesisTestRuntimeConfig*(consensusFork: ConsensusFork): RuntimeConfig =
   var res = defaultRuntimeConfig
   case consensusFork
+  of ConsensusFork.Gloas:
+    res.GLOAS_FORK_EPOCH = GENESIS_EPOCH
+    res.FULU_FORK_EPOCH = GENESIS_EPOCH
+    res.ELECTRA_FORK_EPOCH = GENESIS_EPOCH
+    res.DENEB_FORK_EPOCH = GENESIS_EPOCH
+    res.CAPELLA_FORK_EPOCH = GENESIS_EPOCH
+    res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
+    res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
   of ConsensusFork.Fulu:
     res.FULU_FORK_EPOCH = GENESIS_EPOCH
     res.ELECTRA_FORK_EPOCH = GENESIS_EPOCH

--- a/tests/consensus_spec/test_fixture_merkle_proof.nim
+++ b/tests/consensus_spec/test_fixture_merkle_proof.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -68,9 +68,11 @@ suite "EF - Merkle proof" & preset():
         continue
       let objName = path
       withConsensusFork(fork):
-        for kind, path in walkDir(suitePath, relative = true, checkDir = true):
-          case objName
-          of "BeaconBlockBody":
-            runTest(suiteName, suitePath/path, consensusFork.BeaconBlockBody)
-          else:
-            raiseAssert "Unknown test object: " & suitePath/path
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          for kind, path in walkDir(suitePath, relative = true, checkDir = true):
+            case objName
+            of "BeaconBlockBody":
+              runTest(suiteName, suitePath/path, consensusFork.BeaconBlockBody)
+            else:
+              raiseAssert "Unknown test object: " & suitePath/path

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -168,9 +168,12 @@ suite "Block pool processing" & preset():
       shufflingRef = dag.getShufflingRef(dag.head, nextEpoch, false).valueOr:
         raiseAssert "false"
       nextEpochProposers = withState(dag.headState):
-        get_beacon_proposer_indices(
-          forkyState.data, shufflingRef.shuffled_active_validator_indices,
-          nextEpoch)
+        when consensusFork == ConsensusFork.Gloas:
+          default(seq[Opt[ValidatorIndex]])
+        else:
+          get_beacon_proposer_indices(
+            forkyState.data, shufflingRef.shuffled_active_validator_indices,
+            nextEpoch)
 
     check:
       # get_beacon_proposer_indices based on ShufflingRef matches EpochRef

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -25,7 +25,7 @@ suite "Light client" & preset():
     headPeriod = 4.SyncCommitteePeriod
   let
     cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
-      static: doAssert ConsensusFork.high == ConsensusFork.Fulu
+      static: doAssert ConsensusFork.high == ConsensusFork.Gloas
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch
       res.BELLATRIX_FORK_EPOCH = 2.Epoch

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -28,7 +28,7 @@ suite "Light client processor" & preset():
     highPeriod = 6.SyncCommitteePeriod
   let
     cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
-      static: doAssert ConsensusFork.high == ConsensusFork.Fulu
+      static: doAssert ConsensusFork.high == ConsensusFork.Gloas
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch
       res.BELLATRIX_FORK_EPOCH = 2.Epoch
@@ -36,6 +36,7 @@ suite "Light client processor" & preset():
       res.DENEB_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 2).Epoch
       res.ELECTRA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 3).Epoch
       res.FULU_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 4).Epoch
+      res.GLOAS_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 5).Epoch
       res
 
   const numValidators = SLOTS_PER_EPOCH

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -26,6 +26,7 @@ suite "Light client processor" & preset():
     lowPeriod = 0.SyncCommitteePeriod
     lastPeriodWithSupermajority = 4.SyncCommitteePeriod
     highPeriod = 6.SyncCommitteePeriod
+  debugGloasComment "add res.GLOAS_FORK_EPOCH = ..."
   let
     cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
       static: doAssert ConsensusFork.high == ConsensusFork.Gloas
@@ -36,7 +37,6 @@ suite "Light client processor" & preset():
       res.DENEB_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 2).Epoch
       res.ELECTRA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 3).Epoch
       res.FULU_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 4).Epoch
-      res.GLOAS_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 5).Epoch
       res
 
   const numValidators = SLOTS_PER_EPOCH

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -98,8 +98,11 @@ proc getBlock(
         ElectraBlockContents % [feeRecipient, SomeSignature],
           ElectraSignedBlockContents).signed_block.message)
     of ConsensusFork.Fulu:
-      debugFuluComment "electra test signing node getblock"
+      debugFuluComment "fulu test signing node getblock"
       raiseAssert "fulu unsupported"
+    of ConsensusFork.Gloas:
+      debugFuluComment "gloas test signing node getblock"
+      raiseAssert "gloas unsupported"
   except ValueError:
     # https://github.com/nim-lang/Nim/pull/23356
     raiseAssert "Arguments match the format string"
@@ -119,6 +122,9 @@ func init(t: typedesc[Web3SignerForkedBeaconBlock],
     Web3SignerForkedBeaconBlock(
       kind: ConsensusFork.Fulu,
       data: forked.fuluData.toBeaconBlockHeader)
+  of ConsensusFork.Gloas:
+    debugGloasComment ""
+    raiseAssert "supports Gloas not yet"
 
 proc createKeystore(dataDir, pubkey,
                     store, password: string): Result[void, string] =

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -158,4 +158,5 @@ suite "Blinded block conversions":
           electra_steps
         when consensusFork >= ConsensusFork.Fulu:
           fulu_steps
-        static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+        debugGloasComment ""
+        static: doAssert high(ConsensusFork) == ConsensusFork.Gloas

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -108,10 +108,12 @@ suite "Validator change pool testing suite":
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).proposer_slashings.lenu64 ==
-            min(i + 1, MAX_PROPOSER_SLASHINGS)
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).proposer_slashings.lenu64 ==
+              min(i + 1, MAX_PROPOSER_SLASHINGS)
 
   test "addValidatorChangeMessage/getAttesterSlashingMessage (Phase 0)":
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS + 5:
@@ -129,10 +131,12 @@ suite "Validator change pool testing suite":
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).phase0_attester_slashings.lenu64 ==
-            min(i + 1, MAX_ATTESTER_SLASHINGS)
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).phase0_attester_slashings.lenu64 ==
+              min(i + 1, MAX_ATTESTER_SLASHINGS)
 
   test "addValidatorChangeMessage/getAttesterSlashingMessage (Electra)":
     var
@@ -159,10 +163,12 @@ suite "Validator change pool testing suite":
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).electra_attester_slashings.lenu64 ==
-            min(i + 1, MAX_ATTESTER_SLASHINGS_ELECTRA)
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).electra_attester_slashings.lenu64 ==
+              min(i + 1, MAX_ATTESTER_SLASHINGS_ELECTRA)
 
   test "addValidatorChangeMessage/getVoluntaryExitMessage":
     # Need to advance state or it will not accept voluntary exits
@@ -186,10 +192,12 @@ suite "Validator change pool testing suite":
         check: pool[].isSeen(msg)
 
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).voluntary_exits.lenu64 ==
-            min(i + 1, MAX_VOLUNTARY_EXITS)
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).voluntary_exits.lenu64 ==
+              min(i + 1, MAX_VOLUNTARY_EXITS)
 
   test "addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)":
     # Need to advance state or it will not accept execution changes
@@ -217,9 +225,11 @@ suite "Validator change pool testing suite":
         check: pool[].isSeen(msg)
 
       withState(dag.headState):
-        # Too early to get BLS to execution changes for blocks
-        check pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).bls_to_execution_changes.len == 0
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          # Too early to get BLS to execution changes for blocks
+          check pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).bls_to_execution_changes.len == 0
 
   test "addValidatorChangeMessage/getBlsToExecutionChange (post-capella)":
     # Need to advance state or it will not accept execution changes
@@ -251,13 +261,15 @@ suite "Validator change pool testing suite":
         check: pool[].isSeen(msg)
 
       withState(dag.headState):
-        let blsToExecutionChanges = pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).bls_to_execution_changes
-        check:
-          blsToExecutionChanges.lenu64 == min(i + 1, MAX_BLS_TO_EXECUTION_CHANGES)
+        debugGloasComment ""
+        when consensusFork != ConsensusFork.Gloas:
+          let blsToExecutionChanges = pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).bls_to_execution_changes
+          check:
+            blsToExecutionChanges.lenu64 == min(i + 1, MAX_BLS_TO_EXECUTION_CHANGES)
 
-          # Ensure priority of API to gossip messages is observed
-          allIt(priorityMessages, pool[].isSeen(it))
+            # Ensure priority of API to gossip messages is observed
+            allIt(priorityMessages, pool[].isSeen(it))
 
   test "pre-pre-fork voluntary exit":
     var
@@ -280,8 +292,10 @@ suite "Validator change pool testing suite":
       {}).expect("ok")
 
     withState(dag.headState):
-      check:
-        # Message signed with a (fork-2) domain can no longer be added as that
-        # fork is not present in the BeaconState and thus fails transition
-        pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).voluntary_exits.lenu64 == 0
+      debugGloasComment ""
+      when consensusFork != ConsensusFork.Gloas:
+        check:
+          # Message signed with a (fork-2) domain can no longer be added as that
+          # fork is not present in the BeaconState and thus fails transition
+          pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).voluntary_exits.lenu64 == 0

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -187,52 +187,55 @@ proc addTestBlock*(
         ValidatorSig()
 
   withState(state):
-    let execution_payload =
-      when consensusFork > ConsensusFork.Bellatrix:
-        default(consensusFork.ExecutionPayloadForSigning)
-      elif consensusFork == ConsensusFork.Bellatrix:
-        if cfg.CAPELLA_FORK_EPOCH != FAR_FUTURE_EPOCH:
-          # Can't keep correctly doing this once Capella happens, but LVH search
-          # test relies on merging. So, merge only if no Capella transition.
-          default(bellatrix.ExecutionPayloadForSigning)
-        else:
-          if forkyState.data.slot > cfg.lastPremergeSlotInTestCfg:
-            if is_merge_transition_complete(forkyState.data):
-              const feeRecipient = default(Eth1Address)
-              build_empty_execution_payload(forkyState.data, feeRecipient)
-            else:
-              build_empty_merge_execution_payload(forkyState.data)
-          else:
+    when consensusFork == ConsensusFork.Gloas:
+      debugGloasComment ""
+      default(ForkedSignedBeaconBlock)
+    else:
+      let execution_payload =
+        when consensusFork > ConsensusFork.Bellatrix:
+          default(consensusFork.ExecutionPayloadForSigning)
+        elif consensusFork == ConsensusFork.Bellatrix:
+          if cfg.CAPELLA_FORK_EPOCH != FAR_FUTURE_EPOCH:
+            # Can't keep correctly doing this once Capella happens, but LVH search
+            # test relies on merging. So, merge only if no Capella transition.
             default(bellatrix.ExecutionPayloadForSigning)
-      else:
-        default(bellatrix.ExecutionPayloadForSigning)
+          else:
+            if forkyState.data.slot > cfg.lastPremergeSlotInTestCfg:
+              if is_merge_transition_complete(forkyState.data):
+                const feeRecipient = default(Eth1Address)
+                build_empty_execution_payload(forkyState.data, feeRecipient)
+              else:
+                build_empty_merge_execution_payload(forkyState.data)
+            else:
+              default(bellatrix.ExecutionPayloadForSigning)
+        else:
+          default(bellatrix.ExecutionPayloadForSigning)
 
-    let message = makeBeaconBlock(
-      cfg,
-      consensusFork,
-      forkyState,
-      cache,
-      proposer_index,
-      randao_reveal,
-      # Keep deposit counts internally consistent.
-      Eth1Data(
-        deposit_root: eth1_data.deposit_root,
-        deposit_count: forkyState.data.eth1_deposit_index + deposits.lenu64,
-        block_hash: eth1_data.block_hash),
-      graffiti,
-      when consensusFork >= ConsensusFork.Electra:
-        electraAttestations
-      else:
-        attestations,
-      deposits,
-      BeaconBlockValidatorChanges(),
-      sync_aggregate,
-      execution_payload,
-      verificationFlags = {skipBlsValidation}).expect("block")
+      let message = makeBeaconBlock(
+        cfg,
+        consensusFork,
+        forkyState,
+        cache,
+        proposer_index,
+        randao_reveal,
+        # Keep deposit counts internally consistent.
+        Eth1Data(
+          deposit_root: eth1_data.deposit_root,
+          deposit_count: forkyState.data.eth1_deposit_index + deposits.lenu64,
+          block_hash: eth1_data.block_hash),
+        graffiti,
+        when consensusFork >= ConsensusFork.Electra:
+          electraAttestations
+        else:
+          attestations,
+        deposits,
+        BeaconBlockValidatorChanges(),
+        sync_aggregate,
+        execution_payload,
+        verificationFlags = {skipBlsValidation}).expect("block")
 
-
-    signBlock(
-        forkyState.data.fork, forkyState.data.genesis_validators_root, message, privKey, flags)
+      signBlock(
+          forkyState.data.fork, forkyState.data.genesis_validators_root, message, privKey, flags)
 
 proc makeTestBlock*(
     state: ForkedHashedBeaconState,

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -79,7 +79,7 @@ proc getTestStates*(
     info = ForkedEpochInfo()
     cfg = defaultRuntimeConfig
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Fulu
+  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
   if consensusFork >= ConsensusFork.Altair:
     cfg.ALTAIR_FORK_EPOCH = 1.Epoch
   if consensusFork >= ConsensusFork.Bellatrix:
@@ -92,6 +92,8 @@ proc getTestStates*(
     cfg.ELECTRA_FORK_EPOCH = 5.Epoch
   if consensusFork >= ConsensusFork.Fulu:
     cfg.FULU_FORK_EPOCH = 6.Epoch
+  if consensusFork >= ConsensusFork.Gloas:
+    cfg.GLOAS_FORK_EPOCH = 7.Epoch
 
   for i, epoch in stateEpochs:
     let slot = epoch.Epoch.start_slot


### PR DESCRIPTION
Fairly minimal, 1000-line no-op of a commit.

Makes Gloas a copy of Fulu. Mostly fills in `spec/forks`, but wherever possible it just avoids calling anything in `withFoo` in Gloas.

From here, each step can be filled in incrementally, in parallel, without creating ramifying changes across the entire codebase.