### PR TITLE
Store runtime SECONDS_PER_SLOT value in RuntimeConfig

### DIFF
--- a/beacon_chain/rpc/rest_config_api.nim
+++ b/beacon_chain/rpc/rest_config_api.nim
@@ -212,7 +212,7 @@ proc installConfigApiHandlers*(router: var RestRouter, node: BeaconNode) =
             Base10.toString(uint64(cfg.FULU_FORK_EPOCH)),
 
           SECONDS_PER_SLOT:
-            Base10.toString(SECONDS_PER_SLOT),
+            Base10.toString(cfg.time.SECONDS_PER_SLOT),
           SECONDS_PER_ETH1_BLOCK:
             Base10.toString(cfg.SECONDS_PER_ETH1_BLOCK),
           MIN_VALIDATOR_WITHDRAWABILITY_DELAY:

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -41,6 +41,9 @@ const
   MAX_SUPPORTED_REQUEST_BLOB_SIDECARS*: uint64 = 1152
 
 type
+  TimeConfig* = object
+    SECONDS_PER_SLOT*: uint64
+
   Version* = distinct array[4, byte]
 
   Eth1Address* = eth.Address
@@ -83,7 +86,7 @@ type
     GLOAS_FORK_EPOCH*: Epoch
 
     # Time parameters
-    # TODO SECONDS_PER_SLOT*: uint64
+    time*: TimeConfig
     SECONDS_PER_ETH1_BLOCK*: uint64
     MIN_VALIDATOR_WITHDRAWABILITY_DELAY*: uint64
     SHARD_COMMITTEE_PERIOD*: uint64
@@ -246,8 +249,9 @@ when const_preset == "mainnet":
 
     # Time parameters
     # ---------------------------------------------------------------
-    # 12 seconds
-    # TODO SECONDS_PER_SLOT: 12,
+    time: TimeConfig(
+      # 12 seconds
+      SECONDS_PER_SLOT: 12),
     # 14 (estimate from Eth1 mainnet)
     SECONDS_PER_ETH1_BLOCK: 14,
     # 2**8 (= 256) epochs ~27 hours
@@ -417,8 +421,9 @@ elif const_preset == "gnosis":
 
     # Time parameters
     # ---------------------------------------------------------------
-    # 5 seconds
-    # TODO SECONDS_PER_SLOT: 5,
+    time: TimeConfig(
+      # 5 seconds
+      SECONDS_PER_SLOT: 5),
     # 14 (estimate from Eth1 mainnet)
     SECONDS_PER_ETH1_BLOCK: 5,
     # 2**8 (= 256) epochs ~27 hours
@@ -585,8 +590,9 @@ elif const_preset == "minimal":
 
     # Time parameters
     # ---------------------------------------------------------------
-    # [customized] Faster for testing purposes
-    # TODO SECONDS_PER_SLOT: 6,
+    time: TimeConfig(
+      # [customized] Faster for testing purposes
+      SECONDS_PER_SLOT: 6),
     # 14 (estimate from Eth1 mainnet)
     SECONDS_PER_ETH1_BLOCK: 14,
     # 2**8 (= 256) epochs
@@ -760,6 +766,9 @@ template parse(T: type UInt256, input: string): T =
 func parse(T: type DomainType, input: string): T
            {.raises: [ValueError].} =
   DomainType hexToByteArray(input, 4)
+
+func parse(T: typedesc[TimeConfig], input: string): T {.raises: [ValueError].} =
+  raise (ref ValueError)(msg: "Unexpected TimeConfig value")
 
 func cmpBlobParameters*(x, y: BlobParameters): int =
   # Don't care about ties and want reverse order.
@@ -976,7 +985,7 @@ proc readRuntimeConfig*(
   checkCompatibility REORG_PARENT_WEIGHT_THRESHOLD
   checkCompatibility REORG_MAX_EPOCHS_SINCE_FINALIZATION
 
-  for name, field in cfg.fieldPairs():
+  template assignValue(name: static string, field: untyped): untyped =
     if values.hasKey(name):
       when field is seq[BlobParameters]:
         field = blobScheduleEntries
@@ -989,6 +998,11 @@ proc readRuntimeConfig*(
     elif name == "BLOB_SCHEDULE":
       when field is seq[BlobParameters]:
         field = blobScheduleEntries
+
+  for name, field in cfg.fieldPairs():
+    assignValue(name, field)
+  for name, field in cfg.time.fieldPairs():
+    assignValue(name, field)
 
   if cfg.PRESET_BASE != const_preset:
     raise (ref PresetIncompatibleError)(


### PR DESCRIPTION
As an initial step for making SECONDS_PER_SLOT configurable, store the value from config.yaml in RuntimeConfig. As the rest of the code still uses the compile time constant from the {.intdefine.}, the preset loader still checks the value to be compatible (effectively keeping it static):

> Cannot override config (required: SECONDS_PER_SLOT==12 - config: SECONDS_PER_SLOT=5)

Storing the parsed value is still necessary eventually, doing it now to keep the rest of the diffs small.