### PR TITLE
Extend SSZ generic tests with CompatibleUnion tests

### DIFF
--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -179,7 +179,7 @@ proc checkProgressiveList(
   var typeIdent: string
   let wasMatched =
     try:
-      scanf(sszSubType, "proglist_$+", typeIdent)
+      scanf(sszSubType, "proglist_$+_", typeIdent)
     except ValueError:
       false  # Parsed `size` is out of range
   doAssert wasMatched
@@ -199,6 +199,8 @@ proc checkProgressiveList(
     checkBasic(seq[UInt128], dir, expectedHash)
   of "uint256":
     checkBasic(seq[UInt256], dir, expectedHash)
+  else:
+    raise newException(ValueError, "unknown ssz type in test: " & sszSubType)
 
 macro testVector(typeIdent: string, size: int): untyped =
   # find the compile-time type to test

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -14,7 +14,7 @@ import
     strutils, streams, strformat, strscans,
     macros, typetraits],
   # Status libraries
-  faststreams, snappy, stint, ../testutil,
+  faststreams, serialization/case_objects, snappy, stint, ../testutil,
   # Third-party
   yaml,
   # Beacon chain internals
@@ -126,6 +126,32 @@ type
     F: seq[seq[VarTestStruct]]
     G: List[ProgressiveSingleFieldContainerTestStruct, 10]
     H: seq[ProgressiveVarTestStruct]
+
+  SelectorA {.pure.} = enum
+    a = 1
+  CompatibleUnionA {.allowDiscriminatorsWithoutZero.} = object
+    case selector: SelectorA
+    of SelectorA.a: aData: ProgressiveSingleFieldContainerTestStruct
+
+  SelectorBC {.pure.} = enum
+    b = 2
+    c = 3
+  CompatibleUnionBC {.allowDiscriminatorsWithoutZero.} = object
+    case selector: SelectorBC
+    of SelectorBC.b: bData: ProgressiveSingleListContainerTestStruct
+    of SelectorBC.c: cData: ProgressiveVarTestStruct
+
+  SelectorABCA {.pure.} = enum
+    a1 = 1
+    b = 2
+    c = 3
+    a4 = 4
+  CompatibleUnionABCA {.allowDiscriminatorsWithoutZero.} = object
+    case selector: SelectorABCA
+    of SelectorABCA.a1, SelectorABCA.a4:
+      aData: ProgressiveSingleFieldContainerTestStruct
+    of SelectorABCA.b: bData: ProgressiveSingleListContainerTestStruct
+    of SelectorABCA.c: cData: ProgressiveVarTestStruct
 
 # Type specific checks
 # ------------------------------------------------------------------------
@@ -363,6 +389,17 @@ proc sszCheck(dir, sszType, sszSubType: string)
   of "basic_vector": checkVector(sszSubType, dir, expectedHash)
   of "bitvector": checkBitVector(sszSubType, dir, expectedHash)
   of "bitlist": checkBitList(sszSubType, dir, expectedHash)
+  of "compatible_unions":
+    var name: string
+    let wasMatched = scanf(sszSubType, "$+_", name)
+    doAssert wasMatched
+    case name
+    of "CompatibleUnionA": checkBasic(CompatibleUnionA, dir, expectedHash)
+    of "CompatibleUnionBC": checkBasic(CompatibleUnionBC, dir, expectedHash)
+    of "CompatibleUnionABCA": checkBasic(CompatibleUnionABCA, dir, expectedHash)
+    else:
+      raise newException(ValueError,
+        "unknown compatible union in test: " & sszSubType)
   of "containers":
     var name: string
     let wasMatched = scanf(sszSubType, "$+_", name)

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -199,8 +199,6 @@ proc checkProgressiveList(
     checkBasic(seq[UInt128], dir, expectedHash)
   of "uint256":
     checkBasic(seq[UInt256], dir, expectedHash)
-  else:
-    raise newException(ValueError, "unknown ssz type in test: " & sszSubType)
 
 macro testVector(typeIdent: string, size: int): untyped =
   # find the compile-time type to test

--- a/tests/consensus_spec/test_fixture_ssz_generic_types.nim
+++ b/tests/consensus_spec/test_fixture_ssz_generic_types.nim
@@ -179,7 +179,7 @@ proc checkProgressiveList(
   var typeIdent: string
   let wasMatched =
     try:
-      scanf(sszSubType, "proglist_$+_", typeIdent)
+      scanf(sszSubType, "proglist_$+", typeIdent)
     except ValueError:
       false  # Parsed `size` is out of range
   doAssert wasMatched


### PR DESCRIPTION
Implement test runner for new consensus-spec test format for EIP-8016 CompatibleUnion. New tests will automatically be picked up once they become available.

- https://github.com/ethereum/consensus-specs/pull/4581