### PR TITLE
Bump nim-stew

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -391,7 +391,7 @@ template toRaw*(x: ValidatorPubKey | SomeSig): auto =
   x.blob
 
 func toHex*(x: BlsCurveType): string =
-  toHex(toRaw(x))
+  byteutils.toHex(toRaw(x))
 
 func toHex*(x: CookedPubKey): string =
   toHex(x.toPubKey())


### PR DESCRIPTION
- https://github.com/status-im/nim-stew/releases/tag/v0.4.2

This was already partially applied, except:

- toHex/to0xHex iterator
- importops: add `tryImport` for testing if an import exists
- rm deprecated stew/results
- deprecate stew/shims/parseutils
- sequtils: findIt
- v0.4.2