### PR TITLE
Pass SECONDS_PER_SLOT to BeaconClock module

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -778,6 +778,7 @@ AllTests-mainnet
 + Voluntary exit signatures                                                                  OK
 + execution payload bid signatures                                                           OK
 + execution payload envelope signatures                                                      OK
++ payload attestation message signatures                                                     OK
 ```
 ## Network metadata
 ```diff

--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -31,16 +31,25 @@ type
     ##
     # TODO consider NTP and network-adjusted timestamps as outlined here:
     #      https://ethresear.ch/t/network-adjusted-timestamps/4187
+    timeConfig: TimeConfig
     genesis: Time
 
   GetBeaconTimeFn* = proc(): BeaconTime {.gcsafe, raises: [].}
 
-proc init*(T: type BeaconClock, genesis_time: uint64): Opt[T] =
-  # Since we'll be converting beacon time differences to nanoseconds,
-  # the time can't be outrageously far from now
-  if genesis_time > (getTime().toUnix().uint64 + 100'u64 * 365'u64 * 24'u64 *
-        60'u64 * 60'u64) or
-      genesis_time < GENESIS_SLOT * SECONDS_PER_SLOT:
+proc init*(
+    T: type BeaconClock,
+    timeConfig: TimeConfig,
+    genesis_time: uint64): Opt[T] =
+  let
+    SECONDS_PER_SLOT = timeConfig.SECONDS_PER_SLOT
+    MIN_GENESIS_TIME = GENESIS_SLOT * SECONDS_PER_SLOT
+    MAX_GENESIS_TIME =
+      # Since we'll be converting beacon time differences to nanoseconds,
+      # the time can't be outrageously far from now
+      getTime().toUnix().uint64 +
+      100'u64 * 365'u64 * 24'u64 * 60'u64 * 60'u64
+  if SECONDS_PER_SLOT notin MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT or
+      genesis_time notin MIN_GENESIS_TIME .. MAX_GENESIS_TIME:
     Opt.none(BeaconClock)
   else:
     let
@@ -49,7 +58,9 @@ proc init*(T: type BeaconClock, genesis_time: uint64): Opt[T] =
       # offset to genesis instead of applying it at every time conversion
       unixGenesisOffset = times.seconds(int(GENESIS_SLOT * SECONDS_PER_SLOT))
 
-    Opt.some T(genesis: unixGenesis - unixGenesisOffset)
+    Opt.some T(
+      timeConfig: timeConfig,
+      genesis: unixGenesis - unixGenesisOffset)
 
 func toBeaconTime*(c: BeaconClock, t: Time): BeaconTime =
   BeaconTime(ns_since_genesis: inNanoseconds(t - c.genesis))

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -208,14 +208,19 @@ proc restValidatorExit(config: BeaconNodeConf) {.async.} =
     quit 1
 
   let currentEpoch = block:
+    if config.eth2Network.isNone:
+      fatal "Please specify the intended network for the exits"
+      quit 1
     let
-      beaconClock = BeaconClock.init(genesis.genesis_time).valueOr:
+      metadata = config.loadEth2Network()
+      genesisTime = genesis.genesis_time
+      beaconClock = BeaconClock.init(metadata.cfg.time, genesisTime).valueOr:
         error "Server returned invalid genesis time", genesis
         quit 1
 
       time = getTime()
       slot = beaconClock.toSlot(time).slot
-    Epoch(slot.uint64 div 32)
+    slot.epoch
 
   let exitAtEpoch = if config.exitAtEpoch.isSome:
     Epoch config.exitAtEpoch.get
