### PR TITLE
Reduce code duplication in DB state / block tests

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -35,38 +35,41 @@ AllTests-mainnet
 ```diff
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
-+ sanity check Altair blocks [Preset: mainnet]                                               OK
-+ sanity check Altair states [Preset: mainnet]                                               OK
-+ sanity check Altair states, reusing buffers [Preset: mainnet]                              OK
-+ sanity check Bellatrix blocks [Preset: mainnet]                                            OK
-+ sanity check Bellatrix states [Preset: mainnet]                                            OK
-+ sanity check Bellatrix states, reusing buffers [Preset: mainnet]                           OK
-+ sanity check Capella blocks [Preset: mainnet]                                              OK
-+ sanity check Capella states [Preset: mainnet]                                              OK
-+ sanity check Capella states, reusing buffers [Preset: mainnet]                             OK
-+ sanity check Deneb blocks [Preset: mainnet]                                                OK
-+ sanity check Deneb states [Preset: mainnet]                                                OK
-+ sanity check Deneb states, reusing buffers [Preset: mainnet]                               OK
-+ sanity check Electra blocks [Preset: mainnet]                                              OK
-+ sanity check Electra states [Preset: mainnet]                                              OK
-+ sanity check Electra states, reusing buffers [Preset: mainnet]                             OK
-+ sanity check Fulu blocks [Preset: mainnet]                                                 OK
-+ sanity check Fulu states [Preset: mainnet]                                                 OK
-+ sanity check Fulu states, reusing buffers [Preset: mainnet]                                OK
 + sanity check altair and cross-fork getState rollback [Preset: mainnet]                     OK
++ sanity check altair blocks [Preset: mainnet]                                               OK
++ sanity check altair states [Preset: mainnet]                                               OK
++ sanity check altair states, reusing buffers [Preset: mainnet]                              OK
 + sanity check bellatrix and cross-fork getState rollback [Preset: mainnet]                  OK
++ sanity check bellatrix blocks [Preset: mainnet]                                            OK
++ sanity check bellatrix states [Preset: mainnet]                                            OK
++ sanity check bellatrix states, reusing buffers [Preset: mainnet]                           OK
 + sanity check blobs [Preset: mainnet]                                                       OK
 + sanity check capella and cross-fork getState rollback [Preset: mainnet]                    OK
++ sanity check capella blocks [Preset: mainnet]                                              OK
++ sanity check capella states [Preset: mainnet]                                              OK
++ sanity check capella states, reusing buffers [Preset: mainnet]                             OK
 + sanity check data columns [Preset: mainnet]                                                OK
 + sanity check deneb and cross-fork getState rollback [Preset: mainnet]                      OK
++ sanity check deneb blocks [Preset: mainnet]                                                OK
++ sanity check deneb states [Preset: mainnet]                                                OK
++ sanity check deneb states, reusing buffers [Preset: mainnet]                               OK
 + sanity check electra and cross-fork getState rollback [Preset: mainnet]                    OK
++ sanity check electra blocks [Preset: mainnet]                                              OK
++ sanity check electra states [Preset: mainnet]                                              OK
++ sanity check electra states, reusing buffers [Preset: mainnet]                             OK
 + sanity check fulu and cross-fork getState rollback [Preset: mainnet]                       OK
++ sanity check fulu blocks [Preset: mainnet]                                                 OK
++ sanity check fulu states [Preset: mainnet]                                                 OK
++ sanity check fulu states, reusing buffers [Preset: mainnet]                                OK
 + sanity check genesis roundtrip [Preset: mainnet]                                           OK
   sanity check gloas and cross-fork getState rollback [Preset: mainnet]                      Skip
-+ sanity check phase 0 blocks [Preset: mainnet]                                              OK
-+ sanity check phase 0 states [Preset: mainnet]                                              OK
-+ sanity check phase 0 states, reusing buffers [Preset: mainnet]                             OK
+  sanity check gloas blocks [Preset: mainnet]                                                Skip
+  sanity check gloas states [Preset: mainnet]                                                Skip
+  sanity check gloas states, reusing buffers [Preset: mainnet]                               Skip
++ sanity check phase0 blocks [Preset: mainnet]                                               OK
 + sanity check phase0 getState rollback [Preset: mainnet]                                    OK
++ sanity check phase0 states [Preset: mainnet]                                               OK
++ sanity check phase0 states, reusing buffers [Preset: mainnet]                              OK
 + sanity check state diff roundtrip [Preset: mainnet]                                        OK
 ```
 ## Beacon chain file test suite

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -16,7 +16,7 @@ import
   ./testutil
 
 from std/algorithm import sort
