### PR TITLE
Disable concurrent requests in legacy sync manager

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -27,7 +27,7 @@ const
   StatusExpirationTime* = chronos.minutes(2)
     ## Time time it takes for the peer's status information to expire.
 
-  ConcurrentRequestsCount* = 3
+  ConcurrentRequestsCount* = 1  # Higher values require reviewing `pending == 0`
     ## Number of requests performed by one peer in single syncing step
 
   RepeatingFailuresCount* = 2


### PR DESCRIPTION
This gets rid of the race that led to #7394 by disabling some of the optimizations introduced in #6722. Given that sync manager will be replaced soon for Fulu, and the long time typically needed until the issue is triggered, not sure how important / appropriate.