### PR TITLE
Remove deposit_contract from Docker build script

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -13,7 +13,7 @@ on:
   #pull_request:
 
 env:
-  # Build and include deposit_contract nimbus_signing_node nimbus_light_client in archive
+  # Build and include nimbus_signing_node nimbus_light_client in archive
   BUILD_TOOLS: 1
 
 jobs:

--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -24,7 +24,7 @@ echo "Build Tools = ${BUILD_TOOLS}"
 
 if [[ "${BUILD_TOOLS}" == "1" ]]; then
   echo "Including tools in distribution"
-  BINARIES="${BINARIES} deposit_contract nimbus_signing_node nimbus_light_client"
+  BINARIES="${BINARIES} nimbus_signing_node nimbus_light_client"
 fi
 
 echo -e "\nPLATFORM=${PLATFORM}"


### PR DESCRIPTION
#7155 removed deposit_contract binary but did not remove it from the tooling build used by the on-demand nightly action, failing that build. Stop requesting to build it as it's gone.