### PR TITLE
Retain SECONDS_PER_SLOT from config

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -878,8 +878,7 @@ proc readRuntimeConfig*(
   # Certain config keys are baked into the binary at compile-time
   # and cannot be overridden via config.
   template checkCompatibility(
-      constValue: untyped, name: string, operator: untyped = `==`,
-      discardValue = true): untyped =
+      constValue: untyped, name: string, operator: untyped = `==`): untyped =
     if values.hasKey(name):
       const opDesc = astToStr(operator)
       try:
@@ -897,8 +896,7 @@ proc readRuntimeConfig*(
               "Cannot override config" &
               " (required: " & name & " " & opDesc & " " & $constValue &
               " - config: " & name & "=" & values[name] & ")")
-        if discardValue:
-          values.del name
+        values.del name
       except ValueError:
         raise (ref PresetFileError)(msg: "Unable to parse " & name)
 
@@ -907,9 +905,6 @@ proc readRuntimeConfig*(
     block:
       const name = astToStr(constValue)
       checkCompatibility(constValue, name, operator)
-
-  checkCompatibility MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
-                     "SECONDS_PER_SLOT", `in`, discardValue = false
 
   checkCompatibility BLS_WITHDRAWAL_PREFIX
 
@@ -1034,6 +1029,30 @@ proc readRuntimeConfig*(
   var unknowns: seq[string]
   for name in values.keys:
     unknowns.add name
+
+  template checkParsedValue(
+      constValue: untyped, value: auto, operator: untyped = `==`): untyped =
+    const opDesc = astToStr(operator)
+    try:
+      when constValue is distinct:
+        if not operator(distinctBase(value), distinctBase(constValue)):
+          raise (ref PresetFileError)(msg:
+            "Cannot override config" &
+            " (required: " & name & " " &
+            opDesc & " " & $distinctBase(constValue) &
+            " - config: " & name & "=" & values[name] & ")")
+      else:
+        if not operator(value, constValue):
+          raise (ref PresetFileError)(msg:
+            "Cannot override config" &
+            " (required: " & name & " " & opDesc & " " & $constValue &
+            " - config: " & name & "=" & values[name] & ")")
+    except ValueError:
+      raise (ref PresetFileError)(msg: "Unable to parse " & name)
+
+  checkParsedValue(
+    MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
+    cfg.timeParams.SECONDS_PER_SLOT, `in`)
 
   (cfg, unknowns)
 

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -878,7 +878,8 @@ proc readRuntimeConfig*(
   # Certain config keys are baked into the binary at compile-time
   # and cannot be overridden via config.
   template checkCompatibility(
-      constValue: untyped, name: string, operator: untyped = `==`): untyped =
+      constValue: untyped, name: string, operator: untyped = `==`,
+      discardValue = true): untyped =
     if values.hasKey(name):
       const opDesc = astToStr(operator)
       try:
@@ -896,7 +897,8 @@ proc readRuntimeConfig*(
               "Cannot override config" &
               " (required: " & name & " " & opDesc & " " & $constValue &
               " - config: " & name & "=" & values[name] & ")")
-        values.del name
+        if discardValue:
+          values.del name
       except ValueError:
         raise (ref PresetFileError)(msg: "Unable to parse " & name)
 
@@ -907,7 +909,7 @@ proc readRuntimeConfig*(
       checkCompatibility(constValue, name, operator)
 
   checkCompatibility MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
-                     "SECONDS_PER_SLOT", `in`
+                     "SECONDS_PER_SLOT", `in`, discardValue = false
 
   checkCompatibility BLS_WITHDRAWAL_PREFIX
 

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -1031,7 +1031,8 @@ proc readRuntimeConfig*(
     unknowns.add name
 
   template checkParsedValue(
-      name: string, value: auto, constValue: untyped, operator: untyped = `==`): untyped =
+      name: string, value: auto,
+      constValue: untyped, operator: untyped = `==`): untyped =
     const opDesc = astToStr(operator)
     try:
       when constValue is distinct:
@@ -1040,13 +1041,13 @@ proc readRuntimeConfig*(
             "Cannot override config" &
             " (required: " & name & " " &
             opDesc & " " & $distinctBase(constValue) &
-            " - config: " & name & "=" & value & ")")
+            " - config: " & name & "=" & $value & ")")
       else:
         if not operator(value, constValue):
           raise (ref PresetFileError)(msg:
             "Cannot override config" &
             " (required: " & name & " " & opDesc & " " & $constValue &
-            " - config: " & name & "=" & value & ")")
+            " - config: " & name & "=" & $value & ")")
     except ValueError:
       raise (ref PresetFileError)(msg: "Unable to parse " & name)
 

--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -1031,7 +1031,7 @@ proc readRuntimeConfig*(
     unknowns.add name
 
   template checkParsedValue(
-      constValue: untyped, value: auto, operator: untyped = `==`): untyped =
+      name: string, value: auto, constValue: untyped, operator: untyped = `==`): untyped =
     const opDesc = astToStr(operator)
     try:
       when constValue is distinct:
@@ -1040,19 +1040,19 @@ proc readRuntimeConfig*(
             "Cannot override config" &
             " (required: " & name & " " &
             opDesc & " " & $distinctBase(constValue) &
-            " - config: " & name & "=" & values[name] & ")")
+            " - config: " & name & "=" & value & ")")
       else:
         if not operator(value, constValue):
           raise (ref PresetFileError)(msg:
             "Cannot override config" &
             " (required: " & name & " " & opDesc & " " & $constValue &
-            " - config: " & name & "=" & values[name] & ")")
+            " - config: " & name & "=" & value & ")")
     except ValueError:
       raise (ref PresetFileError)(msg: "Unable to parse " & name)
 
   checkParsedValue(
-    MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT,
-    cfg.timeParams.SECONDS_PER_SLOT, `in`)
+    "SECONDS_PER_SLOT", cfg.timeParams.SECONDS_PER_SLOT,
+    MIN_SECONDS_PER_SLOT .. MAX_SECONDS_PER_SLOT, `in`)
 
   (cfg, unknowns)
 


### PR DESCRIPTION
Accidentally removed the logic that retains SECONDS_PER_SLOT in #7658. Ensure it doesn't get discarded after the compatibility check.