### PR TITLE
Correctly pass RuntimeConfig when initializing database in ncli_db

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -503,7 +503,7 @@ proc new*(T: type BeaconChainDBV0,
 
 proc new*(T: type BeaconChainDB,
           db: SqStoreRef,
-          cfg: RuntimeConfig = defaultRuntimeConfig
+          cfg: RuntimeConfig
     ): BeaconChainDB =
   if not db.readOnly:
     # Remove the deposits table we used before we switched
@@ -653,7 +653,7 @@ proc new*(T: type BeaconChainDB,
 
 proc new*(T: type BeaconChainDB,
           dir: string,
-          cfg: RuntimeConfig = defaultRuntimeConfig,
+          cfg: RuntimeConfig,
           inMemory = false,
           readOnly = false
     ): BeaconChainDB =

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -227,8 +227,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
 
   echo "Opening database..."
   let
-    db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
-    dbBenchmark = BeaconChainDB.new("benchmark")
+    db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
+    dbBenchmark = BeaconChainDB.new("benchmark", cfg)
   defer:
     db.close()
     dbBenchmark.close()
@@ -390,8 +390,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
     processBlocks(blocks[i])
   printTimers(false, timers)
 
-proc cmdDumpState(conf: DbConf) =
-  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+proc cmdDumpState(conf: DbConf, cfg: RuntimeConfig) =
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer: db.close()
 
   let
@@ -428,7 +428,7 @@ proc cmdDumpState(conf: DbConf) =
     echo "Couldn't load ", stateRoot
 
 proc cmdPutState(conf: DbConf, cfg: RuntimeConfig) =
-  let db = BeaconChainDB.new(conf.databaseDir.string)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg)
   defer: db.close()
 
   for file in conf.stateFile:
@@ -448,8 +448,8 @@ proc cmdPutState(conf: DbConf, cfg: RuntimeConfig) =
     withState(state[]):
       db.putState(forkyState)
 
-proc cmdDumpBlock(conf: DbConf) =
-  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+proc cmdDumpBlock(conf: DbConf, cfg: RuntimeConfig) =
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer: db.close()
 
   for blockRoot in conf.blockRootx:
@@ -469,7 +469,7 @@ proc cmdDumpBlock(conf: DbConf) =
       echo "Couldn't load ", blockRoot, ": ", e.msg
 
 proc cmdPutBlock(conf: DbConf, cfg: RuntimeConfig) =
-  let db = BeaconChainDB.new(conf.databaseDir.string)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg)
   defer: db.close()
 
   for file in conf.blckFile:
@@ -521,7 +521,7 @@ proc cmdPutBlob(conf: DbConf, cfg: RuntimeConfig) =
 
 proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
   echo "Opening database..."
-  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer: db.close()
 
   if (let v = ChainDAGRef.isInitialized(db); v.isErr()):
@@ -557,7 +557,7 @@ proc cmdVerifyEra(conf: DbConf, cfg: RuntimeConfig) =
   echo root
 
 proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
-  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer: db.close()
 
   if (let v = ChainDAGRef.isInitialized(db); v.isErr()):
@@ -676,7 +676,7 @@ proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
     quit QuitFailure
 
 proc cmdImportEra(conf: DbConf, cfg: RuntimeConfig) =
-  let db = BeaconChainDB.new(conf.databaseDir.string)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg)
   defer: db.close()
 
   type Timers = enum
@@ -741,7 +741,7 @@ type
 proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
   echo "Opening database..."
   let
-    db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+    db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer:
     db.close()
 
@@ -978,7 +978,7 @@ proc insertValidators(db: SqStoreRef, state: ForkedHashedBeaconState,
 proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
   # Create a database with performance information for every epoch
   info "Opening database..."
-  let db = BeaconChainDB.new(conf.databaseDir.string, readOnly = true)
+  let db = BeaconChainDB.new(conf.databaseDir.string, cfg, readOnly = true)
   defer: db.close()
 
   if (let v = ChainDAGRef.isInitialized(db); v.isErr()):
@@ -1214,11 +1214,11 @@ when isMainModule:
   of DbCmd.bench:
     cmdBench(conf, cfg)
   of DbCmd.dumpState:
-    cmdDumpState(conf)
+    cmdDumpState(conf, cfg)
   of DbCmd.putState:
     cmdPutState(conf, cfg)
   of DbCmd.dumpBlock:
-    cmdDumpBlock(conf)
+    cmdDumpBlock(conf, cfg)
   of DbCmd.putBlock:
     cmdPutBlock(conf, cfg)
   of DbCmd.putBlob:

--- a/tests/consensus_spec/test_fixture_light_client_data_collection.nim
+++ b/tests/consensus_spec/test_fixture_light_client_data_collection.nim
@@ -133,7 +133,7 @@ proc runTest(suiteName, path: string, consensusFork: static ConsensusFork) =
       (cfg, _) = readRuntimeConfig(path/"config.yaml")
       initial_state = loadForkedState(
         path/"initial_state.ssz_snappy", consensusFork)
-      db = BeaconChainDB.new("", cfg = cfg, inMemory = true)
+      db = BeaconChainDB.new("", cfg, inMemory = true)
     defer: db.close()
     ChainDAGRef.preInit(db, initial_state[])
 

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -166,7 +166,7 @@ suite "BlobQuarantine data structure test suite " & preset():
   setup:
     let
       cfg {.used.} = defaultRuntimeConfig
-      db {.used.} = BeaconChainDB.new("", inMemory = true, cfg = cfg)
+      db {.used.} = BeaconChainDB.new("", cfg, inMemory = true)
       quarantine {.used.} = db.getQuarantineDB()
 
   teardown:
@@ -1065,7 +1065,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
   setup:
     let
       cfg {.used.} = defaultRuntimeConfig
-      db {.used.} = BeaconChainDB.new("", inMemory = true, cfg = cfg)
+      db {.used.} = BeaconChainDB.new("", cfg, inMemory = true)
       quarantine {.used.} = db.getQuarantineDB()
 
   teardown:


### PR DESCRIPTION
In ncli_db, some operations did not pass the RuntimeConfig to BeaconChainDB.new. Fix these instances, and make RuntimeConfig required when initializing BeaconChainDB to avoid this problem in the future.