### PR TITLE
Use correct size when querying beacon block summaries

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -1370,10 +1370,11 @@ iterator getAncestorSummaries*(db: BeaconChainDB, root: Eth2Digest):
   )
   SELECT v FROM next;
   """
+  static: doAssert BeaconBlockSummary.isFixedSize
   let
     stmt = expectDb db.db.prepareStmt(
       summariesQuery, array[32, byte],
-      array[sizeof(BeaconBlockSummary), byte],
+      array[BeaconBlockSummary.fixedPortionSize, byte],
       managed = false)
 
   defer: # in case iteration is stopped along the way


### PR DESCRIPTION
`sizeof(BeaconBlockSummary)` is 48 due to weird padding, but the data that's stored is only 40 bytes (SSZ encoded slot + root).