### PR TITLE
Pass TimeConfig to ValidatorMonitor

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -913,6 +913,7 @@ proc init*(
   # break existing setups
   let
     validatorMonitor = newClone(ValidatorMonitor.init(
+      cfg.time,
       config.validatorMonitorAuto,
       config.validatorMonitorTotals.get(
         not config.validatorMonitorDetails)))

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -377,7 +377,7 @@ proc doTrustedNodeSync*(
   # Coming this far, we've done what ChainDAGRef.preInit would normally do -
   # we can now load a ChainDAG to start backfilling it
   let
-    validatorMonitor = newClone(ValidatorMonitor.init(false, false))
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time, false, false))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, eraPath = eraDir)
     backfillSlot = max(dag.backfill.slot, 1.Slot) - 1
     horizon = max(dag.horizon, dag.frontfill.valueOr(BlockId()).slot)

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -194,6 +194,8 @@ type
     summaries: array[2, EpochSummary] # We monitor the current and previous epochs
 
   ValidatorMonitor* = object
+    timeConfig: TimeConfig
+
     epoch: Epoch # The most recent epoch seen in monitoring
 
     monitors: Table[ValidatorPubKey, ref MonitoredValidator]
@@ -257,8 +259,12 @@ proc addAutoMonitor*(
   info "Started monitoring validator",
     validator = shortLog(pubkey), pubkey, index
 
-func init*(T: type ValidatorMonitor, autoRegister = false, totals = false): T =
-  T(autoRegister: autoRegister, totals: totals)
+func init*(
+    T: type ValidatorMonitor,
+    timeConfig: TimeConfig,
+    autoRegister = false,
+    totals = false): T =
+  T(timeConfig: timeConfig, autoRegister: autoRegister, totals: totals)
 
 template summaryIdx(epoch: Epoch): int = (epoch.uint64 mod 2).int
 

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -239,7 +239,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
 
   echo "Initializing block pool..."
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = withTimerRet(timers[tInit]):
       ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
@@ -531,7 +531,7 @@ proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
   echo "Initializing block pool..."
 
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
   let bid = dag.getBlockId(fromHex(Eth2Digest, conf.blockRoot)).valueOr:
@@ -569,7 +569,7 @@ proc cmdExportEra(conf: DbConf, cfg: RuntimeConfig) =
     tBlocks
 
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
   let tmpState = assignClone(dag.headState)
@@ -751,7 +751,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
 
   echo "# Initializing block pool..."
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
   var
@@ -987,7 +987,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
 
   echo "Initializing block pool..."
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
   let outDb = SqStoreRef.init(conf.outDir, "validatorDb").expect("DB")

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -77,7 +77,7 @@ cli do(
   ChainDAGRef.preInit(db, genesisState[])
   let rng = HmacDrbgContext.new()
   var
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
     taskpool =
       try:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -101,7 +101,7 @@ proc initialLoad(
 
   let
     cfg = forkedState[].kind.genesisTestRuntimeConfig
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
     fkChoice = newClone(ForkChoice.init(
       dag.getFinalizedEpochRef(), dag.finalizedHead.blck))

--- a/tests/consensus_spec/test_fixture_light_client_data_collection.nim
+++ b/tests/consensus_spec/test_fixture_light_client_data_collection.nim
@@ -138,7 +138,7 @@ proc runTest(suiteName, path: string, consensusFork: static ConsensusFork) =
     ChainDAGRef.preInit(db, initial_state[])
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init(false, false))
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time, false, false))
       dag = ChainDAGRef.init(cfg, db, validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(
           serve: true, importMode: LightClientDataImportMode.Full))

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -83,7 +83,7 @@ suite "Attestation pool electra processing" & preset():
     const TOTAL_COMMITTEES = 2
     var
       cfg = genesisTestRuntimeConfig(ConsensusFork.Electra)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(
         ChainDAGRef, cfg,
         cfg.makeTestDB(

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -115,7 +115,7 @@ proc getTestStates(
     consensusFork: ConsensusFork): seq[ref ForkedHashedBeaconState] =
   let
     db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
   var testStates = getTestStates(dag.headState, consensusFork)
 
@@ -258,7 +258,7 @@ suite "Beacon chain DB" & preset():
     block:
       var
         db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-        validatorMonitor = newClone(ValidatorMonitor.init())
+        validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
         dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
         state = ForkedHashedBeaconState.new(
           (ref consensusFork.BeaconState)(slot: 10.Slot)[])

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -43,7 +43,7 @@ suite "Block processor" & preset():
         res.BELLATRIX_FORK_EPOCH = GENESIS_EPOCH
         res
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
     var
       taskpool = Taskpool.new()
@@ -112,7 +112,7 @@ suite "Block processor" & preset():
 
     # check that init also reloads block graph
     var
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     check:

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -47,7 +47,7 @@ suite "Block pool processing" & preset():
       cfg = defaultRuntimeConfig
     var
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier {.used.} = BatchVerifier.init(rng, taskpool)
@@ -283,7 +283,7 @@ suite "Block pool altair processing" & preset():
         res
     var
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
@@ -360,7 +360,7 @@ suite "chain DAG finalization tests" & preset():
       cfg = defaultRuntimeConfig
     var
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
@@ -510,7 +510,7 @@ suite "chain DAG finalization tests" & preset():
     check: dag.head.root == parentRoot
 
     let
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that the state reloaded from database resembles what we had before
@@ -561,7 +561,7 @@ suite "chain DAG finalization tests" & preset():
     check: added.isOk()
 
     var
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that we can apply the block after the orphaning
@@ -609,7 +609,7 @@ suite "chain DAG finalization tests" & preset():
         cur = cur.parent
 
     let
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that the state reloaded from database resembles what we had before
@@ -642,7 +642,7 @@ suite "chain DAG finalization tests" & preset():
 
         # If the beacon node were to exit _now_, this is what the DB looks like.
         # Validate that we can initialize a new DAG from this database.
-        let validatorMonitor2 = newClone(ValidatorMonitor.init())
+        let validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
         discard ChainDAGRef.init(cfg, db, validatorMonitor2, {})
         testPassed = true
     dag.setHeadCb(onHeadChanged)
@@ -689,7 +689,7 @@ suite "Old database versions" & preset():
     db.putGenesisBlock(genBlock.root)
 
     var
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db,validatorMonitor, {})
       state = newClone(dag.headState)
       cache = StateCache()
@@ -714,7 +714,8 @@ suite "Diverging hardforks":
         res
     var
       db = phase0RuntimeConfig.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(
+        ValidatorMonitor.init(phase0RuntimeConfig.time))
       dag = init(ChainDAGRef, phase0RuntimeConfig, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
@@ -739,7 +740,8 @@ suite "Diverging hardforks":
     check b1Add.isOk()
     dag.updateHead(b1Add[], quarantine[], [])
 
-    let validatorMonitorAltair = newClone(ValidatorMonitor.init())
+    let validatorMonitorAltair = newClone(
+      ValidatorMonitor.init(altairRuntimeConfig.time))
 
     let dagAltair = init(
       ChainDAGRef, altairRuntimeConfig, db, validatorMonitorAltair, {})
@@ -771,7 +773,8 @@ suite "Diverging hardforks":
     check b2Add.isOk()
     dag.updateHead(b2Add[], quarantine[], [])
 
-    let validatorMonitor = newClone(ValidatorMonitor.init())
+    let validatorMonitor = newClone(
+      ValidatorMonitor.init(altairRuntimeConfig.time))
 
     let dagAltair = init(
       ChainDAGRef, altairRuntimeConfig, db, validatorMonitor, {})
@@ -808,7 +811,7 @@ suite "Backfill":
     ChainDAGRef.preInit(db, tailState[])
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     var cache = StateCache()
@@ -917,7 +920,7 @@ suite "Backfill":
     ChainDAGRef.preInit(db, tailState[])
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     check:
@@ -928,7 +931,7 @@ suite "Backfill":
       dag.backfill == blocks[^2].phase0Data.message.toBeaconBlockSummary()
 
     let
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
 
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
@@ -952,7 +955,7 @@ suite "Backfill":
     ChainDAGRef.preInit(db, tailState[])
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     check:
@@ -986,7 +989,7 @@ suite "Backfill":
     dag.updateHead(nextAdd, quarantine[], [])
 
     let
-      validatorMonitor2 = newClone(ValidatorMonitor.init())
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg.time))
 
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
     check:
@@ -997,7 +1000,7 @@ suite "Backfill":
 
     for i in 1..blocks.len:
       let
-        validatorMonitor = newClone(ValidatorMonitor.init())
+        validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
         dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
       check dag.backfill == (
@@ -1024,7 +1027,7 @@ suite "Backfill":
 
     block:
       let
-        validatorMonitor = newClone(ValidatorMonitor.init())
+        validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
         dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
         genBlock = get_initial_beacon_block(genState[])
       check:
@@ -1032,7 +1035,7 @@ suite "Backfill":
         dag.backfill == default(BeaconBlockSummary)
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
     check dag.backfill == default(BeaconBlockSummary)
 
@@ -1069,7 +1072,7 @@ suite "Starting states":
     ChainDAGRef.preInit(db, tailState[])
 
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
     # check that we can update head to itself
@@ -1171,7 +1174,7 @@ suite "Latest valid hash" & preset():
         res
     var
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       verifier = BatchVerifier.init(rng, taskpool)
@@ -1238,7 +1241,7 @@ suite "Pruning":
         doAssert res.MIN_EPOCHS_FOR_BLOCK_REQUESTS == 4
         res
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
       tmpState = assignClone(dag.headState)
 
@@ -1290,7 +1293,7 @@ suite "State history":
     const numValidators = SLOTS_PER_EPOCH
     let
       cfg = defaultRuntimeConfig
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(numValidators),
         validatorMonitor, {})