-from std/sequtils import allIt, mapIt, toSeq
+from std/sequtils import allIt, toSeq
 from snappy import encodeFramed, uncompressedLenFramed
 from ../beacon_chain/consensus_object_pools/block_pools_types import
   ChainDAGRef

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -16,7 +16,7 @@ import
   ./testutil
 
 from std/algorithm import sort
-from std/sequtils import toSeq
+from std/sequtils import allIt, mapIt, toSeq
 from snappy import encodeFramed, uncompressedLenFramed
 from ../beacon_chain/consensus_object_pools/block_pools_types import
   ChainDAGRef
@@ -34,109 +34,89 @@ from ./teststateutil import getTestStates
 when isMainModule:
   import chronicles # or some random compile error happens...
 
-proc getPhase0StateRef(db: BeaconChainDB, root: Eth2Digest):
-    phase0.NilableBeaconStateRef =
+template BeaconStateRef(kind: static ConsensusFork): typedesc =
+  when kind == ConsensusFork.Gloas:
+    gloas.BeaconStateRef
+  elif kind == ConsensusFork.Fulu:
+    fulu.BeaconStateRef
+  elif kind == ConsensusFork.Electra:
+    electra.BeaconStateRef
+  elif kind == ConsensusFork.Deneb:
+    deneb.BeaconStateRef
+  elif kind == ConsensusFork.Capella:
+    capella.BeaconStateRef
+  elif kind == ConsensusFork.Bellatrix:
+    bellatrix.BeaconStateRef
+  elif kind == ConsensusFork.Altair:
+    altair.BeaconStateRef
+  elif kind == ConsensusFork.Phase0:
+    phase0.BeaconStateRef
+  else:
+    {.error: "BeaconStateRef unsupported in " & $kind.}
+
+template NilableBeaconStateRef(kind: static ConsensusFork): typedesc =
+  when kind == ConsensusFork.Gloas:
+    gloas.NilableBeaconStateRef
+  elif kind == ConsensusFork.Fulu:
+    fulu.NilableBeaconStateRef
+  elif kind == ConsensusFork.Electra:
+    electra.NilableBeaconStateRef
+  elif kind == ConsensusFork.Deneb:
+    deneb.NilableBeaconStateRef
+  elif kind == ConsensusFork.Capella:
+    capella.NilableBeaconStateRef
+  elif kind == ConsensusFork.Bellatrix:
+    bellatrix.NilableBeaconStateRef
+  elif kind == ConsensusFork.Altair:
+    altair.NilableBeaconStateRef
+  elif kind == ConsensusFork.Phase0:
+    phase0.NilableBeaconStateRef
+  else:
+    {.error: "NilableBeaconStateRef unsupported in " & $kind.}
+
+template TrustedBeaconBlock(kind: static ConsensusFork): typedesc =
+  when kind == ConsensusFork.Gloas:
+    gloas.TrustedBeaconBlock
+  elif kind == ConsensusFork.Fulu:
+    fulu.TrustedBeaconBlock
+  elif kind == ConsensusFork.Electra:
+    electra.TrustedBeaconBlock
+  elif kind == ConsensusFork.Deneb:
+    deneb.TrustedBeaconBlock
+  elif kind == ConsensusFork.Capella:
+    capella.TrustedBeaconBlock
+  elif kind == ConsensusFork.Bellatrix:
+    bellatrix.TrustedBeaconBlock
+  elif kind == ConsensusFork.Altair:
+    altair.TrustedBeaconBlock
+  elif kind == ConsensusFork.Phase0:
+    phase0.TrustedBeaconBlock
+  else:
+    {.error: "TrustedBeaconBlock unsupported in " & $kind.}
+
+proc getStateRef(
+    db: BeaconChainDB,
+    consensusFork: static ConsensusFork,
+    root: Eth2Digest): auto =
   # load beaconstate the way the block pool does it - into an existing instance
