### PR TITLE
Prefer runtime TimeParams over compiletime

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -196,7 +196,7 @@ func contains*(self: ForkChoiceBackend, block_root: Eth2Digest): bool =
 proc update_time*(
     self: var ForkChoice, dag: ChainDAGRef, time: BeaconTime): FcResult[void] =
   # `time` is the wall time, meaning it changes on every call typically
-  let step_size = seconds(dag.timeParams.SECONDS_PER_SLOT.int)
+  let step_size = seconds(dag.timeParams.SECONDS_PER_SLOT.int64)
   if time > self.checkpoints.time:
     let
       preSlot = self.checkpoints.time.slotOrZero(dag.timeParams)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -196,7 +196,7 @@ func contains*(self: ForkChoiceBackend, block_root: Eth2Digest): bool =
 proc update_time*(
     self: var ForkChoice, dag: ChainDAGRef, time: BeaconTime): FcResult[void] =
   # `time` is the wall time, meaning it changes on every call typically
-  const step_size = seconds(SECONDS_PER_SLOT.int)
+  let step_size = seconds(dag.timeParams.SECONDS_PER_SLOT.int)
   if time > self.checkpoints.time:
     let
       preSlot = self.checkpoints.time.slotOrZero(dag.timeParams)

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2453,7 +2453,8 @@ proc createEth2Node*(rng: ref HmacDrbgContext,
       historyGossip = 3,
       fanoutTTL = chronos.seconds(60),
       # 2 epochs matching maximum valid attestation lifetime
-      seenTTL = chronos.seconds(int(SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2)),
+      seenTTL = chronos.seconds(int(
+        cfg.timeParams.SECONDS_PER_SLOT * SLOTS_PER_EPOCH * 2)),
       gossipThreshold = -4000,
       publishThreshold = -8000,
       graylistThreshold = -16000, # also disconnect threshold

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1907,7 +1907,8 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
       # int64 conversion is safe
       doAssert slotsToNextSyncCommitteePeriod <= SLOTS_PER_SYNC_COMMITTEE_PERIOD
       "in " & toTimeLeftString(
-        SECONDS_PER_SLOT.int64.seconds * slotsToNextSyncCommitteePeriod.int64)
+        node.dag.timeParams.SECONDS_PER_SLOT.int64.seconds *
+        slotsToNextSyncCommitteePeriod.int64)
     else:
       "none"
 
@@ -1944,7 +1945,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # logging slot end since the nextActionWaitTime can be short
   let advanceCutoff = node.beaconClock.fromNow(
     slot.start_beacon_time(node.dag.timeParams) +
-    chronos.seconds(int(SECONDS_PER_SLOT - 1)))
+    chronos.seconds(int(node.dag.timeParams.SECONDS_PER_SLOT - 1)))
 
   let proposalFcu =
     if advanceCutoff.inFuture:

--- a/beacon_chain/sync/light_client_sync_helpers.nim
+++ b/beacon_chain/sync/light_client_sync_helpers.nim
@@ -136,5 +136,5 @@ func nextLcSyncTaskDelay*(
       else:
         # Next sync committee period
         chronos.seconds(
-          (SLOTS_PER_SYNC_COMMITTEE_PERIOD * SECONDS_PER_SLOT).int64)
+          (SLOTS_PER_SYNC_COMMITTEE_PERIOD * timeParams.SECONDS_PER_SLOT).int64)
   rng.computeDelayWithJitter(remainingDuration)

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -616,7 +616,7 @@ suite "Attestation pool electra processing" & preset():
         pool[].addForkChoice(
           epochRef, blckRef, unrealized, signedBlock.message,
           blckRef.slot.start_beacon_time(cfg.timeParams) +
-          SECONDS_PER_SLOT.int64.seconds)
+          cfg.timeParams.SECONDS_PER_SLOT.int64.seconds)
 
       bc1 = get_beacon_committee(
         state[], getStateField(state[], slot) - 1, 1.CommitteeIndex,

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -136,8 +136,8 @@ suite "Gossip validation " & preset():
     check:
       # Too far in the past
       validateAttestation(
-        pool, batchCrypto, att_1_0,
-        beaconTime - (SECONDS_PER_SLOT * SLOTS_PER_EPOCH - 1).int.seconds,
+        pool, batchCrypto, att_1_0, beaconTime -
+        (cfg.timeParams.SECONDS_PER_SLOT * SLOTS_PER_EPOCH - 1).int.seconds,
         subnet, true).waitFor().isErr
 
     block:

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -24,7 +24,7 @@ suite "Light client" & preset():
   const  # Test config, should be long enough to cover interesting transitions
     headPeriod = 4.SyncCommitteePeriod
   let
-    cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
+    cfg = block:  # Fork schedule that covers each `LightClientDataFork`
       static: doAssert ConsensusFork.high == ConsensusFork.Gloas
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -91,7 +91,7 @@ suite "Light client processor" & preset():
       proc getBeaconTime(): BeaconTime =
         BeaconTime(ns_since_genesis: time.nanoseconds)
       func setTimeToSlot(slot: Slot) =
-        time = chronos.seconds((slot * SECONDS_PER_SLOT).int64)
+        time = chronos.seconds((slot * cfg.timeParams.SECONDS_PER_SLOT).int64)
 
       var numOnStoreInitializedCalls = 0
       func onStoreInitialized() = inc numOnStoreInitializedCalls

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -27,17 +27,16 @@ suite "Light client processor" & preset():
     lastPeriodWithSupermajority = 4.SyncCommitteePeriod
     highPeriod = 6.SyncCommitteePeriod
   debugGloasComment "add res.GLOAS_FORK_EPOCH = ..."
-  let
-    cfg = block:  # Fork schedule so that each `LightClientDataFork` is covered
-      static: doAssert ConsensusFork.high == ConsensusFork.Gloas
-      var res = defaultRuntimeConfig
-      res.ALTAIR_FORK_EPOCH = 1.Epoch
-      res.BELLATRIX_FORK_EPOCH = 2.Epoch
-      res.CAPELLA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 1).Epoch
-      res.DENEB_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 2).Epoch
-      res.ELECTRA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 3).Epoch
-      res.FULU_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 4).Epoch
-      res
+  let cfg = block:  # Fork schedule that covers each `LightClientDataFork`
+    static: doAssert ConsensusFork.high == ConsensusFork.Gloas
+    var res = defaultRuntimeConfig
+    res.ALTAIR_FORK_EPOCH = 1.Epoch
+    res.BELLATRIX_FORK_EPOCH = 2.Epoch
+    res.CAPELLA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 1).Epoch
+    res.DENEB_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 2).Epoch
+    res.ELECTRA_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 3).Epoch
+    res.FULU_FORK_EPOCH = (EPOCHS_PER_SYNC_COMMITTEE_PERIOD * 4).Epoch
+    res
 
   const numValidators = SLOTS_PER_EPOCH
   let
@@ -90,7 +89,7 @@ suite "Light client processor" & preset():
       var time = chronos.seconds(0)
       proc getBeaconTime(): BeaconTime =
         BeaconTime(ns_since_genesis: time.nanoseconds)
-      func setTimeToSlot(slot: Slot) =
+      proc setTimeToSlot(slot: Slot) =
         time = chronos.seconds((slot * cfg.timeParams.SECONDS_PER_SLOT).int64)
 
       var numOnStoreInitializedCalls = 0


### PR DESCRIPTION
Change a couple uses of compiletime constant to use runtime config, where it is local and does not span across multiple modules.