### PR TITLE
Reply with Access-Control-Expose-Headers if configured with CORS

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -138,6 +138,9 @@ template rng*(node: BeaconNode): ref HmacDrbgContext =
 proc currentSlot*(node: BeaconNode): Slot =
   node.beaconClock.now.slotOrZero
 
+func hasRestAllowedOrigin*(node: BeaconNode): bool =
+  node.config.restAllowedOrigin.isSome
+
 func getPayloadBuilderAddress*(config: BeaconNodeConf): Opt[string] =
   if config.payloadBuilderEnable:
     Opt.some config.payloadBuilderUrl

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -161,15 +161,16 @@ proc handleDataSidecarRequest*[
     let dataSidecar = new DataSidecarsType.T
     if getDataSidecar(node.dag.db, bid.root, dataIndex, dataSidecar[]):
       discard data[].add dataSidecar[]
+  let consensusFork = node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch)
 
   if contentType == sszMediaType:
     RestApiResponse.sszResponse(
-      data[], headers = [("eth-consensus-version",
-        node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch).toString())])
+      data[], consensusFork, node.hasRestAllowedOrigin)
   elif contentType == jsonMediaType:
-    RestApiResponse.jsonResponseDataSidecars(
-      data[].asSeq(), node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch),
-      Opt.some(node.dag.is_optimistic(bid)), node.dag.isFinalized(bid))
+    RestApiResponse.jsonResponseFinalizedWVersion(
+      data[].asSeq(),
+      Opt.some(node.dag.is_optimistic(bid)), node.dag.isFinalized(bid),
+      consensusFork, node.hasRestAllowedOrigin)
   else:
     RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
@@ -1149,15 +1150,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         signedMaybeBlindedBlck: auto, consensusFork: ConsensusFork): untyped =
       if contentType == sszMediaType:
         RestApiResponse.sszResponse(
-          signedMaybeBlindedBlck,
-          [("eth-consensus-version", consensusFork.toString())])
+          signedMaybeBlindedBlck, consensusFork, node.hasRestAllowedOrigin)
       elif contentType == jsonMediaType:
         RestApiResponse.jsonResponseBlock(
           signedMaybeBlindedBlck,
-          consensusFork,
           node.getBlockOptimistic(bdata),
-          node.dag.isFinalized(bid)
-        )
+          node.dag.isFinalized(bid),
+          consensusFork, node.hasRestAllowedOrigin)
       else:
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
@@ -1364,24 +1363,21 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       bid = node.getBlockId(blockIdent).valueOr:
         return RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
-    let contentType =
-      block:
+      contentType = block:
         let res = preferredContentType(jsonMediaType,
                                        sszMediaType)
         if res.isErr():
           return RestApiResponse.jsonError(Http406, ContentNotAcceptableError)
         res.get()
+      consensusFork = node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch)
 
     if contentType == sszMediaType:
       var data: seq[byte]
       if not node.dag.getBlockSSZ(bid, data):
         return RestApiResponse.jsonError(Http404, BlockNotFoundError)
 
-      let
-        fork = node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch)
-        headers = [("eth-consensus-version", fork.toString())]
-
-      RestApiResponse.sszResponsePlain(data, headers)
+      RestApiResponse.sszResponsePlain(
+        data, consensusFork, node.hasRestAllowedOrigin)
     elif contentType == jsonMediaType:
       let bdata = node.dag.getForkedBlock(bid).valueOr:
         return RestApiResponse.jsonError(Http404, BlockNotFoundError)
@@ -1389,8 +1385,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       RestApiResponse.jsonResponseBlock(
         bdata.asSigned(),
         node.getBlockOptimistic(bdata),
-        node.dag.isFinalized(bid)
-      )
+        node.dag.isFinalized(bid),
+        node.hasRestAllowedOrigin)
     else:
       RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
@@ -1450,8 +1446,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         forkyBlck.message.body.attestations.asSeq(),
         node.getBlockOptimistic(bdata),
         node.dag.isFinalized(bid),