-  let res = (phase0.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
+  var res: consensusFork.NilableBeaconStateRef =
+    (consensusFork.BeaconStateRef)()
+  if not db.getState(root, res[], noRollback):
+    res = nil
+  res
 
-proc getAltairStateRef(db: BeaconChainDB, root: Eth2Digest):
-    altair.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existing instance
-  let res = (altair.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-proc getBellatrixStateRef(db: BeaconChainDB, root: Eth2Digest):
-    bellatrix.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existing instance
-  let res = (bellatrix.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-proc getCapellaStateRef(db: BeaconChainDB, root: Eth2Digest):
-    capella.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existing instance
-  let res = (capella.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-proc getDenebStateRef(db: BeaconChainDB, root: Eth2Digest):
-    deneb.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existing instance
-  let res = (deneb.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-proc getElectraStateRef(db: BeaconChainDB, root: Eth2Digest):
-    electra.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existing instance
-  let res = (electra.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-proc getFuluStateRef(db: BeaconChainDB, root: Eth2Digest):
-    fulu.NilableBeaconStateRef =
-  # load beaconstate the way the block pool does it - into an existence instance
-  let res = (fulu.BeaconStateRef)()
-  if db.getState(root, res[], noRollback):
-    return res
-
-func withDigest(blck: phase0.TrustedBeaconBlock):
-    phase0.TrustedSignedBeaconBlock =
-  phase0.TrustedSignedBeaconBlock(
+func withDigest(blck: ForkyTrustedBeaconBlock): auto =
+  typeof(blck).kind.TrustedSignedBeaconBlock(
     message: blck,
-    root: hash_tree_root(blck)
-  )
+    root: hash_tree_root(blck))
 
-func withDigest(blck: altair.TrustedBeaconBlock):
-    altair.TrustedSignedBeaconBlock =
-  altair.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-func withDigest(blck: bellatrix.TrustedBeaconBlock):
-    bellatrix.TrustedSignedBeaconBlock =
-  bellatrix.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-func withDigest(blck: capella.TrustedBeaconBlock):
-    capella.TrustedSignedBeaconBlock =
-  capella.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-func withDigest(blck: deneb.TrustedBeaconBlock):
-    deneb.TrustedSignedBeaconBlock =
-  deneb.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-func withDigest(blck: electra.TrustedBeaconBlock):
-    electra.TrustedSignedBeaconBlock =
-  electra.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-func withDigest(blck: fulu.TrustedBeaconBlock):
-    fulu.TrustedSignedBeaconBlock =
-  fulu.TrustedSignedBeaconBlock(
-    message: blck,
-    root: hash_tree_root(blck)
-  )
-
-proc getTestStates(consensusFork: ConsensusFork): auto =
+proc getTestStates(
+    cfg: RuntimeConfig,
+    consensusFork: ConsensusFork): seq[ref ForkedHashedBeaconState] =
   let
-    db = makeTestDB(SLOTS_PER_EPOCH)
+    db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
     validatorMonitor = newClone(ValidatorMonitor.init())
-    dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+    dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
   var testStates = getTestStates(dag.headState, consensusFork)
 
   # Ensure transitions beyond just adding validators and increasing slots
@@ -147,661 +127,137 @@ proc getTestStates(consensusFork: ConsensusFork): auto =
 
 # Each set of states gets used twice, so scope them to module
 let
-  testStatesPhase0    = getTestStates(ConsensusFork.Phase0)
-  testStatesAltair    = getTestStates(ConsensusFork.Altair)
-  testStatesBellatrix = getTestStates(ConsensusFork.Bellatrix)
-  testStatesCapella   = getTestStates(ConsensusFork.Capella)
-  testStatesDeneb     = getTestStates(ConsensusFork.Deneb)
-  testStatesElectra   = getTestStates(ConsensusFork.Electra)
-  testStatesFulu      = getTestStates(ConsensusFork.Fulu)
-
-doAssert len(testStatesPhase0) > 8
-doAssert len(testStatesAltair) > 8
-doAssert len(testStatesBellatrix) > 8
-doAssert len(testStatesCapella) > 8
-doAssert len(testStatesDeneb) > 8
-doAssert len(testStatesElectra) > 8
-doAssert len(testStatesFulu) > 8
+  cfg = defaultRuntimeConfig
+  testStates = block:
+    var res: array[ConsensusFork, seq[ref ForkedHashedBeaconState]]
+    for consensusFork in ConsensusFork:
+      res[consensusFork] = cfg.getTestStates(consensusFork)
+    res
+doAssert testStates.allIt(it.len > 8)
 
 suite "Beacon chain DB" & preset():
   test "empty database" & preset():
-    var
-      db = BeaconChainDB.new("", inMemory = true)
+    var db = BeaconChainDB.new("", cfg, inMemory = true)
     check:
-      db.getPhase0StateRef(ZERO_HASH).isNil
+      db.getStateRef(ConsensusFork.Phase0, ZERO_HASH).isNil
       db.getBlock(ZERO_HASH, phase0.TrustedSignedBeaconBlock).isNone
 
-  test "sanity check phase 0 blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Phase0.genesisTestRuntimeConfig, inMemory = true)
+  template doBlockTest(consensusFork: static ConsensusFork): untyped =
+    block:
+      let db = BeaconChainDB.new(
+        "", consensusFork.genesisTestRuntimeConfig, inMemory = true)
 
-    let
-      signedBlock = withDigest((phase0.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
+      let
+        signedBlock = withDigest((consensusFork.TrustedBeaconBlock)())
+        root = hash_tree_root(signedBlock.message)
 
-    db.putBlock(signedBlock)
+      db.putBlock(signedBlock)
 
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      db.getBlock(root, phase0.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
+      var tmp, tmp2: seq[byte]
+      check db.containsBlock(root)
+      const fork = consensusFork
+      withAll(ConsensusFork):
+        let ok = db.containsBlock(root, consensusFork.TrustedSignedBeaconBlock)
+        check ok == (consensusFork == fork)
+      check:
+        db.getBlock(
+          root, consensusFork.TrustedSignedBeaconBlock).get() == signedBlock
+        db.getBlockSSZ(root, tmp, consensusFork.TrustedSignedBeaconBlock)
+        db.getBlockSZ(root, tmp2, consensusFork.TrustedSignedBeaconBlock)
+        tmp == SSZ.encode(signedBlock)
+        tmp2 == encodeFramed(tmp)
+        uncompressedLenFramed(tmp2).isSome
 
-    check:
-      db.delBlock(ConsensusFork.Phase0, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, phase0.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, phase0.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, phase0.TrustedSignedBeaconBlock)
+        db.delBlock(consensusFork, root)
+        not db.containsBlock(root)
+      withAll(ConsensusFork):
+        check not db.containsBlock(root, consensusFork.TrustedSignedBeaconBlock)
+      check:
+        db.getBlock(root, consensusFork.TrustedSignedBeaconBlock).isErr()
+        not db.getBlockSSZ(root, tmp, consensusFork.TrustedSignedBeaconBlock)
+        not db.getBlockSZ(root, tmp2, consensusFork.TrustedSignedBeaconBlock)
 
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Altair blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Altair.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((altair.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, altair.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, altair.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Altair, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, altair.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, altair.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, altair.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Bellatrix blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Bellatrix.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((bellatrix.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, bellatrix.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, bellatrix.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Bellatrix, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, bellatrix.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, bellatrix.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, bellatrix.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Capella blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Capella.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((capella.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      db.getBlock(root, capella.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, capella.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, capella.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Capella, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, capella.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, capella.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, capella.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Deneb blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Deneb.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((deneb.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, deneb.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, deneb.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, deneb.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Deneb, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      db.getBlock(root, deneb.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, deneb.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, deneb.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Electra blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Electra.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((electra.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      db.getBlock(root, electra.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, electra.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, electra.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Electra, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      db.getBlock(root, electra.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, electra.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, electra.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check Fulu blocks" & preset():
-    let db = BeaconChainDB.new(
-      "", ConsensusFork.Fulu.genesisTestRuntimeConfig, inMemory = true)
-
-    let
-      signedBlock = withDigest((fulu.TrustedBeaconBlock)())
-      root = hash_tree_root(signedBlock.message)
-
-    db.putBlock(signedBlock)
-
-    var tmp, tmp2: seq[byte]
-    check:
-      db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, fulu.TrustedSignedBeaconBlock).get() == signedBlock
-      db.getBlockSSZ(root, tmp, fulu.TrustedSignedBeaconBlock)
-      db.getBlockSZ(root, tmp2, fulu.TrustedSignedBeaconBlock)
-      tmp == SSZ.encode(signedBlock)
-      tmp2 == encodeFramed(tmp)
-      uncompressedLenFramed(tmp2).isSome
-
-    check:
-      db.delBlock(ConsensusFork.Fulu, root)
-      not db.containsBlock(root)
-      not db.containsBlock(root, phase0.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, altair.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, bellatrix.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, capella.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, deneb.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, electra.TrustedSignedBeaconBlock)
-      not db.containsBlock(root, fulu.TrustedSignedBeaconBlock)
-      db.getBlock(root, fulu.TrustedSignedBeaconBlock).isErr()
-      not db.getBlockSSZ(root, tmp, fulu.TrustedSignedBeaconBlock)
-      not db.getBlockSZ(root, tmp2, fulu.TrustedSignedBeaconBlock)
-
-    db.putStateRoot(root, signedBlock.message.slot, root)
-    var root2 = root
-    root2.data[0] = root.data[0] + 1
-    db.putStateRoot(root, signedBlock.message.slot + 1, root2)
-
-    check:
-      db.getStateRoot(root, signedBlock.message.slot).get() == root
-      db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
-
-    db.close()
-
-  test "sanity check phase 0 states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesPhase0:
-      let root = state[].phase0Data.root
-      db.putState(root, state[].phase0Data.data)
+      db.putStateRoot(root, signedBlock.message.slot, root)
+      var root2 = root
+      root2.data[0] = root.data[0] + 1
+      db.putStateRoot(root, signedBlock.message.slot + 1, root2)
 
       check:
-        db.containsState(root)
-        hash_tree_root(db.getPhase0StateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Phase0, root)
-      check:
-        not db.containsState(root)
-        db.getPhase0StateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Altair states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesAltair:
-      let root = state[].altairData.root
-      db.putState(root, state[].altairData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getAltairStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Altair, root)
-      check:
-        not db.containsState(root)
-        db.getAltairStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Bellatrix states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesBellatrix:
-      let root = state[].bellatrixData.root
-      db.putState(root, state[].bellatrixData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getBellatrixStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Bellatrix, root)
-      check:
-        not db.containsState(root)
-        db.getBellatrixStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Capella states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesCapella:
-      let root = state[].capellaData.root
-      db.putState(root, state[].capellaData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getCapellaStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Capella, root)
-      check:
-        not db.containsState(root)
-        db.getCapellaStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Deneb states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesDeneb:
-      let root = state[].denebData.root
-      db.putState(root, state[].denebData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getDenebStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Deneb, root)
-      check:
-        not db.containsState(root)
-        db.getDenebStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Electra states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesElectra:
-      let root = state[].electraData.root
-      db.putState(root, state[].electraData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getElectraStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Electra, root)
-      check:
-        not db.containsState(root)
-        db.getElectraStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check Fulu states" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-
-    for state in testStatesFulu:
-      let root = state[].fuluData.root
-      db.putState(root, state[].fuluData.data)
-
-      check:
-        db.containsState(root)
-        hash_tree_root(db.getFuluStateRef(root)[]) == root
-
-      db.delState(ConsensusFork.Fulu, root)
-      check:
-        not db.containsState(root)
-        db.getFuluStateRef(root).isNil
-
-    db.close()
-
-  test "sanity check phase 0 states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (phase0.BeaconStateRef)()
-
-    for state in testStatesPhase0:
-      let root = state[].phase0Data.root
-      db.putState(root, state[].phase0Data.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Phase0, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Altair states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (altair.BeaconStateRef)()
-
-    for state in testStatesAltair:
-      let root = state[].altairData.root
-      db.putState(root, state[].altairData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Altair, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Bellatrix states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (bellatrix.BeaconStateRef)()
-
-    for state in testStatesBellatrix:
-      let root = state[].bellatrixData.root
-      db.putState(root, state[].bellatrixData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Bellatrix, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Capella states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (capella.BeaconStateRef)()
-
-    for state in testStatesCapella:
-      let root = state[].capellaData.root
-      db.putState(root, state[].capellaData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Capella, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Deneb states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (deneb.BeaconStateRef)()
-
-    for state in testStatesDeneb:
-      let root = state[].denebData.root
-      db.putState(root, state[].denebData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Deneb, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Electra states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (electra.BeaconStateRef)()
-
-    for state in testStatesElectra:
-      let root = state[].electraData.root
-      db.putState(root, state[].electraData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Electra, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
-
-  test "sanity check Fulu states, reusing buffers" & preset():
-    let db = makeTestDB(SLOTS_PER_EPOCH)
-    let stateBuffer = (fulu.BeaconStateRef)()
-
-    for state in testStatesFulu:
-      let root = state[].fuluData.root
-      db.putState(root, state[].fuluData.data)
-
-      check:
-        db.getState(root, stateBuffer[], noRollback)
-        db.containsState(root)
-        hash_tree_root(stateBuffer[]) == root
-
-      db.delState(ConsensusFork.Fulu, root)
-      check:
-        not db.containsState(root)
-        not db.getState(root, stateBuffer[], noRollback)
-
-    db.close()
+        db.getStateRoot(root, signedBlock.message.slot).get() == root
+        db.getStateRoot(root, signedBlock.message.slot + 1).get() == root2
+
+      db.close()
+
+  withAll(ConsensusFork):
+    let name = "sanity check " & $consensusFork & " blocks"
+    test name & preset():
+      when consensusFork >= ConsensusFork.Gloas:
+        skip()
+      else:
+        consensusFork.doBlockTest()
+
+  template doStateTest(consensusFork: static ConsensusFork): untyped =
+    block:
+      let db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+
+      for state in testStates[consensusFork]:
+        let root = state[].forky(consensusFork).root
+        db.putState(root, state[].forky(consensusFork).data)
+
+        check:
+          db.containsState(root)
+          hash_tree_root(db.getStateRef(consensusFork, root)[]) == root
+
+        db.delState(consensusFork, root)
+        check:
+          not db.containsState(root)
+          db.getStateRef(consensusFork, root).isNil
+
+      db.close()
+
+  withAll(ConsensusFork):
+    let name = "sanity check " & $consensusFork & " states"
+    test name & preset():
+      when consensusFork >= ConsensusFork.Gloas:
+        skip()
+      else:
+        consensusFork.doStateTest()
+
+  template doStateTestReusingBuffers(
+      consensusFork: static ConsensusFork): untyped =
+    block:
+      let
+        db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+        stateBuffer = (consensusFork.BeaconStateRef)()
+
+      for state in testStates[consensusFork]:
+        let root = state[].forky(consensusFork).root
+        db.putState(root, state[].forky(consensusFork).data)
+
+        check:
+          db.getState(root, stateBuffer[], noRollback)
+          db.containsState(root)
+          hash_tree_root(stateBuffer[]) == root
+
+        db.delState(consensusFork, root)
+        check:
+          not db.containsState(root)
+          not db.getState(root, stateBuffer[], noRollback)
+
+      db.close()
+
+  withAll(ConsensusFork):
+    let name = "sanity check " & $consensusFork & " states, reusing buffers"
+    test name & preset():
+      when consensusFork >= ConsensusFork.Gloas:
+        skip()
+      else:
+        consensusFork.doStateTestReusingBuffers()
 
   template doRollbackTest(consensusFork: static ConsensusFork): untyped =
     block:
-      let cfg = defaultRuntimeConfig
       var
-        db = makeTestDB(SLOTS_PER_EPOCH)
+        db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
         validatorMonitor = newClone(ValidatorMonitor.init())
         dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
         state = ForkedHashedBeaconState.new(
@@ -826,17 +282,17 @@ suite "Beacon chain DB" & preset():
         state[].phase0Data.data.slot != 10.Slot
 
   withAll(ConsensusFork):
-    var name = "sanity check " & $consensusFork &
+    let name = "sanity check " & $consensusFork &
       (if consensusFork > ConsensusFork.Phase0: " and cross-fork" else: "") &
       " getState rollback"
     test name & preset():
       when consensusFork >= ConsensusFork.Gloas:
         skip()
       else:
-        doRollbackTest(consensusFork)
+        consensusFork.doRollbackTest()
 
   test "find ancestors" & preset():
-    var db = BeaconChainDB.new("", inMemory = true)
+    var db = BeaconChainDB.new("", cfg, inMemory = true)
 
     let
       a0 = withDigest(
@@ -871,7 +327,7 @@ suite "Beacon chain DB" & preset():
     # state. We've been bit by this because we've had a bug in the BLS
     # serialization where an all-zero default-initialized bls signature could
     # not be deserialized because the deserialization was too strict.
-    var db = BeaconChainDB.new("", inMemory = true)
+    var db = BeaconChainDB.new("", cfg, inMemory = true)
 
     let
       state = newClone(initialize_hashed_beacon_state_from_eth1(
@@ -881,7 +337,7 @@ suite "Beacon chain DB" & preset():
     db.putState(state[].root, state[].data)
 
     check db.containsState(state[].root)
-    let state2 = db.getPhase0StateRef(state[].root)
+    let state2 = db.getStateRef(ConsensusFork.Phase0, state[].root)
     db.delState(ConsensusFork.Phase0, state[].root)
     check not db.containsState(state[].root)
     db.close()
@@ -890,7 +346,7 @@ suite "Beacon chain DB" & preset():
       hash_tree_root(state2[]) == state[].root
 
   test "sanity check state diff roundtrip" & preset():
-    var db = BeaconChainDB.new("", inMemory = true)
+    var db = BeaconChainDB.new("", cfg, inMemory = true)
 
     # TODO htr(diff) probably not interesting/useful, but stand-in
     let
@@ -924,7 +380,7 @@ suite "Beacon chain DB" & preset():
       blobSidecar1 = BlobSidecar(signed_block_header: blockHeader0, index: 2)
       blobSidecar2 = BlobSidecar(signed_block_header: blockHeader1, index: 2)
 
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
 
     var
       buf: seq[byte]
@@ -1024,7 +480,7 @@ suite "Beacon chain DB" & preset():
       dataColumnSidecar1 = fulu.DataColumnSidecar(signed_block_header: blockHeader0, index: 2)
       dataColumnSidecar2 = fulu.DataColumnSidecar(signed_block_header: blockHeader1, index: 2)
 
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
 
     var
       buf: seq[byte]
@@ -1112,7 +568,7 @@ suite "Quarantine" & preset():
 
   setup:
     let
-      db = BeaconChainDB.new("", inMemory = true, cfg = cfg)
+      db = BeaconChainDB.new("", cfg, inMemory = true)
       quarantine = db.getQuarantineDB()
 
   teardown:


### PR DESCRIPTION
In the DB tests, there is a lot of copy paste logic for running tests across the various forks. Collapse to a common parameterized impl by using the fork templates.