### PR TITLE
Use BPO specific gossip channels and SSZ REST contexts for light client

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -904,7 +904,7 @@ proc updateBeaconMetrics(
     beacon_current_active_validators.set(active_validators)
 
     beacon_head_execution_number.set(
-      when consensusFork >= ConsensusFork.Bellatrix and 
+      when consensusFork >= ConsensusFork.Bellatrix and
           consensusFork < ConsensusFork.Gloas:
         debugGloasComment "handle correctly for gloas"
         forkyState.data.latest_execution_payload_header.block_number.toGaugeValue
@@ -1382,6 +1382,9 @@ template genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
 
 proc genesisBlockRoot*(dag: ChainDAGRef): Eth2Digest =
   dag.db.getGenesisBlock().expect("DB must be initialized with genesis block")
+
+func forkDigestAtEpoch*(dag: ChainDAGRef, epoch: Epoch): ForkDigest =
+  dag.forkDigests[].atEpoch(epoch, dag.cfg)
 
 func getEpochRef*(
     dag: ChainDAGRef, state: ForkedHashedBeaconState, cache: var StateCache): EpochRef =

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -287,11 +287,13 @@ proc installMessageValidators*(
 
   template validate[T: SomeForkyLightClientObject](
       msg: T,
-      contextFork: ConsensusFork,
+      expectedContextBytes: ForkDigest,
       validatorProcName: untyped): ValidationResult =
     msg.logReceived()
 
-    if contextFork != lightClient.cfg.consensusForkAtEpoch(msg.contextEpoch):
+    let contextBytes =
+      lightClient.forkDigests[].atEpoch(msg.contextEpoch, lightClient.cfg)
+    if contextBytes != expectedContextBytes:
       msg.logDropped(
         (ValidationResult.Reject, cstring "Invalid context fork"))
       return ValidationResult.Reject
@@ -346,30 +348,29 @@ proc installMessageValidators*(
 
   let forkDigests = lightClient.forkDigests
   for consensusFork in ConsensusFork:
-    withLcDataFork(lcDataForkAtConsensusFork(consensusFork)):
-      when lcDataFork > LightClientDataFork.None:
-        closureScope:
-          let
-            contextFork = consensusFork
-            digest = forkDigests[].atConsensusFork(contextFork)
+    for forkDigest in consensusFork.forkDigests(forkDigests[]):
+      withLcDataFork(lcDataForkAtConsensusFork(consensusFork)):
+        when lcDataFork > LightClientDataFork.None:
+          closureScope:
+            let contextBytes = forkDigest
 
-          # light_client_optimistic_update
-          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_finality_update
-          lightClient.network.addValidator(
-            getLightClientFinalityUpdateTopic(digest), proc (
-              msg: lcDataFork.LightClientFinalityUpdate,
-              src: PeerId
-            ): ValidationResult =
-              validate(msg, contextFork, processLightClientFinalityUpdate))
+            # light_client_optimistic_update
+            # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_finality_update
+            lightClient.network.addValidator(
+              getLightClientFinalityUpdateTopic(forkDigest), proc (
+                msg: lcDataFork.LightClientFinalityUpdate,
+                src: PeerId
+              ): ValidationResult =
+                validate(msg, contextBytes, processLightClientFinalityUpdate))
 
-          # light_client_optimistic_update
-          # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
-          lightClient.network.addValidator(
-            getLightClientOptimisticUpdateTopic(digest), proc (
-              msg: lcDataFork.LightClientOptimisticUpdate,
-              src: PeerId
-            ): ValidationResult =
-              validate(msg, contextFork, processLightClientOptimisticUpdate))
+            # light_client_optimistic_update
+            # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#light_client_optimistic_update
+            lightClient.network.addValidator(
+              getLightClientOptimisticUpdateTopic(forkDigest), proc (
+                msg: lcDataFork.LightClientOptimisticUpdate,
+                src: PeerId
+              ): ValidationResult =
+                validate(msg, contextBytes, processLightClientOptimisticUpdate))
 
 proc updateGossipStatus*(
     lightClient: LightClient, slot: Slot, dagIsBehind = default(Option[bool])) =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -205,24 +205,24 @@ proc loadChainDag(
     if dag == nil: return
     withForkyFinalityUpdate(data):
       when lcDataFork > LightClientDataFork.None:
-        let contextFork =
-          dag.cfg.consensusForkAtEpoch(forkyFinalityUpdate.contextEpoch)
+        let
+          contextEpoch = forkyFinalityUpdate.contextEpoch
+          contextFork = dag.cfg.consensusForkAtEpoch(contextEpoch)
+          contextBytes = dag.forkDigestAtEpoch(contextEpoch)
         eventBus.finUpdateQueue.emit(
           RestVersioned[ForkedLightClientFinalityUpdate](
-            data: data,
-            jsonVersion: contextFork,
-            sszContext: dag.forkDigests[].atConsensusFork(contextFork)))
+            data: data, jsonVersion: contextFork, sszContext: contextBytes))
   proc onLightClientOptimisticUpdate(data: ForkedLightClientOptimisticUpdate) =
     if dag == nil: return
     withForkyOptimisticUpdate(data):
       when lcDataFork > LightClientDataFork.None:
-        let contextFork =
-          dag.cfg.consensusForkAtEpoch(forkyOptimisticUpdate.contextEpoch)
+        let
+          contextEpoch = forkyOptimisticUpdate.contextEpoch
+          contextFork = dag.cfg.consensusForkAtEpoch(contextEpoch)
+          contextBytes = dag.forkDigestAtEpoch(contextEpoch)
         eventBus.optUpdateQueue.emit(
           RestVersioned[ForkedLightClientOptimisticUpdate](
-            data: data,
-            jsonVersion: contextFork,
-            sszContext: dag.forkDigests[].atConsensusFork(contextFork)))
+            data: data, jsonVersion: contextFork, sszContext: contextBytes))
 
   let
     chainDagFlags =
@@ -466,7 +466,7 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork >= ConsensusFork.Fulu and 
+        when consensusFork >= ConsensusFork.Fulu and
             consensusFork < ConsensusFork.Gloas:
           debugGloasComment "no blob_kzg_commitments field for gloas"
           let cres = dataColumnQuarantine[].popSidecars(forkyBlck.root, forkyBlck)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -120,13 +120,16 @@ proc main() {.noinline, raises: [CatchableError].} =
   for consensusFork in ConsensusFork:
     for forkDigest in consensusFork.forkDigests(forkDigests[]):
       withConsensusFork(consensusFork):
-        network.addValidator(
-          getBeaconBlocksTopic(forkDigest), proc (
-              signedBlock: consensusFork.SignedBeaconBlock,
-              src: PeerId
-          ): ValidationResult =
-            toValidationResult(
-              optimisticProcessor.processSignedBeaconBlock(signedBlock)))
+        when consensusFork >= ConsensusFork.Gloas:
+          debugGloasComment "consensusFork.SignedBeaconBlock support missing"
+        else:
+          network.addValidator(
+            getBeaconBlocksTopic(forkDigest), proc (
+                signedBlock: consensusFork.SignedBeaconBlock,
+                src: PeerId
+            ): ValidationResult =
+              toValidationResult(
+                optimisticProcessor.processSignedBeaconBlock(signedBlock)))
   lightClient.installMessageValidators()
   waitFor network.startListening()
   waitFor network.start()

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -117,15 +117,16 @@ proc main() {.noinline, raises: [CatchableError].} =
     PeerSync, PeerSync.NetworkState.init(
       cfg, forkDigests, genesisBlockRoot, getBeaconTime))
 
