### PR TITLE
Only bundle named network metadata when SECONDS_PER_SLOT matches preset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Fix nim cache conflicts
-        run: | 
+        run: |
           echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
           echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
 
@@ -246,6 +246,9 @@ jobs:
           for executable in "${executables[@]}"; do
             nim c --passC:-fsyntax-only --noLinking:on -d:chronicles_log_level=TRACE "${executable}"
           done
+
+      - name: Build with custom SECONDS_PER_SLOT
+        run: nim c --passC:-fsyntax-only --noLinking:on -d:chronicles_log_level=TRACE -d:SECONDS_PER_SLOT=1 beacon_chain/nimbus_beacon_node
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,9 @@ jobs:
           done
 
       - name: Build with custom SECONDS_PER_SLOT
-        run: nim c --passC:-fsyntax-only --noLinking:on -d:chronicles_log_level=TRACE -d:SECONDS_PER_SLOT=1 beacon_chain/nimbus_beacon_node
+        run: |
+          source env.sh
+          nim c --passC:-fsyntax-only --noLinking:on -d:chronicles_log_level=TRACE -d:SECONDS_PER_SLOT=1 beacon_chain/nimbus_beacon_node
 
   lint:
     name: "Lint"

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1154,9 +1154,9 @@ proc loadEth2Network*(eth2Network: Option[string]): Eth2NetworkMetadata =
     if eth2Network.isSome:
       getMetadataForNetwork(eth2Network.get)
     else:
-      when const_preset == "gnosis":
+      when IsGnosisSupported:
         getMetadataForNetwork("gnosis")
-      elif const_preset == "mainnet":
+      elif IsMainnetSupported:
         getMetadataForNetwork("mainnet")
       else:
         # Presumably other configurations can have other defaults, but for now

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -201,7 +201,7 @@ proc loadCompileTimeNetworkMetadata(
   else:
     macros.error "config.yaml not found for network '" & path
 
-when const_preset == "gnosis":
+when IsGnosisSupported:
   when incbinEnabled:
     let
       gnosisGenesisVar {.importc: "gnosis_mainnet_genesis".}: ptr UncheckedArray[byte]
@@ -247,7 +247,7 @@ when const_preset == "gnosis":
       doAssert network.cfg.GLOAS_FORK_EPOCH == FAR_FUTURE_EPOCH
       doAssert ConsensusFork.high == ConsensusFork.Gloas
 
-elif const_preset == "mainnet":
+elif IsMainnetSupported:
   when incbinEnabled:
     # Nim is very inefficent at loading large constants from binary files so we
     # use this trick instead which saves significant amounts of compile time
@@ -360,7 +360,7 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
     warn "https://blog.ethereum.org/2025/09/01/holesky-shutdown-announcement suggests migrating to Hoodi or Sepolia"
 
   let metadata =
-    when const_preset == "gnosis":
+    when IsGnosisSupported:
       case toLowerAscii(networkName)
       of "gnosis":
         gnosisMetadata
@@ -373,7 +373,7 @@ proc getMetadataForNetwork*(networkName: string): Eth2NetworkMetadata =
       else:
         loadRuntimeMetadata()
 
-    elif const_preset == "mainnet":
+    elif IsMainnetSupported:
       case toLowerAscii(networkName)
       of "mainnet":
         mainnetMetadata
@@ -404,9 +404,9 @@ proc getRuntimeConfig*(eth2Network: Option[string]): RuntimeConfig =
     if eth2Network.isSome:
       getMetadataForNetwork(eth2Network.get)
     else:
-      when const_preset == "mainnet":
+      when IsMainnetSupported:
         mainnetMetadata
-      elif const_preset == "gnosis":
+      elif IsGnosisSupported:
         gnosisMetadata
       else:
         # This is a non-standard build (i.e. minimal), and the function was
@@ -416,7 +416,7 @@ proc getRuntimeConfig*(eth2Network: Option[string]): RuntimeConfig =
 
   metadata.cfg
 
-when const_preset in ["mainnet", "gnosis"]:
+when IsMainnetSupported or IsGnosisSupported:
   template bakedInGenesisStateAsBytes(networkName: untyped): untyped =
     when incbinEnabled:
       `networkName Genesis`.toOpenArray(0, `networkName GenesisSize` - 1)
@@ -435,22 +435,22 @@ when const_preset in ["mainnet", "gnosis"]:
   template bakedBytes*(metadata: GenesisMetadata): auto =
     case metadata.networkName
     of "mainnet":
-      when const_preset == "mainnet":
+      when IsMainnetSupported:
         bakedInGenesisStateAsBytes mainnet
       else:
         raiseAssert availableOnlyInMainnetBuild
     of "sepolia":
-      when const_preset == "mainnet":
+      when IsMainnetSupported:
         bakedInGenesisStateAsBytes sepolia
       else:
         raiseAssert availableOnlyInMainnetBuild
     of "gnosis":
-      when const_preset == "gnosis":
+      when IsGnosisSupported:
         bakedInGenesisStateAsBytes gnosis
       else:
         raiseAssert availableOnlyInGnosisBuild
     of "chiado":
-      when const_preset == "gnosis":
+      when IsGnosisSupported:
         bakedInGenesisStateAsBytes chiado
       else:
         raiseAssert availableOnlyInGnosisBuild

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -729,6 +729,12 @@ else:
 
   # createConstantsFromPreset const_preset
 
+const IsMainnetSupported*: bool =
+  const_preset == "mainnet" and SECONDS_PER_SLOT == 12
+
+const IsGnosisSupported*: bool =
+  const_preset == "gnosis" and SECONDS_PER_SLOT == 5
+
 const
   MIN_SECONDS_PER_SLOT* = 1'u64
   MAX_SECONDS_PER_SLOT* = int64.high.uint64 div 1_000_000_000'u64


### PR DESCRIPTION
When customizing `SECONDS_PER_SLOT` to a value that is incompatible with the named networks for the preset (e.g., Hoodi, for `mainnet`), do not bundle support for those named networks as that would fail compilation.