### PR TITLE
Pass TimeConfig to nextSlot/EpochStartTime

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -95,7 +95,8 @@ func durationOrZero*(d: tuple[inFuture: bool, offset: Duration]): Duration =
     ZeroDuration
 
 func nextSlotStartTime*(
-    exSlot: tuple[afterGenesis: bool, slot: Slot]): BeaconTime =
+    exSlot: tuple[afterGenesis: bool, slot: Slot],
+    timeConfig: TimeConfig): BeaconTime =
   if exSlot.afterGenesis:
     (exSlot.slot + 1).start_beacon_time()
   else:
@@ -105,7 +106,8 @@ func nextSlotStartTime*(
     genesisTime - timeDiff
 
 func nextEpochStartTime*(
-    exSlot: tuple[afterGenesis: bool, slot: Slot]): BeaconTime =
+    exSlot: tuple[afterGenesis: bool, slot: Slot],
+    timeConfig: TimeConfig): BeaconTime =
   if exSlot.afterGenesis:
     (exSlot.slot.epoch + 1).start_slot.start_beacon_time()
   else:

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1468,7 +1468,7 @@ proc waitForNextEpoch*(service: ClientServiceRef,
   let
     vc = service.client
     currentSlot = vc.beaconClock.now().toSlot()
-    nextEpochTime = currentSlot.nextEpochStartTime()
+    nextEpochTime = currentSlot.nextEpochStartTime(vc.timeConfig)
     sleepTime = vc.beaconClock.fromNow(nextEpochTime).durationOrZero() + delay
   debug "Sleeping until next epoch", service = service.name,
                                      sleep_time = sleepTime, delay = delay
@@ -1483,7 +1483,7 @@ proc waitForNextSlot*(
        currentSlot: tuple[afterGenesis: bool, slot: Slot]
      ): Future[void] {.async: (raises: [CancelledError], raw: true).} =
   let
-    nextSlotTime = currentSlot.nextSlotStartTime()
+    nextSlotTime = currentSlot.nextSlotStartTime(vc.timeConfig)
     sleepTime = vc.beaconClock.fromNow(nextSlotTime).durationOrZero()
   sleepAsync(sleepTime)
 


### PR DESCRIPTION
start_beacon_time depends on SECONDS_PER_SLOT so needs to be known eventually in nextSlotStartTime and nextEpochStartTime helpers.