### PR TITLE
ci: clean workspace and set XDG_CACHE_HOME

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,15 @@ jobs:
 
     name: ${{ matrix.target.os }}-${{ matrix.target.cpu }}${{ matrix.branch != '' && ' (Nim ' || '' }}${{ matrix.branch-short }}${{ matrix.branch != '' && ')' || '' }}
     runs-on: ${{ matrix.builder }}
+
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
+      - name: Clean workspace (very aggressive)
+        if: contains(matrix.builder, 'self-hosted')
+        run: rm -rf "$GITHUB_WORKSPACE"/*
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -207,6 +215,12 @@ jobs:
     name: "Developer builds"
     runs-on: ['self-hosted','ubuntu-22.04']
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
+      - name: Clean workspace (very aggressive)
+        run: rm -rf "$GITHUB_WORKSPACE"/*
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,6 +21,9 @@ jobs:
     name: Linux AMD64 release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -67,6 +70,9 @@ jobs:
     name: Linux ARM64 release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Install packages
         env:
           DEBIAN_FRONTEND: "noninteractive"
@@ -121,6 +127,9 @@ jobs:
     name: Linux ARM release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Install packages
         env:
           DEBIAN_FRONTEND: "noninteractive"
@@ -175,6 +184,9 @@ jobs:
     name: Windows AMD64 release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -221,6 +233,9 @@ jobs:
     name: macOS AMD64 release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -267,6 +282,9 @@ jobs:
     name: macOS ARM64 release asset
     runs-on: ubuntu-latest
     steps:
+      - name: Fix nim cache conflicts
+        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- GH Runners are not ephemeral by default : https://docs.github.com/en/actions/reference/runners/self-hosted-runners#ephemeral-runners-for-autoscaling
- Hence we cleanup the workspace directory before each job is run.
- We also set `XDG_CACHE_HOME` to a temporary directory in the github runner to prevent collision issues between nim cache.