### PR TITLE
Pass TimeParams to toSlot

### DIFF
--- a/beacon_chain/beacon_clock.nim
+++ b/beacon_chain/beacon_clock.nim
@@ -69,7 +69,7 @@ func toBeaconTime*(c: BeaconClock, t: Time): BeaconTime =
   BeaconTime(ns_since_genesis: inNanoseconds(t - c.genesis))
 
 func toSlot*(c: BeaconClock, t: Time): tuple[afterGenesis: bool, slot: Slot] =
-  c.toBeaconTime(t).toSlot()
+  c.toBeaconTime(t).toSlot(c.timeParams)
 
 proc now*(c: BeaconClock): BeaconTime =
   ## Current time, in slots - this may end up being less than GENESIS_SLOT(!)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -780,11 +780,8 @@ proc addBlock*(
 
       discard await idleAsync().withTimeout(idleTimeout)
 
-      let
-        wallTime = self.getBeaconTime()
-        (afterGenesis, _) = wallTime.toSlot()
-
-      if not afterGenesis:
+      let wallTime = self.getBeaconTime()
+      if not wallTime.afterGenesis:
         fatal "Processing block before genesis, clock turned back?"
         quit 1
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -223,7 +223,7 @@ proc processSignedBeaconBlock*(
 
   let
     wallTime = self.getCurrentBeaconTime()
-    (afterGenesis, wallSlot) = wallTime.toSlot()
+    (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
 
   logScope:
     blockRoot = shortLog(signedBlock.root)
@@ -298,11 +298,15 @@ proc processBlobSidecar*(
 
   let
     wallTime = self.getCurrentBeaconTime()
-    (_, wallSlot) = wallTime.toSlot()
+    (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
 
   logScope:
     blob = shortLog(blobSidecar)
     wallSlot
+
+  if not afterGenesis:
+    notice "Blob before genesis"
+    return errIgnore("Blob before genesis")
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime -
@@ -343,13 +347,19 @@ proc processDataColumnSidecar*(
     dataColumnSidecar: fulu.DataColumnSidecar,
     subnet_id: uint64): ValidationRes =
   template block_header: untyped = dataColumnSidecar.signed_block_header.message
+
   let
-    block_root = hash_tree_root(block_header)
     wallTime = self.getCurrentBeaconTime()
-    (_, wallSlot) = wallTime.toSlot()
+    (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
+
   logScope:
     dcs = shortLog(dataColumnSidecar)
     wallSlot
+
+  if not afterGenesis:
+    notice "Data column before genesis"
+    return errIgnore("Data column before genesis")
+
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime -
     block_header.slot.start_beacon_time(self.dag.timeParams)
@@ -358,12 +368,16 @@ proc processDataColumnSidecar*(
   let v =
     self.dag.validateDataColumnSidecar(self.quarantine, self.dataColumnQuarantine,
                                        dataColumnSidecar, wallTime, subnet_id)
+
   if v.isErr():
     debug "Dropping data column", error = v.error()
     data_column_sidecars_dropped.inc(1, [$v.error[0]])
     return v
+
+  let block_root = hash_tree_root(block_header)
   debug "Data column validated, putting data column in quarantine"
   self.dataColumnQuarantine[].put(block_root, newClone(dataColumnSidecar))
+
   if (let o = self.quarantine[].popSidecarless(block_root); o.isSome):
     withBlck(o[]):
       when consensusFork >= ConsensusFork.Fulu and
@@ -388,13 +402,16 @@ proc processDataColumnSidecar*(
     dataColumnSidecar: gloas.DataColumnSidecar,
     subnet_id: uint64): ValidationRes =
   let
-    block_root = dataColumnSidecar.beacon_block_root
     wallTime = self.getCurrentBeaconTime()
-    (_, wallSlot) = wallTime.toSlot()
+    (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
 
   logScope:
     dcs = shortLog(dataColumnSidecar)
     wallSlot
+
+  if not afterGenesis:
+    notice "Data column before genesis"
+    return errIgnore("Data column before genesis")
 
   debug "Data column received (Gloas - quarantine not implemented)"
 
@@ -465,7 +482,7 @@ proc processAttestation*(
     fork: ConsensusFork):
     Future[ValidationRes] {.async: (raises: [CancelledError]).} =
   var wallTime = self.getCurrentBeaconTime()
-  let (afterGenesis, wallSlot) = wallTime.toSlot()
+  let (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
 
   logScope:
     attestation = shortLog(attestation)
@@ -529,7 +546,7 @@ proc processSignedAggregateAndProof*(
     fork: ConsensusFork): Future[ValidationRes]
     {.async: (raises: [CancelledError]).} =
   var wallTime = self.getCurrentBeaconTime()
-  let (afterGenesis, wallSlot) = wallTime.toSlot()
+  let (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
 
   logScope:
     aggregate = shortLog(signedAggregateAndProof.message.aggregate)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -81,15 +81,17 @@ func check_attestation_block(
   ok()
 
 func check_propagation_slot_range(
-    consensusFork: ConsensusFork, msgSlot: Slot, wallTime: BeaconTime):
-    Result[Slot, ValidationError] =
-  let futureSlot = (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot()
-
+    timeParams: TimeParams,
+    consensusFork: ConsensusFork,
+    msgSlot: Slot,
+    wallTime: BeaconTime): Result[Slot, ValidationError] =
+  let futureSlot =
+    (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
   if not futureSlot.afterGenesis or msgSlot > futureSlot.slot:
     return errIgnore("Attestation slot in the future")
 
-  let pastSlot = (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot()
-
+  let pastSlot =
+    (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
   if not pastSlot.afterGenesis:
     return ok(msgSlot)
 
@@ -120,15 +122,17 @@ func check_propagation_slot_range(
 
   ok(msgSlot)
 
-func check_slot_exact(msgSlot: Slot, wallTime: BeaconTime):
-    Result[Slot, ValidationError] =
-  let futureSlot = (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot()
-
+func check_slot_exact(
+    timeParams: TimeParams,
+    msgSlot: Slot,
+    wallTime: BeaconTime): Result[Slot, ValidationError] =
+  let futureSlot =
+    (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
   if not futureSlot.afterGenesis or msgSlot > futureSlot.slot:
     return errIgnore("Sync committee slot in the future")
 
-  let pastSlot = (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot()
-
+  let pastSlot =
+    (wallTime - MAXIMUM_GOSSIP_CLOCK_DISPARITY).toSlot(timeParams)
   if pastSlot.afterGenesis and msgSlot < pastSlot.slot:
     return errIgnore("Sync committee slot in the past")
 
@@ -1007,7 +1011,8 @@ proc validateAttestation*(
     let
       wallEpoch = wallTime.slotOrZero(pool.dag.timeParams).epoch
       consensusFork = pool.dag.cfg.consensusForkAtEpoch(wallEpoch)
-      v = check_propagation_slot_range(consensusFork, slot, wallTime)
+      v = pool.dag.timeParams.check_propagation_slot_range(
+        consensusFork, slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 
@@ -1177,7 +1182,8 @@ proc validateAttestation*(
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#beacon_attestation_subnet_id
   # modifies this for Deneb and newer forks.
   block:
-    let v = check_propagation_slot_range(consensusFork, slot, wallTime)
+    let v = pool.dag.timeParams.check_propagation_slot_range(
+      consensusFork, slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 
@@ -1358,7 +1364,8 @@ proc validateAggregate*(
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.2/specs/deneb/p2p-interface.md#beacon_aggregate_and_proof
   # modifies this for Deneb and newer forks.
   block:
-    let v = check_propagation_slot_range(consensusFork, slot, wallTime)
+    let v = pool.dag.timeParams.check_propagation_slot_range(
+      consensusFork, slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 
@@ -1723,7 +1730,7 @@ proc validateSyncCommitteeMessage*(
     # [IGNORE] The message's slot is for the current slot (with a
     # `MAXIMUM_GOSSIP_CLOCK_DISPARITY` allowance), i.e.
     # `sync_committee_message.slot == current_slot`.
-    let v = check_slot_exact(msg.slot, wallTime)
+    let v = dag.timeParams.check_slot_exact(msg.slot, wallTime)
     if v.isErr():
       return err(v.error())
 
@@ -1815,7 +1822,8 @@ proc validateContribution*(
     # [IGNORE] The contribution's slot is for the current slot
     # (with a MAXIMUM_GOSSIP_CLOCK_DISPARITY allowance)
     # i.e. contribution.slot == current_slot.
-    let v = check_slot_exact(msg.message.contribution.slot, wallTime)
+    let v = dag.timeParams.check_slot_exact(
+      msg.message.contribution.slot, wallTime)
     if v.isErr():  # [IGNORE]
       return err(v.error())
 

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -468,12 +468,8 @@ proc addObject*(
   #   - `LightClientUpdatesByRange`
   #   - `GetLightClientFinalityUpdate`
   #   - `GetLightClientOptimisticUpdate`
-
-  let
-    wallTime = self.getBeaconTime()
-    (afterGenesis, _) = wallTime.toSlot()
-
-  if not afterGenesis:
+  let wallTime = self.getBeaconTime()
+  if not wallTime.afterGenesis:
     let mayProcessBeforeGenesis =
       when obj is ForkedLightClientBootstrap:
         withForkyBootstrap(obj):

--- a/beacon_chain/gossip_processing/optimistic_processor.nim
+++ b/beacon_chain/gossip_processing/optimistic_processor.nim
@@ -59,7 +59,7 @@ proc processSignedBeaconBlock*(
     signedBlock: ForkySignedBeaconBlock): ValidationRes =
   let
     wallTime = self.getBeaconTime()
-    (afterGenesis, wallSlot) = wallTime.toSlot()
+    (afterGenesis, wallSlot) = wallTime.toSlot(self.timeParams)
 
   logScope:
     blockRoot = shortLog(signedBlock.root)

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -489,7 +489,7 @@ proc runPreGenesisWaitingLoop(
   while true:
     let
       currentTime = vc.beaconClock.now()
-      currentSlot = currentTime.toSlot()
+      currentSlot = currentTime.toSlot(vc.timeParams)
       currentEpoch = currentSlot.slot.epoch()
 
     if currentSlot.afterGenesis or currentEpoch < PREGENESIS_EPOCHS_COUNT:
@@ -514,7 +514,7 @@ proc runGenesisWaitingLoop(
   while true:
     let
       currentTime = vc.beaconClock.now()
-      currentSlot = currentTime.toSlot()
+      currentSlot = currentTime.toSlot(vc.timeParams)
 
     if currentSlot.afterGenesis:
       break

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -112,7 +112,12 @@ template `<`*(a, b: TimeDiff): bool = a.nanoseconds < b.nanoseconds
 template `<=`*(a, b: TimeDiff): bool = a.nanoseconds <= b.nanoseconds
 template `<`*(a: TimeDiff, b: Duration): bool = a.nanoseconds < b.nanoseconds
 
-func toSlot*(t: BeaconTime): tuple[afterGenesis: bool, slot: Slot] =
+func afterGenesis*(t: BeaconTime): bool =
+  t.ns_since_genesis >= 0
+
+func toSlot*(
+    t: BeaconTime,
+    timeParams: TimeParams): tuple[afterGenesis: bool, slot: Slot] =
   if t == FAR_FUTURE_BEACON_TIME:
     (true, FAR_FUTURE_SLOT)
   elif t.ns_since_genesis >= 0:
@@ -192,7 +197,7 @@ func light_client_optimistic_update_time*(
   s.start_beacon_time(timeParams) + lightClientOptimisticUpdateSlotOffset
 
 func slotOrZero*(time: BeaconTime, timeParams: TimeParams): Slot =
-  let exSlot = time.toSlot
+  let exSlot = time.toSlot(timeParams)
   if exSlot.afterGenesis: exSlot.slot
   else: Slot(0)
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -813,7 +813,7 @@ proc init*(t: typedesc[ProposedData], epoch: Epoch, dependentRoot: Eth2Digest,
   ProposedData(epoch: epoch, dependentRoot: dependentRoot, duties: @data)
 
 proc getCurrentSlot*(vc: ValidatorClientRef): Opt[Slot] =
-  let res = vc.beaconClock.now().toSlot()
+  let res = vc.beaconClock.now().toSlot(vc.timeParams)
   if res.afterGenesis:
     Opt.some(res.slot)
   else:
@@ -1466,7 +1466,7 @@ proc waitForNextEpoch*(service: ClientServiceRef,
      async: (raises: [CancelledError], raw: true) .}=
   let
     vc = service.client
-    currentSlot = vc.beaconClock.now().toSlot()
+    currentSlot = vc.beaconClock.now().toSlot(vc.timeParams)
     nextEpochTime = currentSlot.nextEpochStartTime(vc.timeParams)
     sleepTime = vc.beaconClock.fromNow(nextEpochTime).durationOrZero() + delay
   debug "Sleeping until next epoch", service = service.name,
@@ -1488,7 +1488,10 @@ proc waitForNextSlot*(
 
 proc waitForNextSlot*(service: ClientServiceRef): Future[void] {.
      async: (raises: [CancelledError], raw: true).} =
-  service.client.waitForNextSlot(service.client.beaconClock.now().toSlot())
+  let
+    vc = service.client
+    currentSlot = vc.beaconClock.now().toSlot(vc.timeParams)
+  service.client.waitForNextSlot(currentSlot)
 
 func compareUnsorted*[T](a, b: openArray[T]): bool =
   if len(a) != len(b):

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -228,7 +228,7 @@ proc isSynced*(node: BeaconNode, head: BlockRef): bool =
   let
     # The slot we should be at, according to the clock
     beaconTime = node.beaconClock.now()
-    wallSlot = beaconTime.toSlot()
+    wallSlot = beaconTime.toSlot(node.dag.timeParams)
 
   # TODO if everyone follows this logic, the network will not recover from a
   #      halt: nobody will be producing blocks because everone expects someone


### PR DESCRIPTION
Next step of the compile-time --> run-time transition for time params, targeting the `toSlot` flavor with pre-genesis support.