### PR TITLE
Require passing RuntimeConfig explicitly when using makeTestDB

### DIFF
--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -86,8 +86,8 @@ suite "Attestation pool electra processing" & preset():
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(
         ChainDAGRef, cfg,
-        makeTestDB(
-          TOTAL_COMMITTEES * TARGET_COMMITTEE_SIZE * SLOTS_PER_EPOCH, cfg = cfg),
+        cfg.makeTestDB(
+          TOTAL_COMMITTEES * TARGET_COMMITTEE_SIZE * SLOTS_PER_EPOCH),
         validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier {.used.} = BatchVerifier.init(rng, taskpool)

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -114,7 +114,7 @@ proc getTestStates(
     cfg: RuntimeConfig,
     consensusFork: ConsensusFork): seq[ref ForkedHashedBeaconState] =
   let
-    db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+    db = cfg.makeTestDB(SLOTS_PER_EPOCH)
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
   var testStates = getTestStates(dag.headState, consensusFork)
@@ -198,7 +198,7 @@ suite "Beacon chain DB" & preset():
 
   template doStateTest(consensusFork: static ConsensusFork): untyped =
     block:
-      let db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      let db = cfg.makeTestDB(SLOTS_PER_EPOCH)
 
       for state in testStates[consensusFork]:
         let root = state[].forky(consensusFork).root
@@ -227,7 +227,7 @@ suite "Beacon chain DB" & preset():
       consensusFork: static ConsensusFork): untyped =
     block:
       let
-        db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+        db = cfg.makeTestDB(SLOTS_PER_EPOCH)
         stateBuffer = (consensusFork.BeaconStateRef)()
 
       for state in testStates[consensusFork]:
@@ -257,7 +257,7 @@ suite "Beacon chain DB" & preset():
   template doRollbackTest(consensusFork: static ConsensusFork): untyped =
     block:
       var
-        db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+        db = cfg.makeTestDB(SLOTS_PER_EPOCH)
         validatorMonitor = newClone(ValidatorMonitor.init())
         dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
         state = ForkedHashedBeaconState.new(
@@ -380,7 +380,7 @@ suite "Beacon chain DB" & preset():
       blobSidecar1 = BlobSidecar(signed_block_header: blockHeader0, index: 2)
       blobSidecar2 = BlobSidecar(signed_block_header: blockHeader1, index: 2)
 
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
 
     var
       buf: seq[byte]
@@ -480,7 +480,7 @@ suite "Beacon chain DB" & preset():
       dataColumnSidecar1 = fulu.DataColumnSidecar(signed_block_header: blockHeader0, index: 2)
       dataColumnSidecar2 = fulu.DataColumnSidecar(signed_block_header: blockHeader1, index: 2)
 
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
 
     var
       buf: seq[byte]

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -42,7 +42,7 @@ suite "Block processor" & preset():
         res.ALTAIR_FORK_EPOCH = GENESIS_EPOCH
         res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
         res
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
     var

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -46,7 +46,7 @@ suite "Block pool processing" & preset():
       rng = HmacDrbgContext.new()
       cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -282,7 +282,7 @@ suite "Block pool altair processing" & preset():
         res.ALTAIR_FORK_EPOCH = Epoch(1)
         res
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -359,7 +359,7 @@ suite "chain DAG finalization tests" & preset():
       rng = HmacDrbgContext.new()
       cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -713,7 +713,7 @@ suite "Diverging hardforks":
         res.ALTAIR_FORK_EPOCH = 2.Epoch
         res
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = phase0RuntimeConfig)
+      db = phase0RuntimeConfig.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, phase0RuntimeConfig, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -1170,7 +1170,7 @@ suite "Latest valid hash" & preset():
         res.BELLATRIX_FORK_EPOCH = 2.Epoch
         res
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -1237,7 +1237,7 @@ suite "Pruning":
         res.MIN_EPOCHS_FOR_BLOCK_REQUESTS = res.safeMinEpochsForBlockRequests()
         doAssert res.MIN_EPOCHS_FOR_BLOCK_REQUESTS == 4
         res
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       tmpState = assignClone(dag.headState)
@@ -1292,7 +1292,7 @@ suite "State history":
       cfg = defaultRuntimeConfig
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
-        cfg, makeTestDB(numValidators, cfg = cfg),
+        cfg, cfg.makeTestDB(numValidators),
         validatorMonitor, {})
       quarantine = newClone(Quarantine.init(dag.cfg))
       rng = HmacDrbgContext.new()
@@ -1413,7 +1413,7 @@ suite "Ancestry":
       cfg = defaultRuntimeConfig
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
-        cfg, makeTestDB(numValidators, cfg = cfg),
+        cfg, cfg.makeTestDB(numValidators),
         validatorMonitor, {})
       quarantine = newClone(Quarantine.init(dag.cfg))
       rng = HmacDrbgContext.new()
