### PR TITLE
Remove unused genesisSnapshotContent

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -101,7 +101,6 @@ type
     backfiller*: SyncManager[Peer, PeerId]
     untrustedManager*: SyncManager[Peer, PeerId]
     syncOverseer*: SyncOverseerRef
-    genesisSnapshotContent*: string
     processor*: ref Eth2Processor
     batchVerifier*: ref BatchVerifier
     blockProcessor*: ref BlockProcessor


### PR DESCRIPTION
#1274 introduced a `genesisSnapshotContent` property. It was never used.