### PR TITLE
Cleanup defaultRuntimeConfig use in blockchain_dag tests

### DIFF
--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -100,9 +100,9 @@ proc initialLoad(
   ChainDAGRef.preInit(db, forkedState[])
 
   let
+    cfg = forkedState[].kind.genesisTestRuntimeConfig
     validatorMonitor = newClone(ValidatorMonitor.init())
-    dag = ChainDAGRef.init(
-      forkedState[].kind.genesisTestRuntimeConfig, db, validatorMonitor, {})
+    dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
     fkChoice = newClone(ForkChoice.init(
       dag.getFinalizedEpochRef(), dag.finalizedHead.blck))
 

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -331,7 +331,7 @@ suite "Beacon chain DB" & preset():
 
     let
       state = newClone(initialize_hashed_beacon_state_from_eth1(
-        defaultRuntimeConfig, mockEth1BlockHash, 0,
+        cfg, mockEth1BlockHash, 0,
         makeInitialDeposits(SLOTS_PER_EPOCH), {skipBlsValidation}))
 
     db.putState(state[].root, state[].data)
@@ -564,8 +564,6 @@ suite "Beacon chain DB" & preset():
     db.close()
 
 suite "Quarantine" & preset():
-  const cfg = defaultRuntimeConfig
-
   setup:
     let
       db = BeaconChainDB.new("", cfg, inMemory = true)

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -42,11 +42,13 @@ type
 
 suite "Block pool processing" & preset():
   setup:
-    let rng = HmacDrbgContext.new()
+    let
+      rng = HmacDrbgContext.new()
+      cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier {.used.} = BatchVerifier.init(rng, taskpool)
       quarantine {.used.} = Quarantine.init(dag.cfg)
@@ -121,10 +123,8 @@ suite "Block pool processing" & preset():
       dag.validatorKey(validators).isNone()
 
     # Skip one slot to get a gap
-    check:
-      process_slots(
-        defaultRuntimeConfig, state[], getStateField(state[], slot) + 1, cache,
-        info, {}).isOk()
+    check cfg.process_slots(
+      state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
 
     let
       b4 = addTestBlock(state[], cache).phase0Data
@@ -275,14 +275,14 @@ suite "Block pool processing" & preset():
 
 suite "Block pool altair processing" & preset():
   setup:
-    let rng = HmacDrbgContext.new()
-
+    let
+      rng = HmacDrbgContext.new()
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = Epoch(1)
+        res
     var
-      cfg = defaultRuntimeConfig
-    cfg.ALTAIR_FORK_EPOCH = Epoch(1)
-
-    var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -293,9 +293,8 @@ suite "Block pool altair processing" & preset():
 
     # Advance to altair
     check:
-      process_slots(
-        cfg, state[], cfg.ALTAIR_FORK_EPOCH.start_slot(), cache,
-        info, {}).isOk()
+      cfg.process_slots(
+        state[], cfg.ALTAIR_FORK_EPOCH.start_slot(), cache, info, {}).isOk()
 
       state[].kind == ConsensusFork.Altair
 
@@ -356,11 +355,13 @@ suite "Block pool altair processing" & preset():
 
 suite "chain DAG finalization tests" & preset():
   setup:
-    let rng = HmacDrbgContext.new()
+    let
+      rng = HmacDrbgContext.new()
+      cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
       quarantine = Quarantine.init(dag.cfg)
@@ -372,11 +373,9 @@ suite "chain DAG finalization tests" & preset():
     var
       blck = makeTestBlock(dag.headState, cache).phase0Data
       tmpState = assignClone(dag.headState)
-    check:
-      process_slots(
-        defaultRuntimeConfig, tmpState[],
-        getStateField(tmpState[], slot) + (5 * SLOTS_PER_EPOCH).uint64,
-        cache, info, {}).isOk()
+    check cfg.process_slots(
+      tmpState[], getStateField(tmpState[], slot) + (5 * SLOTS_PER_EPOCH),
+      cache, info, {}).isOk()
 
     let lateBlock = addTestBlock(tmpState[], cache).phase0Data
     block:
@@ -386,9 +385,8 @@ suite "chain DAG finalization tests" & preset():
     assign(tmpState[], dag.headState)
 
     # skip slots so we can test gappy getBlockIdAtSlot
-    check process_slots(
-      defaultRuntimeConfig, tmpState[],
-      getStateField(tmpState[], slot) + 2.uint64,
+    check cfg.process_slots(
+      tmpState[], getStateField(tmpState[], slot) + 2.uint64,
       cache, info, {}).isOk()
 
     for i in 0 ..< (SLOTS_PER_EPOCH * 6):
@@ -513,7 +511,7 @@ suite "chain DAG finalization tests" & preset():
 
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init())
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that the state reloaded from database resembles what we had before
     check:
@@ -551,8 +549,8 @@ suite "chain DAG finalization tests" & preset():
     # The loop creates multiple branches, which StateCache isn't suitable for
     cache = StateCache()
 
-    doAssert process_slots(
-      defaultRuntimeConfig, prestate[], getStateField(prestate[], slot) + 1,
+    doAssert cfg.process_slots(
+      prestate[], getStateField(prestate[], slot) + 1,
       cache, info, {}).isOk()
 
     # create another block, orphaning the head
@@ -564,7 +562,7 @@ suite "chain DAG finalization tests" & preset():
 
     var
       validatorMonitor2 = newClone(ValidatorMonitor.init())
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that we can apply the block after the orphaning
     let added2 = dag2.addHeadBlock(verifier, blck, nilPhase0Callback)
@@ -579,10 +577,9 @@ suite "chain DAG finalization tests" & preset():
       dag.pruneAtFinalization()
 
     # Advance past epoch so that the epoch transition is gapped
-    check:
-      process_slots(
-        defaultRuntimeConfig, dag.headState, Slot(SLOTS_PER_EPOCH * 6 + 2),
-        cache, info, {}).isOk()
+    check cfg.process_slots(
+      dag.headState, Slot(SLOTS_PER_EPOCH * 6 + 2),
+      cache, info, {}).isOk()
 
     let blck = makeTestBlock(
       dag.headState, cache,
@@ -613,7 +610,7 @@ suite "chain DAG finalization tests" & preset():
 
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init())
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that the state reloaded from database resembles what we had before
     check:
@@ -646,8 +643,7 @@ suite "chain DAG finalization tests" & preset():
         # If the beacon node were to exit _now_, this is what the DB looks like.
         # Validate that we can initialize a new DAG from this database.
         let validatorMonitor2 = newClone(ValidatorMonitor.init())
-        discard ChainDAGRef.init(
-          defaultRuntimeConfig, db, validatorMonitor2, {})
+        discard ChainDAGRef.init(cfg, db, validatorMonitor2, {})
         testPassed = true
     dag.setHeadCb(onHeadChanged)
 
@@ -664,8 +660,9 @@ suite "Old database versions" & preset():
   setup:
     let
       rng = HmacDrbgContext.new()
+      cfg = defaultRuntimeConfig
       genState = newClone(initialize_hashed_beacon_state_from_eth1(
-        defaultRuntimeConfig, ZERO_HASH, 0,
+        cfg, ZERO_HASH, 0,
         makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
         {skipBlsValidation}))
       genBlock = get_initial_beacon_block(genState[])
@@ -679,7 +676,7 @@ suite "Old database versions" & preset():
       sq = SqStoreRef.init("", "test", inMemory = true).expect(
         "working database (out of memory?)")
       v0 = BeaconChainDBV0.new(sq, readOnly = false)
-      db = BeaconChainDB.new(sq)
+      db = BeaconChainDB.new(sq, cfg)
 
     # preInit a database to a v1.0.12 state
     v0.putStateV0(genState[].root, genState[].data)
@@ -693,7 +690,7 @@ suite "Old database versions" & preset():
 
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db,validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db,validatorMonitor, {})
       state = newClone(dag.headState)
       cache = StateCache()
       att0 = makeFullAttestations(state[], dag.tail.root, 0.Slot, cache)
@@ -705,17 +702,18 @@ suite "Old database versions" & preset():
 
 suite "Diverging hardforks":
   setup:
-    let rng = HmacDrbgContext.new()
-
+    let
+      rng = HmacDrbgContext.new()
+      phase0RuntimeConfig = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = FAR_FUTURE_EPOCH
+        res
+      altairRuntimeConfig = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = 2.Epoch
+        res
     var
-      phase0RuntimeConfig = defaultRuntimeConfig
-      altairRuntimeConfig = defaultRuntimeConfig
-
-    phase0RuntimeConfig.ALTAIR_FORK_EPOCH = FAR_FUTURE_EPOCH
-    altairRuntimeConfig.ALTAIR_FORK_EPOCH = 2.Epoch
-
-    var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = phase0RuntimeConfig)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, phase0RuntimeConfig, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -782,10 +780,11 @@ suite "Diverging hardforks":
 suite "Backfill":
   setup:
     let
+      cfg = defaultRuntimeConfig
       genState = (ref ForkedHashedBeaconState)(
         kind: ConsensusFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, ZERO_HASH, 0,
+          cfg, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
           {skipBlsValidation}))
       tailState = assignClone(genState[])
