### PR TITLE
Name the default beacon node command better

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -64,7 +64,7 @@ else:
 
 type
   BNStartUpCmd* {.pure.} = enum
-    noCommand
+    beaconNode # match name in unified binary
     deposits
     wallets
     record
@@ -124,6 +124,7 @@ type
     Lenient = "lenient"
 
   BeaconNodeConf* = object
+    # When updating, coordinate option names with EL and other binaries
     configFile* {.
       desc: "Loads the configuration from a TOML file"
       name: "config-file" .}: Option[InputFile]
@@ -264,9 +265,9 @@ type
 
     case cmd* {.
       command
-      defaultValue: BNStartUpCmd.noCommand .}: BNStartUpCmd
+      defaultValue: BNStartUpCmd.beaconNode .}: BNStartUpCmd
 
-    of BNStartUpCmd.noCommand:
+    of BNStartUpCmd.beaconNode:
       runAsServiceFlag* {.
         windowsOnly
         defaultValue: false,
@@ -1226,7 +1227,7 @@ proc createDumpDirs*(config: BeaconNodeConf) =
     raiseAssert "createDumpDirs should be used only in the right context"
 
   case config.cmd
-  of BNStartUpCmd.noCommand:
+  of BNStartUpCmd.beaconNode:
     if config.dumpEnabled:
       if (let res = secureCreatePath(config.dumpDirInvalid); res.isErr):
         warn "Could not create dump directory",
@@ -1389,7 +1390,7 @@ template databaseDir*(config: AnyConf): string =
 
 func runAsService*(config: BeaconNodeConf): bool =
   case config.cmd
-  of noCommand:
+  of BNStartUpCmd.beaconNode:
     config.runAsServiceFlag
   else:
     false

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2325,7 +2325,7 @@ proc getPersistentNetKeys*(
 proc getPersistentNetKeys*(
     rng: var HmacDrbgContext, config: BeaconNodeConf): NetKeyPair =
   case config.cmd
-  of BNStartUpCmd.noCommand, BNStartUpCmd.record:
+  of BNStartUpCmd.beaconNode, BNStartUpCmd.record:
     rng.getPersistentNetKeys(
       string(config.dataDir), config.netKeyFile, config.netKeyInsecurePassword,
       allowLoadExisting = true)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2838,7 +2838,7 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
   let rng = HmacDrbgContext.new()
 
   case config.cmd
-  of BNStartUpCmd.noCommand:
+  of BNStartUpCmd.beaconNode:
     createPidFile(config.dataDir.string / "beacon_node.pid")
     ProcessState.setupStopHandlers()
 


### PR DESCRIPTION
Allows running `nimbus_beacon_node beaconNode` to match `nimbus beaconNode`, keeping the names the same in the two binaries to ease future upgrade paths.

Technically, if someone was using `nimbus_beacon_node noCommand` that would break with this change, but that's never been documented, nor does it appear in any `--help` or other sources of publically available functionality so no actual user impact is expected for now.