### PR TITLE
fix attempting to call undeclared routine: 'allIt'

### DIFF
--- a/beacon_chain/buildinfo.nim
+++ b/beacon_chain/buildinfo.nim
@@ -10,7 +10,7 @@
 ## This module implements the version tagging details of all binaries included
 ## in the Nimbus release process (i.e. beacon_node, validator_client, etc)
 
-import std/[os, strutils]
+import std/[os, sequtils, strutils]
 
 proc gitFolderExists(path: string): bool {.compileTime.} =
   # walk up parent folder to find `.git` folder


### PR DESCRIPTION
I noticed `nix` derivation fails with :

```
> Hint: [Link] 
> Hint: mm: refc; threads: on; opt: speed; options: -d:release 
> 87283 lines; 3.444s; 114.578MiB peakmem; proj: /build/source/tools/generate_makefile.nim; out: /build/source/build/generate_makefile [SuccessX] 
> Build completed successfully: build/generate_makefile 
> for D in beacon_chain ncli research tools; do [ -e "${D}/nimbus_validator_client.nim" ] && TOOL_DIR="${D}" && break; done && \ 
> echo -e "\\x1B[92mBuilding:\\x1B[39m" "build/nimbus_validator_client" && \ 
> MAKE="make" V="1" "/build/source/vendor/nimbus-build-system/scripts/env.sh" scripts/compile_nim_program.sh nimbus_validator_client "${TOOL_DIR}/nimbus_validator_client.nim" -d:release --parallelBuild:1 -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,lodestar,prysm,teku,grandine -d:disableMarchNative -d:git_revision_override=fff623f3 --verbosity:1 -d:chronicles_log_level="DEBUG" && \ 
> echo -e "\\x1B[92mBuild completed successfully:\\x1B[39m" "build/nimbus_validator_client" 
> Building: build/nimbus_validator_client 
> Hint: used config file '/build/source/vendor/nimbus-build-system/vendor/Nim/config/nim.cfg' [Conf] 
> Hint: used config file '/build/source/vendor/nimbus-build-system/vendor/Nim/config/config.nims' [Conf] 
> Hint: used config file '/build/source/config.nims' [Conf] > Hint: used config file '/build/source/beacon_chain/nim.cfg' [Conf] > Hint: used config file '/build/source/beacon_chain/nimbus_validator_client.nim.cfg' [Conf] 
> /build/source/beacon_chain/version.nim(23, 43) template/generic instantiation of `generateGitRevision` from here 
> /build/source/beacon_chain/buildinfo.nim(46, 15) template/generic instantiation of `doAssert` from here 
> /build/source/beacon_chain/buildinfo.nim(47, 28) Error: attempting to call undeclared routine: 'allIt' 
> make: *** [Makefile:451: nimbus_validator_client] Error 1
```

importing `sequtils` fixes it.