### PR TITLE
Fix BPO fork digest enumeration for Gloas and later

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1214,8 +1214,8 @@ iterator forkDigests*(consensusFork: ConsensusFork, forkDigests: ForkDigests): F
   yield forkDigests.atConsensusFork(consensusFork)
 
   if consensusFork >= ConsensusFork.Fulu:
-    for (_, consensusFork, forkDigest) in forkDigests.bpos:
-      if consensusFork == consensusFork:
+    for (_, bpoConsensusFork, forkDigest) in forkDigests.bpos:
+      if bpoConsensusFork == consensusFork:
         yield forkDigest
 
 template asSigned*(


### PR DESCRIPTION
Variable was shadowed, fix it by assigning a new name.