### PR TITLE
don't use an x86-specific gcc/clang flag on non-x86 platforms

### DIFF
--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,13 +7,13 @@
 
 mode = ScriptMode.Verbose
 
-version       = "24.12.0"
+version       = "25.9.0"
 author        = "Status Research & Development GmbH"
 description   = "The Nimbus beacon chain node is a highly efficient Ethereum 2.0 client"
 license       = "MIT or Apache License 2.0"
 
 requires(
-  "nim == 2.0.12",
+  "nim == 2.2.4",
   "https://github.com/status-im/NimYAML",
   "bearssl",
   "blscurve",

--- a/config.nims
+++ b/config.nims
@@ -121,12 +121,13 @@ elif defined(riscv64):
 else:
   switch("passC", "-march=native")
   switch("passL", "-march=native")
-  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
-  # ("-fno-asynchronous-unwind-tables" breaks Nim's exception raising, sometimes)
-  # For non-Windows targets, https://github.com/bitcoin-core/secp256k1/issues/1623
-  # also suggests disabling the same flag to address Ubuntu 22.04/recent AMD CPUs.
-  switch("passC", "-mno-avx512f")
-  switch("passL", "-mno-avx512f")
+  if defined(i386) or defined(amd64):
+    # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782
+    # ("-fno-asynchronous-unwind-tables" breaks Nim's exception raising, sometimes)
+    # For non-Windows targets, https://github.com/bitcoin-core/secp256k1/issues/1623
+    # also suggests disabling the same flag to address Ubuntu 22.04/recent AMD CPUs.
+    switch("passC", "-mno-avx512f")
+    switch("passL", "-mno-avx512f")
 
 # omitting frame pointers in nim breaks the GC
 # https://github.com/nim-lang/Nim/issues/10625


### PR DESCRIPTION
e.g., non-macOS arm64:
- https://github.com/status-im/nimbus-eth2/issues/7464