-  withAll(ConsensusFork):
-    let forkDigest = forkDigests[].atConsensusFork(consensusFork)
-    network.addValidator(
-      getBeaconBlocksTopic(forkDigest), proc (
-          signedBlock: consensusFork.SignedBeaconBlock,
-          src: PeerId
-      ): ValidationResult =
-        toValidationResult(
-          optimisticProcessor.processSignedBeaconBlock(signedBlock)))
+  for consensusFork in ConsensusFork:
+    for forkDigest in consensusFork.forkDigests(forkDigests[]):
+      withConsensusFork(consensusFork):
+        network.addValidator(
+          getBeaconBlocksTopic(forkDigest), proc (
+              signedBlock: consensusFork.SignedBeaconBlock,
+              src: PeerId
+          ): ValidationResult =
+            toValidationResult(
+              optimisticProcessor.processSignedBeaconBlock(signedBlock)))
   lightClient.installMessageValidators()
   waitFor network.startListening()
   waitFor network.start()

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -102,10 +102,9 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
           else:
             continue
         contextFork = node.dag.cfg.consensusForkAtEpoch(contextEpoch)
+        contextBytes = node.dag.forkDigestAtEpoch(contextEpoch)
       updates.add RestVersioned[ForkedLightClientUpdate](
-        data: update,
-        jsonVersion: contextFork,
-        sszContext: node.dag.forkDigests[].atConsensusFork(contextFork))
+        data: update, jsonVersion: contextFork, sszContext: contextBytes)
 
     return
       if contentType == sszMediaType:

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1209,6 +1209,14 @@ template atEpoch*(
   else:
     forkDigests.atConsensusFork(cfg.consensusForkAtEpoch(epoch))
 
+iterator forkDigests*(consensusFork: ConsensusFork, forkDigests: ForkDigests): ForkDigest =
+  yield forkDigests.atConsensusFork(consensusFork)
+
+  if consensusFork >= ConsensusFork.Fulu:
+    for (_, consensusFork, forkDigest) in forkDigests.bpos:
+      if consensusFork == consensusFork:
+        yield forkDigest
+
 template asSigned*(
     x: ForkedTrustedSignedBeaconBlock): ForkedSignedBeaconBlock =
   isomorphicCast[ForkedSignedBeaconBlock](x)

--- a/beacon_chain/sync/light_client_protocol.nim
+++ b/beacon_chain/sync/light_client_protocol.nim
@@ -46,8 +46,7 @@ proc readChunkPayload*(
       let res = await eth2_network.readChunkPayload(
         conn, peer, MsgType.Forky(lcDataFork))
       if res.isOk:
-        if contextFork !=
-            peer.network.cfg.consensusForkAtEpoch(res.get.contextEpoch):
+        if peer.network.forkDigestAtEpoch(res.get.contextEpoch) != contextBytes:
           return neterr InvalidContextBytes
         return ok MsgType.init(res.get)
       else:
@@ -57,12 +56,8 @@ proc readChunkPayload*(
 
 {.pop.}
 
-func forkDigestAtEpoch(state: LightClientNetworkState,
-                       epoch: Epoch): ForkDigest =
-  state.dag.forkDigests[].atEpoch(epoch, state.dag.cfg)
-
-p2pProtocol LightClientSync(version = 1,
-                       networkState = LightClientNetworkState):
+p2pProtocol LightClientSync(
+    version = 1, networkState = LightClientNetworkState):
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/p2p-interface.md#getlightclientbootstrap
   proc lightClientBootstrap(
       peer: Peer,
@@ -78,7 +73,7 @@ p2pProtocol LightClientSync(version = 1,
       when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyBootstrap.contextEpoch
-          contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+          contextBytes = dag.forkDigestAtEpoch(contextEpoch).data
 
         # TODO extract from libp2pProtocol
         peer.awaitQuota(
@@ -120,8 +115,7 @@ p2pProtocol LightClientSync(version = 1,
         when lcDataFork > LightClientDataFork.None:
           let
             contextEpoch = forkyUpdate.contextEpoch
-            contextBytes =
-              peer.networkState.forkDigestAtEpoch(contextEpoch).data
+            contextBytes = dag.forkDigestAtEpoch(contextEpoch).data
 
           # TODO extract from libp2pProtocol
           peer.awaitQuota(
@@ -148,7 +142,7 @@ p2pProtocol LightClientSync(version = 1,
       when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyFinalityUpdate.contextEpoch
-          contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+          contextBytes = dag.forkDigestAtEpoch(contextEpoch).data
 
         # TODO extract from libp2pProtocol
         peer.awaitQuota(
@@ -174,7 +168,7 @@ p2pProtocol LightClientSync(version = 1,
       when lcDataFork > LightClientDataFork.None:
         let
           contextEpoch = forkyOptimisticUpdate.contextEpoch
-          contextBytes = peer.networkState.forkDigestAtEpoch(contextEpoch).data
+          contextBytes = dag.forkDigestAtEpoch(contextEpoch).data
 
         # TODO extract from libp2pProtocol
         peer.awaitQuota(


### PR DESCRIPTION
Fulu uses epoch specific fork digests (BPO), use them where applicable:

- Certain REST APIs put the ForkDigest into the SSZ data, i.e., the LC data by range endpoint packs multiple results and uses this
- Gossip channels are BPO specific for LC data topics, and in the nimbus_light_client blocks topic subscription
- Gossip validation needs to check the fork digest for a match, the simpler consensus version check is not strict enough