### PR TITLE
Avoid using SECONDS_PER_SLOT in legacy SyncManager

### DIFF
--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -880,14 +880,15 @@ proc syncLoop[A, B](
       await man.notInSyncEvent.wait()
 
       # Give the node time to connect to peers and get the sync process started
-      await sleepAsync(seconds(SECONDS_PER_SLOT.int64))
+      const pollInterval = seconds(15)
+      await sleepAsync(pollInterval)
 
       var
         stamp = SyncMoment.now(man.queue.progress())
         syncCount = 0
 
       while man.inProgress:
-        await sleepAsync(seconds(SECONDS_PER_SLOT.int64))
+        await sleepAsync(pollInterval)
 
         let
           newStamp = SyncMoment.now(man.queue.progress())


### PR DESCRIPTION
For computing processing speed, we currently update the measurements every SECONDS_PER_SLOT. However, that can also just be some arbitrary frequency with a few updates per minute.