@@ -1706,9 +1706,8 @@ template runShufflingTests(cfg: RuntimeConfig, numRandomTests: int) =
       deposit_count: deposits.lenu64)
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(
-      cfg, makeTestDB(
-        numValidators, eth1Data = Opt.some(eth1Data),
-        flags = {}, cfg = cfg),
+      cfg, cfg.makeTestDB(
+        numValidators, eth1Data = Opt.some(eth1Data), flags = {}),
       validatorMonitor, {})
     quarantine = newClone(Quarantine.init(dag.cfg))
     rng = HmacDrbgContext.new()

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -44,7 +44,7 @@ suite "Gossip validation " & preset():
     var
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
-        cfg, makeTestDB(SLOTS_PER_EPOCH * 3, cfg = cfg), validatorMonitor, {})
+        cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3), validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier {.used.} = BatchVerifier.init(rng, taskpool)
       quarantine = newClone(Quarantine.init(dag.cfg))
@@ -307,7 +307,7 @@ suite "Gossip validation - Altair":
   template prepare(numValidators: Natural): untyped {.dirty.} =
     let
       dag = ChainDAGRef.init(
-        cfg, makeTestDB(numValidators, cfg = cfg), validatorMonitor, {})
+        cfg, cfg.makeTestDB(numValidators), validatorMonitor, {})
       batchCrypto = BatchCrypto.new(
         rng, eager = proc(): bool = false,
         genesis_validators_root = dag.genesis_validators_root, taskpool).expect(

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -79,7 +79,7 @@ suite "Light client" & preset():
     let
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = ChainDAGRef.init(
-        cfg, makeTestDB(num_validators, cfg = cfg), validatorMonitor, {},
+        cfg, cfg.makeTestDB(num_validators), validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(
           serve: true,
           importMode: LightClientDataImportMode.OnlyNew))

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -233,7 +233,7 @@ suite "Light client" & preset():
     dag.advanceToSlot(finalizedSlot, verifier, quarantine[])
 
     # Initialize new DAG from checkpoint
-    let cpDb = BeaconChainDB.new("", cfg = cfg, inMemory = true)
+    let cpDb = BeaconChainDB.new("", cfg, inMemory = true)
     ChainDAGRef.preInit(cpDb, genesisState[])
     ChainDAGRef.preInit(cpDb, dag.headState) # dag.getForkedBlock(dag.head.bid).get)
     let cpDag = ChainDAGRef.init(

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -43,7 +43,7 @@ suite "Light client processor" & preset():
   let
     validatorMonitor = newClone(ValidatorMonitor.init())
     dag = ChainDAGRef.init(
-      cfg, makeTestDB(numValidators, cfg = cfg), validatorMonitor, {},
+      cfg, cfg.makeTestDB(numValidators), validatorMonitor, {},
       lcDataConfig = LightClientDataConfig(
         serve: true,
         importMode: LightClientDataImportMode.OnlyNew))

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -42,7 +42,7 @@ suite "state diff tests" & preset():
   setup:
     let cfg = defaultRuntimeConfig
     var
-      db = makeTestDB(SLOTS_PER_EPOCH, cfg = cfg)
+      db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init())
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -82,9 +82,8 @@ suite "Validator change pool testing suite":
         tmp
 
       validatorMonitor = newClone(ValidatorMonitor.init())
-      dag = init(
-        ChainDAGRef, cfg, makeTestDB(SLOTS_PER_EPOCH * 3, cfg = cfg),
-        validatorMonitor, {})
+      dag = ChainDAGRef.init(
+        cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3), validatorMonitor, {})
       fork {.used.} = dag.forkAtEpoch(Epoch(0))
       genesis_validators_root = dag.genesis_validators_root
       pool = newClone(ValidatorChangePool.init(dag))

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -21,10 +21,10 @@ from ../beacon_chain/spec/beaconstate import
 export beacon_chain_db, testblockutil, kvstore, kvstore_sqlite3
 
 proc makeTestDB*(
+    cfg: RuntimeConfig,
     validators: Natural,
     eth1Data = Opt.none(Eth1Data),
-    flags: UpdateFlags = {},
-    cfg = defaultRuntimeConfig): BeaconChainDB =
+    flags: UpdateFlags = {}): BeaconChainDB =
   # Blob support requires DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH
   # Data column support requires FULU_FORK_EPOCH != FAR_FUTURE_EPOCH
   var cfg = cfg

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -63,7 +63,7 @@ proc makeTestDB*(
         hash_tree_root(default(BeaconBlockBody(consensusFork)))
       forkyState.root = hash_tree_root(forkyState.data)
 
-  result = BeaconChainDB.new("", cfg = cfg, inMemory = true)
+  result = BeaconChainDB.new("", cfg, inMemory = true)
   ChainDAGRef.preInit(result, genState[])
 
 proc getEarliestInvalidBlockRoot*(


### PR DESCRIPTION
Avoid mishaps by requiring explicit passing of RuntimeConfig in tests.