### PR TITLE
Simplify `forkchoiceUpdated` flow

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -32,7 +32,7 @@ proc addResolvedHeadBlock(
        dag: ChainDAGRef,
        state: var ForkedHashedBeaconState,
        trustedBlock: ForkyTrustedSignedBeaconBlock,
-       executionValid: bool,
+       optimisticStatus: OptimisticStatus,
        parent: BlockRef, cache: var StateCache,
        onBlockAdded: OnForkyBlockAdded,
        stateDataDur, sigVerifyDur, stateVerifyDur: Duration
@@ -43,14 +43,15 @@ proc addResolvedHeadBlock(
 
   let
     blockRoot = trustedBlock.root
-    blockRef = BlockRef.init(
-      blockRoot, executionValid = executionValid, trustedBlock.message)
+    blockRef = BlockRef.init(blockRoot, optimisticStatus, trustedBlock.message)
     startTick = Moment.now()
 
   link(parent, blockRef)
 
-  if executionValid:
-    dag.markBlockVerified(blockRef)
+  if optimisticStatus == OptimisticStatus.valid:
+    # Since the new block has a valid payload, its ancestors also do but this
+    # might be the first time we learn of it
+    parent.markExecutionValid(true)
 
   dag.forkBlocks.incl(KeyedBlockRef.init(blockRef))
 
@@ -81,7 +82,7 @@ proc addResolvedHeadBlock(
   debug "Block resolved",
     blockRoot = shortLog(blockRoot),
     blck = shortLog(trustedBlock.message),
-    executionValid, heads = dag.heads.len(),
+    optimisticStatus, heads = dag.heads.len(),
     stateDataDur, sigVerifyDur, stateVerifyDur,
     putBlockDur = putBlockTick - startTick,
     epochRefDur = epochRefTick - putBlockTick
@@ -134,26 +135,28 @@ proc checkStateTransition(
   else:
     ok()
 
-proc advanceClearanceState*(dag: ChainDAGRef) =
+proc advanceClearanceState*(dag: ChainDAGRef, nextSlot: Slot) =
   # When the chain is synced, the most likely block to be produced is the block
   # right after head - we can exploit this assumption and advance the state
   # to that slot before the block arrives, thus allowing us to do the expensive
   # epoch transition ahead of time.
   # Notably, we use the clearance state here because that's where the block will
   # first be seen - later, this state will be copied to the head state!
-  let advanced = withState(dag.clearanceState):
-    forkyState.data.slot > forkyState.data.latest_block_header.slot
-  if not advanced:
-    let
-      startTick = Moment.now()
-      next = getStateField(dag.clearanceState, slot) + 1
-    var
-      cache = StateCache()
-      info = ForkedEpochInfo()
-    dag.advanceSlots(dag.clearanceState, next, true, cache, info,
-                     dag.updateFlags)
+  let head = dag.head
+  if dag.clearanceState.matches_block_slot(head.root, nextSlot):
+    return
+
+  let startTick = Moment.now()
+  var cache = StateCache()
+  if dag.updateState(
+    dag.clearanceState,
+    BlockSlotId.init(head.bid, nextSlot),
+    true,
+    cache,
+    dag.updateFlags,
+  ):
     debug "Prepared clearance state for next block",
-      next, updateStateDur = Moment.now() - startTick
+      nextSlot, head, updateStateDur = Moment.now() - startTick
 
 proc checkHeadBlock*(
     dag: ChainDAGRef, signedBlock: ForkySignedBeaconBlock):
@@ -225,7 +228,7 @@ proc checkHeadBlock*(
 proc addHeadBlockWithParent*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock, parent: BlockRef,
-    executionValid: bool, onBlockAdded: OnForkyBlockAdded
+    optimisticStatus: OptimisticStatus, onBlockAdded: OnForkyBlockAdded
     ): Result[BlockRef, VerifierError] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.
@@ -307,7 +310,7 @@ proc addHeadBlockWithParent*(
   ok addResolvedHeadBlock(
     dag, dag.clearanceState,
     signedBlock.asTrusted(),
-    executionValid,
+    optimisticStatus,
     parent, cache,
     onBlockAdded,
     stateDataDur = stateDataTick - startTick,
@@ -553,7 +556,7 @@ proc addBackfillBlockData*(
     discard addResolvedHeadBlock(
       dag, dag.clearanceState,
       forkyBlck.asTrusted(),
-      true,
+      OptimisticStatus.notValidated,
       parent, cache,
       blockHandler,
       proposerVerifyTick - startTick,

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -14,6 +14,13 @@ import
 export chronicles, forks
 
 type
+  OptimisticStatus* {.pure.} = enum
+    # A simplified version of `PayloadStatusV1`
+    # https://github.com/ethereum/consensus-specs/blob/927073b0aafc958aef4689010fb4f97d22813015/sync/optimistic.md?plain=1#L55
+    notValidated
+    valid
+    invalidated
+
   BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to finalized head, and to
     ## have a corresponding entry in database.
@@ -31,7 +38,7 @@ type
       ## Root that can be used to retrieve block data from database
 
     executionBlockHash*: Opt[Eth2Digest]
-    executionValid*: bool
+    optimisticStatus*: OptimisticStatus
 
     parent*: BlockRef ##\
       ## Not nil, except for the finalized head
@@ -50,48 +57,51 @@ template root*(blck: BlockRef): Eth2Digest = blck.bid.root
 template slot*(blck: BlockRef): Slot = blck.bid.slot
 
 func init*(
-    T: type BlockRef, root: Eth2Digest,
-    executionBlockHash: Opt[Eth2Digest], executionValid: bool, slot: Slot):
-    BlockRef =
+    T: type BlockRef,
+    root: Eth2Digest,
+    executionBlockHash: Opt[Eth2Digest],
+    optimisticStatus: OptimisticStatus,
+    slot: Slot,
+): BlockRef =
   BlockRef(
     bid: BlockId(root: root, slot: slot),
-    executionBlockHash: executionBlockHash, executionValid: executionValid)
+    executionBlockHash: executionBlockHash,
+    optimisticStatus: optimisticStatus,
+  )
 
 func init*(
-    T: type BlockRef, root: Eth2Digest, executionValid: bool,
+    T: type BlockRef, root: Eth2Digest, _: OptimisticStatus,
     blck: phase0.SomeBeaconBlock | altair.SomeBeaconBlock |
           phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock): BlockRef =
   # Use same formal parameters for simplicity, but it's impossible for these
   # blocks to be optimistic.
-  BlockRef.init(root, Opt.some ZERO_HASH, executionValid = true, blck.slot)
+  BlockRef.init(root, Opt.some ZERO_HASH, OptimisticStatus.valid, blck.slot)
 
 func init*(
-    T: type BlockRef, root: Eth2Digest, executionValid: bool,
+    T: type BlockRef, root: Eth2Digest, optimisticStatus: OptimisticStatus,
     blck: bellatrix.SomeBeaconBlock | bellatrix.TrustedBeaconBlock |
           capella.SomeBeaconBlock | capella.TrustedBeaconBlock |
           deneb.SomeBeaconBlock | deneb.TrustedBeaconBlock |
           electra.SomeBeaconBlock | electra.TrustedBeaconBlock |
           fulu.SomeBeaconBlock | fulu.TrustedBeaconBlock): BlockRef =
   BlockRef.init(
-    root,
-    Opt.some blck.body.execution_payload.block_hash,
-    executionValid =
-      executionValid or blck.body.execution_payload.block_hash == ZERO_HASH,
-    blck.slot
+    root, Opt.some blck.body.execution_payload.block_hash, optimisticStatus, blck.slot
   )
 
 func init*(
-    T: type BlockRef, root: Eth2Digest, executionValid: bool,
+    T: type BlockRef, root: Eth2Digest, optimisticStatus: OptimisticStatus,
     blck: gloas.SomeBeaconBlock | gloas.TrustedBeaconBlock): BlockRef =
   debugGloasComment "is this right?"
   BlockRef.init(
     root,
     Opt.some blck.body.signed_execution_payload_header.message.block_hash,
-    executionValid =
-      executionValid or
-      blck.body.signed_execution_payload_header.message.block_hash ==
-      ZERO_HASH,
-    blck.slot)
+    if optimisticStatus == OptimisticStatus.valid or
+        blck.body.signed_execution_payload_header.message.block_hash == ZERO_HASH:
+      OptimisticStatus.valid
+    else:
+      optimisticStatus,
+    blck.slot,
+  )
 
 func parent*(bs: BlockSlot): BlockSlot =
   ## Return a blockslot representing the previous slot, using the parent block
@@ -242,6 +252,24 @@ func shortLog*(v: BlockSlot): string =
     shortLog(v.blck)
   else: # There was a gap - log it
     shortLog(v.blck) & "@" & $v.slot
+
+func executionValid*(blck: BlockRef): bool =
+  blck.optimisticStatus == OptimisticStatus.valid
+
+proc markExecutionValid*(blck: BlockRef, valid: bool) =
+  ## Mark a block as having a valid or invalid excecution payload
+  if not valid:
+    blck.optimisticStatus = OptimisticStatus.invalidated
+    debug "Optimistic status updated", blck = shortLog(blck), valid
+  else:
+    # Being valid implies that the ancestors are also valid
+    var cur = blck
+
+    while cur != nil and cur.optimisticStatus == OptimisticStatus.notValidated:
+      cur.optimisticStatus = OptimisticStatus.valid
+      debug "Optimistic status updated", blck = shortLog(cur), valid
+
+      cur = cur.parent
 
 chronicles.formatIt BlockSlot: shortLog(it)
 chronicles.formatIt BlockRef: shortLog(it)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -16,10 +16,10 @@ export chronicles, forks
 type
   OptimisticStatus* {.pure.} = enum
     # A simplified version of `PayloadStatusV1`
-    # https://github.com/ethereum/consensus-specs/blob/927073b0aafc958aef4689010fb4f97d22813015/sync/optimistic.md?plain=1#L55
-    notValidated
-    valid
-    invalidated
+    # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.6/sync/optimistic.md#helpers
+    notValidated = "NOT_VALIDATED"
+    valid = "VALID"
+    invalidated = "INVALIDATED"
 
   BlockRef* = ref object
     ## Node in object graph guaranteed to lead back to finalized head, and to
@@ -96,7 +96,7 @@ func init*(
     root,
     Opt.some blck.body.signed_execution_payload_header.message.block_hash,
     if optimisticStatus == OptimisticStatus.valid or
-        blck.body.signed_execution_payload_header.message.block_hash == ZERO_HASH:
+        blck.body.signed_execution_payload_header.message.block_hash.isZero:
       OptimisticStatus.valid
     else:
       optimisticStatus,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1114,11 +1114,21 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   for blck in db.getAncestorSummaries(head.root):
     # The execution block root gets filled in as needed. Nonfinalized Bellatrix
     # and later blocks are loaded as optimistic, which gets adjusted that first
-    # `VALID` fcU from an EL plus markBlockVerified. Pre-merge blocks still get
+    # `VALID` fcU from an EL plus markExecutionValid. Pre-merge blocks still get
     # marked as `VALID`.
-    let newRef = BlockRef.init(
-      blck.root, Opt.none Eth2Digest, executionValid = false,
-      blck.summary.slot)
+    let newRef =
+      if cfg.consensusForkAtEpoch(blck.summary.slot.epoch) >= ConsensusFork.Bellatrix:
+        BlockRef.init(
+          blck.root,
+          Opt.none Eth2Digest,
+          OptimisticStatus.notValidated,
+          blck.summary.slot,
+        )
+      else:
+        BlockRef.init(
+          blck.root, Opt.some ZERO_HASH, OptimisticStatus.valid, blck.summary.slot
+        )
+
     if headRef == nil:
       headRef = newRef
 
@@ -1957,7 +1967,6 @@ proc pruneBlockSlot(dag: ChainDAGRef, bs: BlockSlot) =
     # Update light client data
     dag.deleteLightClientData(bs.blck.bid)
 
-    bs.blck.executionValid = true
     dag.forkBlocks.excl(KeyedBlockRef.init(bs.blck))
     discard dag.db.delBlock(
       dag.cfg.consensusForkAtEpoch(bs.blck.slot.epoch), bs.blck.root)
@@ -2017,26 +2026,7 @@ func is_optimistic*(dag: ChainDAGRef, bid: BlockId): bool =
         # it could have been orphaned or the DB is slightly inconsistent.
         # Report it as optimistic until it becomes reachable or gets deleted
         return true
-  not blck.executionValid
-
-proc markBlockVerified*(dag: ChainDAGRef, blck: BlockRef) =
-  var cur = blck
-
-  while true:
-    cur.executionValid = true
-
-    debug "markBlockVerified", blck = shortLog(cur)
-
-    if cur.parent.isNil:
-      break
-
-    cur = cur.parent
-
-    # Always check at least as far back as the parent so that when a new block
-    # is added with executionValid already set, it stil sets the ancestors, to
-    # the next valid in the chain.
-    if cur.executionValid:
-      return
+  blck.optimisticStatus != OptimisticStatus.valid
 
 iterator syncSubcommittee*(
     syncCommittee: openArray[ValidatorIndex],
@@ -2324,8 +2314,7 @@ proc pruneHistory*(dag: ChainDAGRef, startup = false) =
           if dag.db.clearBlocks(fork):
             break
 
-proc loadExecutionBlockHash*(
-    dag: ChainDAGRef, bid: BlockId): Opt[Eth2Digest] =
+proc loadExecutionBlockHash*(dag: ChainDAGRef, bid: BlockId): Opt[Eth2Digest] =
   let blockData = dag.getForkedBlock(bid).valueOr:
     # Besides database inconsistency issues, this is hit with checkpoint sync.
     # The initial `BlockRef` is created before the checkpoint block is loaded.
@@ -2341,10 +2330,21 @@ proc loadExecutionBlockHash*(
     else:
       Opt.some ZERO_HASH
 
-proc loadExecutionBlockHash*(
-    dag: ChainDAGRef, blck: BlockRef): Opt[Eth2Digest] =
+proc loadExecutionBlockHash*(dag: ChainDAGRef, blck: BlockRef): Opt[Eth2Digest] =
   if blck.executionBlockHash.isNone:
+    # Execution block hashes are loaded lazily during startup
     blck.executionBlockHash = dag.loadExecutionBlockHash(blck.bid)
+
+    if blck.executionBlockHash == static(Opt.some(ZERO_HASH)):
+      # The block belongs to Bellatrix+ but the merge has not yet happened
+      # meaning that its ancestors are also pre-merge
+      blck.markExecutionValid(true)
+
+      var cur = blck.parent
+      while cur != nil and cur.executionBlockHash.isNone:
+        cur.executionBlockHash = blck.executionBlockHash
+        cur = cur.parent
+
   blck.executionBlockHash
 
 from std/packedsets import PackedSet, incl, items
@@ -2533,7 +2533,7 @@ proc updateHead*(
       justified = shortLog(getStateField(
         dag.headState, current_justified_checkpoint)),
       finalized = shortLog(getStateField(dag.headState, finalized_checkpoint)),
-      isOptHead = not newHead.executionValid
+      optStatus = newHead.optimisticStatus
 
     if not(isNil(dag.onReorgHappened)):
       let
@@ -2555,7 +2555,7 @@ proc updateHead*(
       justified = shortLog(getStateField(
         dag.headState, current_justified_checkpoint)),
       finalized = shortLog(getStateField(dag.headState, finalized_checkpoint)),
-      isOptHead = not newHead.executionValid
+      optStatus = newHead.optimisticStatus
 
     if not(isNil(dag.onHeadChanged)):
       let

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -16,8 +16,6 @@ import
   ../beacon_clock,
   ./common_tools
 
-from ../spec/beaconstate import
-  get_expected_withdrawals
 from ../spec/eth2_apis/dynamic_fee_recipients import
   DynamicFeeRecipientsStore, getDynamicFeeRecipient
 from ../validators/action_tracker import ActionTracker, getNextProposalSlot
@@ -106,7 +104,7 @@ proc checkExpectedBlock(self: var ConsensusManager) =
 
   if self.dag.head.slot < self.expectedSlot or not self.dag.head.executionValid:
     # Don't trigger `expectBlock` if the head is optimistic - this gives the
-    # forkchoiceUpdated call time to maybe update the optimistic status before
+    # `forkchoiceUpdated` call time to maybe update the optimistic status before
     # it's time to validate
     return
 
@@ -288,7 +286,7 @@ proc proposalForkchoiceUpdated*(
     self: ref ConsensusManager, proposalSlot: Slot, deadline: DeadlineFuture
 ) {.async: (raises: [CancelledError]).} =
   ## Send a "warm-up" forkchoiceUpdated to the execution client, assuming that
-  ## `clearanceState` has been updated to the expected epooch of the proposal
+  ## `clearanceState` has been updated to the expected epoch of the proposal
   if self.forkchoiceInflight:
     debug "Skipping proposal fcU, forkchoiceUpdated already in flight", proposalSlot
     return
@@ -486,7 +484,7 @@ proc updateExecutionHead*(
   ## In the case that we were optimistically synced and the execution client has
   ## determined that the payload was invalid, we will also attempt to update
   ## the consensus head towards a valid / nonValidated block by rerunning
-  ## fork choice with the new information in mind.
+  ## fork choice with the new information about invalid blocks in mind.
 
   if self.forkchoiceInflight:
     return

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -334,7 +334,7 @@ proc proposalForkchoiceUpdated*(
         return
 
       when consensusFork >= ConsensusFork.Deneb:
-        # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
+        # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/prague.md
         # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
         let attributes = PayloadAttributesV3(
           timestamp: Quantity timestamp,
@@ -461,7 +461,7 @@ proc forkchoiceUpdated(
       true
     of OptimisticStatus.invalidated:
       if head.blck.executionValid:
-        # https://github.com/ethereum/consensus-specs/blob/927073b0aafc958aef4689010fb4f97d22813015/sync/optimistic.md?plain=1#L420
+        # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.6/sync/optimistic.md#transitioning-from-valid---invalidated-or-invalidated---valid
         warn "Previously valid execution payload turned invalid during fork choice update - check execution client for faults and restart the beacon node",
           blck = head.blck,
           prevStatus = head.blck.optimisticStatus,

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -10,6 +10,7 @@
 import
   chronicles, chronos,
   ../spec/datatypes/base,
+  ../spec/beaconstate,
   ../consensus_object_pools/[blockchain_dag, block_quarantine, attestation_pool],
   ../el/el_manager,
   ../beacon_clock,
@@ -55,6 +56,11 @@ type
     # Tracking last proposal forkchoiceUpdated payload information
     # ----------------------------------------------------------------
     optimisticHead: tuple[bid: BlockId, execution_block_hash: Eth2Digest]
+    optimisticHeadStatus: OptimisticStatus
+      ## forkchoiceUpdated response about the optimistic head
+
+    forkchoiceInflight: bool
+      ## True when there's an async `forkchoiceUpdated` in flight
 
 # Initialization
 # ------------------------------------------------------------------------------
@@ -85,11 +91,23 @@ func new*(T: type ConsensusManager,
 # Consensus Management
 # -----------------------------------------------------------------------------------
 
+func to*(v: PayloadExecutionStatus, T: type OptimisticStatus): T =
+  case v
+  of PayloadExecutionStatus.valid:
+    OptimisticStatus.valid
+  of PayloadExecutionStatus.syncing, PayloadExecutionStatus.accepted:
+    OptimisticStatus.notValidated
+  of invalid, invalid_block_hash:
+    OptimisticStatus.invalidated
+
 proc checkExpectedBlock(self: var ConsensusManager) =
   if self.expectedBlockReceived == nil:
     return
 
-  if self.dag.head.slot < self.expectedSlot:
+  if self.dag.head.slot < self.expectedSlot or not self.dag.head.executionValid:
+    # Don't trigger `expectBlock` if the head is optimistic - this gives the
+    # forkchoiceUpdated call time to maybe update the optimistic status before
+    # it's time to validate
     return
 
   self.expectedBlockReceived.complete(true)
@@ -132,7 +150,8 @@ func shouldSyncOptimistically*(
   true
 
 func shouldSyncOptimistically*(self: ConsensusManager, wallSlot: Slot): bool =
-  if self.optimisticHead.execution_block_hash.isZero:
+  if self.optimisticHeadStatus == OptimisticStatus.invalidated or
+      self.optimisticHead.execution_block_hash.isZero:
     return false
 
   shouldSyncOptimistically(
@@ -146,73 +165,20 @@ func optimisticHead*(self: ConsensusManager): BlockId =
 func optimisticExecutionBlockHash*(self: ConsensusManager): Eth2Digest =
   self.optimisticHead.execution_block_hash
 
-func setOptimisticHead*(
+proc setOptimisticHead*(
     self: var ConsensusManager,
     bid: BlockId, execution_block_hash: Eth2Digest) =
-  self.optimisticHead = (bid: bid, execution_block_hash: execution_block_hash)
-
-proc updateExecutionClientHead*(
-    self: ref ConsensusManager,
-    newHead: BeaconHead
-): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
-  let headExecutionBlockHash =
-    self.dag.loadExecutionBlockHash(newHead.blck).valueOr:
-      # `BlockRef` are only created for blocks that have passed
-      # execution block hash validation, either explicitly in
-      # `block_processor.storeBlock`, or implicitly, e.g., through
-      # checkpoint sync. With checkpoint sync, the checkpoint block
-      # is initially not available, so if there is a reorg to it,
-      # this may be triggered. Such a reorg could happen if the first
-      # imported chain is completely invalid (after the checkpoint block)
-      # and is subsequently pruned, in which case checkpoint block is head.
-      # Because execution block hash validation has already passed,
-      # we can treat this as `SYNCING`.
-      warn "Failed to load head execution block hash", head = newHead.blck
-      return Opt[void].ok()
-
-  if headExecutionBlockHash.isZero:
-    # Blocks without execution payloads can't be optimistic.
-    self.dag.markBlockVerified(newHead.blck)
-    return Opt[void].ok()
-
-  template callForkchoiceUpdated(attributes: untyped): auto =
-    await self.elManager.forkchoiceUpdated(
-      headBlockHash = headExecutionBlockHash,
-      safeBlockHash = newHead.safeExecutionBlockHash,
-      finalizedBlockHash = newHead.finalizedExecutionBlockHash,
-      payloadAttributes = Opt.none attributes)
-
-  # Can't use dag.head here because it hasn't been updated yet
-  let
-    consensusFork =
-      self.dag.cfg.consensusForkAtEpoch(newHead.blck.bid.slot.epoch)
-    (payloadExecutionStatus, _) = withConsensusFork(consensusFork):
-      when consensusFork >= ConsensusFork.Bellatrix:
-        callForkchoiceUpdated(consensusFork.PayloadAttributes)
-      else:
-        callForkchoiceUpdated(PayloadAttributesV1)
-
-  case payloadExecutionStatus
-  of PayloadExecutionStatus.valid:
-    self.dag.markBlockVerified(newHead.blck)
-  of PayloadExecutionStatus.invalid, PayloadExecutionStatus.invalid_block_hash:
-    self.attestationPool[].forkChoice.mark_root_invalid(newHead.blck.root)
-    self.quarantine[].addUnviable(newHead.blck.root)
-    return Opt.none(void)
-  of PayloadExecutionStatus.accepted, PayloadExecutionStatus.syncing:
-    # Don't do anything. Either newHead.blck.executionValid was already false,
-    # in which case it'd be superfluous to set it to false again, or the block
-    # was marked as `VALID` in the `newPayload` path already, in which case it
-    # is fine to keep it as valid here. Conceptually, were this to be lines of
-    # code, it'd be something like
-    # if newHead.blck.executionValid:
-    #   do nothing because of latter case
-    # else:
-    #   do nothing because it's a no-op
-    # So, either way, do nothing.
-    discard
-
-  return Opt[void].ok()
+  if self.optimisticHeadStatus == OptimisticStatus.invalidated:
+    # If the light client was wrong in the past, either the execution client or
+    # the light client has been compromised and we shouldn't trust either until
+    # a restart
+    warn "Ignoring optimistic head update due to previous invalidity",
+      bid, execution_block_hash
+  else:
+    let newHead = (bid: bid, execution_block_hash: execution_block_hash)
+    if self.optimisticHead != newHead:
+      self.optimisticHead = newHead
+      self.optimisticHeadStatus = OptimisticStatus.notValidated
 
 func getKnownValidatorsForBlsChangeTracking(
     self: ConsensusManager, newHead: BlockRef): seq[ValidatorIndex] =
@@ -253,11 +219,6 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
       warn "Head selection failed, using previous head",
         head = shortLog(self.dag.head), wallSlot
       return
-    executionBlockHash = self.dag.loadExecutionBlockHash(newHead.blck)
-
-  if executionBlockHash.isSome and executionBlockHash.unsafeGet.isZero:
-    # Blocks without execution payloads can't be optimistic.
-    self.dag.markBlockVerified(newHead.blck)
 
   self.updateHead(newHead.blck)
 
@@ -323,129 +284,259 @@ proc getFeeRecipient*(
 proc getGasLimit*(self: ConsensusManager, pubkey: ValidatorPubKey): uint64 =
   getGasLimit(self.validatorsDir, self.defaultGasLimit, pubkey)
 
-proc runProposalForkchoiceUpdated*(
-    self: ref ConsensusManager, wallSlot: Slot): Future[Opt[void]] {.async: (raises: [CancelledError]).} =
-  let
-    nextWallSlot = wallSlot + 1
-    (validatorIndex, nextProposer) = self.checkNextProposer(wallSlot).valueOr:
-      return err()
-  debug "runProposalForkchoiceUpdated: expected to be proposing next slot",
-    nextWallSlot, validatorIndex, nextProposer
+proc proposalForkchoiceUpdated*(
+    self: ref ConsensusManager, proposalSlot: Slot, deadline: DeadlineFuture
+) {.async: (raises: [CancelledError]).} =
+  ## Send a "warm-up" forkchoiceUpdated to the execution client, assuming that
+  ## `clearanceState` has been updated to the expected epooch of the proposal
+  if self.forkchoiceInflight:
+    debug "Skipping proposal fcU, forkchoiceUpdated already in flight", proposalSlot
+    return
 
-  # In Capella and later, computing correct withdrawals would mean creating a
-  # proposal state. Instead, only do that at proposal time.
-  if nextWallSlot.is_epoch:
-    debug "runProposalForkchoiceUpdated: not running early fcU for epoch-aligned proposal slot",
-      nextWallSlot, validatorIndex, nextProposer
-    return err()
+  let head = self.dag.head
+
+  # Sending the proposal fcU requires that the state epoch matches the proposal
+  # epoch so that the withdrawals can be computed correctly
+  if self.dag.clearanceState.matches_block_slot(head.root, proposalSlot):
+    debug "Skipping proposal fcU, clearance state not prepared", head, proposalSlot
+
+    return
+
+  let
+    preSlot = proposalSlot - 1
+    (validatorIndex, nextProposer) = self.checkNextProposer(preSlot).valueOr:
+      debug "Skipping proposal fcU, no proposers registered", head, proposalSlot
+      return
+
+  self.forkchoiceInflight = true
+  defer:
+    self.forkchoiceInflight = false
 
   # Approximately lines up with validator_duties version. Used optimistically/
   # opportunistically, so mismatches are fine if not too frequent.
-  let
-    timestamp = withState(self.dag.headState):
-      compute_timestamp_at_slot(forkyState.data, nextWallSlot)
-    # If the current head block still forms the basis of the eventual proposal
-    # state, then its `get_randao_mix` will remain unchanged as well, as it is
-    # constant until the next block.
-    prevRandao = withState(self.dag.headState):
-      get_randao_mix(forkyState.data, get_current_epoch(forkyState.data))
-    feeRecipient = self[].getFeeRecipient(
-      nextProposer, Opt.some(validatorIndex), nextWallSlot.epoch)
-    beaconHead = self.attestationPool[].getBeaconHead(self.dag.head)
-    headBlockHash = ? self.dag.loadExecutionBlockHash(beaconHead.blck)
-
-  if headBlockHash.isZero:
-    return err()
-
-  let safeBlockHash = beaconHead.safeExecutionBlockHash
-
-  withState(self.dag.headState):
-    template callForkchoiceUpdated(fcPayloadAttributes: auto) =
-      let (status, _) = await self.elManager.forkchoiceUpdated(
-        headBlockHash, safeBlockHash,
-        beaconHead.finalizedExecutionBlockHash,
-        payloadAttributes = Opt.some fcPayloadAttributes)
-      debug "Fork-choice updated for proposal", status
-
-    static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
-    when consensusFork >= ConsensusFork.Gloas:
+  withState(self.dag.clearanceState):
+    when consensusFork == ConsensusFork.Gloas:
       debugGloasComment "well, likely can't keep reusing V3 much longer"
-    elif consensusFork >= ConsensusFork.Deneb:
-      # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
-      # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
-      callForkchoiceUpdated(PayloadAttributesV3(
-        timestamp: Quantity timestamp,
-        prevRandao: Bytes32 prevRandao.to(Hash32),
-        suggestedFeeRecipient: feeRecipient,
-        withdrawals:
-          toEngineWithdrawals get_expected_withdrawals(forkyState.data),
-        parentBeaconBlockRoot: beaconHead.blck.bid.root.to(Hash32)))
-    elif consensusFork >= ConsensusFork.Capella:
-      callForkchoiceUpdated(PayloadAttributesV2(
-        timestamp: Quantity timestamp,
-        prevRandao: Bytes32 prevRandao.to(Hash32),
-        suggestedFeeRecipient: feeRecipient,
-        withdrawals:
-          toEngineWithdrawals get_expected_withdrawals(forkyState.data)))
-    else:
-      callForkchoiceUpdated(PayloadAttributesV1(
-        timestamp: Quantity timestamp,
-        prevRandao: Bytes32 prevRandao.to(Hash32),
-        suggestedFeeRecipient: feeRecipient))
-
-  ok()
-
-proc updateHeadWithExecution*(
-    self: ref ConsensusManager, initialNewHead: BeaconHead,
-    getBeaconTimeFn: GetBeaconTimeFn) {.async: (raises: [CancelledError]).} =
-  ## Trigger fork choice and update the DAG with the new head block
-  ## This does not automatically prune the DAG after finalization
-  ## `pruneFinalized` must be called for pruning.
-
-  # Grab the new head according to our latest attestation data
-  try:
-    # Ensure dag.updateHead has most current information
-    var
-      attempts = 0
-      newHead = initialNewHead
-    while (await self.updateExecutionClientHead(newHead)).isErr:
-      # This proc is called on every new block; guarantee timely return
-      inc attempts
-      const maxAttempts = 5
-      if attempts >= maxAttempts:
-        warn "updateHeadWithExecution: too many attempts to recover from invalid payload",
-          attempts, maxAttempts, newHead, initialNewHead
-        break
-
-      # Select new head for next attempt
+    elif consensusFork in ConsensusFork.Bellatrix .. ConsensusFork.Fulu:
+      debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer
       let
-        wallTime = getBeaconTimeFn()
-        nextHead = self.attestationPool[].selectOptimisticHead(wallTime).valueOr:
-          warn "Head selection failed after invalid block, using previous head",
-            newHead, wallSlot = wallTime.slotOrZero
-          break
-      warn "updateHeadWithExecution: attempting to recover from invalid payload",
-        attempts, maxAttempts, newHead, initialNewHead, nextHead
-      newHead = nextHead
+        timestamp = compute_timestamp_at_slot(forkyState.data, proposalSlot)
+        # If the current head block still forms the basis of the eventual proposal
+        # state, then its `get_randao_mix` will remain unchanged as well, as it is
+        # constant until the next block.
+        prevRandao = get_randao_mix(forkyState.data, get_current_epoch(forkyState.data))
+        feeRecipient = self[].getFeeRecipient(
+          nextProposer, Opt.some(validatorIndex), proposalSlot.epoch
+        )
+        beaconHead = self.attestationPool[].getBeaconHead(head)
+        headBlockHash = self.dag.loadExecutionBlockHash(beaconHead.blck).valueOr:
+          return
+
+      if headBlockHash.isZero:
+        return
+
+      when consensusFork >= ConsensusFork.Deneb:
+        # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
+        # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
+        let attributes = PayloadAttributesV3(
+          timestamp: Quantity timestamp,
+          prevRandao: Bytes32 prevRandao.to(Hash32),
+          suggestedFeeRecipient: feeRecipient,
+          withdrawals: toEngineWithdrawals get_expected_withdrawals(forkyState.data),
+          parentBeaconBlockRoot: beaconHead.blck.bid.root.to(Hash32),
+        )
+      elif consensusFork >= ConsensusFork.Capella:
+        let attributes = PayloadAttributesV2(
+          timestamp: Quantity timestamp,
+          prevRandao: Bytes32 prevRandao.to(Hash32),
+          suggestedFeeRecipient: feeRecipient,
+          withdrawals: toEngineWithdrawals get_expected_withdrawals(forkyState.data),
+        )
+      else:
+        let attributes = PayloadAttributesV1(
+          timestamp: Quantity timestamp,
+          prevRandao: Bytes32 prevRandao.to(Hash32),
+          suggestedFeeRecipient: feeRecipient,
+        )
+
+      let (status, _) = await self.elManager.forkchoiceUpdated(
+        headBlockHash,
+        beaconHead.safeExecutionBlockHash,
+        beaconHead.finalizedExecutionBlockHash,
+        Opt.some(attributes),
+        deadline,
+        false,
+      )
+      debug "Fork-choice updated for proposal", status, headBlockHash, attributes
+    elif consensusFork in ConsensusFork.Phase0 .. ConsensusFork.Altair:
+      discard
+    else:
+      {.error: "Unknown consensus fork " & $consensusFork.}
+
+proc forkchoiceUpdated*(
+    self: ref ConsensusManager,
+    slot: Slot,
+    headBlockHash, safeBlockHash, finalizedBlockHash: Eth2Digest,
+    deadline: DeadlineFuture,
+    retry: bool,
+): Future[PayloadExecutionStatus] {.async: (raises: [CancelledError]).} =
+  ## Call non-proposer version of forkchoiceUpdated using the given slot to
+  ## select the correct PayloadAttributes version
+  withConsensusFork(self[].dag.cfg.consensusForkAtEpoch(slot.epoch)):
+    when consensusFork >= ConsensusFork.Bellatrix:
+      if headBlockHash.isZero:
+        # Merge not yet activated
+        PayloadExecutionStatus.valid
+      else:
+        let (status, _) = await self.elManager.forkchoiceUpdated(
+          headBlockHash,
+          safeBlockHash,
+          finalizedBlockHash,
+          Opt.none consensusFork.PayloadAttributes,
+          deadline,
+          retry,
+        )
+        status
+    else:
+      PayloadExecutionStatus.valid
+
+proc forkchoiceUpdated(
+    self: ref ConsensusManager,
+    head: BeaconHead,
+    wallSlot: Slot,
+    deadline: DeadlineFuture,
+    retry: bool,
+): Future[bool] {.async: (raises: [CancelledError]).} =
+  ## Send forkchoiceUpdated to the client, return false iff the head was invalid
+  ## and true otherwise
+
+  if self[].shouldSyncOptimistically(wallSlot):
+    # No point retrying for optimistic slots since there will be a new attempt
+    # "soon"
+    # However, we will make the call even if the optimistic head hasn't changed
+    # since the last slot since the finalized / safe blocks might have changed
+    let status = await self.forkchoiceUpdated(
+      self.optimisticHead.bid.slot, self.optimisticHead.execution_block_hash,
+      head.safeExecutionBlockHash, head.finalizedExecutionBlockHash, deadline, false,
+    )
+
+    self.optimisticHeadStatus = status.to(OptimisticStatus)
+
+    case self.optimisticHeadStatus
+    of OptimisticStatus.valid, OptimisticStatus.notValidated:
+      true
+    of OptimisticStatus.invalidated:
+      warn "Light execution payload invalid - the execution client or the light client data is faulty",
+        payloadExecutionStatus = status,
+        optimisticBlockHash = self.optimisticHead.execution_block_hash
+      false
+  else:
+    let
+      headExecutionBlockHash = self.dag.loadExecutionBlockHash(head.blck).valueOr:
+        # `BlockRef` are only created for blocks that have passed
+        # execution block hash validation, either explicitly in
+        # `block_processor.storeBlock`, or implicitly, e.g., through
+        # checkpoint sync. With checkpoint sync, the checkpoint block
+        # is initially not available, so if there is a reorg to it,
+        # this may be triggered. Such a reorg could happen if the first
+        # imported chain is completely invalid (after the checkpoint block)
+        # and is subsequently pruned, in which case checkpoint block is head.
+        # Because execution block hash validation has already passed,
+        # we can treat this as `SYNCING`.
+        warn "Failed to load head execution block hash", head = head.blck
+        return true
+      status = await self.forkchoiceUpdated(
+        head.blck.slot, headExecutionBlockHash, head.safeExecutionBlockHash,
+        head.finalizedExecutionBlockHash, deadline, retry,
+      )
+
+    case status.to(OptimisticStatus)
+    of OptimisticStatus.valid:
+      head.blck.markExecutionValid(true)
+      true
+    of OptimisticStatus.notValidated:
+      if head.blck.optimisticStatus != OptimisticStatus.notValidated:
+        info "Previously validated block not accepted as new head by execution client",
+          blck = head.blck,
+          prevStatus = head.blck.optimisticStatus,
+          payloadExecutionStatus = status
+      true
+    of OptimisticStatus.invalidated:
+      if head.blck.executionValid:
+        # https://github.com/ethereum/consensus-specs/blob/927073b0aafc958aef4689010fb4f97d22813015/sync/optimistic.md?plain=1#L420
+        warn "Previously valid execution payload turned invalid during fork choice update - check execution client for faults and restart the beacon node",
+          blck = head.blck,
+          prevStatus = head.blck.optimisticStatus,
+          payloadExecutionStatus = status
+
+      head.blck.markExecutionValid(false)
+      self.attestationPool[].forkChoice.mark_root_invalid(head.blck.root)
+      self.quarantine[].addUnviable(head.blck.root)
+      false
+
+proc updateExecutionHead*(
+    self: ref ConsensusManager,
+    deadline: DeadlineFuture,
+    retry: bool,
+    getBeaconTimeFn: GetBeaconTimeFn,
+) {.async: (raises: [CancelledError]).} =
+  ## Update the execution client with consensus information from the latest
+  ## head selection.
+  ##
+  ## In the case that we were optimistically synced and the execution client has
+  ## determined that the payload was invalid, we will also attempt to update
+  ## the consensus head towards a valid / nonValidated block by rerunning
+  ## fork choice with the new information in mind.
+
+  if self.forkchoiceInflight:
+    return
+
+  self.forkchoiceInflight = true
+  defer:
+    self.forkchoiceInflight = false
+
+  var
+    attempts = 0
+    wallTime = getBeaconTimeFn()
+    head = self.attestationPool[].getBeaconHead(self.dag.head)
+
+  while not (await self.forkchoiceUpdated(head, wallTime.slotOrZero(), deadline, retry)):
+    # Each failed call to forkchoiceUpdated that fails should reveal new
+    # information about the suggested new head - a side effect of the failure is
+    # that the block should be marked as invalid and removed from fork choice
+    # consideration, meaning that a new fork choice should select either an
+    # earlier block or a different fork (as attestations keep coming in).
+    #
+    # When light client data is available, we might also run into the case where
+    # the optimistic head is broken - this is very bad and light client head
+    # will simply be ignored until the next restart.
+
+    if deadline.finished:
+      # We will try again soon .. hopefully with a new head
+      warn "Deadline expired while looking for valid payload", attempts, head
+      break
+
+    # Select new head for next attempt
+    wallTime = getBeaconTimeFn()
+    let nextHead = self.attestationPool[].selectOptimisticHead(wallTime).valueOr:
+      warn "Head selection failed after invalid block, using previous head",
+        head, wallSlot = wallTime.slotOrZero
+      break
+
+    warn "updateHeadWithExecution: attempting to recover from invalid payload",
+      attempts, head, nextHead
+
+    head = nextHead
 
     # Store the new head in the chain DAG - this may cause epochs to be
     # justified and finalized
     self.dag.updateHead(
-      newHead.blck, self.quarantine[],
-      self[].getKnownValidatorsForBlsChangeTracking(newHead.blck))
+      head.blck,
+      self.quarantine[],
+      self[].getKnownValidatorsForBlsChangeTracking(head.blck),
+    )
 
-    # If this node should propose next slot, start preparing payload. Both
-    # fcUs are useful: the updateExecutionClientHead(newHead) call updates
-    # the head state (including optimistic status) that self.dagUpdateHead
-    # needs while runProposalForkchoiceUpdated requires RANDAO information
-    # from the head state corresponding to the `newHead` block, which only
-    # self.dag.updateHead(...) sets up.
-    discard await self.runProposalForkchoiceUpdated(getBeaconTimeFn().slotOrZero)
-
-    self[].checkExpectedBlock()
-  except CatchableError as exc:
-    debug "updateHeadWithExecution error",
-      error = exc.msg
+    attempts += 1
 
 proc pruneStateCachesAndForkChoice*(self: var ConsensusManager) =
   ## Prune unneeded and invalidated data after finalization

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -16,14 +16,13 @@ import
 from std/deques import Deque, addLast, contains, initDeque, items, len, shrink
 from std/sequtils import anyIt, mapIt
 from ../consensus_object_pools/consensus_manager import
-  ConsensusManager, checkNextProposer, optimisticExecutionBlockHash,
-  runProposalForkchoiceUpdated, shouldSyncOptimistically, updateHead,
-  updateHeadWithExecution
+  ConsensusManager, to, updateHead, updateExecutionHead
 from ../consensus_object_pools/blockchain_dag import
   getBlockRef, getForkedBlock, getProposer, forkAtEpoch, loadExecutionBlockHash,
-  markBlockVerified, validatorKey, is_optimistic
+  markExecutionValid, validatorKey, is_optimistic
 from ../beacon_clock import GetBeaconTimeFn, toFloatSeconds
-from ../consensus_object_pools/block_dag import BlockRef, root, shortLog, slot
+from ../consensus_object_pools/block_dag import
+  BlockRef, OptimisticStatus, executionValid, root, shortLog, slot
 from ../consensus_object_pools/block_pools_types import
   EpochRef, VerifierError
 from ../consensus_object_pools/block_quarantine import
@@ -111,12 +110,6 @@ type
     lastPayload: Slot
       ## The slot at which we sent a payload to the execution client the last
       ## time
-
-  NewPayloadStatus* {.pure.} = enum
-    valid
-    notValid
-    invalid
-    noResponse
 
 # Initialization
 # ------------------------------------------------------------------------------
@@ -367,8 +360,7 @@ proc expectValidForkchoiceUpdated(
       safeBlockHash, finalizedBlockHash,
       receivedBlock = shortLog(receivedBlock)
 
-from ../consensus_object_pools/attestation_pool import
-  addForkChoice, selectOptimisticHead, BeaconHead
+from ../consensus_object_pools/attestation_pool import addForkChoice
 from ../consensus_object_pools/spec_cache import get_attesting_indices
 
 proc newExecutionPayload*(
@@ -407,30 +399,26 @@ proc getExecutionValidity(
           fulu.SignedBeaconBlock,
     deadline: DeadlineFuture,
     retry: bool,
-): Future[NewPayloadStatus] {.async: (raises: [CancelledError]).} =
+): Future[Opt[OptimisticStatus]] {.async: (raises: [CancelledError]).} =
   if not blck.message.is_execution_block:
-    return NewPayloadStatus.valid  # vacuously
+    return Opt.some(OptimisticStatus.valid) # vacuously
 
-  let executionPayloadStatus = (
-    await elManager.newExecutionPayload(blck.message, deadline, retry)
-  ).valueOr:
-    return NewPayloadStatus.noResponse
+  let status = (await elManager.newExecutionPayload(blck.message, deadline, retry)).valueOr:
+    return Opt.none(OptimisticStatus)
 
-  case executionPayloadStatus
-  of PayloadExecutionStatus.invalid, PayloadExecutionStatus.invalid_block_hash:
+  let optimisticStatus = status.to(OptimisticStatus)
+
+  if optimisticStatus == OptimisticStatus.invalidated:
     # Blocks come either from gossip or request manager requests. In the
     # former case, they've passed libp2p gossip validation which implies
     # correct signature for correct proposer,which makes spam expensive,
     # while for the latter, spam is limited by the request manager.
     info "execution payload invalid from EL client newPayload",
-      executionPayloadStatus,
+      executionPayloadStatus = status,
       executionPayload = shortLog(blck.message.body.execution_payload),
       blck = shortLog(blck)
-    NewPayloadStatus.invalid
-  of PayloadExecutionStatus.syncing, PayloadExecutionStatus.accepted:
-    NewPayloadStatus.notValid
-  of PayloadExecutionStatus.valid:
-    NewPayloadStatus.valid
+
+  Opt.some(optimisticStatus)
 
 proc checkBlobOrColumnlessSignature(
     self: BlockProcessor,
@@ -481,22 +469,6 @@ proc enqueueBlock*(
       src: src))
   except AsyncQueueFullError:
     raiseAssert "unbounded queue"
-
-proc updateHead*(
-    consensusManager: ref ConsensusManager,
-    getBeaconTimeFn: GetBeaconTimeFn,
-): Result[void, string] =
-  let
-    attestationPool = consensusManager.attestationPool
-    wallTime = getBeaconTimeFn()
-    wallSlot = wallTime.slotOrZero()
-    newHead =
-      attestationPool[].selectOptimisticHead(wallSlot.start_beacon_time)
-  if newHead.isOk():
-    consensusManager[].updateHead(newHead.get.blck)
-    ok()
-  else:
-    err("Head selection failed, using previous head")
 
 proc enqueueQuarantine(self: var BlockProcessor, root: Eth2Digest) =
   ## Enqueue blocks whose parent is `root` - ie when `root` has been added to
@@ -695,7 +667,7 @@ proc storeBlock(
 
   const consensusFork = typeof(signedBlock).kind
   let
-    payloadStatus =
+    optimisticStatusRes =
       if maybeFinalized and
           (self.lastPayload + SLOTS_PER_PAYLOAD) > signedBlock.message.slot and
           (signedBlock.message.slot + PAYLOAD_PRE_WALL_SLOTS) < wallSlot and
@@ -706,22 +678,18 @@ proc storeBlock(
         # from an honest source (or when we're close to head).
         # Occasionally we also send a payload to the EL so that it can
         # progress in its own sync.
-        NewPayloadStatus.noResponse
+        Opt.none(OptimisticStatus)
       else:
         when consensusFork == ConsensusFork.Gloas:
           debugGloasComment "need getExecutionValidity on gloas blocks"
-          NewPayloadStatus.valid
+          Opt.some OptimisticStatus.valid
         elif consensusFork >= ConsensusFork.Bellatrix:
           await self.consensusManager.elManager.getExecutionValidity(
             signedBlock, deadline, shouldRetry())
         else:
-          NewPayloadStatus.valid # vacuously
-    payloadValid = payloadStatus == NewPayloadStatus.valid
+          Opt.some(OptimisticStatus.valid) # vacuously
 
-  if NewPayloadStatus.invalid == payloadStatus:
-    return err(VerifierError.Invalid)
-
-  if NewPayloadStatus.noResponse == payloadStatus:
+  let optimisticStatus = optimisticStatusRes.valueOr:
     # When the execution layer is not available to verify the payload, we do the
     # required checks on the CL instead and proceed as if the EL was syncing
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#verify_and_notify_new_payload
@@ -762,6 +730,13 @@ proc storeBlock(
         if signedBlock.root in self.invalidBlockRoots:
           returnWithError "Block root treated as invalid via config",
             $signedBlock.root
+
+      OptimisticStatus.notValidated
+    else:
+      OptimisticStatus.valid
+
+  if OptimisticStatus.invalidated == optimisticStatus:
+    return err(VerifierError.Invalid)
 
   let newPayloadTick = Moment.now()
 
@@ -811,7 +786,7 @@ proc storeBlock(
 
   let
     blckRes = dag.addHeadBlockWithParent(
-        self.verifier, signedBlock, parent.value(), payloadValid) do (
+        self.verifier, signedBlock, parent.value(), optimisticStatus) do (
       blckRef: BlockRef, trustedBlock: Trusted,
       epochRef: EpochRef, unrealized: FinalityCheckpoints):
       # Callback add to fork choice if valid
@@ -854,119 +829,33 @@ proc storeBlock(
 
   let addHeadBlockTick = Moment.now()
 
-  # Eagerly update head: the incoming block "should" get selected.
+  # Update consensus head - in the happy case where we are in sync and the
+  # execution client has validated the block, this will allow validators to
+  # start attesting via the `checkExpectedBlock` mechanism - notably, this can
+  # be done without waiting for `forkchoiceUpdated` as the execution client
+  # already validated the payload.
   #
-  # storeBlock gets called from validator_duties, which depends on its not
-  # blocking progress any longer than necessary, and processBlock here, in
-  # which case it's fine to await for a while on engine API results.
+  # In the unhappy case, the head update kickstarts any pruning and cleanup work
+  # which helps conserve resources, ie also a good thing to be doing just after
+  # having added a block.
+  let previousExecutionValid = dag.head.executionValid
+  self.consensusManager[].updateHead(wallSlot)
+
+  # After producing attestations, we might be asked to produce a block for the
+  # next slot, for which there is a hard requirement on the execution client
+  # fork choice being up to date - there's also a soft requirement that the
+  # execution head follows the consensus head as closely as possible as this
+  # keeps the execution client healthy and up to date with finality, so as soon
+  # as we've updated the consensus head we'll do the same for execution.
   #
-  # Three general scenarios: (1) pre-merge; (2) merge, already `VALID` by way
-  # of `newPayload`; (3) optimistically imported, need to call fcU before DAG
-  # updateHead. Because in a non-finalizing network, completing sync isn't as
-  # useful because regular reorgs likely still occur, and when finalizing the
-  # EL is only called every SLOTS_PER_PAYLOAD slots regardless, await, rather
-  # than asyncSpawn forkchoiceUpdated calls.
-  #
-  # This reduces in-flight fcU spam, which both reduces EL load and decreases
-  # otherwise somewhat unpredictable CL head movement.
-
-  # Grab the new head according to our latest attestation data; determines how
-  # async this needs to be.
-  let newHead = attestationPool[].selectOptimisticHead(
-    wallSlot.start_beacon_time)
-
-  if newHead.isOk:
-    template elManager(): auto = self.consensusManager.elManager
-    if self.consensusManager[].shouldSyncOptimistically(wallSlot):
-      # Optimistic head is far in the future; report it as head block to EL.
-
-      # Note that the specification allows an EL client to skip fcU processing
-      # if an update to an ancestor is requested.
-      # > Client software MAY skip an update of the forkchoice state and MUST
-      #   NOT begin a payload build process if `forkchoiceState.headBlockHash`
-      #   references an ancestor of the head of canonical chain.
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/paris.md#specification-1
-      #
-      # However, in practice, an EL client may not have completed importing all
-      # block headers, so may be unaware of a block's ancestor status.
-      # Therefore, hopping back and forth between the optimistic head and the
-      # chain DAG head does not work well in practice, e.g., Geth:
-      # - "Beacon chain gapped" from DAG head to optimistic head,
-      # - followed by "Beacon chain reorged" from optimistic head back to DAG.
-      self.consensusManager[].updateHead(newHead.get.blck)
-
-      template callForkchoiceUpdated(attributes: untyped) =
-        if  NewPayloadStatus.noResponse != payloadStatus and
-            not self.consensusManager[].optimisticExecutionBlockHash.isZero:
-          discard await elManager.forkchoiceUpdated(
-            headBlockHash =
-              self.consensusManager[].optimisticExecutionBlockHash,
-            safeBlockHash = newHead.get.safeExecutionBlockHash,
-            finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
-            payloadAttributes = Opt.none attributes,
-            deadline = deadline,
-            retry = shouldRetry())
-
-      let consensusFork = self.consensusManager.dag.cfg.consensusForkAtEpoch(
-        newHead.get.blck.bid.slot.epoch)
-      withConsensusFork(consensusFork):
-        when consensusFork >= ConsensusFork.Bellatrix:
-          callForkchoiceUpdated(consensusFork.PayloadAttributes)
-    else:
-      let
-        headExecutionBlockHash =
-          dag.loadExecutionBlockHash(newHead.get.blck).get(ZERO_HASH)
-        wallSlot = self.getBeaconTime().slotOrZero
-      if  headExecutionBlockHash.isZero or
-          NewPayloadStatus.noResponse == payloadStatus:
-        # Blocks without execution payloads can't be optimistic, and don't try
-        # to fcU to a block the EL hasn't seen
-        self.consensusManager[].updateHead(newHead.get.blck)
-      elif newHead.get.blck.executionValid:
-        # `forkchoiceUpdated` necessary for EL client only.
-        self.consensusManager[].updateHead(newHead.get.blck)
-
-        template callExpectValidFCU(payloadAttributeType: untyped): auto =
-          await elManager.expectValidForkchoiceUpdated(
-            headBlockPayloadAttributesType = payloadAttributeType,
-            headBlockHash = headExecutionBlockHash,
-            safeBlockHash = newHead.get.safeExecutionBlockHash,
-            finalizedBlockHash = newHead.get.finalizedExecutionBlockHash,
-            receivedBlock = signedBlock,
-            deadline = deadline,
-            retry = shouldRetry())
-
-        template callForkChoiceUpdated: auto =
-          case self.consensusManager.dag.cfg.consensusForkAtEpoch(
-              newHead.get.blck.bid.slot.epoch)
-          of ConsensusFork.Gloas:
-            debugGloasComment ""
-          of ConsensusFork.Deneb, ConsensusFork.Electra, ConsensusFork.Fulu:
-            # https://github.com/ethereum/execution-apis/blob/90a46e9137c89d58e818e62fa33a0347bba50085/src/engine/prague.md
-            # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
-            callExpectValidFCU(payloadAttributeType = PayloadAttributesV3)
-          of ConsensusFork.Capella:
-            callExpectValidFCU(payloadAttributeType = PayloadAttributesV2)
-          of  ConsensusFork.Phase0, ConsensusFork.Altair,
-              ConsensusFork.Bellatrix:
-            callExpectValidFCU(payloadAttributeType = PayloadAttributesV1)
-
-        if self.consensusManager.checkNextProposer(wallSlot).isNone:
-          # No attached validator is next proposer, so use non-proposal fcU
-          callForkChoiceUpdated()
-        else:
-          # Some attached validator is next proposer, so prepare payload. As
-          # updateHead() updated the DAG head, runProposalForkchoiceUpdated,
-          # which needs the state corresponding to that head block, can run.
-          if (await self.consensusManager.runProposalForkchoiceUpdated(
-              wallSlot)).isNone:
-            callForkChoiceUpdated()
-      else:
-        await self.consensusManager.updateHeadWithExecution(
-          newHead.get, self.getBeaconTime)
-  else:
-    warn "Head selection failed, using previous head",
-      head = shortLog(dag.head), wallSlot
+  # In the case that the execution client is not responding to payloads or
+  # that we skipped sending the payload altogether per the above
+  # `SLOTS_PER_PAYLOAD` logic, we will skip the execution client update.
+  if optimisticStatusRes.isSome():
+    # retry fcU until the deadline expires, in case the previous payload was
+    # valid to increase chances of leaving this function with a still-valid head
+    await self.consensusManager.updateExecutionHead(
+      deadline, retry = previousExecutionValid, self.getBeaconTime)
 
   let
     updateHeadTick = Moment.now()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1862,13 +1862,32 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # logging slot end since the nextActionWaitTime can be short
   let advanceCutoff = node.beaconClock.fromNow(
     slot.start_beacon_time() + chronos.seconds(int(SECONDS_PER_SLOT - 1)))
-  if advanceCutoff.inFuture:
-    # We wait until there's only a second left before the next slot begins, then
-    # we advance the clearance state to the next slot - this gives us a high
-    # probability of being prepared for the block that will arrive and the
-    # epoch processing that follows
-    await sleepAsync(advanceCutoff.offset)
-    node.dag.advanceClearanceState()
+
+  let proposalFcu =
+    if advanceCutoff.inFuture:
+      # We wait until there's only a second left before the next slot begins, then
+      # we advance the clearance state to the next slot - this gives us a high
+      # probability of being prepared for the block that will arrive and the
+      # epoch processing that follows
+      await sleepAsync(advanceCutoff.offset)
+      let
+        nextSlot = slot + 1
+        nextSlotCutoff = node.beaconClock.fromNow(nextSlot.start_beacon_time)
+        head = node.dag.head # could be a new head compared to earlier
+
+      if nextSlotCutoff.inFuture and node.isSynced(head) and head.executionValid:
+        node.dag.advanceClearanceState(nextSlot)
+
+        # If there is a proposal, we want to let the execution client know a bit
+        # earlier - the risk is that fork choice changes again before the proposal
+        # but this risk should be small
+        node.consensusManager.proposalForkchoiceUpdated(
+          nextSlot, sleepAsync(nextSlotCutoff.offset)
+        )
+      else:
+        nil
+    else:
+      nil
 
   # Prepare action tracker for the next slot
   node.consensusManager[].actionTracker.updateSlot(slot + 1)
@@ -1919,6 +1938,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   node.network.updateNextForkDigest(nextForkDigest)
 
   await node.updateGossipStatus(slot + 1)
+
+  if proposalFcu != nil:
+    await proposalFcu
 
 func formatNextConsensusFork(
     node: BeaconNode, withVanityArt = false): Opt[string] =

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1434,20 +1434,20 @@ template get_updated_effective_balance*(
     balance
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/capella/beacon-chain.md#new-get_expected_withdrawals
-template get_expected_withdrawals_aux*(
-    state: capella.BeaconState | deneb.BeaconState, epoch: Epoch,
-    fetch_balance: untyped): seq[Withdrawal] =
+proc get_expected_withdrawals*(
+    state: capella.BeaconState | deneb.BeaconState): seq[Withdrawal] =
   let
+    epoch = get_current_epoch(state)
     num_validators = lenu64(state.validators)
     bound = min(len(state.validators), MAX_VALIDATORS_PER_WITHDRAWALS_SWEEP)
   var
     withdrawal_index = state.next_withdrawal_index
-    validator_index {.inject.} = state.next_withdrawal_validator_index
+    validator_index = state.next_withdrawal_validator_index
     withdrawals: seq[Withdrawal] = @[]
   for _ in 0 ..< bound:
     let
       validator = state.validators[validator_index]
-      balance = fetch_balance
+      balance = state.balances[validator_index]
     if is_fully_withdrawable_validator(
         typeof(state).kind, validator, balance, epoch):
       var w = Withdrawal(
@@ -1470,11 +1470,6 @@ template get_expected_withdrawals_aux*(
       break
     validator_index = (validator_index + 1) mod num_validators
   withdrawals
-
-func get_expected_withdrawals*(
-    state: capella.BeaconState | deneb.BeaconState): seq[Withdrawal] =
-  get_expected_withdrawals_aux(state, get_current_epoch(state)) do:
-    state.balances[validator_index]
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/electra/beacon-chain.md#modified-get_expected_withdrawals
 # This partials count is used in exactly one place, while in general being able

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -265,9 +265,7 @@ proc blockProcessingLoop(overseer: SyncOverseerRef): Future[void] {.
               bchunk.resfut.complete(Result[void, string].err(msg))
               break innerLoop
 
-          consensusManager.updateHead(overseer.getBeaconTimeFn).isOkOr:
-            bchunk.resfut.complete(Result[void, string].err(error))
-            break innerLoop
+          consensusManager[].updateHead(overseer.getBeaconTimeFn().slotOrZero())
 
         bchunk.resfut.complete(Result[void, string].ok())
 

--- a/tests/testbcutil.nim
+++ b/tests/testbcutil.nim
@@ -11,7 +11,8 @@ import results
 
 from ../beacon_chain/consensus_object_pools/block_clearance import
   addHeadBlockWithParent
-from ../beacon_chain/consensus_object_pools/block_dag import BlockRef
+from ../beacon_chain/consensus_object_pools/block_dag import
+  BlockRef, OptimisticStatus
 from ../beacon_chain/consensus_object_pools/block_pools_types import
   ChainDAGRef, OnForkyBlockAdded, VerifierError
 from ../beacon_chain/spec/forks import ForkySignedBeaconBlock
@@ -24,4 +25,4 @@ proc addHeadBlock*(
     ): Result[BlockRef, VerifierError] =
   addHeadBlockWithParent(
     dag, verifier, signedBlock, ? dag.checkHeadBlock(signedBlock),
-    executionValid = true, onBlockAdded)
+    OptimisticStatus.valid, onBlockAdded)

--- a/tests/testbcutil.nim
+++ b/tests/testbcutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
With recent cleanups to payload handling, it becomes feasible to simplify the `forkchoiceUpdated` flow as well - the new flow is based on the following observations:

* when the beacon node is synced, it is likely that the execution client will be able to process the next payload promptly as well
* when both consensus and execution blocks are valid, we can start attesting, even though the corresponding `forkchoiceUpdated` has not yet happened
* when a proposal is due for the next slot, there is benefit in letting the execution client know ahead of time, but not so early that we send it stale information
* the proposal state - or indeed the state for the next slot - is being computed a second before the slot ends and provides a good opportunity for collecting proposal information for `forkchoiceUpdated`

Therefore:

* always update the local consensus head as soon as block verification is done, before sending out `forkchoiceUpdated` - this allows attestation work to start
* update execution head lazily while attestations (potentially) are being sent out
* in the unhappy case, keep recomputing consensus for every block that gets invalidated until the usual block processing deadline ends (instead of a fixed number of attempts)
* keep track of optimistic head status - if the execution client says the optimistic head is invalid, stop using it in fork choice updates - this can happen in the unlikely case that the sync committee votes for an invalid execution block (!) and is a defence of last resort
* introduce `OptimisticStatus` based on optimistic spec terminology, as a replacement for NewPayloadStatus
* keep track of detailed optimistic state in `BlockRef` - this allows reporting unusual state transitions more consistently than the existing "expectValid" flow that only happens with new blocks
* prevent "payload forkchoiceUpdated" from happening concurrently with "regular forkchoiceUpdated"
* reduce duplicated/overlapping logic between block processor and consensus manager, letting the latter do all consensus-related work including notifying the EL
* update clearance state more aggressively when we're synced, ie even if we have to reorg it