### PR TITLE
Docs: Use consensus light client naming throughout the guide

### DIFF
--- a/docs/the_nimbus_book/src/el-light-client.md
+++ b/docs/the_nimbus_book/src/el-light-client.md
@@ -1,18 +1,18 @@
-# Light client
+# Consensus light client
 
 !!! warning
-    The light client is currently in BETA and details around running it may change.
+    The consensus light client is currently in BETA and details around running it may change.
 
-The Nimbus Light Client is a light-weight alternative to running a full beacon node, when you're not planning on becoming a validator but still want to run an Ethereum execution layer client.
+The Nimbus Consensus Light Client is a light-weight alternative to running a full beacon node, when you're not planning on becoming a validator but still want to run an Ethereum execution layer client.
 
 Execution layer (EL) clients provide the [Web3 API](https://ethereum.github.io/execution-apis/api-documentation/) to expose information stored on the Ethereum blockchain.
 Since the merge 🐼, execution clients can no longer run standalone.
 
 ## Comparison
 
-Compared to a full beacon node, a light client has several advantages and disadvantages.
+Compared to a full beacon node, a consensus light client has several advantages and disadvantages.
 
-| Feature | Beacon Node | Light Client |
+| Feature | Beacon Node | Consensus Light Client |
 | -- | -- | -- |
 | Disk usage | ~200GB | **<1MB** |
 | Bandwidth | *TBD* | **TBD (low)** |
@@ -20,8 +20,8 @@ Compared to a full beacon node, a light client has several advantages and disadv
 | Head delay | **None** | 4/3 slot (15 s) |
 | Security | **Full** | Light |
 
-Light clients delegate full validation to other network participants and operate under a honest supermajority (> 2/3) assumption among elected participants.
-Due to this delegation, light clients are typically behind by ~4/3 slots (~15 seconds on Ethereum mainnet).
+Consensus light clients delegate full validation to other network participants and operate under a honest supermajority (> 2/3) assumption among elected participants.
+Due to this delegation, consensus light clients are typically behind by ~4/3 slots (~15 seconds on Ethereum mainnet).
 
 !!! note
     If you are validating, you must run a full beacon node.
@@ -29,7 +29,7 @@ Due to this delegation, light clients are typically behind by ~4/3 slots (~15 se
 
 ## Building from source
 
-The Nimbus light client is currently not bundled as part of the Docker images and needs to be built from source.
+The Nimbus consensus light client is currently not bundled as part of the Docker images and needs to be built from source.
 
 ### 1. Clone the `nimbus-eth2` repository
 
@@ -40,7 +40,7 @@ cd nimbus-eth2
 
 ### 2. Run the build process
 
-To build the Nimbus light client and its dependencies, make sure you have [all prerequisites](./install.md) and then run:
+To build the Nimbus consensus light client and its dependencies, make sure you have [all prerequisites](./install.md) and then run:
 
 ```sh
 make -j4 nimbus_light_client
@@ -56,10 +56,10 @@ When the process finishes, the `nimbus_light_client` executable can be found in 
 
 Follow the [regular instructions](./eth1.md) for running the execution client, taking note of its JWT secret configuration that you will need in the next step.
 
-## Running the light client
+## Running the consensus light client
 
-The light client starts syncing from a trusted block.
-This trusted block should be somewhat recent ([~1-2 weeks](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/phase0/weak-subjectivity.md)) and needs to be configured each time when starting the light client.
+The consensus light client starts syncing from a trusted block.
+This trusted block should be somewhat recent ([~1-2 weeks](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/phase0/weak-subjectivity.md)) and needs to be configured each time when starting the consensus light client.
 
 ### 1. Obtaining a trusted block root
 
@@ -80,13 +80,13 @@ A block root may be obtained from another trusted beacon node, or from a trusted
     Otherwise, for example if the bottom-most slot was `Missed`, go back and pick a different epoch.
 
 !!! warning
-    Selecting a block root from an untrusted source or using an outdated block root may lead to the light client syncing to an unexpected state.
-    If that happens, stop the light client and restart it with a new trusted block root.
+    Selecting a block root from an untrusted source or using an outdated block root may lead to the consensus light client syncing to an unexpected state.
+    If that happens, stop the consensus light client and restart it with a new trusted block root.
     Depending on the EL client, its database must be deleted and sync restarted from scratch.
 
-### 2. Starting the light client
+### 2. Starting the consensus light client
 
-To start the light client, run the following commands (inserting your own trusted block root):
+To start the consensus light client, run the following commands (inserting your own trusted block root):
 
 === "Mainnet"
     ```sh
@@ -107,12 +107,12 @@ To start the light client, run the following commands (inserting your own truste
     ```
 
 !!! tip
-    The light client can be left running in the background.
+    The consensus light client can be left running in the background.
     Note that a new trusted block root is required when restarting.
 
 ## Observing the sync process
 
-After a while, the light client will pick up beacon block headers from the Ethereum network and start informing the EL client about the latest data.
+After a while, the consensus light client will pick up beacon block headers from the Ethereum network and start informing the EL client about the latest data.
 You should see logs similar to the following:
 
 ### Nimbus

--- a/docs/the_nimbus_book/src/execution-client.md
+++ b/docs/the_nimbus_book/src/execution-client.md
@@ -7,7 +7,7 @@
 
     If you're looking for information about setting up an execution client for validator duties or any other production usage, see the [execution clients guide](./eth1.md).
 
-The Nimbus execution client is a light-weight implementation of the Ethereum execution protocol. Paired with a [beacon node](./quick-start.md) or [light client](./el-light-client.md), it provides access to Ethereum blockchain for dapps and users alike via the standard [Web3 API](https://ethereum.github.io/execution-apis/api-documentation/).
+The Nimbus execution client is a light-weight implementation of the Ethereum execution protocol. Paired with a [beacon node](./quick-start.md) or [consensus light client](./el-light-client.md), it provides access to Ethereum blockchain for dapps and users alike via the standard [Web3 API](https://ethereum.github.io/execution-apis/api-documentation/).
 
 ## Building from source
 
@@ -132,7 +132,7 @@ See the [era file guide](./era-store.md) for more information.
 
 ## Launch the client
 
-In order for the execution client to operate, you need to connect a consensus node. This can be the [Nimbus beacon node](./quick-start.md), a [supported consensus client](https://ethereum.org/en/developers/docs/nodes-and-clients/#consensus-clients) or a [light client](./el-light-client.md).
+In order for the execution client to operate, you need to connect a consensus node. This can be the [Nimbus beacon node](./quick-start.md), a [supported consensus client](https://ethereum.org/en/developers/docs/nodes-and-clients/#consensus-clients) or a [consensus light client](./el-light-client.md).
 
 The consensus node connects to the execution client via the Engine API which is enabled using `--engine-api` and by default runs on port `8551`.
 

--- a/docs/the_nimbus_book/src/index.md
+++ b/docs/the_nimbus_book/src/index.md
@@ -4,7 +4,7 @@ Nimbus is a client for the Ethereum network that is [lightweight](https://our.st
 
 Its efficiency and low resource consumption allows it to perform well on all kinds of systems: ranging from Raspberry Pi and mobile devices — where it contributes to low power consumption and security — to powerful servers where it leaves resources free to perform other tasks.
 
-This book describes the consensus protocol implementation which includes a [beacon node](./quick-start.md), [validator client](./validator-client.md) and [light client](./el-light-client.md).
+This book describes the consensus protocol implementation which includes a [beacon node](./quick-start.md), [validator client](./validator-client.md) and [consensus light client](./el-light-client.md).
 
 An [execution client](https://github.com/status-im/nimbus-eth1) is also under development - see its [quickstart guide](./execution-client.md).
 
@@ -18,7 +18,7 @@ Our companion project [fluffy](https://github.com/status-im/nimbus-eth1/tree/mas
 * [Web3Signer](https://docs.web3signer.consensys.net/en/latest/) remote signing
 * [Validator monitoring](./validator-monitor.md) and [performance analysis](./attestation-performance.md) tooling
 * [External block builder](./external-block-builder.md) (PBS / mev-boost) support with execution client fallback
-* [Light consensus client](./el-light-client.md) for running an execution client without a full beacon node
+* [Consensus light client](./el-light-client.md) for running an execution client without a full beacon node
 
 
 ## Design goals
@@ -45,7 +45,7 @@ You can read this book from start to finish, or you might want to read just spec
 * Coming from a different client? Check out the [migration guide](./migration.md).
 * Visualize the important metrics with [Grafana and Prometheus](./metrics-pretty-pictures.md).
 * Interested in becoming a validator? Follow the [validator guide](./run-a-validator.md).
-* If you're not planning on becoming a validator, you can run the [light client](./el-light-client.md).
+* If you're not planning on becoming a validator, you can run the [consensus light client](./el-light-client.md).
 
 ## Get in touch
 

--- a/docs/the_nimbus_book/src/light-client-data.md
+++ b/docs/the_nimbus_book/src/light-client-data.md
@@ -1,11 +1,11 @@
 # Light client data
 
-Nimbus is configured by default to serve data that allows light clients to stay in sync with the Ethereum network.
+Nimbus beacon node is configured by default to serve data that allows consensus light clients to stay in sync with the Ethereum network.
 Light client data is imported incrementally and does not affect validator performance.
 Information about the light client sync protocol can be found in the [Ethereum consensus specs](https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/sync-protocol.md).
 
 !!! note
-    Nimbus also implements a [standalone light client](./el-light-client.md) that may be used to sync an execution layer (EL) client.
+    Nimbus also implements a [standalone consensus light client](./el-light-client.md) that may be used to sync an execution layer (EL) client.
 
 ## Configuration
 

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -82,12 +82,12 @@ The `head` root is also printed in the log output at regular intervals.
 
 ## Advanced
 
-### Verify the downloaded state through the Nimbus light client
+### Verify the downloaded state through the Nimbus consensus light client
 
 !!! note ""
     This feature is available from `v23.4.0` onwards.
 
-The `--trusted-block-root` option enables you to leverage the Nimbus light client in order to minimize the required trust in the specified Beacon API endpoint. After downloading a state snapshot, the light client will verify that it conforms to the established consensus on the network. Note that the provided `--trusted-block-root` should be somewhat recent, and that additional security precautions such as comparing the state root against block explorers is still recommended.
+The `--trusted-block-root` option enables you to leverage the Nimbus consensus light client in order to minimize the required trust in the specified Beacon API endpoint. After downloading a state snapshot, the consensus light client will verify that it conforms to the established consensus on the network. Note that the provided `--trusted-block-root` should be somewhat recent, and that additional security precautions such as comparing the state root against block explorers is still recommended.
 
 ### Sync deposit history
 


### PR DESCRIPTION
Use consensus light client naming throughout the nimbus guide instead of just light client. At the main page this term is already being used but in the rest of the guide it is not.

It is a source of confusion when naming the page just "light client" in terms of what this light client is and what it does.

This will even more so become the case as this guide becomes the general guide of all Nimbus products (and thus other light clients such as the verified proxy and the portal client).

So I think it is best to always name it specifically consensus light client. Other option would be cl light client or beacon light client (but the latter I like less as I think it is less valid as it doesn't really do the beacon tasks).