@@ -370,7 +375,7 @@ proc doDeposits*(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
   case config.depositsCmd
   of DepositsCmd.createTestnetDeposits:
     if config.eth2Network.isNone:
-      fatal "Please specify the intended testnet for the deposits"
+      fatal "Please specify the intended network for the deposits"
       quit 1
     let metadata = config.loadEth2Network()
     var seed: KeySeed

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -243,10 +243,11 @@ proc ETHBeaconClockCreateFromState(
   ## Returns:
   ## * Pointer to an initialized beacon clock based on the beacon state or
   ##   NULL if the state contained an invalid time.
-  let beaconClock = BeaconClock.new()
-  beaconClock[] =
-    BeaconClock.init(getStateField(state[], genesis_time)).valueOr:
-      return nil
+  let
+    genesisTime = getStateField(state[], genesis_time)
+    beaconClock = BeaconClock.new()
+  beaconClock[] = BeaconClock.init(cfg[].time, genesisTime).valueOr:
+    return nil
   beaconClock.toUnmanagedPtr()
 
 proc ETHBeaconClockDestroy(beaconClock: ptr BeaconClock) {.exported.} =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -731,7 +731,7 @@ proc init*(
         metadata, config.genesisState, config.genesisStateUrl)
     let
       genesisTime = getStateField(genesisState[], genesis_time)
-      beaconClock = BeaconClock.init(genesisTime).valueOr:
+      beaconClock = BeaconClock.init(metadata.cfg.time, genesisTime).valueOr:
         fatal "Invalid genesis time in genesis state", genesisTime
         quit 1
       currentSlot = beaconClock.now().slotOrZero()
@@ -927,7 +927,7 @@ proc init*(
       config, cfg, db, eventBus,
       validatorMonitor, networkGenesisValidatorsRoot)
     genesisTime = getStateField(dag.headState, genesis_time)
-    beaconClock = BeaconClock.init(genesisTime).valueOr:
+    beaconClock = BeaconClock.init(cfg.time, genesisTime).valueOr:
       fatal "Invalid genesis time in state", genesisTime
       quit 1
 

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -73,7 +73,7 @@ proc main() {.noinline, raises: [CatchableError].} =
         raiseAssert "Invalid baked-in state: " & err.msg
 
     genesisTime = getStateField(genesisState[], genesis_time)
-    beaconClock = BeaconClock.init(genesisTime).valueOr:
+    beaconClock = BeaconClock.init(cfg.time, genesisTime).valueOr:
       error "Invalid genesis time in state", genesisTime
       quit 1
     getBeaconTime = beaconClock.getBeaconTimeFn()

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -211,9 +211,11 @@ proc initClock(
   # This procedure performs initialization of BeaconClock using current genesis
   # information. It also performs waiting for genesis.
   let
-    res = BeaconClock.init(vc.beaconGenesis.genesis_time).valueOr:
+    res = BeaconClock.init(
+        vc.timeConfig, vc.beaconGenesis.genesis_time).valueOr:
       raise (ref ValidatorClientError)(
-        msg: "Invalid genesis time: " & $vc.beaconGenesis.genesis_time)
+        msg: "Invalid genesis time: " & $vc.beaconGenesis.genesis_time &
+             "; seconds_per_slot=" & $vc.timeConfig.SECONDS_PER_SLOT)
     currentTime = res.now()
     currentSlot = currentTime.slotOrZero()
     currentEpoch = currentSlot.epoch()

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -175,7 +175,7 @@ proc doTrustedNodeSync*(
         doAssert genesisState != nil, "Already checked for `TrustedBlockRoot`"
         let
           genesisTime = getStateField(genesisState[], genesis_time)
-          beaconClock = BeaconClock.init(genesisTime).valueOr:
+          beaconClock = BeaconClock.init(cfg.time, genesisTime).valueOr:
             error "Invalid genesis time in state", genesisTime
             quit 1
           getBeaconTime = beaconClock.getBeaconTimeFn()

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -138,8 +138,10 @@ cli do(validatorsDir: string, secretsDir: string,
             break
 
   var
-    clock = BeaconClock.init(getStateField(state[], genesis_time)).valueOr:
-      error "Invalid genesis time in state"
+    genesisTime = getStateField(state[], genesis_time)
+    beaconClock = BeaconClock.init(cfg.time, genesisTime).valueOr:
+      error "Invalid genesis time in state",
+        genesis_time = genesisTime, seconds_per_slot = cfg.time.SECONDS_PER_SLOT
       quit 1
     validators: Table[ValidatorIndex, ValidatorPrivKey]
     validatorKeys: Table[ValidatorPubKey, ValidatorPrivKey]
@@ -182,7 +184,7 @@ cli do(validatorsDir: string, secretsDir: string,
       slot = getStateField(state[], slot) + 1
     process_slots(cfg, state[], slot, cache, info, {}).expect("works")
 
-    if start_beacon_time(slot) > clock.now():
+    if start_beacon_time(slot) > beaconClock.now():
       notice "Ran out of time",
         epoch = slot.epoch
       break


### PR DESCRIPTION
Retain time config when initializing `BeaconClock` as the next step to make SECONDS_PER_SLOT runtime configurable.