### PR TITLE
Remove macOS AMD64 from nightly build

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -237,57 +237,6 @@ jobs:
           path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
           retention-days: 2
 
-  build-macos-amd64:
-    name: macOS AMD64 release asset
-    runs-on: ubuntu-latest
-    steps:
-      - name: Fix nim cache conflicts
-        run: |
-          echo "XDG_CACHE_HOME=${{ runner.temp }}/.nim-cache" >> $GITHUB_ENV
-          echo "CI_CACHE=${{ runner.temp }}/.nbs-cache" >> $GITHUB_ENV
-
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: unstable
-
-      - name: Build project
-        id: make_dist
-        run: |
-          make dist-macos
-          cd dist
-          ARCHIVE=$(echo *.tar.gz)
-          tar -xzf ${ARCHIVE}
-          NEW_ARCHIVE_DIR="nimbus-eth2_macOS_amd64_$(date +%Y%m%d)_$(git rev-parse --short=8 HEAD)"
-          mv ${ARCHIVE%.tar.gz} ${NEW_ARCHIVE_DIR}
-          tar -czf ${NEW_ARCHIVE_DIR}.tar.gz ${NEW_ARCHIVE_DIR}
-          cp ${NEW_ARCHIVE_DIR}.tar.gz nimbus-eth2_macOS_amd64_nightly_latest.tar.gz
-          echo "::set-output name=archive::"${NEW_ARCHIVE_DIR}.tar.gz
-          echo "::set-output name=archive_dir::"${NEW_ARCHIVE_DIR}
-
-      - name: Upload archive artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_archive
-          path: |
-            ./dist/${{ steps.make_dist.outputs.archive }}
-            ./dist/nimbus-eth2_macOS_amd64_nightly_latest.tar.gz
-          retention-days: 2
-
-      - name: Upload BN checksum artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_checksum_bn
-          path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_beacon_node.sha512sum
-          retention-days: 2
-
-      - name: Upload VC checksum artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: macOS_amd64_checksum_vc
-          path: ./dist/${{ steps.make_dist.outputs.archive_dir }}/build/nimbus_validator_client.sha512sum
-          retention-days: 2
-
   build-macos-arm64:
     name: macOS ARM64 release asset
     runs-on: ubuntu-latest
@@ -341,7 +290,7 @@ jobs:
 
   prepare-prerelease:
     name: Prepare pre-release
-    needs: [build-amd64, build-arm64, build-arm, build-win64, build-macos-amd64, build-macos-arm64]
+    needs: [build-amd64, build-arm64, build-arm, build-win64, build-macos-arm64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -371,9 +320,6 @@ jobs:
           echo '# Windows AMD64' >> release_notes.md
           cat Windows_amd64_checksum_bn/* >> release_notes.md
           cat Windows_amd64_checksum_vc/* >> release_notes.md
-          echo '# macOS AMD64' >> release_notes.md
-          cat macOS_amd64_checksum_bn/* >> release_notes.md
-          cat macOS_amd64_checksum_vc/* >> release_notes.md
           echo '# macOS ARM64' >> release_notes.md
           cat macOS_arm64_checksum_bn/* >> release_notes.md
           cat macOS_arm64_checksum_vc/* >> release_notes.md
@@ -395,7 +341,6 @@ jobs:
             Linux_arm64_archive/* \
             Linux_arm_archive/* \
             Windows_amd64_archive/* \
-            macOS_amd64_archive/* \
             macOS_arm64_archive/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -417,9 +362,6 @@ jobs:
             Windows_amd64_archive
             Windows_amd64_checksum_bn
             Windows_amd64_checksum_vc
-            macOS_amd64_archive
-            macOS_amd64_checksum_bn
-            macOS_amd64_checksum_vc
             macOS_arm64_archive
             macOS_arm64_checksum_bn
             macOS_arm64_checksum_vc


### PR DESCRIPTION
Follows up on #7697 and f491646040c96f7b62f36f2133742edb432d5efc to fix the nightly build which still uses a Makefile target that was removed.