@@ -1411,7 +1414,7 @@ suite "Ancestry":
     const numValidators = SLOTS_PER_EPOCH
     let
       cfg = defaultRuntimeConfig
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(numValidators),
         validatorMonitor, {})
@@ -1704,7 +1707,7 @@ template runShufflingTests(cfg: RuntimeConfig, numRandomTests: int) =
     eth1Data = Eth1Data(
       deposit_root: deposits.attachMerkleProofs(),
       deposit_count: deposits.lenu64)
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(
       cfg, cfg.makeTestDB(
         numValidators, eth1Data = Opt.some(eth1Data), flags = {}),

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -42,7 +42,7 @@ suite "Gossip validation " & preset():
       rng = HmacDrbgContext.new()
       cfg = defaultRuntimeConfig
     var
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3), validatorMonitor, {})
       taskpool = Taskpool.new()
@@ -296,7 +296,7 @@ suite "Gossip validation - Altair":
 
   setup:
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       quarantine = newClone(Quarantine.init(cfg))
       rng = HmacDrbgContext.new()
       syncCommitteePool = newClone(SyncCommitteeMsgPool.init(rng, cfg))

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -77,7 +77,7 @@ suite "Light client" & preset():
   setup:
     const num_validators = SLOTS_PER_EPOCH
     let
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(num_validators), validatorMonitor, {},
         lcDataConfig = LightClientDataConfig(

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -41,7 +41,7 @@ suite "Light client processor" & preset():
 
   const numValidators = SLOTS_PER_EPOCH
   let
-    validatorMonitor = newClone(ValidatorMonitor.init())
+    validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
     dag = ChainDAGRef.init(
       cfg, cfg.makeTestDB(numValidators), validatorMonitor, {},
       lcDataConfig = LightClientDataConfig(

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -43,7 +43,7 @@ suite "state diff tests" & preset():
     let cfg = defaultRuntimeConfig
     var
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
 
   test "random slot differences" & preset():

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -81,7 +81,7 @@ suite "Validator change pool testing suite":
         tmp.FULU_FORK_EPOCH = Epoch(tmp.SHARD_COMMITTEE_PERIOD) + 5
         tmp
 
-      validatorMonitor = newClone(ValidatorMonitor.init())
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg.time))
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3), validatorMonitor, {})
       fork {.used.} = dag.forkAtEpoch(Epoch(0))


### PR DESCRIPTION
ValidatorMonitor uses slot.attestation_deadline() for metrics / logs, which ultimately depends on SECONDS_PER_SLOT. Passing that config now reduces the subsequent diff when the compile-time constant is replaced.