-        consensusFork
-      )
+        consensusFork, node.hasRestAllowedOrigin)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolAttestations
   router.api2(MethodGet, "/eth/v1/beacon/pool/attestations") do (
@@ -1514,11 +1509,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     if consensusFork < ConsensusFork.Electra:
       return RestApiResponse.jsonResponseWVersion(
         toSeq(node.attestationPool[].attestations(vslot, vindex)),
-        consensusFork)
+        consensusFork, node.hasRestAllowedOrigin)
     else:
       return RestApiResponse.jsonResponseWVersion(
         toSeq(node.attestationPool[].electraAttestations(vslot, vindex)),
-        consensusFork)
+        consensusFork, node.hasRestAllowedOrigin)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolAttestations
   router.api2(MethodPost, "/eth/v1/beacon/pool/attestations") do (
@@ -1568,7 +1563,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     contentBody: Option[ContentBody]) -> RestApiResponse:
 
     let
-      headerVersion = request.headers.getString("Eth-Consensus-Version")
+      headerVersion = request.headers.getString("eth-consensus-version")
       consensusVersion = ConsensusFork.init(headerVersion)
     if consensusVersion.isNone():
       return RestApiResponse.jsonError(Http400, FailedToObtainConsensusForkError)
@@ -1656,18 +1651,18 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       when consensusFork < ConsensusFork.Electra:
         RestApiResponse.jsonResponseWVersion(
           toSeq(node.validatorChangePool.phase0_attester_slashings),
-          contextFork)
+          contextFork, node.hasRestAllowedOrigin)
       else:
         RestApiResponse.jsonResponseWVersion(
           toSeq(node.validatorChangePool.electra_attester_slashings),
-          contextFork)
+          contextFork, node.hasRestAllowedOrigin)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashingsV2
   router.api(MethodPost, "/eth/v2/beacon/pool/attester_slashings") do (
     contentBody: Option[ContentBody]) -> RestApiResponse:
 
     let
-      headerVersion = request.headers.getString("Eth-Consensus-Version")
+      headerVersion = request.headers.getString("eth-consensus-version")
       consensusVersion = ConsensusFork.init(headerVersion)
     if consensusVersion.isNone():
       return RestApiResponse.jsonError(Http400, FailedToObtainConsensusForkError)
@@ -1860,7 +1855,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             forkyState.data.pending_deposits,
             node.getStateOptimistic(state),
             node.dag.isFinalized(bslot.bid),
-            consensusFork)
+            consensusFork, node.hasRestAllowedOrigin)
         else:
           RestApiResponse.jsonError(Http400, SlotFromTheIncorrectForkError,
                                     $error)
@@ -1891,7 +1886,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             forkyState.data.pending_partial_withdrawals,
             node.getStateOptimistic(state),
             node.dag.isFinalized(bslot.bid),
-            consensusFork)
+            consensusFork, node.hasRestAllowedOrigin)
         else:
           RestApiResponse.jsonError(Http400, SlotFromTheIncorrectForkError,
                                     $error)
@@ -1922,7 +1917,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             forkyState.data.pending_consolidations,
             node.getStateOptimistic(state),
             node.dag.isFinalized(bslot.bid),
-            consensusFork)
+            consensusFork, node.hasRestAllowedOrigin)
         else:
           RestApiResponse.jsonError(Http400, SlotFromTheIncorrectForkError,
                                     $error)

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -45,8 +45,8 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
     MethodGet, "/eth/v2/debug/beacon/states/{state_id}",
     {RestServerMetricsType.Status, Response}) do (
     state_id: StateIdent) -> RestApiResponse:
-    let bslot =
-      block:
+    let
+      bslot = block:
         if state_id.isErr():
           return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                            $state_id.error())
@@ -55,8 +55,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                            $bres.error())
         bres.get()
-    let contentType =
-      block:
+      contentType = block:
         let res = preferredContentType(jsonMediaType,
                                        sszMediaType)
         if res.isErr():
@@ -68,11 +67,12 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if contentType == jsonMediaType:
           RestApiResponse.jsonResponseState(
             state, node.getStateOptimistic(state),
-            node.dag.isFinalized(bslot.bid))
+            node.dag.isFinalized(bslot.bid),
+            node.hasRestAllowedOrigin)
         elif contentType == sszMediaType:
