### PR TITLE
Pass TimeConfig to slot deadline functions

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -62,6 +62,9 @@ proc init*(
       timeConfig: timeConfig,
       genesis: unixGenesis - unixGenesisOffset)
 
+func timeConfig*(c: BeaconClock): TimeConfig =
+  c.timeConfig  # Readonly
+
 func toBeaconTime*(c: BeaconClock, t: Time): BeaconTime =
   BeaconTime(ns_since_genesis: inNanoseconds(t - c.genesis))
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -293,7 +293,7 @@ proc process_block*(self: var ForkChoice,
   # Add proposer score boost if the block is timely
   let slot = self.checkpoints.time.slotOrZero
   if slot == blck.slot and
-      self.checkpoints.time < slot.attestation_deadline and
+      self.checkpoints.time < slot.attestation_deadline(dag.cfg.time) and
       self.checkpoints.proposer_boost_root == ZERO_HASH:
     self.checkpoints.proposer_boost_root = blckRef.root
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -471,7 +471,9 @@ proc processAttestation*(
     return errIgnore("Attestation before genesis")
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - attestation.data.slot.attestation_deadline
+  let
+    timeConfig = self.dag.cfg.time
+    delay = wallTime - attestation.data.slot.attestation_deadline(timeConfig)
   debug "Attestation received", delay
 
   let v = when attestation is phase0.Attestation:
@@ -537,8 +539,9 @@ proc processSignedAggregateAndProof*(
 
   # Potential under/overflows are fine; would just create odd logs
   let
+    timeConfig = self.dag.cfg.time
     slot = signedAggregateAndProof.message.aggregate.data.slot
-    delay = wallTime - slot.aggregate_deadline
+    delay = wallTime - slot.aggregate_deadline(timeConfig)
   debug "Aggregate received", delay
 
   let v = await self.attestationPool.validateAggregate(
@@ -700,7 +703,10 @@ proc processSyncCommitteeMessage*(
     wallSlot
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime - syncCommitteeMsg.slot.sync_committee_message_deadline
+  let
+    timeConfig = self.dag.cfg.time
+    slot = syncCommitteeMsg.slot
+    delay = wallTime - slot.sync_committee_message_deadline(timeConfig)
   debug "Sync committee message received", delay
 
   # Now proceed to validation
@@ -748,8 +754,9 @@ proc processSignedContributionAndProof*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let
+    timeConfig = self.dag.cfg.time
     slot = contributionAndProof.message.contribution.slot
-    delay = wallTime - slot.sync_contribution_deadline
+    delay = wallTime - slot.sync_contribution_deadline(timeConfig)
   debug "Contribution received", delay
 
   # Now proceed to validation

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1977,7 +1977,8 @@ proc validateLightClientFinalityUpdate*(
       else:
         GENESIS_SLOT
     currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-    forwardTime = signature_slot.light_client_finality_update_time
+    forwardTime = signature_slot
+      .light_client_finality_update_time(dag.cfg.time)
   if currentTime < forwardTime:
     # [IGNORE] The `finality_update` is received after the block at
     # `signature_slot` was given enough time to propagate through the network.
@@ -2014,7 +2015,8 @@ proc validateLightClientOptimisticUpdate*(
       else:
         GENESIS_SLOT
     currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-    forwardTime = signature_slot.light_client_optimistic_update_time
+    forwardTime = signature_slot
+      .light_client_optimistic_update_time(dag.cfg.time)
   if currentTime < forwardTime:
     # [IGNORE] The `optimistic_update` is received after the block at
     # `signature_slot` was given enough time to propagate through the network.

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -514,7 +514,8 @@ func toValidationError(
           else:
             GENESIS_SLOT
         currentTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-        forwardTime = signature_slot.light_client_finality_update_time
+        forwardTime = signature_slot
+          .light_client_finality_update_time(self.cfg.time)
       if currentTime < forwardTime:
         # [IGNORE] The `finality_update` is received after the block
         # at `signature_slot` was given enough time to propagate through

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -164,19 +164,31 @@ func start_beacon_time*(s: Slot): BeaconTime =
   if s > maxSlot: FAR_FUTURE_BEACON_TIME
   else: BeaconTime(ns_since_genesis: int64(uint64(s) * NANOSECONDS_PER_SLOT))
 
-func block_deadline*(s: Slot): BeaconTime =
+func block_deadline*(s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time
-func attestation_deadline*(s: Slot): BeaconTime =
+
+func attestation_deadline*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + attestationSlotOffset
-func aggregate_deadline*(s: Slot): BeaconTime =
+
+func aggregate_deadline*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + aggregateSlotOffset
-func sync_committee_message_deadline*(s: Slot): BeaconTime =
+
+func sync_committee_message_deadline*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + syncCommitteeMessageSlotOffset
-func sync_contribution_deadline*(s: Slot): BeaconTime =
+
+func sync_contribution_deadline*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + syncContributionSlotOffset
-func light_client_finality_update_time*(s: Slot): BeaconTime =
+
+func light_client_finality_update_time*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + lightClientFinalityUpdateSlotOffset
-func light_client_optimistic_update_time*(s: Slot): BeaconTime =
+
+func light_client_optimistic_update_time*(
+    s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time + lightClientOptimisticUpdateSlotOffset
 
 func slotOrZero*(time: BeaconTime): Slot =

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -62,7 +62,7 @@ proc serveAttestation(
       raise exc
 
   logScope:
-    delay = vc.getDelay(attestationSlot.attestation_deadline())
+    delay = vc.getDelay(attestationSlot.attestation_deadline(vc.timeConfig))
 
   debug "Sending attestation"
 
@@ -94,7 +94,7 @@ proc serveAttestation(
       submitAttestation(attestation)
 
   if res:
-    let delay = vc.getDelay(attestationSlot.attestation_deadline())
+    let delay = vc.getDelay(attestationSlot.attestation_deadline(vc.timeConfig))
     beacon_attestations_sent.inc()
     beacon_attestation_sent_delay.observe(delay.toFloatSeconds())
     notice "Attestation published"
@@ -136,7 +136,7 @@ proc serveAggregateAndProof*(
   let signedProof = phase0.SignedAggregateAndProof(
     message: proof, signature: signature)
   logScope:
-    delay = vc.getDelay(slot.aggregate_deadline())
+    delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
 
   debug "Sending aggregated attestation", fork = fork
 
@@ -202,7 +202,7 @@ proc serveAggregateAndProofV2*(
         raiseAssert "Unsupported SignedAggregateAndProof"
 
   logScope:
-    delay = vc.getDelay(slot.aggregate_deadline())
+    delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
 
   debug "Sending aggregated attestation", fork = fork
 
@@ -316,7 +316,7 @@ proc produceAndPublishAttestations*(
               inc(errored)
           (succeed, errored, failed)
 
-    let delay = vc.getDelay(slot.attestation_deadline())
+    let delay = vc.getDelay(slot.attestation_deadline(vc.timeConfig))
     debug "Attestation statistics", total = len(pendingAttestations),
           succeed = statistics[0], failed_to_deliver = statistics[1],
           not_accepted = statistics[2], delay = delay, slot = slot,
@@ -414,7 +414,7 @@ proc produceAndPublishAggregates(
             inc(errored)
         (succeed, errored, failed)
 
-    let delay = vc.getDelay(slot.aggregate_deadline())
+    let delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
     debug "Aggregated attestation statistics", total = len(aggregates),
           succeed = statistics[0], failed_to_deliver = statistics[1],
           not_accepted = statistics[2], delay = delay, slot = slot,
@@ -433,7 +433,7 @@ proc publishAttestationsAndAggregates(
   let vc = service.client
 
   block:
-    let delay = vc.getDelay(slot.attestation_deadline())
+    let delay = vc.getDelay(slot.attestation_deadline(vc.timeConfig))
     debug "Producing attestations", delay = delay, slot = slot,
                                     committee_index = committee_index,
                                     duties_count = len(duties)
@@ -449,12 +449,13 @@ proc publishAttestationsAndAggregates(
       debug "Publish attestation request was interrupted"
       raise exc
 
-  let aggregateTime = vc.beaconClock.fromNow(slot.aggregate_deadline())
+  let aggregateTime = vc.beaconClock.fromNow(
+    slot.aggregate_deadline(vc.timeConfig))
   if aggregateTime.inFuture:
     await sleepAsync(aggregateTime.offset)
 
   block:
-    let delay = vc.getDelay(slot.aggregate_deadline())
+    let delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
     debug "Producing aggregate and proofs", delay = delay
   await service.produceAndPublishAggregates(ad, duties)
 
@@ -548,7 +549,7 @@ proc produceAndPublishAttestationsV2*(
             inc(errored)
         (succeed, errored, failed)
 
-    delay = vc.getDelay(slot.attestation_deadline())
+    delay = vc.getDelay(slot.attestation_deadline(vc.timeConfig))
 
   debug "Attestation statistics", total = len(pendingAttestations),
         succeed = statistics[0], failed_to_deliver = statistics[1],
@@ -661,7 +662,7 @@ proc produceAndPublishAggregatesV2(
           inc(errored)
       (succeed, errored, failed)
 
-  let delay = vc.getDelay(slot.aggregate_deadline())
+  let delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
   debug "Aggregated attestation statistics", total = len(aggregates),
         succeed = statistics[0], failed_to_deliver = statistics[1],
         not_accepted = statistics[2], delay = delay, slot = slot,
@@ -676,7 +677,7 @@ proc publishAttestationsAndAggregatesV2(
     vc = service.client
 
   block:
-    let delay = vc.getDelay(slot.attestation_deadline())
+    let delay = vc.getDelay(slot.attestation_deadline(vc.timeConfig))
     debug "Producing attestations", delay = delay, slot = slot,
                                     duties_count = len(duties)
 
@@ -691,13 +692,14 @@ proc publishAttestationsAndAggregatesV2(
       debug "Publish attestation request was interrupted"
       raise exc
 
-  let aggregateTime = vc.beaconClock.fromNow(slot.aggregate_deadline())
+  let aggregateTime = vc.beaconClock.fromNow(
+    slot.aggregate_deadline(vc.timeConfig))
   if aggregateTime.inFuture:
     await sleepAsync(aggregateTime.offset)
 
   block:
     let
-      delay = vc.getDelay(slot.aggregate_deadline())
+      delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
       dutiesByCommittee = getAttesterDutiesByCommittee(duties)
     debug "Producing aggregate and proofs", delay = delay
     var tasks: seq[Future[void].Raising([CancelledError])]

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -193,7 +193,7 @@ proc publishBlockV3(
             raise exc
 
       if res:
-        let delay = vc.getDelay(slot.block_deadline())
+        let delay = vc.getDelay(slot.block_deadline(vc.timeConfig))
         beacon_blocks_sent.inc()
         beacon_blocks_sent_delay.observe(delay.toFloatSeconds())
         notice "Blinded block published", delay = delay
@@ -268,7 +268,7 @@ proc publishBlockV3(
             raise exc
 
       if res:
-        let delay = vc.getDelay(slot.block_deadline())
+        let delay = vc.getDelay(slot.block_deadline(vc.timeConfig))
         beacon_blocks_sent.inc()
         beacon_blocks_sent_delay.observe(delay.toFloatSeconds())
         notice "Block published", delay = delay
@@ -292,9 +292,10 @@ proc publishBlock(
     slot = slot
     wall_slot = currentSlot
 
-  debug "Publishing block", delay = vc.getDelay(slot.block_deadline()),
-                            genesis_root = genesisRoot,
-                            graffiti = graffiti, fork = fork
+  debug "Publishing block",
+        delay = vc.getDelay(slot.block_deadline(vc.timeConfig)),
+        genesis_root = genesisRoot,
+        graffiti = graffiti, fork = fork
   let
     randaoReveal =
       try:
@@ -590,7 +591,7 @@ proc runBlockPollMonitor(service: BlockServiceRef,
       currentTime = vc.beaconClock.now()
       afterSlot = currentTime.slotOrZero()
 
-    if currentTime > afterSlot.attestation_deadline():
+    if currentTime > afterSlot.attestation_deadline(vc.timeConfig):
       # Attestation time already, lets wait for next slot.
       continue
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -856,7 +856,8 @@ proc getDurationToNextAttestation*(vc: ValidatorClientRef,
   if minSlot == FAR_FUTURE_SLOT:
     "<unknown>"
   else:
-    $(minSlot.attestation_deadline() - slot.start_beacon_time())
+    $(minSlot.attestation_deadline(vc.timeConfig) -
+      slot.start_beacon_time())
 
 proc getDurationToNextBlock*(vc: ValidatorClientRef, slot: Slot): string =
   var minSlot = FAR_FUTURE_SLOT
@@ -873,7 +874,8 @@ proc getDurationToNextBlock*(vc: ValidatorClientRef, slot: Slot): string =
   if minSlot == FAR_FUTURE_SLOT:
     "<unknown>"
   else:
-    $(minSlot.block_deadline() - slot.start_beacon_time())
+    $(minSlot.block_deadline(vc.timeConfig) -
+      slot.start_beacon_time())
 
 iterator attesterDutiesForEpoch*(vc: ValidatorClientRef,
                                  epoch: Epoch): DutyAndProof =

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -62,7 +62,8 @@ proc serveSyncCommitteeMessage*(
     message = shortLog(message)
 
   debug "Sending sync committee message",
-        delay = vc.getDelay(message.slot.sync_committee_message_deadline())
+        delay = vc.getDelay(
+          message.slot.sync_committee_message_deadline(vc.timeConfig))
 
   let res =
     try:
@@ -76,7 +77,8 @@ proc serveSyncCommitteeMessage*(
       return false
 
   let
-    delay = vc.getDelay(message.slot.sync_committee_message_deadline())
+    delay = vc.getDelay(
+      message.slot.sync_committee_message_deadline(vc.timeConfig))
     dur = Moment.now() - startTime
 
   if res:
@@ -131,7 +133,7 @@ proc produceAndPublishSyncCommitteeMessages(
       (succeed, errored, failed)
 
   let
-    delay = vc.getDelay(slot.attestation_deadline())
+    delay = vc.getDelay(slot.attestation_deadline(vc.timeConfig))
     dur = Moment.now() - startTime
 
   debug "Sync committee message statistics",
@@ -174,7 +176,7 @@ proc serveContributionAndProof*(
       res.get()
 
   debug "Sending sync contribution",
-        delay = vc.getDelay(slot.sync_contribution_deadline())
+        delay = vc.getDelay(slot.sync_contribution_deadline(vc.timeConfig))
 
   let restSignedProof = RestSignedContributionAndProof.init(
     proof, signature)
@@ -326,7 +328,7 @@ proc produceAndPublishContributions(
           (succeed, errored, failed)
 
     let
-      delay = vc.getDelay(slot.aggregate_deadline())
+      delay = vc.getDelay(slot.aggregate_deadline(vc.timeConfig))
       dur = Moment.now() - startTime
 
     debug "Sync message contribution statistics",
@@ -353,7 +355,8 @@ proc publishSyncMessagesAndContributions(
     slot = slot
 
   block:
-    let delay = vc.getDelay(slot.sync_committee_message_deadline())
+    let delay = vc.getDelay(
+      slot.sync_committee_message_deadline(vc.timeConfig))
     debug "Producing sync committee messages", delay = delay,
           duties_count = len(duties)
 
@@ -393,15 +396,15 @@ proc publishSyncMessagesAndContributions(
     return
 
   let currentTime = vc.beaconClock.now()
-  if slot.sync_contribution_deadline() > currentTime:
-    let waitDur =
-      nanoseconds((slot.sync_contribution_deadline() - currentTime).nanoseconds)
+  if slot.sync_contribution_deadline(vc.timeConfig) > currentTime:
+    let waitDur = nanoseconds((
+      slot.sync_contribution_deadline(vc.timeConfig) - currentTime).nanoseconds)
     # Sleeping until `sync_contribution_deadline`.
     debug "Waiting for sync contribution deadline", wait_time = waitDur
     await sleepAsync(waitDur)
 
   block:
-    let delay = vc.getDelay(slot.sync_contribution_deadline())
+    let delay = vc.getDelay(slot.sync_contribution_deadline(vc.timeConfig))
     debug "Producing contribution and proofs", delay = delay
 
   try:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -243,7 +243,7 @@ proc handleLightClientUpdates*(node: BeaconNode, slot: Slot)
   static: doAssert lightClientFinalityUpdateSlotOffset ==
     lightClientOptimisticUpdateSlotOffset
   let sendTime = node.beaconClock.fromNow(
-    slot.light_client_finality_update_time())
+    slot.light_client_finality_update_time(node.dag.cfg.time))
   if sendTime.inFuture:
     debug "Waiting to send LC updates", slot, delay = shortLog(sendTime.offset)
     await sleepAsync(sendTime.offset)
@@ -1232,13 +1232,14 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   withState(node.dag.headState):
     node.updateValidators(forkyState.data.validators.asSeq())
 
-  let newHead = await handleProposal(node, head, slot)
+  let
+    timeConfig = node.dag.cfg.time
+    newHead = await handleProposal(node, head, slot)
   head = newHead
 
-  let
-    # The latest point in time when we'll be sending out attestations
-    attestationCutoff = node.beaconClock.fromNow(slot.attestation_deadline())
-
+  # The latest point in time when we'll be sending out attestations
+  let attestationCutoff = node.beaconClock.fromNow(
+    slot.attestation_deadline(timeConfig))
   if attestationCutoff.inFuture:
     debug "Waiting to send attestations",
       head = shortLog(head),
@@ -1266,8 +1267,8 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   # the result in aggregates
   static:
     doAssert aggregateSlotOffset == syncContributionSlotOffset, "Timing change?"
-  let
-    aggregateCutoff = node.beaconClock.fromNow(slot.aggregate_deadline())
+  let aggregateCutoff = node.beaconClock.fromNow(
+    slot.aggregate_deadline(timeConfig))
   if aggregateCutoff.inFuture:
     debug "Waiting to send aggregate attestations",
       aggregateCutoff = shortLog(aggregateCutoff.offset)

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -131,8 +131,9 @@ proc routeSignedBeaconBlock*(
             return err(res.error())
 
   let
+    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].getCurrentBeaconTime()
-    delay = sendTime - blck.message.slot.block_deadline()
+    delay = sendTime - blck.message.slot.block_deadline(timeConfig)
     # The block (and blobs, if present) passed basic gossip validation
     # - we can "safely" broadcast it now. In fact, per the spec, we
     # should broadcast it even if it later fails to apply to our
@@ -263,8 +264,9 @@ proc routeAttestation*(
       return err(res.error()[1])
 
   let
+    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
-    delay = sendTime - attestation.data.slot.attestation_deadline()
+    delay = sendTime - attestation.data.slot.attestation_deadline(timeConfig)
     res = await router[].network.broadcastAttestation(subnet_id, attestation)
 
   if res.isOk():
@@ -334,8 +336,10 @@ proc routeSignedAggregateAndProof*(
       return err(res.error()[1])
 
   let
+    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
-    delay = sendTime - proof.message.aggregate.data.slot.aggregate_deadline()
+    slot = proof.message.aggregate.data.slot
+    delay = sendTime - slot.aggregate_deadline(timeConfig)
     res = await router[].network.broadcastAggregateAndProof(proof)
 
   if res.isOk():
@@ -369,8 +373,9 @@ proc routeSyncCommitteeMessage*(
       return err(res.error()[1])
 
   let
+    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
-    delay = sendTime - msg.slot.sync_committee_message_deadline()
+    delay = sendTime - msg.slot.sync_committee_message_deadline(timeConfig)
 
     res = await router[].network.broadcastSyncCommitteeMessage(
       msg, subcommitteeIdx)
@@ -490,8 +495,10 @@ proc routeSignedContributionAndProof*(
       return err(res.error()[1])
 
   let
+    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
-    delay = sendTime - msg.message.contribution.slot.sync_contribution_deadline()
+    slot = msg.message.contribution.slot
+    delay = sendTime - slot.sync_contribution_deadline(timeConfig)
 
   let res = await router[].network.broadcastSignedContributionAndProof(msg)
   if res.isOk():

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -72,11 +72,9 @@ proc waitAfterBlockCutoff*(clock: BeaconClock, slot: Slot,
   # delay.
 
   # Take into consideration chains with a different slot time
-  const afterBlockDelay = nanos(attestationSlotOffset.nanoseconds div 2)
-  let
-    afterBlockTime = clock.now() + afterBlockDelay
-    afterBlockCutoff = clock.fromNow(
-      min(afterBlockTime, slot.attestation_deadline() + afterBlockDelay))
+  const extraDelay = nanos(attestationSlotOffset.nanoseconds div 2)
+  let afterBlockCutoff = clock.fromNow(
+    min(clock.now(), slot.attestation_deadline(clock.timeConfig)) + extraDelay)
 
   if afterBlockCutoff.inFuture:
     if head.isSome():

--- a/beacon_chain/validators/validator_monitor.nim
+++ b/beacon_chain/validators/validator_monitor.nim
@@ -665,7 +665,7 @@ proc registerAttestation*(
     attestation: phase0.Attestation | SingleAttestation, idx: ValidatorIndex) =
   let
     slot = attestation.data.slot
-    delay = seen_timestamp - slot.attestation_deadline()
+    delay = seen_timestamp - slot.attestation_deadline(self.timeConfig)
 
   self.withMonitor(idx):
     let id = monitor.id
@@ -690,7 +690,7 @@ proc registerAggregate*(
     attesting_indices: openArray[ValidatorIndex]) =
   let
     slot = aggregate_and_proof.aggregate.data.slot
-    delay = seen_timestamp - slot.aggregate_deadline()
+    delay = seen_timestamp - slot.aggregate_deadline(self.timeConfig)
     aggregator_index = aggregate_and_proof.aggregator_index
 
   self.withMonitor(aggregator_index):
@@ -761,7 +761,7 @@ proc registerBeaconBlock*(
     let
       id = monitor.id
       slot = blck.slot
-      delay = seen_timestamp - slot.block_deadline()
+      delay = seen_timestamp - slot.block_deadline(self.timeConfig)
 
     validator_monitor_beacon_block.inc(1, [$src, metricId])
     validator_monitor_beacon_block_delay_seconds.observe(
@@ -780,7 +780,8 @@ proc registerSyncCommitteeMessage*(
     let
       id = monitor.id
       slot = sync_committee_message.slot
-      delay = seen_timestamp - slot.sync_committee_message_deadline()
+      delay = seen_timestamp -
+        slot.sync_committee_message_deadline(self.timeConfig)
 
     validator_monitor_sync_committee_messages.inc(1, [$src, metricId])
     validator_monitor_sync_committee_messages_delay_seconds.observe(
@@ -803,7 +804,7 @@ proc registerSyncContribution*(
     participants: openArray[ValidatorIndex]) =
   let
     slot = contribution_and_proof.contribution.slot
-    delay = seen_timestamp - slot.sync_contribution_deadline()
+    delay = seen_timestamp - slot.sync_contribution_deadline(self.timeConfig)
 
   let aggregator_index = contribution_and_proof.aggregator_index
   self.withMonitor(aggregator_index):

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -173,8 +173,8 @@ cli do(
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
       genesis_validators_root = dag.genesis_validators_root
       fork = dag.forkAtEpoch(slot.epoch)
-      messagesTime = slot.attestation_deadline()
-      contributionsTime = slot.sync_contribution_deadline()
+      messagesTime = slot.attestation_deadline(dag.cfg.time)
+      contributionsTime = slot.sync_contribution_deadline(dag.cfg.time)
 
     var aggregators: seq[Aggregator]
 


### PR DESCRIPTION
Computing a deadline timing for a particular slot duty depends on SECONDS_PER_SLOT, so we also have to pass the TimeConfig to these.