### PR TITLE
Unify block proposer verification

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -28,6 +28,39 @@ export results, signatures_batch, block_dag, blockchain_dag
 logScope:
   topics = "clearance"
 
+proc verifyBlockProposer*(
+    dag: ChainDAGRef,
+    parent: BlockRef,
+    slot: Slot,
+    proposer_index: uint64,
+    blockRoot: Eth2Digest,
+    signature: ValidatorSig,
+): Result[void, tuple[msg: cstring, invalid: bool]] =
+  ## Verify block proposer and signature, making sure to check that the proposer
+  ## was indeed elected for the given slot and that the signature checks out.
+  ##
+  ## Because the signature only covers the block body (via its root), it's
+  ## possible that the block itself is valid while the signature is not: in
+  ## this case false is returned for "invalid".
+  let proposer = dag.getProposer(parent, slot).valueOr:
+    warn "cannot compute proposer for block", parent, slot, proposer_index, blockRoot
+    return err(("verifyBlockProposer: cannot compute proposer", false)) # internal issue
+
+  # `getProposer` returns a trusted proposer index, while `proposer_index` may
+  # be invalid -> convert the former to the latter
+  if uint64(proposer) != proposer_index:
+    return err(("verifyBlockProposer: unexpected proposer", true))
+
+  let
+    proposerKey = dag.validatorKey(proposer).expect("valid after getProposer")
+    fork = dag.forkAtEpoch(slot.epoch)
+  if not verify_block_signature(
+    fork, dag.genesis_validators_root, slot, blockRoot, proposerKey, signature
+  ):
+    return err(("verifyBlockProposer: invalid signature", false))
+
+  ok()
+
 proc addResolvedHeadBlock(
        dag: ChainDAGRef,
        state: var ForkedHashedBeaconState,
@@ -435,7 +468,7 @@ proc addBackfillBlock*(
 
   ok()
 
-proc verifyBlockProposer*(
+proc verifyBlockSignatures*(
     verifier: var BatchVerifier,
     fork: Fork,
     genesis_validators_root: Eth2Digest,
@@ -452,7 +485,7 @@ proc verifyBlockProposer*(
   else:
     ok()
 
-proc addBackfillBlockData*(
+proc addLightForwardBlock*(
     dag: ChainDAGRef,
     consensusFork: static ConsensusFork,
     bdata: BlockData,

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -301,17 +301,17 @@ func pruneAfterFinalization*(
 proc addOrphan*(
     quarantine: var Quarantine,
     finalizedSlot: Slot,
-    signedBlock: ForkedSignedBeaconBlock
+    signedBlock: ForkySignedBeaconBlock
 ): Result[void, cstring] =
   ## Adds block to quarantine's `orphans` and `missing` lists.
 
-  if not isViable(finalizedSlot, getForkedBlockField(signedBlock, slot)):
+  if not isViable(finalizedSlot, signedBlock.message.slot):
     quarantine.addUnviable(signedBlock.root) # will remove from missing
     return err("block unviable")
 
   quarantine.cleanupOrphans(finalizedSlot)
 
-  let parent_root = getForkedBlockField(signedBlock, parent_root)
+  let parent_root = signedBlock.message.parent_root
 
   if parent_root in quarantine.unviable:
     quarantine.addUnviable(signedBlock.root)
@@ -335,7 +335,8 @@ proc addOrphan*(
     quarantine.orphans.del oldest_orphan_key
     quarantine.sidecarless.del oldest_orphan_key[0]
 
-  quarantine.orphans[(signedBlock.root, signedBlock.signature)] = signedBlock
+  quarantine.orphans[(signedBlock.root, signedBlock.signature)] =
+    ForkedSignedBeaconBlock.init(signedBlock)
   quarantine.orphansEvent.fire()
 
   ok()

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -999,6 +999,9 @@ proc applyBlock(
 
   ok()
 
+proc genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
+  getStateField(dag.headState, genesis_validators_root)
+
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
            eraPath = ".",
@@ -1183,8 +1186,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     quit 1
 
   # Need to load state to find genesis validators root, before loading era db
-  dag.era = EraDB.new(
-    cfg, eraPath, getStateField(dag.headState, genesis_validators_root))
+  dag.era = EraDB.new(cfg, eraPath, dag.genesis_validators_root)
 
   # We used an interim finalizedHead while loading the head state above - now
   # that we have loaded the dag up to the finalized slot, we can also set
@@ -1255,8 +1257,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
         slot: dag.tail.slot + 1,
         parent_root: dag.tail.root)
 
-  dag.forkDigests = newClone ForkDigests.init(
-    cfg, getStateField(dag.headState, genesis_validators_root))
+  dag.forkDigests = newClone ForkDigests.init(cfg, dag.genesis_validators_root)
 
   withState(dag.headState):
     dag.validatorMonitor[].registerState(forkyState.data)
@@ -1343,9 +1344,6 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   dag.initLightClientDataCache()
 
   dag
-
-template genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
-  getStateField(dag.headState, genesis_validators_root)
 
 proc genesisBlockRoot*(dag: ChainDAGRef): Eth2Digest =
   dag.db.getGenesisBlock().expect("DB must be initialized with genesis block")

--- a/beacon_chain/consensus_object_pools/blockchain_list.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_list.nim
@@ -167,7 +167,7 @@ proc checkBlobs(signedBlock: ForkedSignedBeaconBlock,
             return err(VerifierError.Invalid)
   ok()
 
-proc addBackfillBlockData*(
+proc addLightForwardBlock*(
     clist: ChainListRef, signedBlock: ForkedSignedBeaconBlock,
     blobsOpt: Opt[BlobSidecars]): Result[void, VerifierError] =
   doAssert(not(isNil(clist)))
@@ -243,5 +243,5 @@ proc untrustedBackfillVerifier*(
 ): Future[Result[void, VerifierError]] {.
   async: (raises: [CancelledError], raw: true).} =
   let retFuture = newFuture[Result[void, VerifierError]]()
-  retFuture.complete(clist.addBackfillBlockData(signedBlock, blobs))
+  retFuture.complete(clist.addLightForwardBlock(signedBlock, blobs))
   retFuture

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -157,7 +157,7 @@ proc dumpInvalidBlock*(
 proc dumpBlock(
     self: BlockProcessor,
     signedBlock: ForkySignedBeaconBlock,
-    res: Result[void, VerifierError]) =
+    res: Result[BlockRef, VerifierError]) =
   if self.dumpEnabled and res.isErr:
     case res.error
     of VerifierError.Invalid:
@@ -168,7 +168,7 @@ proc dumpBlock(
       discard
 
 from ../consensus_object_pools/block_clearance import
-  addBackfillBlock, addHeadBlockWithParent, checkHeadBlock
+  addBackfillBlock, addHeadBlockWithParent, checkHeadBlock, verifyBlockProposer
 
 proc verifySidecars(
     signedBlock: ForkySignedBeaconBlock,
@@ -179,10 +179,7 @@ proc verifySidecars(
   when consensusFork == ConsensusFork.Gloas:
     # For Gloas, we still need to store the columns if they're provided
     # but skip validation since we don't have kzg_commitments in the block
-    if sidecarsOpt.isSome:
-      debugGloasComment "potentially validate against payload envelope"
-      let columns = sidecarsOpt.get()
-      discard
+    debugGloasComment "potentially validate against payload envelope"
   elif consensusFork == ConsensusFork.Fulu:
     if sidecarsOpt.isSome:
       let columns = sidecarsOpt.get()
@@ -332,29 +329,6 @@ proc getExecutionValidity(
 
   Opt.some(optimisticStatus)
 
-proc checkBlobOrColumnlessSignature(
-    self: BlockProcessor,
-    signed_beacon_block: deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
-                         fulu.SignedBeaconBlock):
-    Result[void, cstring] =
-  let dag = self.consensusManager.dag
-  let parent = dag.getBlockRef(signed_beacon_block.message.parent_root).valueOr:
-    return err("checkBlobOrColumnlessSignature called with orphan block")
-  let proposer = getProposer(
-        dag, parent, signed_beacon_block.message.slot).valueOr:
-    return err("checkBlobOrColumnlessSignature: Cannot compute proposer")
-  if distinctBase(proposer) != signed_beacon_block.message.proposer_index:
-    return err("checkBlobOrColumnlessSignature: Incorrect proposer")
-  if not verify_block_signature(
-      dag.forkAtEpoch(signed_beacon_block.message.slot.epoch),
-      getStateField(dag.headState, genesis_validators_root),
-      signed_beacon_block.message.slot,
-      signed_beacon_block.root,
-      dag.validatorKey(proposer).get(),
-      signed_beacon_block.signature):
-    return err("checkBlobOrColumnlessSignature: Invalid proposer signature")
-  ok()
-
 proc addBlock*(
   self: ref BlockProcessor,
   src: MsgSource,
@@ -387,54 +361,45 @@ proc enqueueBlock*(
   # `addBlock` should be used where managing backpressure is appropriate.
   discard self.addBlock(src, blck, sidecarsOpt, maybeFinalized, validationDur)
 
-proc enqueueQuarantine(self: ref BlockProcessor, root: Eth2Digest) =
+proc enqueueQuarantine(self: ref BlockProcessor, parent: BlockRef) =
   ## Enqueue blocks whose parent is `root` - ie when `root` has been added to
   ## the blockchain dag, its direct descendants are now candidates for
   ## processing
-  for quarantined in self.consensusManager.quarantine[].pop(root):
+  let
+    dag = self.consensusManager[].dag
+    quarantine = self.consensusManager[].quarantine
+  for quarantined in quarantine[].pop(parent.root):
     # Process the blocks that had the newly accepted block as parent
-    debug "Block from quarantine",
-      blockRoot = shortLog(root), quarantined = shortLog(quarantined.root)
+    debug "Block from quarantine", parent, quarantined = shortLog(quarantined.root)
 
     withBlck(quarantined):
       when consensusFork == ConsensusFork.Gloas:
         debugGloasComment ""
-        self.enqueueBlock(
-          MsgSource.gossip, forkyBlck, Opt.none(gloas.DataColumnSidecars))
+        const sidecarsOpt = noSidecars
       elif consensusFork == ConsensusFork.Fulu:
-        if len(forkyBlck.message.body.blob_kzg_commitments) == 0:
-          self.enqueueBlock(
-            MsgSource.gossip, forkyBlck, Opt.some(fulu.DataColumnSidecars @[])
-          )
-        else:
-          if (let res = checkBlobOrColumnlessSignature(self[], forkyBlck); res.isErr):
-            warn "Failed to verify signature of unorphaned blobless block",
-              blck = shortLog(forkyBlck), error = res.error()
-            continue
-          let cres = self.dataColumnQuarantine[].popSidecars(forkyBlck.root, forkyBlck)
-          if cres.isSome:
-            self.enqueueBlock(MsgSource.gossip, forkyBlck, cres)
-          else:
-            discard self.consensusManager.quarantine[].addSidecarless(
-              self.consensusManager[].dag.finalizedHead.slot, forkyBlck
-            )
+        let sidecarsOpt =
+          self.dataColumnQuarantine[].popSidecars(forkyBlck.root, forkyBlck)
       elif consensusFork in ConsensusFork.Deneb .. ConsensusFork.Electra:
-        if len(forkyBlck.message.body.blob_kzg_commitments) == 0:
-          self.enqueueBlock(MsgSource.gossip, forkyBlck, Opt.some(BlobSidecars @[]))
-        else:
-          if (let res = checkBlobOrColumnlessSignature(self[], forkyBlck); res.isErr):
-            warn "Failed to verify signature of unorphaned columnless block",
-              blck = shortLog(forkyBlck), error = res.error()
-            continue
-          let bres = self.blobQuarantine[].popSidecars(forkyBlck.root, forkyBlck)
-          if bres.isSome():
-            self.enqueueBlock(MsgSource.gossip, forkyBlck, bres)
-          else:
-            self.consensusManager.quarantine[].addSidecarless(forkyBlck)
+        let sidecarsOpt = self.blobQuarantine[].popSidecars(forkyBlck.root, forkyBlck)
       elif consensusFork in ConsensusFork.Phase0 .. ConsensusFork.Capella:
-        self.enqueueBlock(MsgSource.gossip, forkyBlck, noSidecars)
+        const sidecarsOpt = noSidecars
       else:
         {.error: "Unknown consensus fork " & $consensusFork.}
+
+      when consensusFork in ConsensusFork.Deneb .. ConsensusFork.Fulu:
+        if not sidecarsOpt.isSome():
+          dag.verifyBlockProposer(
+            parent, forkyBlck.message.slot, forkyBlck.message.proposer_index,
+            forkyBlck.root, forkyBlck.signature,
+          ).isOkOr:
+            warn "Failed to verify signature of unorphaned blobless block",
+              blck = shortLog(forkyBlck), error = error.msg
+            continue
+
+          discard quarantine[].addSidecarless(dag.finalizedHead.slot, forkyBlck)
+          continue
+
+      self.enqueueBlock(MsgSource.gossip, forkyBlck, sidecarsOpt)
 
 proc onBlockAdded*(
     dag: ChainDAGRef,
@@ -571,7 +536,7 @@ proc storeBlock(
     maybeFinalized: bool,
     queueTick: Moment,
     validationDur: Duration,
-): Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
+): Future[Result[BlockRef, VerifierError]] {.async: (raises: [CancelledError]).} =
   ## storeBlock is the main entry point for unvalidated blocks - all untrusted
   ## blocks, regardless of origin, pass through here. When storing a block,
   ## we will add it to the dag and pass it to all block consumers that need
@@ -586,9 +551,9 @@ proc storeBlock(
     deadlineTime =
       block:
         let slotTime =
-          (wallSlot + 1).start_beacon_time(dag.timeParams) - 1.seconds
+          (wallSlot + 1).start_beacon_time(dag.timeParams) - chronos.seconds(1)
         if slotTime <= wallTime:
-          0.seconds
+          chronos.seconds(0)
         else:
           chronos.nanoseconds((slotTime - wallTime).nanoseconds)
     deadline = sleepAsync(deadlineTime)
@@ -725,7 +690,7 @@ proc storeBlock(
     blck = shortLog(blck),
     validationDur, queueDur, newPayloadDur, addHeadBlockDur, updateHeadDur
 
-  ok()
+  ok(blck)
 
 proc addBlock*(
     self: ref BlockProcessor,
@@ -776,7 +741,7 @@ proc addBlock*(
         # taking up all CPU - we don't want to _completely_ stop processing blocks
         # in this case - doing so also allows us to benefit from more batching /
         # larger network reads when under load.
-        idleTimeout = 10.milliseconds
+        idleTimeout = chronos.milliseconds(10)
 
       discard await idleAsync().withTimeout(idleTimeout)
 
@@ -799,15 +764,13 @@ proc addBlock*(
 
   if res.isOk():
     # Once a block is successfully stored, enqueue the direct descendants
-    self.enqueueQuarantine(blockRoot)
+    self.enqueueQuarantine(res[])
   else:
     case res.error()
     of VerifierError.MissingParent:
       let finalizedSlot = self.consensusManager.dag.finalizedHead.slot
       if (
-        let r = self.consensusManager.quarantine[].addOrphan(
-          finalizedSlot, ForkedSignedBeaconBlock.init(blck)
-        )
+        let r = self.consensusManager.quarantine[].addOrphan(finalizedSlot, blck)
         r.isErr()
       ):
         debug "Could not add orphan",
@@ -838,4 +801,4 @@ proc addBlock*(
     else:
       discard
 
-  res
+  res.mapConvert(void)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -17,8 +17,8 @@ import
     beaconstate, state_transition_block, forks,
     helpers, network, signatures, peerdas_helpers],
   ../consensus_object_pools/[
-    attestation_pool, blockchain_dag, blob_quarantine, block_quarantine,
-    spec_cache, light_client_pool, sync_committee_msg_pool,
+    attestation_pool, blockchain_dag, blob_quarantine, block_clearance,
+    block_quarantine, spec_cache, light_client_pool, sync_committee_msg_pool,
     validator_change_pool],
   ".."/[beacon_clock],
   ./batch_validation
@@ -510,11 +510,13 @@ proc validateBlobSidecar*(
   # `block_header.parent_root`) passes validation.
   let parent = dag.getBlockRef(block_header.parent_root).valueOr:
     if block_header.parent_root in quarantine[].unviable:
+      # If the parent was unviable, this block is unviable for the same reason
       quarantine[].addUnviable(block_root)
-      return dag.checkedReject("BlobSidecar: parent not validated")
-    else:
-      quarantine[].addMissing(block_header.parent_root)
-      return errIgnore("BlobSidecar: parent not found")
+      # TODO keep track of unviable invalid
+      return errIgnore("BlobSidecar: parent from unviable fork")
+
+    quarantine[].addMissing(block_header.parent_root)
+    return errIgnore("BlobSidecar: parent not found")
 
   # [REJECT] The sidecar is from a higher slot than the sidecar's
   # block's parent (defined by `block_header.parent_root`).
@@ -547,23 +549,13 @@ proc validateBlobSidecar*(
   # shuffling, the sidecar MAY be queued for later processing while proposers
   # for the block's branch are calculated -- in such a case do not
   # REJECT, instead IGNORE this message.
-  let proposer = getProposer(dag, parent, block_header.slot).valueOr:
-    warn "cannot compute proposer for blob"
-    return errIgnore("BlobSidecar: Cannot compute proposer") # internal issue
-
-  if uint64(proposer) != block_header.proposer_index:
-    return dag.checkedReject("BlobSidecar: Unexpected proposer")
-
   # [REJECT] The proposer signature of `blob_sidecar.signed_block_header`,
   # is valid with respect to the `block_header.proposer_index` pubkey.
-  if not verify_block_signature(
-      dag.forkAtEpoch(block_header.slot.epoch),
-      getStateField(dag.headState, genesis_validators_root),
-      block_header.slot,
-      block_root,
-      dag.validatorKey(proposer).get(),
-      blob_sidecar.signed_block_header.signature):
-    return dag.checkedReject("BlobSidecar: Invalid proposer signature")
+  dag.verifyBlockProposer(
+    parent, block_header.slot, block_header.proposer_index, block_root,
+    blob_sidecar.signed_block_header.signature,
+  ).isOkOr:
+    return dag.checkedReject(error.msg)
 
   # [REJECT] The sidecar's blob is valid as verified by `verify_blob_kzg_proof(
   # blob_sidecar.blob, blob_sidecar.kzg_commitment, blob_sidecar.kzg_proof)`.
@@ -647,11 +639,13 @@ proc validateDataColumnSidecar*(
   # `block_header.parent_root`) passes validation.
   let parent = dag.getBlockRef(block_header.parent_root).valueOr:
     if block_header.parent_root in quarantine[].unviable:
+      # If the parent was unviable, this block is unviable for the same reason
       quarantine[].addUnviable(block_root)
-      return dag.checkedReject("DataColumnSidecar: parent not validated")
-    else:
-      quarantine[].addMissing(block_header.parent_root)
-      return errIgnore("DataColumnSidecar: parent not found")
+      # TODO keep track of unviable invalid
+      return errIgnore("DataColumnSidecar: parent from unviable fork")
+
+    quarantine[].addMissing(block_header.parent_root)
+    return errIgnore("DataColumnSidecar: parent not found")
 
   # [REJECT] The sidecar is from a higher slot than the sidecar's
   # block's parent (defined by `block_header.parent_root`).
@@ -684,23 +678,14 @@ proc validateDataColumnSidecar*(
   # shuffling, the sidecar MAY be queued for later processing while proposers
   # for the block's branch are calculated -- in such a case do not
   # REJECT, instead IGNORE this message.
-  let proposer = getProposer(dag, parent, block_header.slot).valueOr:
-    warn "cannot compute proposer for data column"
-    return errIgnore("DataColumnSidecar: Cannot compute proposer") # internal issue
-
-  if uint64(proposer) != block_header.proposer_index:
-    return dag.checkedReject("DataColumnSidecar: Unexpected proposer")
-
   # [REJECT] The proposer signature of `data_column_sidecar.signed_block_header`,
   # is valid with respect to the `block_header.proposer_index` pubkey.
-  if not verify_block_signature(
-      dag.forkAtEpoch(block_header.slot.epoch),
-      getStateField(dag.headState, genesis_validators_root),
-      block_header.slot,
-      block_root,
-      dag.validatorKey(proposer).get(),
-      data_column_sidecar.signed_block_header.signature):
-    return dag.checkedReject("DataColumnSidecar: Invalid proposer signature")
+
+  dag.verifyBlockProposer(
+    parent, block_header.slot, block_header.proposer_index, block_root,
+    data_column_sidecar.signed_block_header.signature,
+  ).isOkOr:
+    return dag.checkedReject(error.msg)
 
   # [REJECT] The sidecar's column data is valid as
   # verified by `verify_data_column_kzg_proofs(sidecar)`
@@ -858,6 +843,7 @@ proc validateBeaconBlock*(
   # passes validation.
   let parent = dag.getBlockRef(signed_beacon_block.message.parent_root).valueOr:
     if signed_beacon_block.message.parent_root in quarantine[].unviable:
+      # If the parent was unviable, this block is unviable for the same reason
       quarantine[].addUnviable(signed_beacon_block.root)
 
       # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/bellatrix/p2p-interface.md#beacon_block
@@ -883,26 +869,22 @@ proc validateBeaconBlock*(
 
         # Implementation restrictions:
         #
-        # - We don't know if the parent state had execution enabled.
-        #   If it had, and the block doesn't have it enabled anymore,
-        #   we end up in the pre-Merge path below (`else`) and REJECT.
-        #   Such a block is clearly invalid, though, without asking the EL.
-        #
         # - We know that the parent was marked unviable, but don't know
         #   whether it was marked unviable due to consensus (REJECT) or
         #   execution (IGNORE) verification failure. We err on the IGNORE side.
         return errIgnore("BeaconBlock: ignored, parent from unviable fork")
       else:
-        # [REJECT] The block's parent (defined by `block.parent_root`) passes
-        # validation.
-        return dag.checkedReject(
-          "BeaconBlock: rejected, parent from unviable fork")
+        # For non-execution blocks, we also don't keep track of unviable forks
+        # or invalid blocks
+        # TODO keep track of unviable invalid
+        return errIgnore("BeaconBlock: ignored, parent from unviable fork")
 
     # When the parent is missing, we can't validate the block - we'll queue it
     # in the quarantine for later processing
-    if (let r = quarantine[].addOrphan(
-        dag.finalizedHead.slot,
-        ForkedSignedBeaconBlock.init(signed_beacon_block)); r.isErr):
+    if (
+      let r = quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
+      r.isErr
+    ):
       debug "validateBeaconBlock: could not add orphan",
        blockRoot = shortLog(signed_beacon_block.root),
        blck = shortLog(signed_beacon_block.message),
@@ -952,27 +934,14 @@ proc validateBeaconBlock*(
   # against the expected shuffling, the block MAY be queued for later
   # processing while proposers for the block's branch are calculated -- in such
   # a case do not REJECT, instead IGNORE this message.
-  let
-    proposer = getProposer(
-        dag, parent, signed_beacon_block.message.slot).valueOr:
-      warn "cannot compute proposer for block"
-      return errIgnore("BeaconBlock: Cannot compute proposer") # internal issue
-
-  if uint64(proposer) != signed_beacon_block.message.proposer_index:
-    quarantine[].addUnviable(signed_beacon_block.root)
-    return dag.checkedReject("BeaconBlock: Unexpected proposer")
-
   # [REJECT] The proposer signature, signed_beacon_block.signature, is valid
   # with respect to the proposer_index pubkey.
-  if not verify_block_signature(
-      dag.forkAtEpoch(signed_beacon_block.message.slot.epoch),
-      getStateField(dag.headState, genesis_validators_root),
-      signed_beacon_block.message.slot,
-      signed_beacon_block.root,
-      dag.validatorKey(proposer).get(),
-      signed_beacon_block.signature):
-    quarantine[].addUnviable(signed_beacon_block.root)
-    return dag.checkedReject("BeaconBlock: Invalid proposer signature")
+  dag.verifyBlockProposer(
+    parent, signed_beacon_block.message.slot,
+    signed_beacon_block.message.proposer_index, signed_beacon_block.root,
+    signed_beacon_block.signature,
+  ).isOkOr:
+    return dag.checkedReject(error.msg)
 
   ok()
 
@@ -1758,7 +1727,8 @@ proc validateSyncCommitteeMessage*(
     blockRoot = msg.beacon_block_root
     blck = dag.getBlockRef(blockRoot).valueOr:
       if blockRoot in quarantine[].unviable:
-        return dag.checkedReject("SyncCommitteeMessage: target invalid")
+        # TODO keep track of unviable invalid blocks
+        return errIgnore("SyncCommitteeMessage: target from unviable fork")
       quarantine[].addMissing(blockRoot)
       return errIgnore("SyncCommitteeMessage: target not found")
 
@@ -1883,7 +1853,9 @@ proc validateContribution*(
     blockRoot = msg.message.contribution.beacon_block_root
     blck = dag.getBlockRef(blockRoot).valueOr:
       if blockRoot in quarantine[].unviable:
-        return dag.checkedReject("Contribution: target invalid")
+        # TODO keep track of unviable invalid blocks
+        return errIgnore("Contribution: target from unviable fork")
+
       quarantine[].addMissing(blockRoot)
       return errIgnore("Contribution: target not found")
 

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -234,7 +234,7 @@ proc blockProcessingLoop(overseer: SyncOverseerRef): Future[void] {.
         for bdata in bchunk.blocks:
           block:
             let res = withBlck(bdata.blck):
-              addBackfillBlockData(
+              addLightForwardBlock(
                 dag,
                 consensusFork,
                 bdata,
@@ -257,7 +257,7 @@ proc blockProcessingLoop(overseer: SyncOverseerRef): Future[void] {.
 
         bchunk.resfut.complete(Result[void, string].ok())
 
-proc verifyBlockProposer(
+proc verifyBlockSignature(
     fork: Fork,
     genesis_validators_root: Eth2Digest,
     immutableValidators: openArray[ImmutableValidatorData2],
@@ -285,7 +285,7 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
     clist =
       block:
         overseer.clist.seekForSlot(dag.head.slot).isOkOr:
-          fatal "Unable to find slot in backfill data", reason = error,
+          fatal "Unable to find slot in light forward sync data", reason = error,
                 path = overseer.clist.path
           quit 1
         overseer.clist
@@ -306,7 +306,7 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
     while true:
       let res = getChainFileTail(handle.handle)
       if res.isErr():
-        fatal "Unable to read backfill data", reason = res.error
+        fatal "Unable to read light forward sync data", reason = res.error
         quit 1
       let bres = res.get()
       if bres.isNone():
@@ -337,12 +337,12 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
               genesis_validators_root =
                 getStateField(dag.clearanceState, genesis_validators_root)
 
-            verifyBlockProposer(batchVerifier[], fork, genesis_validators_root,
-                                dag.db.immutableValidators, blocksOnly).isOkOr:
+            verifyBlockSignatures(batchVerifier[], fork, genesis_validators_root,
+                                  dag.db.immutableValidators, blocksOnly).isOkOr:
               for signedBlock in blocksOnly:
-                verifyBlockProposer(fork, genesis_validators_root,
-                                    dag.db.immutableValidators,
-                                    signedBlock).isOkOr:
+                verifyBlockSignature(fork, genesis_validators_root,
+                                     dag.db.immutableValidators,
+                                     signedBlock).isOkOr:
                   fatal "Unable to verify block proposer",
                         blck = shortLog(signedBlock), reason = error
               return err(VerifierError.Invalid)
@@ -396,7 +396,7 @@ proc initUntrustedSync(overseer: SyncOverseerRef): Future[void] {.
 
   overseer.statusMsg = Opt.some("storing block")
 
-  let res = overseer.clist.addBackfillBlockData(blck.blck, blck.blob)
+  let res = overseer.clist.addLightForwardBlock(blck.blck, blck.blob)
   if res.isErr():
     warn "Unable to store initial block", reason = res.error
     return
@@ -543,7 +543,7 @@ proc mainLoop*(
         return
 
       clist.clear().isOkOr:
-        warn "Unable to remove backfill data file",
+        warn "Unable to remove light forward sync data file",
              path = clist.path.chainFilePath(), reason = error
         quit 1
 

--- a/tests/test_block_quarantine.nim
+++ b/tests/test_block_quarantine.nim
@@ -14,12 +14,12 @@ import
   ../beacon_chain/spec/datatypes/[phase0, deneb],
   ../beacon_chain/consensus_object_pools/block_quarantine
 
-func makeBlock(slot: Slot, parent: Eth2Digest): ForkedSignedBeaconBlock =
+func makeBlock(slot: Slot, parent: Eth2Digest): phase0.SignedBeaconBlock =
   var
     b = phase0.SignedBeaconBlock(
       message: phase0.BeaconBlock(slot: slot, parent_root: parent))
   b.root = hash_tree_root(b.message)
-  ForkedSignedBeaconBlock.init(b)
+  b
 
 func makeBlobbyBlock(slot: Slot, parent: Eth2Digest): deneb.SignedBeaconBlock =
   var
@@ -123,7 +123,7 @@ suite "Block quarantine":
     var quarantine = Quarantine.init(defaultRuntimeConfig)
     var blocks = @[makeBlock(Slot 0, ZERO_HASH)]
     for i in 0..<MaxMissingItems:
-      blocks.add makeBlock(blocks[^1].slot + 1, blocks[^1].root)
+      blocks.add makeBlock(blocks[^1].message.slot + 1, blocks[^1].root)
 
     # Fill missing list with junk
     for i in 0..<MaxMissingItems:


### PR DESCRIPTION
* verify proposer index/signature the same way across blocks/blobs/columns/quarantine
* rename block clearance helpers to differentiate backfill vs light forward syncing and signature versus proposer checking (the latter includes checking the proposer index against the state)
* avoid redundant parent lookup when re-queueing quarantine blocks
* delay `Forked...` block init in quarantine until the block is actually being added