-          let headers = [("eth-consensus-version", state.kind.toString())]
           withState(state):
-            RestApiResponse.sszResponse(forkyState.data, headers)
+            RestApiResponse.sszResponse(
+              forkyState.data, state.kind, node.hasRestAllowedOrigin)
         else:
           RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
@@ -150,6 +150,6 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
           u_justified_checkpoint: u_justified_checkpoint,
           u_finalized_checkpoint: u_finalized_checkpoint,
           best_child: item.bestChild,
-          bestDescendant: item.bestDescendant))
+          best_descendant: item.bestDescendant))
 
     RestApiResponse.jsonResponsePlain(response)

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -41,10 +41,11 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
           contextFork = node.dag.cfg.consensusForkAtEpoch(contextEpoch)
         return
           if contentType == sszMediaType:
-            let headers = [("eth-consensus-version", contextFork.toString())]
-            RestApiResponse.sszResponse(forkyBootstrap, headers)
+            RestApiResponse.sszResponse(
+              forkyBootstrap, contextFork, node.hasRestAllowedOrigin)
           elif contentType == jsonMediaType:
-            RestApiResponse.jsonResponseWVersion(forkyBootstrap, contextFork)
+            RestApiResponse.jsonResponseWVersion(
+              forkyBootstrap, contextFork, node.hasRestAllowedOrigin)
           else:
             RestApiResponse.jsonError(Http500, InvalidAcceptError)
       else:
@@ -136,11 +137,11 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
           contextFork = node.dag.cfg.consensusForkAtEpoch(contextEpoch)
         return
           if contentType == sszMediaType:
-            let headers = [("eth-consensus-version", contextFork.toString())]
-            RestApiResponse.sszResponse(forkyFinalityUpdate, headers)
+            RestApiResponse.sszResponse(
+              forkyFinalityUpdate, contextFork, node.hasRestAllowedOrigin)
           elif contentType == jsonMediaType:
             RestApiResponse.jsonResponseWVersion(
-              forkyFinalityUpdate, contextFork)
+              forkyFinalityUpdate, contextFork, node.hasRestAllowedOrigin)
           else:
             RestApiResponse.jsonError(Http500, InvalidAcceptError)
       else:
@@ -167,11 +168,11 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
           contextFork = node.dag.cfg.consensusForkAtEpoch(contextEpoch)
         return
           if contentType == sszMediaType:
-            let headers = [("eth-consensus-version", contextFork.toString())]
-            RestApiResponse.sszResponse(forkyOptimisticUpdate, headers)
+            RestApiResponse.sszResponse(
+              forkyOptimisticUpdate, contextFork, node.hasRestAllowedOrigin)
           elif contentType == jsonMediaType:
             RestApiResponse.jsonResponseWVersion(
-              forkyOptimisticUpdate, contextFork)
+              forkyOptimisticUpdate, contextFork, node.hasRestAllowedOrigin)
           else:
             RestApiResponse.jsonError(Http500, InvalidAcceptError)
       else:

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -519,10 +519,9 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
     node.withStateForBlockSlotId(bslot):
       return withState(state):
         when consensusFork >= ConsensusFork.Capella:
-          const historicalSummariesFork = historicalSummariesForkAtConsensusFork(
-              consensusFork
-            )
-            .expect("HistoricalSummariesFork for Capella onwards")
+          const historicalSummariesFork =
+            historicalSummariesForkAtConsensusFork(consensusFork)
+              .expect("HistoricalSummariesFork for Capella onwards")
 
           let response = getHistoricalSummariesResponse(historicalSummariesFork)(
             historical_summaries: forkyState.data.historical_summaries,
@@ -537,11 +536,10 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
               response,
               node.getStateOptimistic(state),
               node.dag.isFinalized(bslot.bid),
-              consensusFork,
-            )
+              consensusFork, node.hasRestAllowedOrigin)
           elif contentType == sszMediaType:
