### PR TITLE
ci: set CI_CACHE to runner.temp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
 
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: | 
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Clean workspace (very aggressive)
         if: contains(matrix.builder, 'self-hosted')
@@ -216,7 +218,9 @@ jobs:
     runs-on: ['self-hosted','ubuntu-22.04']
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Clean workspace (very aggressive)
         run: rm -rf "$GITHUB_WORKSPACE"/*

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -71,7 +73,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Install packages
         env:
@@ -128,7 +132,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Install packages
         env:
@@ -185,7 +191,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -234,7 +242,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -283,7 +293,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fix nim cache conflicts
-        run: echo "XDG_CACHE_HOME=${{ runner.temp }}/.cache" >> $GITHUB_ENV
+        run: |
+          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
+          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
When building nim compiler we pass $CI_CACHE to scripts/build_nim.sh as the 4th argument but its not set anywhere.

https://github.com/status-im/nimbus-build-system/blob/e6c2c9da39c2d368d9cf420ac22692e99715d22c/makefiles/targets.mk#L80-L88

This could be the reason for weird caching we have been seeing on runner-node-02-linux-01-eu-hel1

Explicitly setting $CI_CACHE to {{runner.temp}} ensure we use a fresh directory always so that we do not get a cached version of nim commit to build.

https://github.com/status-im/nimbus-build-system/blob/e6c2c9da39c2d368d9cf420ac22692e99715d22c/scripts/build_nim.sh#L214