### PR TITLE
Fix Nix build without git

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,7 +23,7 @@ assert pkgs.lib.assertMsg ((src.submodules or true) == true)
 let
   inherit (pkgs) stdenv lib writeScriptBin callPackage;
 
-  revision = lib.substring 0 8 (src.rev or "unknown");
+  revision = lib.substring 0 8 (src.rev or "00000000");
 in stdenv.mkDerivation rec {
   pname = "nimbus-eth2";
   version = "${callPackage ./version.nix {}}-${revision}";


### PR DESCRIPTION
buildinfo does not accept "unknown" because it's not a 8-character hex string.

https://github.com/status-im/nimbus-eth2/blob/9839f140628ae0e2e8aa7eb055da5c4bb08171d0/beacon_chain/buildinfo.nim#L42