### PR TITLE
Securely write JWT secret with restrictive permissions

### DIFF
--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -16,8 +16,9 @@ import
 
 from std/base64 import encode
 from std/json import JsonNode, `$`, `%*`
-from std/os import `/`
+from std/os import `/`, splitFile
 from std/strutils import replace
+from ../filepath import secureCreatePath, secureWriteFile
 
 export rand, results
 
@@ -100,14 +101,15 @@ proc checkJwtSecret*(
     let jwtSecretPath = dataDir / jwtSecretFilename
 
     let newSecret = rng.generateBytes(JWT_SECRET_LEN)
-    try:
-      writeFile(jwtSecretPath, newSecret.to0xHex())
-    except IOError as exc:
+    # Write JWT secret with restrictive permissions (0600 on Unix, user-only ACL on Windows)
+    let (dirPath, _, _) = splitFile(jwtSecretPath)
+    discard secureCreatePath(dirPath)
+    let wres = secureWriteFile(jwtSecretPath, newSecret.to0xHex())
+    if wres.isErr():
       # Allow continuing to run, though this is effectively fatal for a merge
       # client using authentication. This keeps it lower-risk initially.
       warn "Could not write JWT secret to data directory",
-        jwtSecretPath,
-        err = exc.msg
+        jwtSecretPath
     return ok(newSecret)
 
   loadJwtSecretFile(jwtSecret.get)


### PR DESCRIPTION


### Description
- **What**: Store `jwt.hex` using `secureCreatePath` and `secureWriteFile` to enforce restrictive permissions (0600 on Unix, user-only ACL on Windows).  
- **Why**: Prevent unintended disclosure of the JWT secret due to permissive default file modes.  
- **Scope**: `beacon_chain/spec/engine_authentication.nim`  
- **Behavior**: Logic unchanged; failure still logs a warning.

#### Changes
- Import `splitFile`, `secureCreatePath`, `secureWriteFile`.
- Replace plain `writeFile` with secure directory creation + secure file write.

#### Security Impact
- Reduces risk of secret leakage via world-readable files.