-            let headers = [("eth-consensus-version", consensusFork.toString())]
-            RestApiResponse.sszResponse(response, headers)
+            RestApiResponse.sszResponse(
+              response, consensusFork, node.hasRestAllowedOrigin)
           else:
             RestApiResponse.jsonError(Http500, InvalidAcceptError)
         else:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -331,21 +331,6 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonError(
       Http410, DeprecatedRemovalProduceBlindedBlockV1)
 
-  func getMaybeBlindedHeaders(
-      consensusFork: ConsensusFork,
-      isBlinded: bool,
-      executionValue: UInt256,
-      consensusValue: UInt256): HttpTable =
-    var res = HttpTable.init()
-    res.add("eth-consensus-version", consensusFork.toString())
-    if isBlinded:
-      res.add("eth-execution-payload-blinded", "true")
-    else:
-      res.add("eth-execution-payload-blinded", "false")
-    res.add("eth-execution-payload-value", toString(executionValue, 10))
-    res.add("eth-consensus-block-value", toString(consensusValue, 10))
-    res
-
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceBlockV3
   router.api(MethodGet, "/eth/v3/validator/blocks/{slot}") do (
       slot: Slot, randao_reveal: Option[ValidatorSig],
@@ -437,16 +422,18 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
               qboostFactor)).valueOr:
             # HTTP 400 error is only for incorrect parameters.
             return RestApiResponse.jsonError(Http500, error)
-          headers = consensusFork.getMaybeBlindedHeaders(
-            message.blck.isBlinded,
-            message.executionValue,
-            message.consensusValue)
 
         if contentType == sszMediaType:
           if message.blck.isBlinded:
-            RestApiResponse.sszResponse(message.blck.blindedData, headers)
+            RestApiResponse.sszResponse(
+              message.blck.blindedData, consensusFork, isBlinded = true,
+              message.executionValue, message.consensusValue,
+              node.hasRestAllowedOrigin)
           else:
-            RestApiResponse.sszResponse(message.blck.data, headers)
+            RestApiResponse.sszResponse(
+              message.blck.data, consensusFork, isBlinded = false,
+              message.executionValue, message.consensusValue,
+              node.hasRestAllowedOrigin)
         elif contentType == jsonMediaType:
           let forked =
             if message.blck.isBlinded:
@@ -459,7 +446,10 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                 message.blck.data,
                 Opt.some message.executionValue,
                 Opt.some message.consensusValue)
-          RestApiResponse.jsonResponsePlain(forked, headers)
+          RestApiResponse.jsonResponsePlain(
+            forked, consensusFork, message.blck.isBlinded,
+            message.executionValue, message.consensusValue,
+            node.hasRestAllowedOrigin)
         else:
           raiseAssert "preferredContentType() returns invalid content type"
       elif consensusFork >= ConsensusFork.Bellatrix:
@@ -467,20 +457,22 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           message = (await node.makeBeaconBlockForHeadAndSlot(
               consensusFork, proposer, qrandao, qgraffiti, qhead, qslot)).valueOr:
             return RestApiResponse.jsonError(Http500, error)
-          headers = consensusFork.getMaybeBlindedHeaders(
-            isBlinded = false,
-            message.executionValue,
-            message.consensusValue)
 
         if contentType == sszMediaType:
-          RestApiResponse.sszResponse(message.blck, headers)
+          RestApiResponse.sszResponse(
+            message.blck, consensusFork, isBlinded = false,
+            message.executionValue, message.consensusValue,
+            node.hasRestAllowedOrigin)
         elif contentType == jsonMediaType:
           let forked = ForkedMaybeBlindedBeaconBlock.init(
             message.blck,
             Opt.some message.executionValue,
             Opt.some message.consensusValue)
 
-          RestApiResponse.jsonResponsePlain(forked, headers)
+          RestApiResponse.jsonResponsePlain(
+            forked, consensusFork, isBlinded = false,
+            message.executionValue, message.consensusValue,
+            node.hasRestAllowedOrigin)
         else:
           raiseAssert "preferredContentType() returns invalid content type"
       else:
