### PR TITLE
Pass TimeConfig to OptimisticProcessor

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -52,7 +52,7 @@ proc initLightClient*(
                 forkyBlck.message)
           else: discard
     optimisticProcessor = initOptimisticProcessor(
-      getBeaconTime, optimisticHandler)
+      cfg.time, getBeaconTime, optimisticHandler)
 
     shouldInhibitSync = func(): bool =
       if isNil(node.syncOverseer):

--- a/beacon_chain/gossip_processing/optimistic_processor.nim
+++ b/beacon_chain/gossip_processing/optimistic_processor.nim
@@ -26,14 +26,17 @@ type
     ): Future[void] {.async: (raises: [CancelledError]).}
 
   OptimisticProcessor* = ref object
+    timeConfig: TimeConfig
     getBeaconTime: GetBeaconTimeFn
     optimisticVerifier: OptimisticBlockVerifier
     processFut: Future[void].Raising([CancelledError])
 
 proc initOptimisticProcessor*(
+    timeConfig: TimeConfig,
     getBeaconTime: GetBeaconTimeFn,
     optimisticVerifier: OptimisticBlockVerifier): OptimisticProcessor =
   OptimisticProcessor(
+    timeConfig: timeConfig,
     getBeaconTime: getBeaconTime,
     optimisticVerifier: optimisticVerifier)
 

--- a/beacon_chain/gossip_processing/optimistic_processor.nim
+++ b/beacon_chain/gossip_processing/optimistic_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2019-2024 Status Research & Development GmbH
+# Copyright (c) 2019-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at http://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at http://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -108,7 +108,7 @@ proc main() {.noinline, raises: [CatchableError].} =
               discard await elManager.newExecutionPayload(forkyBlck.message)
         else: discard
     optimisticProcessor = initOptimisticProcessor(
-      getBeaconTime, optimisticHandler)
+      cfg.time, getBeaconTime, optimisticHandler)
 
     lightClient = createLightClient(
       network, rng, config, cfg, forkDigests, getBeaconTime,


### PR DESCRIPTION
OptimisticProcessor (used to optimistically sync EL while CL is behind) needs SECONDS_PER_SLOT for logging, similar to ValidatorMonitor metrics. Pass it the TimeConfig to keep supporting that.