### PR TITLE
Use TimeParams for defaultSyncHorizon computation

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -612,9 +612,7 @@ type
       syncHorizon* {.
         hidden
         desc: "Number of empty slots to process before considering the client out of sync. Defaults to the number of slots in 10 minutes"
-        defaultValue: defaultSyncHorizon
-        defaultValueDesc: $defaultSyncHorizon
-        name: "sync-horizon" .}: uint64
+        name: "sync-horizon" .}: Option[uint64]
 
       terminalTotalDifficultyOverride* {.
         hidden

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -229,7 +229,7 @@ func isSynced(dag: ChainDAGRef, wallSlot: Slot): bool =
   # the defaultSyncHorizon, it will start triggering in time so that potential
   # discrepancies between the head here, and the head the DAG has (which might
   # not yet be updated) won't be visible.
-  if dag.head.slot + defaultSyncHorizon < wallSlot:
+  if dag.head.slot + dag.timeParams.defaultSyncHorizon < wallSlot:
     false
   else:
     dag.head.executionValid

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2764,6 +2764,8 @@ proc doRunBeaconNode*(
   # works
   for node in metadata.bootstrapNodes:
     config.bootstrapNodes.add node
+  if config.syncHorizon.isNone:
+    config.syncHorizon = some(metadata.cfg.timeParams.defaultSyncHorizon)
 
   block:
     let res =

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -292,6 +292,3 @@ chronicles.formatIt TimeDiff: it.shortLog
 chronicles.formatIt Slot: it.shortLog
 chronicles.formatIt Epoch: it.shortLog
 chronicles.formatIt SyncCommitteePeriod: it.shortLog
-
-const defaultSyncHorizon* =
-  (uint64(10*60) + SECONDS_PER_SLOT - 1) div SECONDS_PER_SLOT

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -1059,3 +1059,7 @@ func defaultLightClientDataMaxPeriods*(cfg: RuntimeConfig): uint64 =
   const epochsPerPeriod = EPOCHS_PER_SYNC_COMMITTEE_PERIOD
   let maxEpochs = cfg.MIN_EPOCHS_FOR_BLOCK_REQUESTS
   (maxEpochs + epochsPerPeriod - 1) div epochsPerPeriod
+
+func defaultSyncHorizon*(timeParams: TimeParams): uint64 =
+  (uint64(10 * 60) + timeParams.SECONDS_PER_SLOT - 1) div
+    timeParams.SECONDS_PER_SLOT

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -234,7 +234,7 @@ proc isSynced*(node: BeaconNode, head: BlockRef): bool =
   #      halt: nobody will be producing blocks because everone expects someone
   #      else to do it
   not wallSlot.afterGenesis or
-    head.slot + node.config.syncHorizon >= wallSlot.slot
+    head.slot + node.config.syncHorizon.get >= wallSlot.slot
 
 proc handleLightClientUpdates*(node: BeaconNode, slot: Slot)
     {.async: (raises: [CancelledError]).} =

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -341,34 +341,41 @@ proc initBeaconNode(basePort: int): Future[BeaconNode] {.async: (raises: []).} =
   except CatchableError as exc:
     raiseAssert exc.msg
 
-  let runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
-    "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
-    "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
-    "--discv5=off",
-    "--network=" & dataDir,
-    "--data-dir=" & nodeDataDir,
-    "--validators-dir=" & nodeValidatorsDir,
-    "--secrets-dir=" & nodeSecretsDir,
-    "--metrics-address=127.0.0.1",
-    "--metrics-port=" & $(basePort + PortKind.Metrics.ord),
-    "--rest=true",
-    "--rest-address=127.0.0.1",
-    "--rest-port=" & $(basePort + PortKind.KeymanagerBN.ord),
-    "--no-el",
-    "--keymanager=true",
-    "--keymanager-address=127.0.0.1",
-    "--keymanager-port=" & $(basePort + PortKind.KeymanagerBN.ord),
-    "--keymanager-token-file=" & tokenFilePath,
-    "--suggested-fee-recipient=" & $defaultFeeRecipient,
-    "--doppelganger-detection=off"], it))
-  except Exception as exc: # TODO fix confutils exceptions
-    raiseAssert exc.msg
+  let
+    metadata =
+      try:
+        loadEth2NetworkMetadata(dataDir).expect("Metadata is compatible")
+      except IOError as exc:
+        raiseAssert exc.msg
+      except PresetFileError as exc:
+        raiseAssert exc.msg
+
+    runNodeConf = try: BeaconNodeConf.load(cmdLine = mapIt([
+      "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
+      "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
+      "--discv5=off",
+      "--network=" & dataDir,
+      "--data-dir=" & nodeDataDir,
+      "--validators-dir=" & nodeValidatorsDir,
+      "--secrets-dir=" & nodeSecretsDir,
+      "--metrics-address=127.0.0.1",
+      "--metrics-port=" & $(basePort + PortKind.Metrics.ord),
+      "--rest=true",
+      "--rest-address=127.0.0.1",
+      "--rest-port=" & $(basePort + PortKind.KeymanagerBN.ord),
+      "--no-el",
+      "--keymanager=true",
+      "--keymanager-address=127.0.0.1",
+      "--keymanager-port=" & $(basePort + PortKind.KeymanagerBN.ord),
+      "--keymanager-token-file=" & tokenFilePath,
+      "--suggested-fee-recipient=" & $defaultFeeRecipient,
+      "--doppelganger-detection=off",
+      "--sync-horizon=" & $(metadata.cfg.timeParams.defaultSyncHorizon)], it))
+    except Exception as exc: # TODO fix confutils exceptions
+      raiseAssert exc.msg
 
   try:
-    let
-      metadata = loadEth2NetworkMetadata(dataDir).expect("Metadata is compatible")
-      taskpool = Taskpool.new()
-
+    let taskpool = Taskpool.new()
     await BeaconNode.init(rng, runNodeConf, metadata, taskpool)
   except CatchableError as exc:
     raiseAssert exc.msg


### PR DESCRIPTION
As the defaultSyncHorizon is the number of slots in 10 minutes, it also depends on TimeParams. Wrap the startup config in optional, and delay initialization with the default value until after metadata is loaded.