@@ -798,7 +797,7 @@ suite "Backfill":
         blocks
 
     let
-      db = BeaconChainDB.new("", inMemory = true)
+      db = BeaconChainDB.new("", cfg, inMemory = true)
 
   test "Backfill to genesis":
     let
@@ -810,7 +809,7 @@ suite "Backfill":
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     var cache = StateCache()
 
@@ -919,7 +918,7 @@ suite "Backfill":
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     check:
       dag.addBackfillBlock(blocks[^1].phase0Data).isOk()
@@ -931,7 +930,7 @@ suite "Backfill":
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init())
 
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     check:
       dag2.getFinalizedEpochRef() != nil
@@ -954,7 +953,7 @@ suite "Backfill":
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     check:
       dag.getFinalizedEpochRef() != nil
@@ -989,7 +988,7 @@ suite "Backfill":
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init())
 
-      dag2 = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor2, {})
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
     check:
       dag2.head.root == next.root
 
@@ -999,7 +998,7 @@ suite "Backfill":
     for i in 1..blocks.len:
       let
         validatorMonitor = newClone(ValidatorMonitor.init())
-        dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+        dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
       check dag.backfill == (
         if i > 1:
@@ -1026,7 +1025,7 @@ suite "Backfill":
     block:
       let
         validatorMonitor = newClone(ValidatorMonitor.init())
-        dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+        dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
         genBlock = get_initial_beacon_block(genState[])
       check:
         dag.addBackfillBlock(genBlock.phase0Data.asSigned()).isOk()
@@ -1034,21 +1033,22 @@ suite "Backfill":
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
     check dag.backfill == default(BeaconBlockSummary)
 
 suite "Starting states":
   setup:
     let
+      cfg = defaultRuntimeConfig
       genState = (ref ForkedHashedBeaconState)(
         kind: ConsensusFork.Phase0,
         phase0Data: initialize_hashed_beacon_state_from_eth1(
-          defaultRuntimeConfig, ZERO_HASH, 0,
+          cfg, ZERO_HASH, 0,
           makeInitialDeposits(SLOTS_PER_EPOCH.uint64, flags = {skipBlsValidation}),
           {skipBlsValidation}))
       tailState = assignClone(genState[])
-      db = BeaconChainDB.new("", inMemory = true)
-      quarantine = newClone(Quarantine.init(defaultRuntimeConfig))
+      db = BeaconChainDB.new("", cfg, inMemory = true)
+      quarantine = newClone(Quarantine.init(cfg))
 
   test "Starting state without block":
     var
@@ -1063,15 +1063,14 @@ suite "Starting states":
         blocks
       tailBlock = blocks[^1]
 
-    check process_slots(
-      defaultRuntimeConfig, tailState[], Slot(SLOTS_PER_EPOCH), cache, info,
-      {}).isOk()
+    check cfg.process_slots(
+      tailState[], Slot(SLOTS_PER_EPOCH), cache, info, {}).isOk()
 
     ChainDAGRef.preInit(db, tailState[])
 
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     # check that we can update head to itself
     dag.updateHead(dag.head, quarantine[], [])
@@ -1163,16 +1162,17 @@ suite "Starting states":
 
 suite "Latest valid hash" & preset():
   setup:
-    let rng = HmacDrbgContext.new()
-
-    var runtimeConfig = defaultRuntimeConfig
-    runtimeConfig.ALTAIR_FORK_EPOCH = 1.Epoch
-    runtimeConfig.BELLATRIX_FORK_EPOCH = 2.Epoch
-
+    let
+      rng = HmacDrbgContext.new()
+      cfg = block:
+        var res = defaultRuntimeConfig
+        res.ALTAIR_FORK_EPOCH = 1.Epoch
+        res.BELLATRIX_FORK_EPOCH = 2.Epoch
+        res
     var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, runtimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init(dag.cfg))
