### PR TITLE
Store runtime SECONDS_PER_SLOT value in ValidatorClient

### DIFF
--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -71,7 +71,7 @@ proc initGenesis(
                     genesis_root = resp.data.data.genesis_validators_root
               gres.add((nodes[i], resp.data.data))
             else:
-              debug "Received unsuccessful response code", endpoint = nodes[i],
+              debug "Received unexpected response code", endpoint = nodes[i],
                     response_code = resp.status
               bres.add(nodes[i])
           elif fut.failed():
@@ -159,7 +159,7 @@ proc initTimeConfig(
           debug "Received incompatible time configuration settings",
                 endpoint = nodes[i], config = resp.data.data
       else:
-        debug "Received unsuccessful time configuration settings response code",
+        debug "Received unexpected time configuration settings response code",
               endpoint = nodes[i], response_code = resp.status
     elif fut.failed():
       let error = fut.error

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -116,14 +116,14 @@ proc initTimeConfig(
 ): Future[Opt[TimeConfig]] {.async: (raises: [CancelledError]).} =
   var pendingRequests: seq[Future[RestResponse[GetSpecVCResponse]]]
   for node in nodes:
-    debug "Requesting time config", node = node
+    debug "Requesting time configuration settings", node = node
     pendingRequests.add(node.client.getSpecVC())
 
   try:
     await allFutures(pendingRequests)
   except CancelledError as exc:
     var pending: seq[Future[void]]
-    debug "Time config request was interrupted"
+    debug "Time configuration settings request was interrupted"
     for future in pendingRequests:
       if not(future.finished()):
         pending.add(future.cancelAndWait())
@@ -140,33 +140,34 @@ proc initTimeConfig(
         if checkConfig(resp.data.data):
           let timeConfig = resp.data.data.time
           if timeConfig.isSome:
-            debug "Received time config", endpoint = nodes[i],
+            debug "Received time configuration settings", endpoint = nodes[i],
                   seconds_per_slot = timeConfig.get.SECONDS_PER_SLOT
             if res.isNone:
               res = timeConfig
             elif timeConfig.get == res.get:
               discard  # Duplicate
             else:
-              warn "Received incompatible time config", endpoint = nodes[i],
+              warn "Received incompatible time configuration settings",
+                    endpoint = nodes[i],
                     seconds_per_slot = timeConfig.get.SECONDS_PER_SLOT,
                     expected_seconds_per_slot = res.get.SECONDS_PER_SLOT
               didEncounterDisagreement = true
           else:
-            debug "Received invalid time config", endpoint = nodes[i],
-                  config = resp.data.data
+            debug "Received invalid time configuration settings",
+                  endpoint = nodes[i], config = resp.data.data
         else:
-          debug "Received incompatible config", endpoint = nodes[i],
-                config = resp.data.data
+          debug "Received incompatible time configuration settings",
+                endpoint = nodes[i], config = resp.data.data
       else:
-        debug "Received unsuccessful response code", endpoint = nodes[i],
-              response_code = resp.status
+        debug "Received unsuccessful time configuration settings response code",
+              endpoint = nodes[i], response_code = resp.status
     elif fut.failed():
       let error = fut.error
-      debug "Could not obtain time config from beacon node",
+      debug "Could not obtain time configuration settings from beacon node",
             endpoint = nodes[i], error_name = error.name,
             reason = error.msg
     else:
-      debug "Interrupted while requesting time config from beacon node",
+      debug "Interrupted while requesting time configuration from beacon node",
             endpoint = nodes[i]
 
   if didEncounterDisagreement:

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -21,7 +21,9 @@ declareGauge validator_client_node_counts,
   "Number of connected beacon nodes and their status",
   labels = ["status"]
 
-proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
+proc initGenesis(
+    vc: ValidatorClientRef
+): Future[(seq[BeaconNodeServerRef], RestGenesis)] {.
      async: (raises: [CancelledError]).} =
   info "Initializing genesis", nodes_count = len(vc.beaconNodes)
   var nodes = vc.beaconNodes
@@ -52,15 +54,14 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
       for future in pendingRequests:
         if not(future.finished()):
           pending.add(future.cancelAndWait())
-      await allFutures(pending)
+      await noCancel allFutures(pending)
       raise exc
 
     let (errorNodes, genesisList) =
       block:
-        var gres: seq[RestGenesis]
+        var gres: seq[(BeaconNodeServerRef, RestGenesis)]
         var bres: seq[BeaconNodeServerRef]
-        for i in 0 ..< len(pendingRequests):
-          let fut = pendingRequests[i]
+        for i, fut in pendingRequests:
           if fut.completed():
             let resp = fut.value
             if resp.status == 200:
@@ -68,7 +69,7 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
                     genesis_time = resp.data.data.genesis_time,
                     genesis_fork_version = resp.data.data.genesis_fork_version,
                     genesis_root = resp.data.data.genesis_validators_root
-              gres.add(resp.data.data)
+              gres.add((nodes[i], resp.data.data))
             else:
               debug "Received unsuccessful response code", endpoint = nodes[i],
                     response_code = resp.status
@@ -95,7 +96,7 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
       # Boyer-Moore majority vote algorithm
       var melem: RestGenesis
       var counter = 0
-      for item in genesisList:
+      for (_, item) in genesisList:
         if counter == 0:
           melem = item
           inc(counter)
@@ -104,7 +105,74 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
             inc(counter)
           else:
             dec(counter)
-      return melem
+      var mnodes: seq[BeaconNodeServerRef]
+      for (node, item) in genesisList:
+        if item == melem:
+          mnodes.add node
+      return (mnodes, melem)
+
+proc initTimeConfig(
+    nodes: seq[BeaconNodeServerRef]
+): Future[Opt[TimeConfig]] {.async: (raises: [CancelledError]).} =
+  var pendingRequests: seq[Future[RestResponse[GetSpecVCResponse]]]
+  for node in nodes:
+    debug "Requesting time config", node = node
+    pendingRequests.add(node.client.getSpecVC())
+
+  try:
+    await allFutures(pendingRequests)
+  except CancelledError as exc:
+    var pending: seq[Future[void]]
+    debug "Time config request was interrupted"
+    for future in pendingRequests:
+      if not(future.finished()):
+        pending.add(future.cancelAndWait())
+    await noCancel allFutures(pending)
+    raise exc
+
+  var
+    res: Opt[TimeConfig]
+    didEncounterDisagreement = false
+  for i, fut in pendingRequests:
+    if fut.completed():
+      let resp = fut.value
+      if resp.status == 200:
+        if checkConfig(resp.data.data):
+          let timeCfg = resp.data.data.time
+          if timeCfg.isSome:
+            debug "Received time config", endpoint = nodes[i],
+                  seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT
+            if res.isNone:
+              res = timeCfg
+            elif timeCfg.get == res.get:
+              discard  # Duplicate
+            else:
+              warn "Received incompatible time config", endpoint = nodes[i],
+                    seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT,
+                    expected_seconds_per_slot = res.get.SECONDS_PER_SLOT
+              didEncounterDisagreement = true
+          else:
+            debug "Received invalid time config", endpoint = nodes[i],
+                  config = resp.data.data
+        else:
+          debug "Received incompatible config", endpoint = nodes[i],
+                config = resp.data.data
+      else:
+        debug "Received unsuccessful response code", endpoint = nodes[i],
+              response_code = resp.status
+    elif fut.failed():
+      let error = fut.error
+      debug "Could not obtain time config from beacon node",
+            endpoint = nodes[i], error_name = error.name,
+            reason = error.msg
+    else:
+      debug "Interrupted while requesting time config from beacon node",
+            endpoint = nodes[i]
+
+  if didEncounterDisagreement:
+    res.reset()
+  res.reset()
+  res
 
 proc addValidatorsFromWeb3Signer(
     vc: ValidatorClientRef,
@@ -312,10 +380,14 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
     else:
       notice "Cannot initialize beacon node", node = node, status = node.status
 
-  vc.beaconGenesis = await vc.initGenesis()
+  let (nodes, genesis) = await vc.initGenesis()
+  vc.timeCfg = (await nodes.initTimeConfig()).valueOr:
+    raise newException(ValidatorClientError, "Could not obtain time config")
+  vc.beaconGenesis = genesis
   info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,
-       genesis_root = vc.beaconGenesis.genesis_validators_root
+       genesis_root = vc.beaconGenesis.genesis_validators_root,
+       seconds_per_slot = vc.timeCfg.SECONDS_PER_SLOT
 
   vc.beaconClock = await vc.initClock()
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -221,11 +221,13 @@ proc initClock(
   if genesisTime.inFuture:
     info "Initializing beacon clock",
          genesis_time = vc.beaconGenesis.genesis_time,
+         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT,
          current_slot = "<n/a>", current_epoch = "<n/a>",
          time_to_genesis = genesisTime.offset
   else:
     info "Initializing beacon clock",
          genesis_time = vc.beaconGenesis.genesis_time,
+         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT,
          current_slot = currentSlot, current_epoch = currentEpoch
   res
 
@@ -382,7 +384,8 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
 
   let (nodes, genesis) = await vc.initGenesis()
   vc.timeConfig = (await nodes.initTimeConfig()).valueOr:
-    raise newException(ValidatorClientError, "Could not obtain time config")
+    raise newException(ValidatorClientError,
+                       "Could not obtain time configuration settings")
   vc.beaconGenesis = genesis
   info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -138,17 +138,17 @@ proc initTimeConfig(
       let resp = fut.value
       if resp.status == 200:
         if checkConfig(resp.data.data):
-          let timeCfg = resp.data.data.time
-          if timeCfg.isSome:
+          let timeConfig = resp.data.data.time
+          if timeConfig.isSome:
             debug "Received time config", endpoint = nodes[i],
-                  seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT
+                  seconds_per_slot = timeConfig.get.SECONDS_PER_SLOT
             if res.isNone:
-              res = timeCfg
-            elif timeCfg.get == res.get:
+              res = timeConfig
+            elif timeConfig.get == res.get:
               discard  # Duplicate
             else:
               warn "Received incompatible time config", endpoint = nodes[i],
-                    seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT,
+                    seconds_per_slot = timeConfig.get.SECONDS_PER_SLOT,
                     expected_seconds_per_slot = res.get.SECONDS_PER_SLOT
               didEncounterDisagreement = true
           else:
@@ -380,13 +380,13 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
       notice "Cannot initialize beacon node", node = node, status = node.status
 
   let (nodes, genesis) = await vc.initGenesis()
-  vc.timeCfg = (await nodes.initTimeConfig()).valueOr:
+  vc.timeConfig = (await nodes.initTimeConfig()).valueOr:
     raise newException(ValidatorClientError, "Could not obtain time config")
   vc.beaconGenesis = genesis
   info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,
        genesis_root = vc.beaconGenesis.genesis_validators_root,
-       seconds_per_slot = vc.timeCfg.SECONDS_PER_SLOT
+       seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT
 
   vc.beaconClock = await vc.initClock()
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -21,16 +21,12 @@ declareGauge validator_client_node_counts,
   "Number of connected beacon nodes and their status",
   labels = ["status"]
 
-type GenesisInfo = tuple[timeCfg: TimeConfig, beaconGenesis: RestGenesis]
-
-proc initGenesis(vc: ValidatorClientRef): Future[GenesisInfo] {.
+proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
      async: (raises: [CancelledError]).} =
   info "Initializing genesis", nodes_count = len(vc.beaconNodes)
   var nodes = vc.beaconNodes
   while true:
-    var
-      pendingConfigRequests: seq[Future[RestResponse[GetSpecVCResponse]]]
-      pendingGenesisRequests: seq[Future[RestResponse[GetGenesisResponse]]]
+    var pendingRequests: seq[Future[RestResponse[GetGenesisResponse]]]
     let offlineNodes = vc.offlineNodes()
     if len(offlineNodes) == 0:
       let sleepDuration = 2.seconds
@@ -46,82 +42,50 @@ proc initGenesis(vc: ValidatorClientRef): Future[GenesisInfo] {.
 
     for node in offlineNodes:
       debug "Requesting genesis information", node = node
-      pendingConfigRequests.add(node.client.getSpecVC())
-      pendingGenesisRequests.add(node.client.getGenesis())
+      pendingRequests.add(node.client.getGenesis())
 
     try:
-      await allFutures(pendingConfigRequests)
-      await allFutures(pendingGenesisRequests)
+      await allFutures(pendingRequests)
     except CancelledError as exc:
       var pending: seq[Future[void]]
       debug "Genesis information request was interrupted"
-      for future in pendingConfigRequests:
-        if not(future.finished()):
-          pending.add(future.cancelAndWait())
-      for future in pendingGenesisRequests:
+      for future in pendingRequests:
         if not(future.finished()):
           pending.add(future.cancelAndWait())
       await allFutures(pending)
       raise exc
 
-    let (errorNodes, resCandidates) = block:
-      var
-        errorNodes: seq[BeaconNodeServerRef]
-        resCandidates: seq[GenesisInfo]
-      doAssert len(pendingConfigRequests) == len(pendingGenesisRequests)
-      let numRequests = len(pendingConfigRequests)
-      for i in 0 ..< numRequests:
-        let
-          configFut = pendingConfigRequests[i]
-          genesisFut = pendingGenesisRequests[i]
-        if configFut.completed() and genesisFut.completed():
-          let
-            configResp = configFut.value
-            genesisResp = genesisFut.value
-          if configResp.status == 200 and genesisResp.status == 200:
-            template configData: untyped = configResp.data.data
-            template genesisData: untyped = genesisResp.data.data
-            if checkConfig(configData):
-              let timeCfg = configData.time
-              if timeCfg.isSome:
-                debug "Received genesis information", endpoint = nodes[i],
-                      seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT,
-                      genesis_time = genesisData.genesis_time,
-                      genesis_fork_version = genesisData.genesis_fork_version,
-                      genesis_root = genesisData.genesis_validators_root
-                resCandidates.add((
-                  timeCfg: timeCfg.get, beaconGenesis: genesisData))
-              else:
-                debug "Received invalid time config", endpoint = nodes[i],
-                      config = configData
-                errorNodes.add(nodes[i])
+    let (errorNodes, genesisList) =
+      block:
+        var gres: seq[RestGenesis]
+        var bres: seq[BeaconNodeServerRef]
+        for i in 0 ..< len(pendingRequests):
+          let fut = pendingRequests[i]
+          if fut.completed():
+            let resp = fut.value
+            if resp.status == 200:
+              debug "Received genesis information", endpoint = nodes[i],
+                    genesis_time = resp.data.data.genesis_time,
+                    genesis_fork_version = resp.data.data.genesis_fork_version,
+                    genesis_root = resp.data.data.genesis_validators_root
+              gres.add(resp.data.data)
             else:
-              debug "Received incompatible config", endpoint = nodes[i],
-                    config = configData
-              errorNodes.add(nodes[i])
+              debug "Received unsuccessful response code", endpoint = nodes[i],
+                    response_code = resp.status
+              bres.add(nodes[i])
+          elif fut.failed():
+            let error = fut.error
+            debug "Could not obtain genesis information from beacon node",
+                  endpoint = nodes[i], error_name = error.name,
+                  reason = error.msg
+            bres.add(nodes[i])
           else:
-            debug "Received unsuccessful response code", endpoint = nodes[i],
-                  response_code = (configResp.status, genesisResp.status)
-            errorNodes.add(nodes[i])
-        elif configFut.failed():
-          let error = configFut.error
-          debug "Could not obtain genesis config from beacon node",
-                endpoint = nodes[i], error_name = error.name,
-                reason = error.msg
-          errorNodes.add(nodes[i])
-        elif genesisFut.failed():
-          let error = genesisFut.error
-          debug "Could not obtain genesis information from beacon node",
-                endpoint = nodes[i], error_name = error.name,
-                reason = error.msg
-          errorNodes.add(nodes[i])
-        else:
-          debug "Interrupted while requesting information from beacon node",
-                endpoint = nodes[i]
-          errorNodes.add(nodes[i])
-      (errorNodes, resCandidates)
+            debug "Interrupted while requesting information from beacon node",
+                  endpoint = nodes[i]
+            bres.add(nodes[i])
+        (bres, gres)
 
-    if len(resCandidates) == 0:
+    if len(genesisList) == 0:
       let sleepDuration = 2.seconds
       info "Could not obtain network genesis information from nodes, repeating",
            sleep_time = sleepDuration
@@ -129,9 +93,9 @@ proc initGenesis(vc: ValidatorClientRef): Future[GenesisInfo] {.
       nodes = errorNodes
     else:
       # Boyer-Moore majority vote algorithm
-      var melem: GenesisInfo
+      var melem: RestGenesis
       var counter = 0
-      for item in resCandidates:
+      for item in genesisList:
         if counter == 0:
           melem = item
           inc(counter)
@@ -348,9 +312,8 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
     else:
       notice "Cannot initialize beacon node", node = node, status = node.status
 
-  (vc.timeCfg, vc.beaconGenesis) = await vc.initGenesis()
-  info "Genesis information", seconds_per_slot = vc.timeCfg.SECONDS_PER_SLOT,
-       genesis_time = vc.beaconGenesis.genesis_time,
+  vc.beaconGenesis = await vc.initGenesis()
+  info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,
        genesis_root = vc.beaconGenesis.genesis_validators_root
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -21,12 +21,16 @@ declareGauge validator_client_node_counts,
   "Number of connected beacon nodes and their status",
   labels = ["status"]
 
-proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
+type GenesisInfo = tuple[timeCfg: TimeConfig, beaconGenesis: RestGenesis]
+
+proc initGenesis(vc: ValidatorClientRef): Future[GenesisInfo] {.
      async: (raises: [CancelledError]).} =
   info "Initializing genesis", nodes_count = len(vc.beaconNodes)
   var nodes = vc.beaconNodes
   while true:
-    var pendingRequests: seq[Future[RestResponse[GetGenesisResponse]]]
+    var
+      pendingConfigRequests: seq[Future[RestResponse[GetSpecVCResponse]]]
+      pendingGenesisRequests: seq[Future[RestResponse[GetGenesisResponse]]]
     let offlineNodes = vc.offlineNodes()
     if len(offlineNodes) == 0:
       let sleepDuration = 2.seconds
@@ -42,50 +46,82 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
 
     for node in offlineNodes:
       debug "Requesting genesis information", node = node
-      pendingRequests.add(node.client.getGenesis())
+      pendingConfigRequests.add(node.client.getSpecVC())
+      pendingGenesisRequests.add(node.client.getGenesis())
 
     try:
-      await allFutures(pendingRequests)
+      await allFutures(pendingConfigRequests)
+      await allFutures(pendingGenesisRequests)
     except CancelledError as exc:
       var pending: seq[Future[void]]
       debug "Genesis information request was interrupted"
-      for future in pendingRequests:
+      for future in pendingConfigRequests:
+        if not(future.finished()):
+          pending.add(future.cancelAndWait())
+      for future in pendingGenesisRequests:
         if not(future.finished()):
           pending.add(future.cancelAndWait())
       await allFutures(pending)
       raise exc
 
-    let (errorNodes, genesisList) =
-      block:
-        var gres: seq[RestGenesis]
-        var bres: seq[BeaconNodeServerRef]
-        for i in 0 ..< len(pendingRequests):
-          let fut = pendingRequests[i]
-          if fut.completed():
-            let resp = fut.value
-            if resp.status == 200:
-              debug "Received genesis information", endpoint = nodes[i],
-                    genesis_time = resp.data.data.genesis_time,
-                    genesis_fork_version = resp.data.data.genesis_fork_version,
-                    genesis_root = resp.data.data.genesis_validators_root
-              gres.add(resp.data.data)
+    let (errorNodes, resCandidates) = block:
+      var
+        errorNodes: seq[BeaconNodeServerRef]
+        resCandidates: seq[GenesisInfo]
+      doAssert len(pendingConfigRequests) == len(pendingGenesisRequests)
+      let numRequests = len(pendingConfigRequests)
+      for i in 0 ..< numRequests:
+        let
+          configFut = pendingConfigRequests[i]
+          genesisFut = pendingGenesisRequests[i]
+        if configFut.completed() and genesisFut.completed():
+          let
+            configResp = configFut.value
+            genesisResp = genesisFut.value
+          if configResp.status == 200 and genesisResp.status == 200:
+            template configData: untyped = configResp.data.data
+            template genesisData: untyped = genesisResp.data.data
+            if checkConfig(configData):
+              let timeCfg = configData.time
+              if timeCfg.isSome:
+                debug "Received genesis information", endpoint = nodes[i],
+                      seconds_per_slot = timeCfg.get.SECONDS_PER_SLOT,
+                      genesis_time = genesisData.genesis_time,
+                      genesis_fork_version = genesisData.genesis_fork_version,
+                      genesis_root = genesisData.genesis_validators_root
+                resCandidates.add((
+                  timeCfg: timeCfg.get, beaconGenesis: genesisData))
+              else:
+                debug "Received invalid time config", endpoint = nodes[i],
+                      config = configData
+                errorNodes.add(nodes[i])
             else:
-              debug "Received unsuccessful response code", endpoint = nodes[i],
-                    response_code = resp.status
-              bres.add(nodes[i])
-          elif fut.failed():
-            let error = fut.error
-            debug "Could not obtain genesis information from beacon node",
-                  endpoint = nodes[i], error_name = error.name,
-                  reason = error.msg
-            bres.add(nodes[i])
+              debug "Received incompatible config", endpoint = nodes[i],
+                    config = configData
+              errorNodes.add(nodes[i])
           else:
-            debug "Interrupted while requesting information from beacon node",
-                  endpoint = nodes[i]
-            bres.add(nodes[i])
-        (bres, gres)
+            debug "Received unsuccessful response code", endpoint = nodes[i],
+                  response_code = (configResp.status, genesisResp.status)
+            errorNodes.add(nodes[i])
+        elif configFut.failed():
+          let error = configFut.error
+          debug "Could not obtain genesis config from beacon node",
+                endpoint = nodes[i], error_name = error.name,
+                reason = error.msg
+          errorNodes.add(nodes[i])
+        elif genesisFut.failed():
+          let error = genesisFut.error
+          debug "Could not obtain genesis information from beacon node",
+                endpoint = nodes[i], error_name = error.name,
+                reason = error.msg
+          errorNodes.add(nodes[i])
+        else:
+          debug "Interrupted while requesting information from beacon node",
+                endpoint = nodes[i]
+          errorNodes.add(nodes[i])
+      (errorNodes, resCandidates)
 
-    if len(genesisList) == 0:
+    if len(resCandidates) == 0:
       let sleepDuration = 2.seconds
       info "Could not obtain network genesis information from nodes, repeating",
            sleep_time = sleepDuration
@@ -93,9 +129,9 @@ proc initGenesis(vc: ValidatorClientRef): Future[RestGenesis] {.
       nodes = errorNodes
     else:
       # Boyer-Moore majority vote algorithm
-      var melem: RestGenesis
+      var melem: GenesisInfo
       var counter = 0
-      for item in genesisList:
+      for item in resCandidates:
         if counter == 0:
           melem = item
           inc(counter)
@@ -312,8 +348,9 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
     else:
       notice "Cannot initialize beacon node", node = node, status = node.status
 
-  vc.beaconGenesis = await vc.initGenesis()
-  info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
+  (vc.timeCfg, vc.beaconGenesis) = await vc.initGenesis()
+  info "Genesis information", seconds_per_slot = vc.timeCfg.SECONDS_PER_SLOT,
+       genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,
        genesis_root = vc.beaconGenesis.genesis_validators_root
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -138,7 +138,7 @@ proc initTimeConfig(
       let resp = fut.value
       if resp.status == 200:
         if checkConfig(resp.data.data):
-          let timeConfig = resp.data.data.time
+          let timeConfig = resp.data.data.getTimeConfig()
           if timeConfig.isSome:
             debug "Received time configuration settings", endpoint = nodes[i],
                   seconds_per_slot = timeConfig.get.SECONDS_PER_SLOT

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -389,8 +389,7 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
   vc.beaconGenesis = genesis
   info "Genesis information", genesis_time = vc.beaconGenesis.genesis_time,
        genesis_fork_version = vc.beaconGenesis.genesis_fork_version,
-       genesis_root = vc.beaconGenesis.genesis_validators_root,
-       seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT
+       genesis_root = vc.beaconGenesis.genesis_validators_root
 
   vc.beaconClock = await vc.initClock()
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -221,14 +221,14 @@ proc initClock(
   if genesisTime.inFuture:
     info "Initializing beacon clock",
          genesis_time = vc.beaconGenesis.genesis_time,
-         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT,
          current_slot = "<n/a>", current_epoch = "<n/a>",
-         time_to_genesis = genesisTime.offset
+         time_to_genesis = genesisTime.offset,
+         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT
   else:
     info "Initializing beacon clock",
          genesis_time = vc.beaconGenesis.genesis_time,
-         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT,
-         current_slot = currentSlot, current_epoch = currentEpoch
+         current_slot = currentSlot, current_epoch = currentEpoch,
+         seconds_per_slot = vc.timeConfig.SECONDS_PER_SLOT
   res
 
 proc shutdownSlashingProtection(vc: ValidatorClientRef) =

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -171,7 +171,6 @@ proc initTimeConfig(
 
   if didEncounterDisagreement:
     res.reset()
-  res.reset()
   res
 
 proc addValidatorsFromWeb3Signer(

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -717,8 +717,8 @@ else:
   # createConstantsFromPreset const_preset
 
 const
-  minSecondsPerSlot* = 1'u64
-  maxSecondsPerSlot* = int64.high.uint64 div 1_000_000_000'u64
+  MIN_SECONDS_PER_SLOT* = 1'u64
+  MAX_SECONDS_PER_SLOT* = int64.high.uint64 div 1_000_000_000'u64
 
 const SLOTS_PER_SYNC_COMMITTEE_PERIOD* =
   SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
@@ -905,7 +905,7 @@ proc readRuntimeConfig*(
       const name = astToStr(constValue)
       checkCompatibility(constValue, name, operator)
 
-  checkCompatibility minSecondsPerSlot .. maxSecondsPerSlot,
+  checkCompatibility MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
                      "SECONDS_PER_SLOT", `in`
   checkCompatibility SECONDS_PER_SLOT  # Temporary, until removed from presets
 

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -886,13 +886,14 @@ proc readRuntimeConfig*(
           if not operator(distinctBase(value), distinctBase(constValue)):
             raise (ref PresetFileError)(msg:
               "Cannot override config" &
-              " (required: " & name & opDesc & $distinctBase(constValue) &
+              " (required: " & name & " " &
+              opDesc & " " & $distinctBase(constValue) &
               " - config: " & name & "=" & values[name] & ")")
         else:
           if not operator(value, constValue):
             raise (ref PresetFileError)(msg:
               "Cannot override config" &
-              " (required: " & name & opDesc & $constValue &
+              " (required: " & name & " " & opDesc & " " & $constValue &
               " - config: " & name & "=" & values[name] & ")")
         values.del name
       except ValueError:

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -716,6 +716,10 @@ else:
 
   # createConstantsFromPreset const_preset
 
+const
+  minSecondsPerSlot* = 1'u64
+  maxSecondsPerSlot* = int64.high.uint64 div 1_000_000_000'u64
+
 const SLOTS_PER_SYNC_COMMITTEE_PERIOD* =
   SLOTS_PER_EPOCH * EPOCHS_PER_SYNC_COMMITTEE_PERIOD
 
@@ -900,7 +904,9 @@ proc readRuntimeConfig*(
       const name = astToStr(constValue)
       checkCompatibility(constValue, name, operator)
 
-  checkCompatibility SECONDS_PER_SLOT
+  checkCompatibility minSecondsPerSlot .. maxSecondsPerSlot,
+                     "SECONDS_PER_SLOT", `in`
+  checkCompatibility SECONDS_PER_SLOT  # Temporary, until removed from presets
 
   checkCompatibility BLS_WITHDRAWAL_PREFIX
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -233,7 +233,7 @@ type
     proposers*: ProposerMap
     syncCommitteeDuties*: SyncCommitteeDutiesMap
     syncCommitteeProofs*: SyncCommitteeProofsMap
-    timeCfg*: TimeConfig
+    timeConfig*: TimeConfig
     beaconGenesis*: RestGenesis
     proposerTasks*: Table[Slot, seq[ProposerTask]]
     dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
@@ -557,8 +557,8 @@ func checkConfig*(c: VCRuntimeConfig): bool =
   c.hasKey("ALTAIR_FORK_VERSION") and c.hasKey("ALTAIR_FORK_EPOCH") and
   not(c.equals("ALTAIR_FORK_EPOCH", FAR_FUTURE_EPOCH))
 
-func checkConfig*(c: VCRuntimeConfig, timeCfg: TimeConfig): bool =
-  c.checkConfig and c.equals("SECONDS_PER_SLOT", timeCfg.SECONDS_PER_SLOT)
+func checkConfig*(c: VCRuntimeConfig, timeConfig: TimeConfig): bool =
+  c.checkConfig and c.equals("SECONDS_PER_SLOT", timeConfig.SECONDS_PER_SLOT)
 
 func time*(c: VCRuntimeConfig): Opt[TimeConfig] =
   let SECONDS_PER_SLOT = block:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -233,6 +233,7 @@ type
     proposers*: ProposerMap
     syncCommitteeDuties*: SyncCommitteeDutiesMap
     syncCommitteeProofs*: SyncCommitteeProofsMap
+    timeCfg*: TimeConfig
     beaconGenesis*: RestGenesis
     proposerTasks*: Table[Slot, seq[ProposerTask]]
     dynamicFeeRecipientsStore*: ref DynamicFeeRecipientsStore
@@ -509,32 +510,32 @@ chronicles.expandIt(SyncCommitteeDuty):
   validator_index = it.validator_index
   validator_sync_committee_indices = it.validator_sync_committee_indices
 
-proc equals*(info: VCRuntimeConfig, name: string, check: uint64): bool =
-  let numstr = info.getOrDefault(name, "missing")
-  if numstr == "missing": return false
-  let value = Base10.decode(uint64, numstr).valueOr:
+func parseConfigValue[T: uint64](_: typedesc[T], str: string): Opt[T] =
+  let res = Base10.decode(uint64, str).valueOr:
+    return Opt.none T
+  Opt.some res
+
+func parseConfigValue[T: DomainType](_: typedesc[T], str: string): Opt[T] =
+  try:
+    var res: DomainType
+    hexToByteArray(str, distinctBase(res))
+    Opt.some res
+  except ValueError:
+    Opt.none T
+
+func equals*[T](info: VCRuntimeConfig, name: string, check: T): bool =
+  let str = info.getOrDefault(name, "missing")
+  if str == "missing": return false
+  let value = T.parseConfigValue(str).valueOr:
     return false
   value == check
 
-proc equals*(info: VCRuntimeConfig, name: string, check: DomainType): bool =
-  let domstr = info.getOrDefault(name, "missing")
-  if domstr == "missing": return false
-  let value =
-    try:
-      var dres: DomainType
-      hexToByteArray(domstr, distinctBase(dres))
-      dres
-    except ValueError:
-      return false
-  value == check
-
-proc equals*(info: VCRuntimeConfig, name: string, check: Epoch): bool =
+func equals*(info: VCRuntimeConfig, name: string, check: Epoch): bool =
   info.equals(name, uint64(check))
 
-proc checkConfig*(c: VCRuntimeConfig): bool =
+func checkConfig*(c: VCRuntimeConfig): bool =
   c.equals("MAX_VALIDATORS_PER_COMMITTEE", MAX_VALIDATORS_PER_COMMITTEE) and
   c.equals("SLOTS_PER_EPOCH", SLOTS_PER_EPOCH) and
-  c.equals("SECONDS_PER_SLOT", SECONDS_PER_SLOT) and
   c.equals("EPOCHS_PER_ETH1_VOTING_PERIOD", EPOCHS_PER_ETH1_VOTING_PERIOD) and
   c.equals("SLOTS_PER_HISTORICAL_ROOT", SLOTS_PER_HISTORICAL_ROOT) and
   c.equals("EPOCHS_PER_HISTORICAL_VECTOR", EPOCHS_PER_HISTORICAL_VECTOR) and
@@ -555,6 +556,20 @@ proc checkConfig*(c: VCRuntimeConfig): bool =
   c.equals("DOMAIN_AGGREGATE_AND_PROOF", DOMAIN_AGGREGATE_AND_PROOF) and
   c.hasKey("ALTAIR_FORK_VERSION") and c.hasKey("ALTAIR_FORK_EPOCH") and
   not(c.equals("ALTAIR_FORK_EPOCH", FAR_FUTURE_EPOCH))
+
+func checkConfig*(c: VCRuntimeConfig, timeCfg: TimeConfig): bool =
+  c.checkConfig and c.equals("SECONDS_PER_SLOT", timeCfg.SECONDS_PER_SLOT)
+
+func time*(c: VCRuntimeConfig): Opt[TimeConfig] =
+  let SECONDS_PER_SLOT = block:
+    const defaultStr = Base10.toString(
+      defaultRuntimeConfig.time.SECONDS_PER_SLOT)
+    ? uint64.parseConfigValue c.getOrDefault("SECONDS_PER_SLOT", defaultStr)
+  if SECONDS_PER_SLOT notin minSecondsPerSlot .. maxSecondsPerSlot:
+    return Opt.none TimeConfig
+  if SECONDS_PER_SLOT != presets.SECONDS_PER_SLOT:
+    return Opt.none TimeConfig  # Temporary, until removed from presets
+  Opt.some TimeConfig(SECONDS_PER_SLOT: SECONDS_PER_SLOT)
 
 proc updateStatus*(node: BeaconNodeServerRef,
                    status: RestBeaconNodeStatus,

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -560,12 +560,12 @@ func checkConfig*(c: VCRuntimeConfig): bool =
 func checkConfig*(c: VCRuntimeConfig, timeConfig: TimeConfig): bool =
   c.checkConfig and c.equals("SECONDS_PER_SLOT", timeConfig.SECONDS_PER_SLOT)
 
-func time*(c: VCRuntimeConfig): Opt[TimeConfig] =
+func getTimeConfig*(c: VCRuntimeConfig): Opt[TimeConfig] =
   let SECONDS_PER_SLOT = block:
     const defaultStr = Base10.toString(
       defaultRuntimeConfig.time.SECONDS_PER_SLOT)
     ? uint64.parseConfigValue c.getOrDefault("SECONDS_PER_SLOT", defaultStr)
-  if SECONDS_PER_SLOT notin minSecondsPerSlot .. maxSecondsPerSlot:
+  if SECONDS_PER_SLOT notin MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT:
     return Opt.none TimeConfig
   if SECONDS_PER_SLOT != presets.SECONDS_PER_SLOT:
     return Opt.none TimeConfig  # Temporary, until removed from presets

--- a/beacon_chain/validator_client/fallback_service.nim
+++ b/beacon_chain/validator_client/fallback_service.nim
@@ -138,7 +138,7 @@ proc checkCompatible(
 
   let
     genesisFlag = (genesis != vc.beaconGenesis)
-    configFlag = not(checkConfig(info, vc.timeCfg))
+    configFlag = not(checkConfig(info, vc.timeConfig))
 
   node.config = info
   node.genesis = Opt.some(genesis)

--- a/beacon_chain/validator_client/fallback_service.nim
+++ b/beacon_chain/validator_client/fallback_service.nim
@@ -138,7 +138,7 @@ proc checkCompatible(
 
   let
     genesisFlag = (genesis != vc.beaconGenesis)
-    configFlag = not(checkConfig(info))
+    configFlag = not(checkConfig(info, vc.timeCfg))
 
   node.config = info
   node.genesis = Opt.some(genesis)


### PR DESCRIPTION
To make SECONDS_PER_SLOT configurable, the validator client needs to be able to parse it from the config endpoint and use it for validating compatibility across different beacon nodes.

- When genesis time is initialized, also fetch and store the time config
- When checking compatibility, compare against the local time config

As the rest of the code is still based on the preset constant, it is also ensured that any non-standard time configs get rejected, same as currently done, just a bit later in the logic.