### PR TITLE
fix crash when block without blobs is unqueued from quarantine

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -426,7 +426,7 @@ proc enqueueQuarantine(self: var BlockProcessor, root: Eth2Digest) =
           self.enqueueBlock(
             MsgSource.gossip,
             quarantined,
-            Opt.some(BlobSidecars @[]),
+            Opt.none(BlobSidecars),
             Opt.some(DataColumnSidecars @[]),
           )
         else:
@@ -449,7 +449,7 @@ proc enqueueQuarantine(self: var BlockProcessor, root: Eth2Digest) =
             MsgSource.gossip,
             quarantined,
             Opt.some(BlobSidecars @[]),
-            Opt.some(DataColumnSidecars @[]),
+            Opt.none(DataColumnSidecars),
           )
         else:
           if (let res = checkBlobOrColumnlessSignature(self, forkyBlck); res.isErr):


### PR DESCRIPTION
If a block that had no blobs is quarantined for later processing, it will cause an assertion defect after the parent is found.