@@ -1182,17 +1182,16 @@ suite "Latest valid hash" & preset():
 
   test "LVH searching":
     # Reach Bellatrix, where execution payloads exist
-    check process_slots(
-      runtimeConfig, state[],
-      getStateField(state[], slot) + (3 * SLOTS_PER_EPOCH).uint64,
+    check cfg.process_slots(
+      state[], getStateField(state[], slot) + (3 * SLOTS_PER_EPOCH),
       cache, info, {}).isOk()
 
     var
-      b1 = addTestBlock(state[], cache, cfg = runtimeConfig).bellatrixData
+      b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       b1Add = dag.addHeadBlock(verifier, b1, nilBellatrixCallback)
-      b2 = addTestBlock(state[], cache, cfg = runtimeConfig).bellatrixData
+      b2 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       b2Add = dag.addHeadBlock(verifier, b2, nilBellatrixCallback)
-      b3 = addTestBlock(state[], cache, cfg = runtimeConfig).bellatrixData
+      b3 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       b3Add = dag.addHeadBlock(verifier, b3, nilBellatrixCallback)
 
     dag.updateHead(b3Add[], quarantine[], [])
@@ -1238,7 +1237,7 @@ suite "Pruning":
         res.MIN_EPOCHS_FOR_BLOCK_REQUESTS = res.safeMinEpochsForBlockRequests()
         doAssert res.MIN_EPOCHS_FOR_BLOCK_REQUESTS == 4
         res
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       tmpState = assignClone(dag.headState)

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -38,12 +38,13 @@ proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
 suite "Gossip validation " & preset():
   setup:
     # Genesis state that results in 3 members per committee
-    let rng = HmacDrbgContext.new()
+    let
+      rng = HmacDrbgContext.new()
+      cfg = defaultRuntimeConfig
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(
-        ChainDAGRef, defaultRuntimeConfig, makeTestDB(SLOTS_PER_EPOCH * 3),
-        validatorMonitor, {})
+      dag = ChainDAGRef.init(
+        cfg, makeTestDB(SLOTS_PER_EPOCH * 3, cfg = cfg), validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier {.used.} = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init(dag.cfg))
@@ -56,10 +57,8 @@ suite "Gossip validation " & preset():
         genesis_validators_root = dag.genesis_validators_root, taskpool).expect(
           "working batcher")
     # Slot 0 is a finalized slot - won't be making attestations for it..
-    check:
-      process_slots(
-        defaultRuntimeConfig, state[], getStateField(state[], slot) + 1,
-        cache, info, {}).isOk()
+    check cfg.process_slots(
+      state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
 
   test "Empty committee when no committee for slot":
     template committee(idx: uint64): untyped =

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -40,10 +40,11 @@ when isMainModule:
 
 suite "state diff tests" & preset():
   setup:
+    let cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH)
+      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(ChainDAGRef, defaultRuntimeConfig, db, validatorMonitor, {})
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
   test "random slot differences" & preset():
     let testStates = getTestStates(dag.headState, ConsensusFork.Capella)

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -83,7 +83,7 @@ suite "Validator change pool testing suite":
 
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(
-        ChainDAGRef, cfg, makeTestDB(SLOTS_PER_EPOCH * 3),
+        ChainDAGRef, cfg, makeTestDB(SLOTS_PER_EPOCH * 3, cfg = cfg),
         validatorMonitor, {})
       fork {.used.} = dag.forkAtEpoch(Epoch(0))
       genesis_validators_root = dag.genesis_validators_root


### PR DESCRIPTION
Extract RuntimeConfig into variable to streamline the DAG tests, and fix a few instances where the cfg was not properly passed to the test DB.