### PR TITLE
rm some misleading forks.kind() overloads

### DIFF
--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -388,7 +388,6 @@ template kind*(
       phase0.TrustedBeaconBlockBody |
       phase0.SigVerifiedSignedBeaconBlock |
       phase0.TrustedSignedBeaconBlock |
-      phase0.Attestation |
       phase0.AggregateAndProof |
       phase0.SignedAggregateAndProof]): ConsensusFork =
   ConsensusFork.Phase0
@@ -468,8 +467,6 @@ template kind*(
       electra.TrustedBeaconBlockBody |
       electra.SigVerifiedSignedBeaconBlock |
       electra.TrustedSignedBeaconBlock |
-      electra.Attestation |
-      electra.SingleAttestation |
       electra.AggregateAndProof |
       electra.SignedAggregateAndProof |
       electra_mev.BlindedBeaconBlock |


### PR DESCRIPTION
These overloads aren't otherwise used once:
- https://github.com/status-im/nimbus-eth2/pull/7689

merges and encourage subtly incorrect usage.