### PR TITLE
Handle cancellation while acquiring sync queue lock

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -716,6 +716,15 @@ proc syncStep[A, B](
     man.queue.push(requests)
     # Cancelling all verification jobs
     let pending = jobs.filterIt(not(it.finished)).mapIt(cancelAndWait(it))
+    debug "Cancelling sync step",
+          peer = peer,
+          peer_score = peer.getScore(),
+          peer_speed = peer.netKbps(),
+          index = index,
+          num_pending = pending.len,
+          sync_ident = man.ident,
+          direction = man.direction,
+          topics = "syncman"
     await noCancel allFutures(pending)
     raise exc
 

--- a/beacon_chain/sync/sync_queue.nim
+++ b/beacon_chain/sync/sync_queue.nim
@@ -871,7 +871,12 @@ proc push*[T](
             raise exc
         pos
 
-  await sq.lock.acquire()
+  try:
+    await sq.lock.acquire()
+  except CancelledError as exc:
+    sq.del(sr)
+    raise exc
+
   try:
     position = sq.findPosition(sr)
 


### PR DESCRIPTION
When acquisition of sync queue lock gets cancelled, the request also needs to be removed from the queue, as it won't be handled anymore.