### PR TITLE
Use correct arch for Nimbus-eth1 testnets

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -536,7 +536,7 @@ download_nimbus_eth1() {
         NIMBUS_ETH1_PLATFORM=Linux_arm64v8
         ;;
       macos-arm64|macos-aarch64)
-        NIMBUS_ETH1_PLATFORM=macOS_amd64
+        NIMBUS_ETH1_PLATFORM=macOS_arm64
         ;;
       windows-amd64|windows-x86_64)
         NIMBUS_ETH1_PLATFORM=Windows_amd64


### PR DESCRIPTION
macos-arm64 should download macOS_arm64 not macOS_amd64.