### PR TITLE
revert nim-kzg4844

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -502,9 +502,6 @@ AllTests-mainnet
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_cells_ OK
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_cells_ OK
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_more_than_h OK
-+ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_shuffled_ha OK
-+ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_shuffled_no OK
-+ KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_invalid_shuffled_on OK
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK
 + KZG - Recover Cells And Kzg Proofs - recover_cells_and_kzg_proofs_case_valid_half_missing_ OK

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -18,7 +18,7 @@ import
 
 from std/algorithm import sorted
 from std/sequtils import anyIt, filterIt, mapIt, toSeq
-from std/strutils import rsplit
+from std/strutils import contains, rsplit
 from stew/byteutils import fromHex
 from ../../beacon_chain/spec/peerdas_helpers import
   recover_matrix, recover_cells_and_proofs_parallel
@@ -400,6 +400,7 @@ proc runRecoverCellsAndKzgProofsParallelInvalidTest(suiteName, suitePath: string
       validRowCount = validData[validData.len - 1].row_index + 1
 
     for kind, path in walkDir(suitePath, relative = true, checkDir = true):
+      if path.contains("recover_cells_and_kzg_proofs_case_invalid_shuffled_"): continue
       let invalidData = loadToJson(os_ops.readFile(suitePath/path/"data.yaml"))[0]
 
       # As per
@@ -526,6 +527,7 @@ suite suiteName:
   block:
     let testsDir = suitePath/"recover_cells_and_kzg_proofs"/"kzg-mainnet"
     for kind, path in walkDir(testsDir, relative = true, checkDir = true):
+      if path.contains("recover_cells_and_kzg_proofs_case_invalid_shuffled_"): continue
       runRecoverCellsAndKzgProofsTest(suiteName, testsDir, testsDir/path)
 
   block:


### PR DESCRIPTION
c-kzg 2.1.2 has a regression causing spurious `fulu.DataColumnSidecar` validation failures.