### PR TITLE
Harden VC against lagspikes across slots

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -85,40 +85,31 @@ proc fromNow*(c: BeaconClock, t: BeaconTime): tuple[inFuture: bool, offset: Dura
 proc fromNow*(c: BeaconClock, slot: Slot): tuple[inFuture: bool, offset: Duration] =
   c.fromNow(slot.start_beacon_time())
 
-proc durationToNextSlot*(c: BeaconClock): Duration =
-  let
-    currentTime = c.now()
-    currentSlot = currentTime.toSlot()
-
-  if currentSlot.afterGenesis:
-    let nextSlot = currentSlot.slot + 1
-    nanoseconds(
-      (nextSlot.start_beacon_time() - currentTime).nanoseconds)
+func durationOrZero*(d: tuple[inFuture: bool, offset: Duration]): Duration =
+  if d.inFuture:
+    d.offset
   else:
-    # absoluteTime = BeaconTime(-currentTime.ns_since_genesis).
-    let
-      absoluteTime = Slot(0).start_beacon_time() +
-        (Slot(0).start_beacon_time() - currentTime)
-      timeToNextSlot = absoluteTime - currentSlot.slot.start_beacon_time()
-    nanoseconds(timeToNextSlot.nanoseconds)
+    ZeroDuration
 
-proc durationToNextEpoch*(c: BeaconClock): Duration =
-  let
-    currentTime = c.now()
-    currentSlot = currentTime.toSlot()
-
-  if currentSlot.afterGenesis:
-    let nextEpochSlot = (currentSlot.slot.epoch() + 1).start_slot()
-    nanoseconds(
-      (nextEpochSlot.start_beacon_time() - currentTime).nanoseconds)
+func nextSlotStartTime*(
+    exSlot: tuple[afterGenesis: bool, slot: Slot]): BeaconTime =
+  if exSlot.afterGenesis:
+    (exSlot.slot + 1).start_beacon_time()
   else:
-    # absoluteTime = BeaconTime(-currentTime.ns_since_genesis).
     let
-      absoluteTime = Slot(0).start_beacon_time() +
-        (Slot(0).start_beacon_time() - currentTime)
-      timeToNextEpoch = absoluteTime -
-        currentSlot.slot.epoch().start_slot().start_beacon_time()
-    nanoseconds(timeToNextEpoch.nanoseconds)
+      genesisTime = GENESIS_SLOT.start_beacon_time()
+      timeDiff = exSlot.slot.start_beacon_time() - genesisTime
+    genesisTime - timeDiff
+
+func nextEpochStartTime*(
+    exSlot: tuple[afterGenesis: bool, slot: Slot]): BeaconTime =
+  if exSlot.afterGenesis:
+    (exSlot.slot.epoch + 1).start_slot.start_beacon_time()
+  else:
+    let
+      genesisTime = GENESIS_SLOT.start_beacon_time()
+      timeDiff = exSlot.slot.epoch.start_slot.start_beacon_time() - genesisTime
+    genesisTime - timeDiff
 
 func saturate*(d: tuple[inFuture: bool, offset: Duration]): Duration =
   if d.inFuture: d.offset else: seconds(0)

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -505,6 +505,8 @@ proc runPreGenesisWaitingLoop(
       debug "Pre-genesis waiting loop was interrupted"
       raise exc
 
+  vc.preGenesisEvent.fire()
+
 proc runGenesisWaitingLoop(
     vc: ValidatorClientRef
 ) {.async: (raises: [CancelledError]).} =
@@ -525,6 +527,8 @@ proc runGenesisWaitingLoop(
     except CancelledError as exc:
       debug "Genesis waiting loop was interrupted"
       raise exc
+
+  vc.genesisEvent.fire()
 
 proc asyncRun*(
     vc: ValidatorClientRef

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -486,54 +486,45 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
 proc runPreGenesisWaitingLoop(
     vc: ValidatorClientRef
 ) {.async: (raises: [CancelledError]).} =
-  var breakLoop = false
-  while not(breakLoop):
+  while true:
     let
-      genesisTime = vc.beaconClock.fromNow(Slot(0))
-      currentEpoch = vc.beaconClock.now().toSlot().slot.epoch()
+      currentTime = vc.beaconClock.now()
+      currentSlot = currentTime.toSlot()
+      currentEpoch = currentSlot.slot.epoch()
 
-    if not(genesisTime.inFuture) or currentEpoch < PREGENESIS_EPOCHS_COUNT:
+    if currentSlot.afterGenesis or currentEpoch < PREGENESIS_EPOCHS_COUNT:
       break
 
     notice "Waiting for genesis",
            genesis_time = vc.beaconGenesis.genesis_time,
-           time_to_genesis = genesisTime.offset
+           time_to_genesis = GENESIS_SLOT.start_beacon_time() - currentTime
 
-    breakLoop =
-      try:
-        await sleepAsync(vc.beaconClock.durationToNextSlot())
-        false
-      except CancelledError as exc:
-        debug "Pre-genesis waiting loop was interrupted"
-        raise exc
-
-  if not(breakLoop):
-    vc.preGenesisEvent.fire()
+    try:
+      await vc.waitForNextSlot(currentSlot)
+    except CancelledError as exc:
+      debug "Pre-genesis waiting loop was interrupted"
+      raise exc
 
 proc runGenesisWaitingLoop(
     vc: ValidatorClientRef
 ) {.async: (raises: [CancelledError]).} =
-  var breakLoop = false
-  while not(breakLoop):
-    let genesisTime = vc.beaconClock.fromNow(Slot(0))
+  while true:
+    let
+      currentTime = vc.beaconClock.now()
+      currentSlot = currentTime.toSlot()
 
-    if not(genesisTime.inFuture):
+    if currentSlot.afterGenesis:
       break
 
     notice "Waiting for genesis",
            genesis_time = vc.beaconGenesis.genesis_time,
-           time_to_genesis = genesisTime.offset
+           time_to_genesis = GENESIS_SLOT.start_beacon_time() - currentTime
 
-    breakLoop =
-      try:
-        await sleepAsync(vc.beaconClock.durationToNextSlot())
-        false
-      except CancelledError as exc:
-        debug "Genesis waiting loop was interrupted"
-        raise exc
-
-  if not(breakLoop):
-    vc.genesisEvent.fire()
+    try:
+      await vc.waitForNextSlot(currentSlot)
+    except CancelledError as exc:
+      debug "Genesis waiting loop was interrupted"
+      raise exc
 
 proc asyncRun*(
     vc: ValidatorClientRef

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -449,12 +449,9 @@ proc publishAttestationsAndAggregates(
       debug "Publish attestation request was interrupted"
       raise exc
 
-  let aggregateTime =
-    # chronos.Duration subtraction could not return negative value, in such
-    # case it will return `ZeroDuration`.
-    vc.beaconClock.durationToNextSlot() - OneThirdDuration
-  if aggregateTime != ZeroDuration:
-    await sleepAsync(aggregateTime)
+  let aggregateTime = vc.beaconClock.fromNow(slot.aggregate_deadline())
+  if aggregateTime.inFuture:
+    await sleepAsync(aggregateTime.offset)
 
   block:
     let delay = vc.getDelay(slot.aggregate_deadline())
@@ -694,12 +691,9 @@ proc publishAttestationsAndAggregatesV2(
       debug "Publish attestation request was interrupted"
       raise exc
 
-  let aggregateTime =
-    # chronos.Duration subtraction could not return negative value, in such
-    # case it will return `ZeroDuration`.
-    vc.beaconClock.durationToNextSlot() - OneThirdDuration
-  if aggregateTime != ZeroDuration:
-    await sleepAsync(aggregateTime)
+  let aggregateTime = vc.beaconClock.fromNow(slot.aggregate_deadline())
+  if aggregateTime.inFuture:
+    await sleepAsync(aggregateTime.offset)
 
   block:
     let
@@ -733,7 +727,7 @@ proc spawnAttestationTasks(
   try:
     for index, duties in dutiesByCommittee:
       tasks.add(service.publishAttestationsAndAggregates(slot, index, duties))
-    let timeout = vc.beaconClock.durationToNextSlot()
+    let timeout = vc.beaconClock.fromNow(slot + 1).durationOrZero()
     await allFutures(tasks).wait(timeout)
   except AsyncTimeoutError:
     # Cancelling all the pending tasks.
@@ -757,7 +751,7 @@ proc spawnAttestationTasksV2(
   await vc.waitForBlock(slot, attestationSlotOffset)
 
   try:
-    let timeout = vc.beaconClock.durationToNextSlot()
+    let timeout = vc.beaconClock.fromNow(slot + 1).durationOrZero()
     await service.publishAttestationsAndAggregatesV2(slot, duties).wait(timeout)
   except AsyncTimeoutError:
     discard

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1465,7 +1465,9 @@ proc waitForNextEpoch*(service: ClientServiceRef,
      async: (raises: [CancelledError], raw: true) .}=
   let
     vc = service.client
-    sleepTime = vc.beaconClock.durationToNextEpoch() + delay
+    currentSlot = vc.beaconClock.now().toSlot()
+    nextEpochTime = currentSlot.nextEpochStartTime()
+    sleepTime = vc.beaconClock.fromNow(nextEpochTime).durationOrZero() + delay
   debug "Sleeping until next epoch", service = service.name,
                                      sleep_time = sleepTime, delay = delay
   sleepAsync(sleepTime)
@@ -1474,12 +1476,18 @@ proc waitForNextEpoch*(service: ClientServiceRef): Future[void] {.
      async: (raises: [CancelledError], raw: true).}=
   waitForNextEpoch(service, ZeroDuration)
 
+proc waitForNextSlot*(
+       vc: ValidatorClientRef,
+       currentSlot: tuple[afterGenesis: bool, slot: Slot]
+     ): Future[void] {.async: (raises: [CancelledError], raw: true).} =
+  let
+    nextSlotTime = currentSlot.nextSlotStartTime()
+    sleepTime = vc.beaconClock.fromNow(nextSlotTime).durationOrZero()
+  sleepAsync(sleepTime)
+
 proc waitForNextSlot*(service: ClientServiceRef): Future[void] {.
      async: (raises: [CancelledError], raw: true).} =
-  let
-    vc = service.client
-    sleepTime = vc.beaconClock.durationToNextSlot()
-  sleepAsync(sleepTime)
+  service.client.waitForNextSlot(service.client.beaconClock.now().toSlot())
 
 func compareUnsorted*[T](a, b: openArray[T]): bool =
   if len(a) != len(b):

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -417,7 +417,7 @@ proc processSyncCommitteeTasks(
   let
     vc = service.client
     duties = vc.getSyncCommitteeDutiesForSlot(slot + 1)
-    timeout = vc.beaconClock.durationToNextSlot()
+    timeout = vc.beaconClock.fromNow(slot + 1).durationOrZero()
 
   logScope:
     slot = slot

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
Replace various `durationToNextSlot()` / `durationToNextEpoch()` calls with a variant locked to the slot currently being processed, to avoid problem if `vc.beaconClock.now()` transitions to a future slot while we are processing (e.g., lag-spike, heavy load, or debugger attached). If that would happen, current `durationToNextSlot()` would also wait for the subsequent slot(s) to complete, rather than the current slot end.