@@ -641,8 +633,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                 UnableToGetAggregatedAttestationError)
           ForkedAttestation.init(phase0_attestation, qfork)
 
-    let headers = HttpTable.init([("eth-consensus-version", qfork.toString())])
-    RestApiResponse.jsonResponsePlain(forked, headers)
+    RestApiResponse.jsonResponsePlain(forked, qfork, node.hasRestAllowedOrigin)
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/publishAggregateAndProofs
   router.api2(MethodPost, "/eth/v1/validator/aggregate_and_proofs") do (
@@ -686,7 +677,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
 
     let
-      headerVersion = request.headers.getString("Eth-Consensus-Version")
+      headerVersion = request.headers.getString("eth-consensus-version")
       consensusVersion = ConsensusFork.init(headerVersion)
     if consensusVersion.isNone():
       return RestApiResponse.jsonError(Http400, FailedToObtainConsensusForkError)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -145,6 +145,32 @@ type
                     fulu.BlockContents | electra_mev.BlindedBeaconBlock |
                     fulu_mev.BlindedBeaconBlock
 
+func ethHeaders(
+    consensusFork: ConsensusFork,
+    hasRestAllowedOrigin: bool): HttpTable =
+  var headers = HttpTable.init [
+    ("eth-consensus-version", consensusFork.toString())]
+  if hasRestAllowedOrigin:
+    headers.add("access-control-expose-headers", "eth-consensus-version")
+  headers
+
+func ethHeaders(
+    consensusFork: ConsensusFork,
+    isBlinded: bool,
+    executionValue: UInt256,
+    consensusValue: UInt256,
+    hasRestAllowedOrigin: bool): HttpTable =
+  var headers = HttpTable.init [
+    ("eth-consensus-version", consensusFork.toString()),
+    ("eth-execution-payload-blinded", if isBlinded: "true" else: "false"),
+    ("eth-execution-payload-value", toString(executionValue, 10)),
+    ("eth-consensus-block-value", toString(consensusValue, 10))]
+  if hasRestAllowedOrigin:
+    headers.add("access-control-expose-headers", static(
+      "eth-consensus-version, eth-execution-payload-blinded, " &
+      "eth-execution-payload-value, eth-consensus-block-value"))
+  headers
+
 func readStrictHexChar(c: char, radix: static[uint8]): Result[int8, cstring] =
   ## Converts an hex char to an int
   const
@@ -276,13 +302,15 @@ proc jsonResponse*(_: typedesc[RestApiResponse], data: auto): RestApiResponse =
 
   RestApiResponse.response(res, Http200, "application/json")
 
-proc jsonResponseBlock*(_: typedesc[RestApiResponse],
-                        data: ForkySignedBlindedBeaconBlock,
-                        consensusFork: ConsensusFork,
-                        execOpt: Opt[bool],
-                        finalized: bool): RestApiResponse =
+proc jsonResponseBlock*(
+    _: typedesc[RestApiResponse],
+    data: ForkySignedBlindedBeaconBlock,
+    execOpt: Opt[bool],
+    finalized: bool,
+    consensusFork: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
   let
-    headers = [("eth-consensus-version", consensusFork.toString())]
+    headers = consensusFork.ethHeaders(hasRestAllowedOrigin)
     res = withRestJsonWriter(w, seq[byte]):
       w.writeObject:
         w.writeField("version", consensusFork)
@@ -292,12 +320,14 @@ proc jsonResponseBlock*(_: typedesc[RestApiResponse],
 
   RestApiResponse.response(res, Http200, "application/json", headers = headers)
 
-proc jsonResponseBlock*(_: typedesc[RestApiResponse],
-                        data: ForkedSignedBeaconBlock,
-                        execOpt: Opt[bool],
-                        finalized: bool): RestApiResponse =
+proc jsonResponseBlock*(
+    _: typedesc[RestApiResponse],
+    data: ForkedSignedBeaconBlock,
+    execOpt: Opt[bool],
+    finalized: bool,
+    hasRestAllowedOrigin: bool): RestApiResponse =
   let
-    headers = [("eth-consensus-version", data.kind.toString())]
+    headers = data.kind.ethHeaders(hasRestAllowedOrigin)
     res = withRestJsonWriter(w, seq[byte]):
       w.writeObject:
         w.writeField("version", data.kind)
@@ -308,30 +338,14 @@ proc jsonResponseBlock*(_: typedesc[RestApiResponse],
 
   RestApiResponse.response(res, Http200, "application/json", headers = headers)
 
-proc jsonResponseDataSidecars*(
+proc jsonResponseState*(
     _: typedesc[RestApiResponse],
-    data: openArray[BlobSidecar | fulu.DataColumnSidecar],
-    version: ConsensusFork,
+    data: ForkedHashedBeaconState,
     execOpt: Opt[bool],
-    finalized: bool
-): RestApiResponse =
+    finalized: bool,
+    hasRestAllowedOrigin: bool): RestApiResponse =
   let
-    headers = [("eth-consensus-version", version.toString())]
-    res = withRestJsonWriter(w, seq[byte]):
-      w.writeObject:
-        w.writeField("version", version)
-        w.writeField("execution_optimistic", execOpt)
-        w.writeField("finalized", finalized)
-        w.writeField("data", data)
-
-  RestApiResponse.response(res, Http200, "application/json", headers = headers)
-
-proc jsonResponseState*(_: typedesc[RestApiResponse],
-                        data: ForkedHashedBeaconState,
-                        execOpt: Opt[bool],
-                        finalized: bool): RestApiResponse =
-  let
-    headers = [("eth-consensus-version", data.kind.toString())]
+    headers = data.kind.ethHeaders(hasRestAllowedOrigin)
     res = withRestJsonWriter(w, seq[byte]):
       w.writeObject:
         w.writeField("version", data.kind)
@@ -367,27 +381,31 @@ proc jsonResponseFinalized*(_: typedesc[RestApiResponse], data: auto,
   let res = RestApiResponse.prepareJsonResponseFinalized(data, exec, finalized)
   RestApiResponse.response(res, Http200, "application/json")
 
-proc jsonResponseFinalizedWVersion*(_: typedesc[RestApiResponse],
-                            data: auto,
-                            exec: Opt[bool],
-                            finalized: bool,
-                            version: ConsensusFork): RestApiResponse =
+proc jsonResponseFinalizedWVersion*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    exec: Opt[bool],
+    finalized: bool,
+    version: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
   let
-    headers = [("eth-consensus-version", version.toString())]
+    headers = version.ethHeaders(hasRestAllowedOrigin)
     res = withRestJsonWriter(w, seq[byte]):
       w.writeObject:
         w.writeField("version", version)
         w.writeField("execution_optimistic", exec)
         w.writeField("finalized", finalized)
         w.writeField("data", data)
-        w.endRecord()
 
   RestApiResponse.response(res, Http200, "application/json", headers = headers)
 
-proc jsonResponseWVersion*(_: typedesc[RestApiResponse], data: auto,
-                           version: ConsensusFork): RestApiResponse =
+proc jsonResponseWVersion*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    version: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
   let
-    headers = [("eth-consensus-version", version.toString())]
+    headers = version.ethHeaders(hasRestAllowedOrigin)
     res = withRestJsonWriter(w, seq[byte]):
       w.writeObject:
         w.writeField("version", version)
@@ -408,18 +426,37 @@ proc jsonResponseVersioned*[T: SomeForkedLightClientObject](
 
   RestApiResponse.response(res, Http200, "application/json")
 
+proc jsonPlainEncoded(data: auto): seq[byte] =
+  withRestJsonWriter(w, seq[byte]):
+    w.writeValue(data)
+
 proc jsonResponsePlain*(_: typedesc[RestApiResponse],
                         data: auto): RestApiResponse =
-  let res = withRestJsonWriter(w, seq[byte]):
-    w.writeValue(data)
-
+  let res = data.jsonPlainEncoded()
   RestApiResponse.response(res, Http200, "application/json")
 
-proc jsonResponsePlain*(_: typedesc[RestApiResponse],
-                        data: auto, headers: HttpTable): RestApiResponse =
-  let res = withRestJsonWriter(w, seq[byte]):
-    w.writeValue(data)
+proc jsonResponsePlain*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    consensusFork: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
+  let
+    res = data.jsonPlainEncoded()
+    headers = consensusFork.ethHeaders(hasRestAllowedOrigin)
+  RestApiResponse.response(res, Http200, "application/json", headers = headers)
 
+proc jsonResponsePlain*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    consensusFork: ConsensusFork,
+    isBlinded: bool,
+    executionValue: UInt256,
+    consensusValue: UInt256,
+    hasRestAllowedOrigin: bool): RestApiResponse =
+  let
+    res = data.jsonPlainEncoded()
+    headers = consensusFork.ethHeaders(
+      isBlinded, executionValue, consensusValue, hasRestAllowedOrigin)
   RestApiResponse.response(res, Http200, "application/json", headers = headers)
 
 proc jsonResponseWMeta*(_: typedesc[RestApiResponse],
@@ -512,24 +549,40 @@ proc sszResponseVersioned*[T: SomeForkedLightClientObject](
       default(seq[byte])
   RestApiResponse.response(res, Http200, "application/octet-stream")
 
-proc sszResponsePlain*(_: typedesc[RestApiResponse], res: seq[byte],
-                       headers: openArray[RestKeyValueTuple] = []
-                      ): RestApiResponse =
-  RestApiResponse.response(res, Http200, "application/octet-stream",
-                           headers = headers)
+proc sszResponsePlain*(
+    _: typedesc[RestApiResponse],
+    res: seq[byte],
+    consensusFork: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
+  let headers = consensusFork.ethHeaders(hasRestAllowedOrigin)
+  RestApiResponse.response(
+    res, Http200, "application/octet-stream", headers = headers)
 
-proc sszResponse*(_: typedesc[RestApiResponse], data: auto,
-                  headers: openArray[RestKeyValueTuple] = []
-                 ): RestApiResponse =
-  let res = SSZ.encode(data)
-  RestApiResponse.response(res, Http200, "application/octet-stream",
-                           headers = headers)
+proc sszResponse*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    consensusFork: ConsensusFork,
+    hasRestAllowedOrigin: bool): RestApiResponse =
+  let
+    res = SSZ.encode(data)
+    headers = consensusFork.ethHeaders(hasRestAllowedOrigin)
+  RestApiResponse.response(
+    res, Http200, "application/octet-stream", headers = headers)
 
-proc sszResponse*(_: typedesc[RestApiResponse], data: auto,
-                  headers: HttpTable): RestApiResponse =
-  let res = SSZ.encode(data)
-  RestApiResponse.response(res, Http200, "application/octet-stream",
-                           headers = headers)
+proc sszResponse*(
+    _: typedesc[RestApiResponse],
+    data: auto,
+    consensusFork: ConsensusFork,
+    isBlinded: bool,
+    executionValue: UInt256,
+    consensusValue: UInt256,
+    hasRestAllowedOrigin: bool): RestApiResponse =
+  let
+    res = SSZ.encode(data)
+    headers = consensusFork.ethHeaders(
+      isBlinded, executionValue, consensusValue, hasRestAllowedOrigin)
+  RestApiResponse.response(
+    res, Http200, "application/octet-stream", headers = headers)
 
 proc parseRoot(value: string): Result[Eth2Digest, cstring] =
   try:


### PR DESCRIPTION
When CORS is used, i.e., when the Nimbus beacon API is accessed from a web browser, by default, custom headers are not accessible from the client side JavaScript code, as they might contain sensitive info.

Because beacon-API uses custom HTTP headers, we have to send a second header to actually make them available. This PR does that for:

- Eth-Consensus-Version
- Eth-Execution-Payload-Blinded
- Eth-Execution-Payload-Value
- Eth-Consensus-Block-Value

The Access-Control-Expose-Headers header is sent if Nimbus is configured with --rest-allow-origin, matching the trigger in Presto that sends the Access-Control-Allow-Origin header.