### PR TITLE
Fix the SECONDS_PER_SLOT compatibility check on loading configs

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -919,9 +919,9 @@ proc readRuntimeConfig*(
       const name = astToStr(constValue)
       checkCompatibility(constValue, name, operator)
 
-  checkCompatibility MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
-                     "SECONDS_PER_SLOT", `in`
   checkCompatibility SECONDS_PER_SLOT  # Temporary, until removed from presets
+  # checkCompatibility MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
+  #                    "SECONDS_PER_SLOT", `in`
 
   checkCompatibility BLS_WITHDRAWAL_PREFIX
 


### PR DESCRIPTION
Can only checkCompatibility once, as it has the sideeffect of removing the value from the table :-) Do the more restrictive check for now.