### PR TITLE
Pass TimeParams to compute_timestamp_at_slot

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -335,7 +335,8 @@ proc prepareNextSlot*(
     elif consensusFork in ConsensusFork.Bellatrix .. ConsensusFork.Fulu:
       debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer
       let
-        timestamp = compute_timestamp_at_slot(forkyState.data, proposalSlot)
+        timestamp = dag.timeParams
+          .compute_timestamp_at_slot(forkyState.data, proposalSlot)
         # If the current head block still forms the basis of the eventual proposal
         # state, then its `get_randao_mix` will remain unchanged as well, as it is
         # constant until the next block.

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -352,7 +352,7 @@ template validateBeaconBlockBellatrix(
     # compute_timestamp_at_slot(state, block.slot).
     let timestampAtSlot =
       withState(dag.headState):
-        compute_timestamp_at_slot(
+        dag.timeParams.compute_timestamp_at_slot(
           forkyState.data, signed_beacon_block.message.slot)
     if not (signed_beacon_block.message.body.execution_payload.timestamp ==
         timestampAtSlot):

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -436,10 +436,11 @@ func is_execution_enabled*(
   is_merge_transition_block(state, body) or is_merge_transition_complete(state)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#compute_timestamp_at_slot
-func compute_timestamp_at_slot*(state: ForkyBeaconState, slot: Slot): uint64 =
+func compute_timestamp_at_slot*(
+    timeParams: TimeParams, state: ForkyBeaconState, slot: Slot): uint64 =
   # Note: This function is unsafe with respect to overflows and underflows.
   let slots_since_genesis = slot - GENESIS_SLOT
-  state.genesis_time + slots_since_genesis * SECONDS_PER_SLOT
+  state.genesis_time + slots_since_genesis * timeParams.SECONDS_PER_SLOT
 
 template append*(w: var RlpWriter, v: bellatrix.Transaction) =
   w.appendRawBytes(distinctBase v)
@@ -552,13 +553,13 @@ func compute_execution_block_hash*(blck: ForkyBeaconBlock): Eth2Digest =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.6/specs/gloas/beacon-chain.md#new-is_builder_payment_withdrawable
 func is_builder_payment_withdrawable*(
-    state: gloas.BeaconState, 
+    state: gloas.BeaconState,
     withdrawal: BuilderPendingWithdrawal): bool =
   ## Check if the builder is slashed and not yet withdrawable.
-  let 
+  let
     builder = state.validators[withdrawal.builder_index]
     current_epoch = state.slot.epoch
-  
+
   builder.withdrawable_epoch >= current_epoch or not builder.slashed
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-beta.0/specs/gloas/beacon-chain.md#new-is_parent_block_full

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -919,7 +919,8 @@ proc process_sync_aggregate*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/beacon-chain.md#process_execution_payload
 proc process_execution_payload*(
-    state: var bellatrix.BeaconState, payload: bellatrix.ExecutionPayload,
+    cfg: RuntimeConfig, state: var bellatrix.BeaconState,
+    payload: bellatrix.ExecutionPayload,
     notify_new_payload: bellatrix.ExecutePayload): Result[void, cstring] =
   # Verify consistency of the parent hash with respect to the previous
   # execution payload header
@@ -933,7 +934,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: payload and state randomness mismatch")
 
   # Verify timestamp
-  if not (payload.timestamp == compute_timestamp_at_slot(state, state.slot)):
+  if not (payload.timestamp == cfg.timeParams
+      .compute_timestamp_at_slot(state, state.slot)):
     return err("process_execution_payload: invalid timestamp")
 
   # Verify the execution payload is valid
@@ -947,7 +949,8 @@ proc process_execution_payload*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#modified-process_execution_payload
 proc process_execution_payload*(
-    state: var capella.BeaconState, payload: capella.ExecutionPayload,
+    cfg: RuntimeConfig, state: var capella.BeaconState,
+    payload: capella.ExecutionPayload,
     notify_new_payload: capella.ExecutePayload): Result[void, cstring] =
   # Verify consistency of the parent hash with respect to the previous
   # execution payload header
@@ -960,7 +963,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: payload and state randomness mismatch")
 
   # Verify timestamp
-  if not (payload.timestamp == compute_timestamp_at_slot(state, state.slot)):
+  if not (payload.timestamp == cfg.timeParams
+      .compute_timestamp_at_slot(state, state.slot)):
     return err("process_execution_payload: invalid timestamp")
 
   # Verify the execution payload is valid
@@ -1011,7 +1015,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: payload and state randomness mismatch")
 
   # Verify timestamp
-  if not (payload.timestamp == compute_timestamp_at_slot(state, state.slot)):
+  if not (payload.timestamp == cfg.timeParams
+      .compute_timestamp_at_slot(state, state.slot)):
     return err("process_execution_payload: invalid timestamp")
 
   # [New in Deneb] Verify commitments are under limit
@@ -1051,7 +1056,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: payload and state randomness mismatch")
 
   # Verify timestamp
-  if not (payload.timestamp == compute_timestamp_at_slot(state, state.slot)):
+  if not (payload.timestamp == cfg.timeParams
+      .compute_timestamp_at_slot(state, state.slot)):
     return err("process_execution_payload: invalid timestamp")
 
   # [New in Deneb] Verify commitments are under limit
@@ -1095,7 +1101,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: payload and state randomness mismatch")
 
   # Verify timestamp
-  if not (payload.timestamp == compute_timestamp_at_slot(state, state.slot)):
+  if not (payload.timestamp == cfg.timeParams
+      .compute_timestamp_at_slot(state, state.slot)):
     return err("process_execution_payload: invalid timestamp")
 
   # Verify commitments are under limit
@@ -1178,7 +1185,8 @@ proc process_execution_payload*(
     return err("process_execution_payload: prev_randao mismatch")
 
   # Verify timestamp
-  if payload.timestamp != compute_timestamp_at_slot(state.data, state.data.slot):
+  if payload.timestamp != cfg.timeParams
+      .compute_timestamp_at_slot(state.data, state.data.slot):
     return err("process_execution_payload: timestamp mismatch")
 
   # Verify commitments are under limit
@@ -1531,7 +1539,7 @@ proc process_block*(
   ? process_block_header(state, blck, flags, cache)
   if is_execution_enabled(state, blck.body):
     ? process_execution_payload(
-        state, blck.body.execution_payload,
+        cfg, state, blck.body.execution_payload,
         func(_: bellatrix.ExecutionPayload): bool = true)  # [New in Bellatrix]
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
@@ -1567,7 +1575,7 @@ proc process_block*(
     ? process_withdrawals(
         state, blck.body.execution_payload)  # [New in Capella]
     ? process_execution_payload(
-        state, blck.body.execution_payload,
+        cfg, state, blck.body.execution_payload,
         func(_: capella.ExecutionPayload): bool = true)  # [Modified in Capella]
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -299,8 +299,8 @@ proc getExecutionPayload*(
         (static(default(Eth2Digest)))
     latestSafe = beaconHead.safeExecutionBlockHash
     latestFinalized = beaconHead.finalizedExecutionBlockHash
-    timestamp = withState(proposalState[]):
-      compute_timestamp_at_slot(forkyState.data, forkyState.data.slot)
+    timestamp = withState(proposalState[]): node.dag.timeParams
+      .compute_timestamp_at_slot(forkyState.data, forkyState.data.slot)
     prevRandao = withState(proposalState[]):
       get_randao_mix(forkyState.data, get_current_epoch(forkyState.data))
     withdrawals = withState(proposalState[]):

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -267,7 +267,7 @@ cli do(validatorsDir: string, secretsDir: string,
                       headBlock = executionHead,
                       safeBlock = executionHead,
                       finalizedBlock = ZERO_HASH,
-                      timestamp = compute_timestamp_at_slot(
+                      timestamp = cfg.timeParams.compute_timestamp_at_slot(
                         forkyState.data, forkyState.data.slot),
                       prevRandao = get_randao_mix(
                         forkyState.data, get_current_epoch(forkyState.data)),

--- a/tests/consensus_spec/bellatrix/test_fixture_operations.nim
+++ b/tests/consensus_spec/bellatrix/test_fixture_operations.nim
@@ -156,7 +156,7 @@ suite baseDescription & "Execution Payload " & preset():
               assignClone(preState)[].hash_tree_root())))
       func executePayload(_: bellatrix.ExecutionPayload): bool = payloadValid
       process_execution_payload(
-        preState, body.execution_payload, executePayload)
+        defaultRuntimeConfig, preState, body.execution_payload, executePayload)
 
   for path in walkTests(OpExecutionPayloadDir):
     let applyExecutionPayload = makeApplyExecutionPayloadCb(path)

--- a/tests/consensus_spec/capella/test_fixture_operations.nim
+++ b/tests/consensus_spec/capella/test_fixture_operations.nim
@@ -173,7 +173,7 @@ suite baseDescription & "Execution Payload " & preset():
               assignClone(preState)[].hash_tree_root())))
       func executePayload(_: capella.ExecutionPayload): bool = payloadValid
       process_execution_payload(
-        preState, body.execution_payload, executePayload)
+        defaultRuntimeConfig, preState, body.execution_payload, executePayload)
 
   for path in walkTests(OpExecutionPayloadDir):
     let applyExecutionPayload = makeApplyExecutionPayloadCb(path)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -88,8 +88,9 @@ func signBlock(
 from eth/eip1559 import EIP1559_INITIAL_BASE_FEE, calcEip1599BaseFee
 from eth/common/eth_types import EMPTY_ROOT_HASH, GasInt
 
-func build_empty_merge_execution_payload(state: bellatrix.BeaconState):
-    bellatrix.ExecutionPayloadForSigning =
+func build_empty_merge_execution_payload(
+    cfg: RuntimeConfig,
+    state: bellatrix.BeaconState): bellatrix.ExecutionPayloadForSigning =
   ## Assuming a pre-state of the same slot, build a valid ExecutionPayload
   ## without any transactions from a non-merged block.
 
@@ -97,7 +98,7 @@ func build_empty_merge_execution_payload(state: bellatrix.BeaconState):
 
   let
     latest = state.latest_execution_payload_header
-    timestamp = compute_timestamp_at_slot(state, state.slot)
+    timestamp = cfg.timeParams.compute_timestamp_at_slot(state, state.slot)
     randao_mix = get_randao_mix(state, get_current_epoch(state))
 
   var payload = bellatrix.ExecutionPayload(
@@ -118,13 +119,14 @@ func build_empty_merge_execution_payload(state: bellatrix.BeaconState):
                                        blockValue: Wei.zero)
 
 func build_empty_execution_payload(
+    cfg: RuntimeConfig,
     state: bellatrix.BeaconState,
     feeRecipient: Eth1Address): bellatrix.ExecutionPayloadForSigning =
   ## Assuming a pre-state of the same slot, build a valid ExecutionPayload
   ## without any transactions.
   let
     latest = state.latest_execution_payload_header
-    timestamp = compute_timestamp_at_slot(state, state.slot)
+    timestamp = cfg.timeParams.compute_timestamp_at_slot(state, state.slot)
     randao_mix = get_randao_mix(state, get_current_epoch(state))
     base_fee = calcEip1599BaseFee(latest.gas_limit,
                                   latest.gas_used,
@@ -199,9 +201,9 @@ proc addTestBlock*(
           if forkyState.data.slot > cfg.lastPremergeSlotInTestCfg:
             if is_merge_transition_complete(forkyState.data):
               const feeRecipient = default(Eth1Address)
-              build_empty_execution_payload(forkyState.data, feeRecipient)
+              cfg.build_empty_execution_payload(forkyState.data, feeRecipient)
             else:
-              build_empty_merge_execution_payload(forkyState.data)
+              cfg.build_empty_merge_execution_payload(forkyState.data)
           else:
             default(bellatrix.ExecutionPayloadForSigning)
       else:


### PR DESCRIPTION
The spec function to convert timestamps to slots is needed for payload validation, so needs access to TimeParams.