### PR TITLE
Pass TimeConfig to slotOrZero

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -75,6 +75,9 @@ proc now*(c: BeaconClock): BeaconTime =
   ## Current time, in slots - this may end up being less than GENESIS_SLOT(!)
   toBeaconTime(c, getTime())
 
+proc currentSlot*(c: BeaconClock): Slot =
+  c.now.slotOrZero(c.timeConfig)
+
 func getBeaconTimeFn*(c: BeaconClock): GetBeaconTimeFn =
   return proc(): BeaconTime = c.now()
 

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -135,7 +135,7 @@ template rng*(node: BeaconNode): ref HmacDrbgContext =
   node.network.rng
 
 proc currentSlot*(node: BeaconNode): Slot =
-  node.beaconClock.now.slotOrZero
+  node.beaconClock.currentSlot
 
 func hasRestAllowedOrigin*(node: BeaconNode): bool =
   node.config.restAllowedOrigin.isSome

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -417,7 +417,8 @@ proc addAttestation*(
   doAssert attestation.signature == signature.toValidatorSig(),
     "Deserialized signature must match the one in the attestation"
 
-  updateCurrent(pool, wallTime.slotOrZero)
+  let timeConfig = pool.dag.cfg.time
+  updateCurrent(pool, wallTime.slotOrZero(timeConfig))
 
   let candidateIdx = pool.candidateIdx(attestation.data.slot)
   if candidateIdx.isNone:

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -511,12 +511,14 @@ proc updateExecutionHead*(
   defer:
     self.forkchoiceInflight = false
 
+  let timeConfig = self.dag.cfg.time
   var
     attempts = 0
     wallTime = getBeaconTimeFn()
     head = self.attestationPool[].getBeaconHead(self.dag.head)
 
-  while not (await self.forkchoiceUpdated(head, wallTime.slotOrZero(), deadline, retry)):
+  while not (await self.forkchoiceUpdated(
+      head, wallTime.slotOrZero(timeConfig), deadline, retry)):
     # Each failed call to forkchoiceUpdated that fails should reveal new
     # information about the suggested new head - a side effect of the failure is
     # that the block should be marked as invalid and removed from fork choice
@@ -536,7 +538,7 @@ proc updateExecutionHead*(
     wallTime = getBeaconTimeFn()
     let nextHead = self.attestationPool[].selectOptimisticHead(wallTime).valueOr:
       warn "Head selection failed after invalid block, using previous head",
-        head, wallSlot = wallTime.slotOrZero
+        head, wallSlot = wallTime.slotOrZero(timeConfig)
       break
 
     warn "updateHeadWithExecution: attempting to recover from invalid payload",

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -138,8 +138,8 @@ proc on_tick(
   self.checkpoints.time = time
 
   let
-    current_slot = time.slotOrZero
-    previous_slot = previous_time.slotOrZero
+    current_slot = time.slotOrZero(dag.cfg.time)
+    previous_slot = previous_time.slotOrZero(dag.cfg.time)
 
   # If this is a new slot, reset store.proposer_boost_root
   if current_slot > previous_slot:
@@ -199,8 +199,8 @@ proc update_time*(self: var ForkChoice, dag: ChainDAGRef, time: BeaconTime):
   const step_size = seconds(SECONDS_PER_SLOT.int)
   if time > self.checkpoints.time:
     let
-      preSlot = self.checkpoints.time.slotOrZero()
-      postSlot = time.slotOrZero()
+      preSlot = self.checkpoints.time.slotOrZero(dag.cfg.time)
+      postSlot = time.slotOrZero(dag.cfg.time)
     # Call on_tick at least once per slot.
     while time >= self.checkpoints.time + step_size:
       ? self.on_tick(dag, self.checkpoints.time + step_size)
@@ -226,7 +226,7 @@ proc on_attestation*(
   ? self.update_time(dag,
     max(wallTime, attestation_slot.start_beacon_time(dag.cfg.time)))
 
-  if attestation_slot < self.checkpoints.time.slotOrZero:
+  if attestation_slot < self.checkpoints.time.slotOrZero(dag.cfg.time):
     for validator_index in attesting_indices:
       # attestation_slot and target epoch must match, per attestation rules
       self.backend.process_attestation(
@@ -293,7 +293,7 @@ proc process_block*(self: var ForkChoice,
     block_root = shortLog(blckRef)
 
   # Add proposer score boost if the block is timely
-  let slot = self.checkpoints.time.slotOrZero
+  let slot = self.checkpoints.time.slotOrZero(dag.cfg.time)
   if slot == blck.slot and
       self.checkpoints.time < slot.attestation_deadline(dag.cfg.time) and
       self.checkpoints.proposer_boost_root == ZERO_HASH:
@@ -367,7 +367,7 @@ proc get_head*(self: var ForkChoice,
   ? self.update_time(dag, wallTime)
 
   self.backend.find_head(
-    self.checkpoints.time.slotOrZero.epoch,
+    self.checkpoints.time.slotOrZero(dag.cfg.time).epoch,
     FinalityCheckpoints(
       justified: self.checkpoints.justified.checkpoint,
       finalized: self.checkpoints.finalized),

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -582,7 +582,7 @@ proc storeBlock(
     startTick = Moment.now()
     vm = self.validatorMonitor
     dag = self.consensusManager.dag
-    wallSlot = wallTime.slotOrZero
+    wallSlot = wallTime.slotOrZero(dag.cfg.time)
     deadlineTime =
       block:
         let slotTime =

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -592,14 +592,19 @@ proc processBlsToExecutionChange*(
     self: ref Eth2Processor, src: MsgSource,
     blsToExecutionChange: SignedBLSToExecutionChange):
     Future[ValidationRes] {.async: (raises: [CancelledError]).} =
+  let
+    timeConfig = self.dag.cfg.time
+    wallTime = self.getCurrentBeaconTime()
+    wallSlot = wallTime.slotOrZero(timeConfig)
+
   logScope:
     blsToExecutionChange = shortLog(blsToExecutionChange)
+    wallSlot
 
   debug "BLS to execution change received"
 
   let v = await self.validatorChangePool[].validateBlsToExecutionChange(
-    self.batchCrypto, blsToExecutionChange,
-    self.getCurrentBeaconTime().slotOrZero.epoch)
+    self.batchCrypto, blsToExecutionChange, wallSlot.epoch)
 
   if v.isOk():
     trace "BLS to execution change validated"
@@ -703,8 +708,9 @@ proc processSyncCommitteeMessage*(
     subcommitteeIdx: SyncSubcommitteeIndex,
     checkSignature: bool = true): Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
   let
+    timeConfig = self.dag.cfg.time
     wallTime = self.getCurrentBeaconTime()
-    wallSlot = wallTime.slotOrZero()
+    wallSlot = wallTime.slotOrZero(timeConfig)
 
   logScope:
     syncCommitteeMsg = shortLog(syncCommitteeMsg)
@@ -713,7 +719,6 @@ proc processSyncCommitteeMessage*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let
-    timeConfig = self.dag.cfg.time
     slot = syncCommitteeMsg.slot
     delay = wallTime - slot.sync_committee_message_deadline(timeConfig)
   debug "Sync committee message received", delay
@@ -751,8 +756,9 @@ proc processSignedContributionAndProof*(
     checkSignature: bool = true):
     Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
   let
+    timeConfig = self.dag.cfg.time
     wallTime = self.getCurrentBeaconTime()
-    wallSlot = wallTime.slotOrZero()
+    wallSlot = wallTime.slotOrZero(timeConfig)
 
   logScope:
     contribution = shortLog(contributionAndProof.message.contribution)
@@ -763,7 +769,6 @@ proc processSignedContributionAndProof*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let
-    timeConfig = self.dag.cfg.time
     slot = contributionAndProof.message.contribution.slot
     delay = wallTime - slot.sync_contribution_deadline(timeConfig)
   debug "Contribution received", delay

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -417,7 +417,7 @@ proc validateBlobSidecar*(
   # `block_header.slot <= current_slot` (a client MAY queue future sidecars
   # for processing at the appropriate slot).
   if not (block_header.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero):
+      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.cfg.time)):
     return errIgnore("BlobSidecar: slot too high")
 
   # [IGNORE] The sidecar is from a slot greater than the latest
@@ -610,7 +610,7 @@ proc validateDataColumnSidecar*(
   # `block_header.slot <= current_slot`(a client MAY queue future sidecars for
   # processing at the appropriate slot).
   if not (block_header.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero):
+      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.cfg.time)):
     return errIgnore("DataColumnSidecar: slot too high")
 
   # [IGNORE] The sidecar is from a slot greater than the latest
@@ -788,7 +788,7 @@ proc validateBeaconBlock*(
   # signed_beacon_block.message.slot <= current_slot (a client MAY queue future
   # blocks for processing at the appropriate slot).
   if not (signed_beacon_block.message.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero):
+      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.cfg.time)):
     return errIgnore("BeaconBlock: slot too high")
 
   # [IGNORE] The block is from a slot greater than the latest finalized slot --
@@ -1004,9 +1004,11 @@ proc validateAttestation*(
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#beacon_attestation_subnet_id
   # modifies this for Deneb and newer forks.
   block:
-    let v = check_propagation_slot_range(
-      pool.dag.cfg.consensusForkAtEpoch(wallTime.slotOrZero.epoch), slot,
-      wallTime)
+    let
+      timeConfig = pool.dag.cfg.time
+      wallEpoch = wallTime.slotOrZero(timeConfig).epoch
+      consensusFork = pool.dag.cfg.consensusForkAtEpoch(wallEpoch)
+      v = check_propagation_slot_range(consensusFork, slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -192,7 +192,7 @@ proc tryForceUpdate(
     self: var LightClientProcessor,
     wallTime: BeaconTime) =
   ## Try to force-update to the next sync committee period.
-  let wallSlot = wallTime.slotOrZero()
+  let wallSlot = wallTime.slotOrZero(self.cfg.time)
   doAssert self.finalizationMode == LightClientFinalizationMode.Optimistic
 
   withForkyStore(self.store[]):
@@ -252,7 +252,7 @@ proc doProcessObject(
     withForkyStore(self.store[]):
       when lcDataFork > LightClientDataFork.None:
         let
-          wallSlot = wallTime.slotOrZero()
+          wallSlot = wallTime.slotOrZero(self.cfg.time)
           upgradedUpdate = update.migratingToDataFork(lcDataFork)
         process_light_client_update(
           forkyStore, upgradedUpdate.forky(lcDataFork), wallSlot,

--- a/beacon_chain/gossip_processing/optimistic_processor.nim
+++ b/beacon_chain/gossip_processing/optimistic_processor.nim
@@ -46,7 +46,7 @@ proc validateBeaconBlock(
     wallTime: BeaconTime): Result[void, ValidationError] =
   ## Minimally validate a block for potential relevance.
   if not (signed_beacon_block.message.slot <=
-      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero):
+      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(self.timeConfig)):
     return errIgnore("BeaconBlock: slot too high")
 
   if not signed_beacon_block.message.is_execution_block():

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -271,7 +271,7 @@ proc ETHBeaconClockGetSlot(beaconClock: ptr BeaconClock): cint {.exported.} =
   ##
   ## See:
   ## * https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/beacon-chain.md#custom-types
-  beaconClock[].now().slotOrZero().cint
+  beaconClock[].currentSlot.cint
 
 const lcDataFork = LightClientDataFork.high
 
@@ -428,7 +428,7 @@ proc ETHLightClientStoreGetNextSyncTask(
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Beacon/getLightClientOptimisticUpdate
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Events/eventstream
   let syncTask = nextLightClientSyncTask(
-    current = beaconClock[].now().slotOrZero().sync_committee_period,
+    current = beaconClock[].currentSlot.sync_committee_period,
     finalized = store[].finalized_header.beacon.slot.sync_committee_period,
     optimistic = store[].optimistic_header.beacon.slot.sync_committee_period,
     isNextSyncCommitteeKnown = store[].is_next_sync_committee_known)
@@ -514,8 +514,7 @@ proc ETHLightClientStoreProcessUpdatesByRange(
   ## See:
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Beacon/getLightClientUpdatesByRange
   let
-    wallTime = beaconClock[].now()
-    currentSlot = wallTime.slotOrZero()
+    currentSlot = beaconClock[].currentSlot
     mediaType = MediaType.init($mediaType)
   var updates =
     try:
@@ -597,8 +596,7 @@ proc ETHLightClientStoreProcessFinalityUpdate(
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Beacon/getLightClientFinalityUpdate
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Events/eventstream
   let
-    wallTime = beaconClock[].now()
-    currentSlot = wallTime.slotOrZero()
+    currentSlot = beaconClock[].currentSlot
     mediaType = MediaType.init($mediaType)
   var finalityUpdate =
     try:
@@ -682,8 +680,7 @@ proc ETHLightClientStoreProcessOptimisticUpdate(
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Beacon/getLightClientOptimisticUpdate
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v2.4.1#/Events/eventstream
   let
-    wallTime = beaconClock[].now()
-    currentSlot = wallTime.slotOrZero()
+    currentSlot = beaconClock[].currentSlot
     mediaType = MediaType.init($mediaType)
   var optimisticUpdate =
     try:

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -282,8 +282,9 @@ proc installMessageValidators*(
   # When registering multiple message validators, IGNORE results take precedence
   # over ACCEPT results. However, because the opposite behaviour is needed here,
   # we handle both full node and light client validation in this module
-  template getLocalWallPeriod(): auto =
-    lightClient.getBeaconTime().slotOrZero().sync_committee_period
+  template getLocalWallPeriod(): SyncCommitteePeriod =
+    lightClient.getBeaconTime().slotOrZero(lightClient.cfg.time)
+      .sync_committee_period
 
   template validate[T: SomeForkyLightClientObject](
       msg: T,

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1629,13 +1629,16 @@ proc getLowSubnets(node: Eth2Node, epoch: Epoch):
       default(CgcBits)
   )
 
+proc getWallEpoch(node: Eth2Node): Epoch =
+  node.getBeaconTime().slotOrZero(node.cfg.time).epoch
+
 proc runDiscoveryLoop(node: Eth2Node) {.async: (raises: [CancelledError]).} =
   debug "Starting discovery loop"
 
   while true:
     let
-      currentEpoch = node.getBeaconTime().slotOrZero.epoch
-      (wantedAttnets, wantedSyncnets, wantedCgcnets) = node.getLowSubnets(currentEpoch)
+      (wantedAttnets, wantedSyncnets, wantedCgcnets) =
+        node.getLowSubnets(node.getWallEpoch)
       wantedAttnetsCount = wantedAttnets.countOnes()
       wantedSyncnetsCount = wantedSyncnets.countOnes()
       wantedCgcnetsCount = wantedCgcnets.countOnes()
@@ -2178,14 +2181,11 @@ func updateMetadataV2ToV3(metadataRes: NetRes[altair.MetaData]):
 proc getMetadata_vx(node: Eth2Node, peer: Peer):
                     Future[NetRes[fulu.MetaData]]
                    {.async: (raises: [CancelledError]).} =
-  let
-    res =
-      if node.getBeaconTime().slotOrZero.epoch >= node.cfg.FULU_FORK_EPOCH:
-        # Directly fetch fulu metadata if available
-        await getMetadata_v3(peer)
-      else:
-        updateMetadataV2ToV3(await getMetadata_v2(peer))
-  return res
+  if node.getWallEpoch >= node.cfg.FULU_FORK_EPOCH:
+    # Directly fetch fulu metadata if available
+    await getMetadata_v3(peer)
+  else:
+    updateMetadataV2ToV3(await getMetadata_v2(peer))
 
 proc updatePeerMetadata(node: Eth2Node, peerId: PeerId) {.async: (raises: [CancelledError]).} =
   trace "updating peer metadata", peerId
@@ -2376,11 +2376,9 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
                      genesis_validators_root: Eth2Digest): Eth2Node
                     {.raises: [CatchableError].} =
   let
-    enrForkId = getENRForkID(
-      cfg, getBeaconTime().slotOrZero.epoch, genesis_validators_root)
-
-    discoveryForkId = getDiscoveryForkID(
-      cfg, getBeaconTime().slotOrZero.epoch, genesis_validators_root)
+    wallEpoch = getBeaconTime().slotOrZero(cfg.time).epoch
+    enrForkId = cfg.getENRForkID(wallEpoch, genesis_validators_root)
+    discoveryForkId = cfg.getDiscoveryForkID(wallEpoch, genesis_validators_root)
 
     listenAddress =
       if config.listenAddress.isSome():
@@ -2777,9 +2775,6 @@ proc updateForkId*(node: Eth2Node, epoch: Epoch, genesis_validators_root: Eth2Di
 
 func forkDigestAtEpoch*(node: Eth2Node, epoch: Epoch): ForkDigest =
   node.forkDigests[].atEpoch(epoch, node.cfg)
-
-proc getWallEpoch(node: Eth2Node): Epoch =
-  node.getBeaconTime().slotOrZero.epoch
 
 proc broadcastAttestation*(
     node: Eth2Node, subnet_id: SubnetId,

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -75,15 +75,18 @@ func forkDigestAtEpoch(state: PeerSyncNetworkState,
                        epoch: Epoch): ForkDigest =
   state.forkDigests[].atEpoch(epoch, state.cfg)
 
+proc getWallEpoch(state: PeerSyncNetworkState): Epoch =
+  state.getBeaconTime().slotOrZero(state.cfg.time).epoch
+
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/p2p-interface.md#status
 proc getCurrentStatusV1(state: PeerSyncNetworkState): StatusMsg =
   let
     dag = state.dag
-    wallSlot = state.getBeaconTime().slotOrZero
+    wallEpoch = state.getWallEpoch
 
   if dag != nil:
     StatusMsg(
-      forkDigest: state.forkDigestAtEpoch(wallSlot.epoch),
+      forkDigest: state.forkDigestAtEpoch(wallEpoch),
       finalizedRoot:
         (if dag.finalizedHead.slot.epoch != GENESIS_EPOCH:
            dag.finalizedHead.blck.root
@@ -96,7 +99,7 @@ proc getCurrentStatusV1(state: PeerSyncNetworkState): StatusMsg =
       headSlot: dag.head.slot)
   else:
     StatusMsg(
-      forkDigest: state.forkDigestAtEpoch(wallSlot.epoch),
+      forkDigest: state.forkDigestAtEpoch(wallEpoch),
       # this defaults to `Root(b'\x00' * 32)` for the genesis finalized
       # checkpoint
       finalizedRoot: ZERO_HASH,
@@ -108,11 +111,11 @@ proc getCurrentStatusV1(state: PeerSyncNetworkState): StatusMsg =
 proc getCurrentStatusV2(state: PeerSyncNetworkState): StatusMsgV2 =
   let
     dag = state.dag
-    wallSlot = state.getBeaconTime().slotOrZero
+    wallEpoch = state.getWallEpoch
 
   if dag != nil:
     StatusMsgV2(
-      forkDigest: state.forkDigestAtEpoch(wallSlot.epoch),
+      forkDigest: state.forkDigestAtEpoch(wallEpoch),
       finalizedRoot:
         (if dag.finalizedHead.slot.epoch != GENESIS_EPOCH:
            dag.finalizedHead.blck.root
@@ -126,7 +129,7 @@ proc getCurrentStatusV2(state: PeerSyncNetworkState): StatusMsgV2 =
       earliestAvailableSlot: dag.earliestAvailableSlot())
   else:
     StatusMsgV2(
-      forkDigest: state.forkDigestAtEpoch(wallSlot.epoch),
+      forkDigest: state.forkDigestAtEpoch(wallEpoch),
       # this defaults to `Root(b'\x00' * 32)` for the genesis finalized
       # checkpoint
       finalizedRoot: ZERO_HASH,
@@ -139,7 +142,9 @@ proc checkStatusMsg(state: PeerSyncNetworkState, status: StatusMsg | StatusMsgV2
     Result[void, cstring] =
   let
     dag = state.dag
-    wallSlot = (state.getBeaconTime() + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero
+    wallSlot = (
+      state.getBeaconTime() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+    ).slotOrZero(state.cfg.time)
 
   if status.finalizedEpoch > status.headSlot.epoch:
     # Can be equal during genesis or checkpoint start
@@ -203,10 +208,8 @@ p2pProtocol PeerSync(version = 1,
     #      this needs more thinking around the ordering of events and the
     #      given incoming flag
 
-    let
-      remoteFork = peer.networkState.getBeaconTime().slotOrZero.epoch()
-
-    if remoteFork >= peer.networkState.cfg.FULU_FORK_EPOCH:
+    let wallEpoch = peer.networkState.getWallEpoch
+    if wallEpoch >= peer.networkState.cfg.FULU_FORK_EPOCH:
       let
         ourStatus = peer.networkState.getCurrentStatusV2()
         theirStatus =
@@ -330,10 +333,8 @@ proc handleStatusV2(peer: Peer,
 
 proc updateStatus*(peer: Peer): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Request `status` of remote peer ``peer``.
-  let
-    nstate = peer.networkState(PeerSync)
-
-  if nstate.getBeaconTime().slotOrZero.epoch() >= nstate.cfg.FULU_FORK_EPOCH:
+  let nstate = peer.networkState(PeerSync)
+  if nstate.getWallEpoch >= nstate.cfg.FULU_FORK_EPOCH:
     let
       ourStatus = getCurrentStatusV2(nstate)
       theirStatus =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -265,7 +265,7 @@ proc checkWeakSubjectivityCheckpoint(
     wsCheckpoint: Checkpoint,
     beaconClock: BeaconClock) =
   let
-    currentSlot = beaconClock.now.slotOrZero
+    currentSlot = beaconClock.currentSlot
     isCheckpointStale = not is_within_weak_subjectivity_period(
       dag.cfg, currentSlot, dag.headState, wsCheckpoint)
 
@@ -369,7 +369,7 @@ proc initFullNode(
     dag.head.slot
 
   proc getLocalWallSlot(): Slot =
-    node.beaconClock.now.slotOrZero
+    node.currentSlot
 
   func getFirstSlotAtFinalizedEpoch(): Slot =
     dag.finalizedHead.slot
@@ -390,8 +390,7 @@ proc initFullNode(
     max(dag.frontfill.get(BlockId()).slot, dag.horizon)
 
   proc isWithinWeakSubjectivityPeriod(): bool =
-    isSlotWithinWeakSubjectivityPeriod(node.dag,
-      node.beaconClock.now().slotOrZero())
+    isSlotWithinWeakSubjectivityPeriod(node.dag, node.currentSlot)
 
   proc forkAtEpoch(epoch: Epoch): ConsensusFork =
     consensusForkAtEpoch(dag.cfg, epoch)
@@ -671,7 +670,7 @@ proc initFullNode(
   block:
     # Add in-process validators to the list of "known" validators such that
     # we start with a reasonable ENR
-    let wallSlot = node.beaconClock.now().slotOrZero()
+    let wallSlot = node.currentSlot
     for validator in node.attachedValidators[].validators.values():
       if config.validatorMonitorAuto:
         node.validatorMonitor[].addMonitor(validator.pubkey, validator.index)
@@ -735,7 +734,7 @@ proc init*(
       beaconClock = BeaconClock.init(metadata.cfg.time, genesisTime).valueOr:
         fatal "Invalid genesis time in genesis state", genesisTime
         quit 1
-      currentSlot = beaconClock.now().slotOrZero()
+      currentSlot = beaconClock.currentSlot
       checkpoint = Checkpoint(
         epoch: epoch(getStateField(genesisState[], slot)),
         root: getStateField(genesisState[], latest_block_header).state_root)
@@ -1023,6 +1022,7 @@ proc init*(
         validatorPool,
         keystoreCache,
         rng,
+        cfg.time,
         keymanagerInitResult.token,
         config.validatorsDir,
         config.secretsDir,
@@ -2094,7 +2094,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
   let
     timeConfig = node.dag.cfg.time
     # The slot we should be at, according to the clock
-    wallSlot = wallTime.slotOrZero
+    wallSlot = wallTime.slotOrZero(timeConfig)
     # If everything was working perfectly, the slot that we should be processing
     expectedSlot = lastSlot + 1
     finalizedEpoch = node.dag.finalizedHead.blck.slot.epoch()
@@ -2156,7 +2156,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
 proc runSlotLoop(node: BeaconNode, startTime: BeaconTime) {.async.} =
   let timeConfig = node.dag.cfg.time
   var
-    curSlot = startTime.slotOrZero()
+    curSlot = startTime.slotOrZero(timeConfig)
     nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
     timeToNextSlot = nextSlot.start_beacon_time(timeConfig) - startTime
 
@@ -2174,7 +2174,7 @@ proc runSlotLoop(node: BeaconNode, startTime: BeaconTime) {.async.} =
 
     let
       wallTime = node.beaconClock.now()
-      wallSlot = wallTime.slotOrZero() # Always > GENESIS!
+      wallSlot = wallTime.slotOrZero(timeConfig)  # Always >= GENESIS!
 
     if wallSlot < nextSlot:
       # While we were sleeping, the system clock changed and time moved
@@ -2560,7 +2560,7 @@ proc run*(node: BeaconNode, stopper: StopFuture) {.raises: [CatchableError].} =
 
   let
     wallTime = node.beaconClock.now()
-    wallSlot = wallTime.slotOrZero()
+    wallSlot = wallTime.slotOrZero(timeConfig)
 
   node.startLightClient()
   node.requestManager.start()

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -174,7 +174,7 @@ proc main() {.noinline, raises: [CatchableError].} =
 
           info "New LC optimistic header"
           if elManager == nil or blockHash.isZero or
-              not isSynced(bid.slot, getBeaconTime().slotOrZero()):
+              not isSynced(bid.slot, beaconClock.currentSlot):
             return
 
           withConsensusFork(consensusFork):
@@ -264,7 +264,7 @@ proc main() {.noinline, raises: [CatchableError].} =
 
   proc onSlot(wallTime: BeaconTime, lastSlot: Slot) =
     let
-      wallSlot = wallTime.slotOrZero()
+      wallSlot = wallTime.slotOrZero(cfg.time)
       expectedSlot = lastSlot + 1
       delay = wallTime - expectedSlot.start_beacon_time(cfg.time)
 
@@ -301,24 +301,24 @@ proc main() {.noinline, raises: [CatchableError].} =
 
   proc runOnSlotLoop() {.async.} =
     var
-      curSlot = getBeaconTime().slotOrZero()
+      curSlot = beaconClock.currentSlot
       nextSlot = curSlot + 1
-      timeToNextSlot = nextSlot.start_beacon_time(cfg.time) - getBeaconTime()
+      timeToNextSlot = nextSlot.start_beacon_time(cfg.time) - beaconClock.now
     while true:
       await sleepAsync(timeToNextSlot)
 
       let
-        wallTime = getBeaconTime()
-        wallSlot = wallTime.slotOrZero()
+        wallTime = beaconClock.now
+        wallSlot = wallTime.slotOrZero(cfg.time)
 
       onSlot(wallTime, curSlot)
 
       curSlot = wallSlot
       nextSlot = wallSlot + 1
-      timeToNextSlot = nextSlot.start_beacon_time(cfg.time) - getBeaconTime()
+      timeToNextSlot = nextSlot.start_beacon_time(cfg.time) - beaconClock.now
 
   proc onSecond(time: Moment) =
-    let wallSlot = getBeaconTime().slotOrZero()
+    let wallSlot = beaconClock.currentSlot
     if checkIfShouldStopAtEpoch(wallSlot, config.stopAtEpoch):
       quit(0)
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -216,8 +216,7 @@ proc initClock(
       raise (ref ValidatorClientError)(
         msg: "Invalid genesis time: " & $vc.beaconGenesis.genesis_time &
              "; seconds_per_slot=" & $vc.timeConfig.SECONDS_PER_SLOT)
-    currentTime = res.now()
-    currentSlot = currentTime.slotOrZero()
+    currentSlot = res.currentSlot()
     currentEpoch = currentSlot.epoch()
     genesisTime = res.fromNow(Slot(0))
 
@@ -242,7 +241,7 @@ proc runVCSlotLoop(
     vc: ValidatorClientRef) {.async: (raises: [CancelledError]).} =
   var
     startTime = vc.beaconClock.now()
-    curSlot = startTime.slotOrZero()
+    curSlot = startTime.slotOrZero(vc.timeConfig)
     nextSlot = curSlot + 1 # No earlier than GENESIS_SLOT + 1
     timeToNextSlot = nextSlot.start_beacon_time(vc.timeConfig) - startTime
 
@@ -461,6 +460,7 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
         validatorPool,
         vc.keystoreCache,
         vc.rng,
+        vc.timeConfig,
         keymanagerInitResult.token,
         vc.config.validatorsDir,
         vc.config.secretsDir,

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -578,7 +578,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
     let
       qpubkey = pubkey.valueOr:
         return keymanagerApiError(Http400, InvalidValidatorPublicKey)
-      currentEpoch = host.getBeaconTimeFn().slotOrZero().epoch()
+      currentEpoch = host.getBeaconTimeFn().slotOrZero(host.timeConfig).epoch()
       qepoch =
         if epoch.isSome():
           let res = epoch.get()

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -1,3 +1,4 @@
+# beacon_chain
 # Copyright (c) 2021-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -259,7 +260,7 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Node/getSyncingStatus
   router.api2(MethodGet, "/eth/v1/node/syncing") do () -> RestApiResponse:
     let
-      wallSlot = node.beaconClock.now().slotOrZero()
+      wallSlot = node.currentSlot
       headSlot = node.dag.head.slot
       distance = wallSlot - headSlot
       isSyncing =

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -1,3 +1,4 @@
+# beacon_chain
 # Copyright (c) 2018-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
@@ -57,8 +58,9 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            $epoch.error())
         let
           res = epoch.get()
+          timeConfig = node.dag.cfg.time
           wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-          wallEpoch = wallTime.slotOrZero().epoch
+          wallEpoch = wallTime.slotOrZero(timeConfig).epoch
         if res > wallEpoch + 1:
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
                                         "Cannot request duties past next epoch")
@@ -118,8 +120,9 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                            $epoch.error())
         let
           res = epoch.get()
+          timeConfig = node.dag.cfg.time
           wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-          wallEpoch = wallTime.slotOrZero().epoch
+          wallEpoch = wallTime.slotOrZero(timeConfig).epoch
         if res > wallEpoch + 1:
           return RestApiResponse.jsonError(Http400, InvalidEpochValueError,
                                         "Cannot request duties past next epoch")
@@ -349,9 +352,10 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         if res <= node.dag.finalizedHead.slot:
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            "Slot already finalized")
-        let wallTime =
-          node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
-        if res > wallTime.slotOrZero:
+        let
+          timeConfig = node.dag.cfg.time
+          wallTime = node.beaconClock.now() + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+        if res > wallTime.slotOrZero(timeConfig):
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            "Slot cannot be in the future")
         res
@@ -499,12 +503,14 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http400, InvalidSlotValueError,
                                            "Slot already finalized")
         let
+          timeConfig = node.dag.cfg.time
           wallTime = node.beaconClock.now()
-        if qslot > (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero:
+          maxTime = wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY
+        if qslot > maxTime.slotOrZero(timeConfig):
           return RestApiResponse.jsonError(
             Http400, InvalidSlotValueError, "Slot cannot be in the future")
         if qslot + SLOTS_PER_EPOCH <
-            (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero:
+            (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(timeConfig):
           return RestApiResponse.jsonError(
             Http400, InvalidSlotValueError,
             "Slot cannot be more than an epoch in the past")
@@ -732,7 +738,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonError(Http503, BeaconNodeInSyncError)
 
     let
-      wallSlot = node.beaconClock.now.slotOrZero
+      wallSlot = node.currentSlot
       wallEpoch = wallSlot.epoch
       head = node.dag.head
 
@@ -958,7 +964,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             return RestApiResponse.jsonError(Http400,
                                              InvalidPrepareBeaconProposerError)
           dres.get()
-      currentEpoch = node.beaconClock.now.slotOrZero.epoch
+      currentEpoch = node.currentSlot.epoch
 
     var
       numUpdated = 0

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -191,7 +191,7 @@ func light_client_optimistic_update_time*(
     s: Slot, timeConfig: TimeConfig): BeaconTime =
   s.start_beacon_time(timeConfig) + lightClientOptimisticUpdateSlotOffset
 
-func slotOrZero*(time: BeaconTime): Slot =
+func slotOrZero*(time: BeaconTime, timeConfig: TimeConfig): Slot =
   let exSlot = time.toSlot
   if exSlot.afterGenesis: exSlot.slot
   else: Slot(0)

--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -365,7 +365,7 @@ proc loop(self: LightClientManager) {.async: (raises: [CancelledError]).} =
 
     # Fetch updates
     let
-      current = wallTime.slotOrZero().sync_committee_period
+      current = wallTime.slotOrZero(self.timeConfig).sync_committee_period
 
       syncTask = nextLightClientSyncTask(
         current = current,

--- a/beacon_chain/sync/light_client_sync_helpers.nim
+++ b/beacon_chain/sync/light_client_sync_helpers.nim
@@ -118,7 +118,7 @@ func nextLcSyncTaskDelay*(
     didLatestSyncTaskProgress: bool
 ): Duration =
   let
-    current = wallTime.slotOrZero().sync_committee_period
+    current = wallTime.slotOrZero(timeConfig).sync_committee_period
     remainingDuration =
       if not current.isGossipSupported(finalized, isNextSyncCommitteeKnown):
         if didLatestSyncTaskProgress:
@@ -129,7 +129,7 @@ func nextLcSyncTaskDelay*(
       elif finalized != optimistic:
         # Current sync committee period
         let
-          wallPeriod = wallTime.slotOrZero().sync_committee_period
+          wallPeriod = wallTime.slotOrZero(timeConfig).sync_committee_period
           deadlineSlot = (wallPeriod + 1).start_slot - 1
           deadline = deadlineSlot.start_beacon_time(timeConfig)
         chronos.nanoseconds((deadline - wallTime).nanoseconds)

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -512,7 +512,7 @@ proc getMissingBlobs(rman: RequestManager): seq[BlobIdentifier] =
   let
     timeConfig = rman.network.cfg.time
     wallTime = rman.getBeaconTime()
-    wallSlot = wallTime.slotOrZero()
+    wallSlot = wallTime.slotOrZero(timeConfig)
     delay = wallTime - wallSlot.start_beacon_time(timeConfig)
     waitDur = TimeDiff(nanoseconds: BLOB_GOSSIP_WAIT_TIME_NS)
 
@@ -625,7 +625,7 @@ proc getMissingDataColumns(rman: RequestManager): seq[DataColumnsByRootIdentifie
   let
     timeConfig = rman.network.cfg.time
     wallTime = rman.getBeaconTime()
-    wallSlot = wallTime.slotOrZero()
+    wallSlot = wallTime.slotOrZero(timeConfig)
     delay = wallTime - wallSlot.start_beacon_time(timeConfig)
 
   const waitDur = TimeDiff(nanoseconds: DATA_COLUMN_GOSSIP_WAIT_TIME_NS)
@@ -748,9 +748,10 @@ proc start*(rman: var RequestManager) =
   rman.blobLoopFuture = rman.requestManagerBlobLoop()
 
 proc switchToColumnLoop*(rman: var RequestManager) =
-  let currentEpoch =
-      rman.getBeaconTime().slotOrZero().epoch()
-
+  let
+    timeConfig = rman.network.cfg.time
+    currentEpoch = rman.getBeaconTime().slotOrZero(timeConfig).epoch()
+    
   if currentEpoch >= rman.network.cfg.FULU_FORK_EPOCH and
      isNil(rman.dataColumnLoopFuture):
     if not(isNil(rman.blobLoopFuture)):

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -60,12 +60,15 @@ iterator chunks*(data: openArray[BlockData],
     yield BlockDataChunk.init(stateCallback,
       data.toOpenArray(i, min(i + maxCount, len(data)) - 1))
 
+proc getWallSlot(overseer: SyncOverseerRef): Slot =
+  overseer.beaconClock.currentSlot
+
 proc syncDistance*(
     overseer: SyncOverseerRef
 ): uint64 =
   let
     dag = overseer.consensusManager.dag
-    wallSlot = overseer.getBeaconTimeFn().slotOrZero()
+    wallSlot = overseer.getWallSlot()
     headSlot = dag.head.slot
   wallSlot - headSlot
 
@@ -148,7 +151,7 @@ proc isWithinWeakSubjectivityPeriod(
     overseer: SyncOverseerRef, slot: Slot): bool =
   let
     dag = overseer.consensusManager.dag
-    currentSlot = overseer.beaconClock.now().slotOrZero()
+    currentSlot = overseer.getWallSlot()
     checkpoint = Checkpoint(
       epoch:
         getStateField(dag.headState, slot).epoch(),
@@ -161,7 +164,7 @@ proc isWithinWeakSubjectivityPeriod(
 proc getLastBlockRetentionPeriodSlot(overseer: SyncOverseerRef): Slot =
   let
     dag = overseer.consensusManager.dag
-    currentSlot = overseer.beaconClock.now().slotOrZero()
+    currentSlot = overseer.getWallSlot()
     slotsCount = dag.cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS * SLOTS_PER_EPOCH
   if currentSlot < slotsCount:
     GENESIS_SLOT
@@ -250,7 +253,7 @@ proc blockProcessingLoop(overseer: SyncOverseerRef): Future[void] {.
               bchunk.resfut.complete(Result[void, string].err(msg))
               break innerLoop
 
-          consensusManager[].updateHead(overseer.getBeaconTimeFn().slotOrZero())
+          consensusManager[].updateHead(overseer.getWallSlot())
 
         bchunk.resfut.complete(Result[void, string].ok())
 
@@ -380,7 +383,7 @@ proc initUntrustedSync(overseer: SyncOverseerRef): Future[void] {.
 
   notice "Received light client block header",
          beacon_header = shortLog(blockHeader),
-         current_slot = overseer.beaconClock.now().slotOrZero()
+         current_slot = overseer.getWallSlot()
 
   overseer.statusMsg = Opt.some("retrieving block")
 
@@ -450,7 +453,7 @@ proc mainLoop*(
   let
     dag = overseer.consensusManager.dag
     clist = overseer.clist
-    currentSlot = overseer.beaconClock.now().slotOrZero()
+    currentSlot = overseer.getWallSlot()
 
   info "Sync overseer starting",
        wall_slot = currentSlot,
@@ -565,7 +568,7 @@ proc syncStatusMessage*(
 ): string =
   let
     dag = overseer.consensusManager.dag
-    wallSlot = overseer.getBeaconTimeFn().slotOrZero()
+    wallSlot = overseer.getWallSlot()
     optimistic = not(dag.head.executionValid)
     optSuffix =
       if not(dag.head.executionValid):

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -18,7 +18,7 @@ import
 
 from presto import RestDecodingError
 from "."/beacon_clock import
-  BeaconClock, fromFloatSeconds, getBeaconTimeFn, init
+  BeaconClock, fromFloatSeconds, currentSlot, init
 
 const
   largeRequestsTimeout = 3.minutes  # Downloading large items such as states.
@@ -178,7 +178,6 @@ proc doTrustedNodeSync*(
           beaconClock = BeaconClock.init(cfg.time, genesisTime).valueOr:
             error "Invalid genesis time in state", genesisTime
             quit 1
-          getBeaconTime = beaconClock.getBeaconTimeFn()
 
           genesis_validators_root =
             getStateField(genesisState[], genesis_validators_root)
@@ -219,7 +218,7 @@ proc doTrustedNodeSync*(
             optimistic =
               store.optimistic_header.beacon.slot.sync_committee_period
             current =
-              getBeaconTime().slotOrZero().sync_committee_period
+              beaconClock.currentSlot.sync_committee_period
             isNextSyncCommitteeKnown =
               store.is_next_sync_committee_known
 
@@ -262,7 +261,7 @@ proc doTrustedNodeSync*(
             updates[i].migrateToDataFork(lcDataFork)
             let res = process_light_client_update(
               store, updates[i].forky(lcDataFork),
-              getBeaconTime().slotOrZero(), cfg, genesis_validators_root)
+              beaconClock.currentSlot, cfg, genesis_validators_root)
             if not res.isOk:
               error "`process_light_client_update` failed", resError = res.error
               quit 1
@@ -287,7 +286,7 @@ proc doTrustedNodeSync*(
 
         let res = process_light_client_update(
           store, finalityUpdate.forky(lcDataFork),
-          getBeaconTime().slotOrZero(), cfg, genesis_validators_root)
+          beaconClock.currentSlot, cfg, genesis_validators_root)
         if not res.isOk:
           error "`process_light_client_update` failed", resError = res.error
           quit 1

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -46,7 +46,7 @@ proc prepareRandao(
     slot: Slot,
     proposerKey: ValidatorPubKey
 ) {.async: (raises: [CancelledError]).} =
-  if slot == vc.beaconClock.now().slotOrZero():
+  if slot == vc.beaconClock.currentSlot():
     # Its impossible to prepare RANDAO in the beginning of the epoch. Epoch
     # signature will be requested by block proposer.
     return
@@ -589,7 +589,7 @@ proc runBlockPollMonitor(service: BlockServiceRef,
 
     let
       currentTime = vc.beaconClock.now()
-      afterSlot = currentTime.slotOrZero()
+      afterSlot = currentTime.slotOrZero(vc.timeConfig)
 
     if currentTime > afterSlot.attestation_deadline(vc.timeConfig):
       # Attestation time already, lets wait for next slot.

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -988,7 +988,7 @@ proc getSubcommitteeIndex*(index: IndexInSyncCommittee): SyncSubcommitteeIndex =
   SyncSubcommitteeIndex(uint16(index) div SYNC_SUBCOMMITTEE_SIZE)
 
 proc currentSlot*(vc: ValidatorClientRef): Slot =
-  vc.beaconClock.now().slotOrZero()
+  vc.beaconClock.now().slotOrZero(vc.timeConfig)
 
 proc addValidator*(vc: ValidatorClientRef, keystore: KeystoreData) =
   let
@@ -1244,7 +1244,7 @@ proc checkedWaitForSlot*(vc: ValidatorClientRef, destinationSlot: Slot,
      async: (raises: [CancelledError]).} =
   let
     currentTime = vc.beaconClock.now()
-    currentSlot = currentTime.slotOrZero()
+    currentSlot = currentTime.slotOrZero(vc.timeConfig)
     chronosOffset = chronos.nanoseconds(
       if offset.nanoseconds < 0: 0'i64 else: offset.nanoseconds)
 
@@ -1263,7 +1263,7 @@ proc checkedWaitForSlot*(vc: ValidatorClientRef, destinationSlot: Slot,
 
     let
       wallTime = vc.beaconClock.now()
-      wallSlot = wallTime.slotOrZero()
+      wallSlot = wallTime.slotOrZero(vc.timeConfig)
 
     logScope:
       wall_time = shortLog(wallTime)
@@ -1308,20 +1308,16 @@ proc checkedWaitForNextSlot*(vc: ValidatorClientRef, curSlot: Opt[Slot],
                              showLogs: bool): Future[Opt[Slot]] {.
      async: (raises: [CancelledError], raw: true).} =
   let
-    currentTime = vc.beaconClock.now()
-    currentSlot = curSlot.valueOr: currentTime.slotOrZero()
+    currentSlot = curSlot.valueOr: vc.currentSlot()
     nextSlot = currentSlot + 1
-
   vc.checkedWaitForSlot(nextSlot, offset, showLogs)
 
 proc checkedWaitForNextSlot*(vc: ValidatorClientRef, offset: TimeDiff,
                              showLogs: bool): Future[Opt[Slot]] {.
      async: (raises: [CancelledError], raw: true).} =
   let
-    currentTime = vc.beaconClock.now()
-    currentSlot = currentTime.slotOrZero()
+    currentSlot = vc.currentSlot()
     nextSlot = currentSlot + 1
-
   vc.checkedWaitForSlot(nextSlot, offset, showLogs)
 
 proc expectBlock*(vc: ValidatorClientRef, slot: Slot,

--- a/beacon_chain/validator_client/doppelganger_service.nim
+++ b/beacon_chain/validator_client/doppelganger_service.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -70,7 +70,7 @@ proc mainLoop(service: DoppelgangerServiceRef) {.async: (raises: []).} =
   # the epoch - there's no activity in the genesis slot, so if we start at or
   # before that, we can safely perform the check for epoch 0 and thus keep
   # validating in epoch 1
-  if vc.beaconClock.now().slotOrZero() > GENESIS_SLOT:
+  if vc.currentSlot() > GENESIS_SLOT:
     try:
       await service.waitForNextEpoch(TIME_DELAY_FROM_SLOT)
     except CancelledError:

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -724,7 +724,7 @@ proc syncCommitteeDutiesLoop(
 proc getNextEpochMiddleSlot(vc: ValidatorClientRef): Slot =
   let
     middleSlot = Slot(SLOTS_PER_EPOCH div 2)
-    currentSlot = vc.beaconClock.now().slotOrZero()
+    currentSlot = vc.currentSlot()
     slotInEpoch = currentSlot.since_epoch_start()
 
   if slotInEpoch >= middleSlot:
@@ -737,7 +737,7 @@ proc pruneSlashingDatabase(
 ) {.async: (raises: [CancelledError]).} =
   let
     vc = service.client
-    currentSlot = vc.beaconClock.now().slotOrZero()
+    currentSlot = vc.currentSlot()
     startTime = Moment.now()
     blockHeader =
       try:

--- a/beacon_chain/validator_client/scoring.nim
+++ b/beacon_chain/validator_client/scoring.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -191,8 +191,7 @@ proc getSyncCommitteeMessageDataScore*(
        vc: ValidatorClientRef,
        cdata: GetBlockRootResponse
      ): float64 =
-  getSyncCommitteeMessageDataScore(
-    vc.rootsSeen, vc.beaconClock.now().slotOrZero(), cdata)
+  getSyncCommitteeMessageDataScore(vc.rootsSeen, vc.currentSlot(), cdata)
 
 proc processVotes(bits: var CommitteeBitsArray,
                   attestation: phase0.Attestation): int =

--- a/beacon_chain/validators/keystore_management.nim
+++ b/beacon_chain/validators/keystore_management.nim
@@ -87,6 +87,7 @@ type
     validatorPool*: ref ValidatorPool
     keystoreCache*: KeystoreCacheRef
     rng*: ref HmacDrbgContext
+    timeConfig*: TimeConfig
     keymanagerToken*: string
     validatorsDir*: string
     secretsDir*: string
@@ -126,6 +127,7 @@ func init*(T: type KeymanagerHost,
            validatorPool: ref ValidatorPool,
            keystoreCache: KeystoreCacheRef,
            rng: ref HmacDrbgContext,
+           timeConfig: TimeConfig,
            keymanagerToken: string,
            validatorsDir: string,
            secretsDir: string,
@@ -142,6 +144,7 @@ func init*(T: type KeymanagerHost,
   T(validatorPool: validatorPool,
     keystoreCache: keystoreCache,
     rng: rng,
+    timeConfig: timeConfig,
     keymanagerToken: keymanagerToken,
     validatorsDir: validatorsDir,
     secretsDir: secretsDir,

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -249,10 +249,12 @@ proc routeAttestation*(
     Future[SendResult] {.async: (raises: [CancelledError]).} =
   ## Process and broadcast attestation - processing will register the it with
   ## the attestation pool
+  let timeConfig = router.processor.dag.cfg.time
   block:
     let
       wallTime = router[].processor.getCurrentBeaconTime()
-      currentFork = router[].dag.cfg.consensusForkAtEpoch(wallTime.slotOrZero.epoch)
+      wallEpoch = wallTime.slotOrZero(timeConfig).epoch
+      currentFork = router[].dag.cfg.consensusForkAtEpoch(wallEpoch)
       res = await router[].processor.processAttestation(
         MsgSource.api, attestation, subnet_id,
         checkSignature = checkSignature, checkValidator = checkValidator,
@@ -264,7 +266,6 @@ proc routeAttestation*(
       return err(res.error()[1])
 
   let
-    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
     delay = sendTime - attestation.data.slot.attestation_deadline(timeConfig)
     res = await router[].network.broadcastAttestation(subnet_id, attestation)
@@ -318,13 +319,15 @@ proc routeSignedAggregateAndProof*(
     checkSignature = true):
     Future[SendResult] {.async: (raises: [CancelledError]).} =
   ## Validate and broadcast aggregate
+  let timeConfig = router.processor.dag.cfg.time
   block:
     # Because the aggregate was (most likely) produced by this beacon node,
     # we already know all attestations in it - we skip the coverage check so
     # that all processing happens anyway
     let
       wallTime = router[].processor.getCurrentBeaconTime()
-      currentFork = router[].dag.cfg.consensusForkAtEpoch(wallTime.slotOrZero.epoch)
+      wallEpoch = wallTime.slotOrZero(timeConfig).epoch
+      currentFork = router[].dag.cfg.consensusForkAtEpoch(wallEpoch)
       res = await router[].processor.processSignedAggregateAndProof(
         MsgSource.api, proof, checkSignature = checkSignature,
         checkCover = false, currentFork)
@@ -336,7 +339,6 @@ proc routeSignedAggregateAndProof*(
       return err(res.error()[1])
 
   let
-    timeConfig = router.processor.dag.cfg.time
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = proof.message.aggregate.data.slot
     delay = sendTime - slot.aggregate_deadline(timeConfig)
@@ -593,8 +595,10 @@ proc routeBlsToExecutionChange*(
             error = res.error()
       return err(res.error()[1])
 
-  if  router[].getCurrentBeaconTime().slotOrZero.epoch <
-      router[].processor[].dag.cfg.CAPELLA_FORK_EPOCH:
+  let
+    timeConfig = router.processor.dag.cfg.time
+    wallEpoch = router[].getCurrentBeaconTime().slotOrZero(timeConfig).epoch
+  if wallEpoch < router[].processor[].dag.cfg.CAPELLA_FORK_EPOCH:
     # Broadcast hasn't failed, it just hasn't happened; desire seems to be to
     # allow queuing up BLS to execution changes.
     return ok()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -235,7 +235,7 @@ proc stepOnBlock(
   # 2. Move state to proper slot
   doAssert dag.updateState(
     state,
-    dag.getBlockIdAtSlot(time.slotOrZero).expect("block exists"),
+    dag.getBlockIdAtSlot(time.slotOrZero(dag.cfg.time)).expect("block exists"),
     save = false,
     stateCache,
     dag.updateFlags
@@ -297,7 +297,8 @@ proc stepChecks(
   for check, val in checks:
     if check == "time":
       doAssert time.ns_since_genesis == val.getInt().seconds.nanoseconds()
-      doAssert fkChoice.checkpoints.time.slotOrZero == time.slotOrZero
+      let slot = fkChoice.checkpoints.time.slotOrZero(dag.cfg.time)
+      doAssert slot == time.slotOrZero(dag.cfg.time)
     elif check == "head":
       let headRoot = fkChoice[].get_head(dag, time).get()
       let headRef = dag.getBlockRef(headRoot).get()

--- a/tests/test_beacon_time.nim
+++ b/tests/test_beacon_time.nim
@@ -25,19 +25,26 @@ suite "Beacon time":
       s0.sync_committee_period() == SyncCommitteePeriod(0)
 
       # Roundtrip far times we treat these as "Infinity"
-      FAR_FUTURE_SLOT.epoch.start_slot() == FAR_FUTURE_SLOT
-      FAR_FUTURE_SLOT.sync_committee_period.start_slot() == FAR_FUTURE_SLOT
-      FAR_FUTURE_EPOCH.start_slot().epoch() == FAR_FUTURE_EPOCH
-      FAR_FUTURE_SLOT ==
-        FAR_FUTURE_SLOT.start_beacon_time(timeConfig).slotOrZero()
-      FAR_FUTURE_PERIOD.start_epoch().sync_committee_period() == FAR_FUTURE_PERIOD
-      FAR_FUTURE_PERIOD.start_slot().sync_committee_period() == FAR_FUTURE_PERIOD
+      FAR_FUTURE_SLOT == FAR_FUTURE_SLOT
+        .epoch.start_slot()
+      FAR_FUTURE_SLOT == FAR_FUTURE_SLOT
+        .sync_committee_period.start_slot()
+      FAR_FUTURE_EPOCH == FAR_FUTURE_EPOCH
+        .start_slot().epoch()
+      FAR_FUTURE_SLOT == FAR_FUTURE_SLOT
+        .start_beacon_time(timeConfig).slotOrZero(timeConfig)
+      FAR_FUTURE_PERIOD == FAR_FUTURE_PERIOD
+        .start_epoch().sync_committee_period()
+      FAR_FUTURE_PERIOD == FAR_FUTURE_PERIOD
+        .start_slot().sync_committee_period()
 
-      BeaconTime(ns_since_genesis: -10000000000).slotOrZero == Slot(0)
+      BeaconTime(ns_since_genesis: -10000000000)
+        .slotOrZero(timeConfig) == GENESIS_SLOT
       Slot(5).since_epoch_start() == 5
       (Epoch(42).start_slot() + 5).since_epoch_start() == 5
 
-      Slot(5).start_beacon_time(timeConfig) > Slot(4).start_beacon_time(timeConfig)
+      Slot(5).start_beacon_time(timeConfig) >
+        Slot(4).start_beacon_time(timeConfig)
 
       Slot(4).start_beacon_time(timeConfig) +
         (Slot(5).start_beacon_time(timeConfig) -


### PR DESCRIPTION
Conversion from time to slot also needs access to the TimeConfig. An alternative design based on storing TimeConfig inside BeaconTime was explored. While that reduces the amount of refactoring, such a design wouldn't be as clean, as it suggests to beacon_time module that each TimeConfig may come from a different BeaconClock. In such a setup (e.g., a hypothetical multi-network VC with various clocks), one would have to retain the entire BeaconClock not just the TimeConfig to catch time operations on times originated from different clocks. Further, the TimeConfig would have to be passed along internally on every minor operation such as adding an offset. Therefore, opted to follow existing approach to just pass TimeConfig explicitly where it will be needed.