### PR TITLE
Apply policy: Retain back through Mainnet's second latest fork

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2382,8 +2382,6 @@ proc processVanityLogs(dag: ChainDAGRef, vanityState: auto) =
         handler()
 
     # Policy: Retain back through Mainnet's second latest fork.
-    ConsensusFork.Deneb.logForkUpgrade(
-      dag.vanityLogs.onUpgradeToDeneb)
     ConsensusFork.Electra.logForkUpgrade(
       dag.vanityLogs.onUpgradeToElectra)
     ConsensusFork.Fulu.logForkUpgrade(

--- a/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
+++ b/beacon_chain/consensus_object_pools/vanity_logs/vanity_logs.nim
@@ -19,10 +19,6 @@ type
     # known by this node appears in a head block
     onKnownBlsToExecutionChange*: LogProc
 
-    # Gets displayed on upgrade to Deneb. May be displayed multiple times
-    # in case of chain reorgs around the upgrade.
-    onUpgradeToDeneb*: LogProc
-
     # Gets displayed on upgrade to Electra. May be displayed multiple times
     # in case of chain reorgs around the upgrade.
     onUpgradeToElectra*: LogProc

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -143,7 +143,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   of StdoutLogKind.Colors:
     VanityLogs(
       onKnownBlsToExecutionChange:     capellaBlink,
-      onUpgradeToDeneb:                denebColor,
       onUpgradeToElectra:              electraColor,
       onKnownCompoundingChange:        electraBlink,
       onUpgradeToFulu:                 fuluColor,
@@ -151,7 +150,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   of StdoutLogKind.NoColors:
     VanityLogs(
       onKnownBlsToExecutionChange:     capellaMono,
-      onUpgradeToDeneb:                denebMono,
       onUpgradeToElectra:              electraMono,
       onKnownCompoundingChange:        electraMono,
       onUpgradeToFulu:                 fuluMono,
@@ -160,8 +158,6 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
     VanityLogs(
       onKnownBlsToExecutionChange:
         (proc() = notice "🦉 BLS to execution changed 🦉"),
-      onUpgradeToDeneb:
-        (proc() = notice "🐟 Proto-Danksharding is ON 🐟"),
       onUpgradeToElectra:
         (proc() = notice "🦒 Compounding is available 🦒"),
       onKnownCompoundingChange:


### PR DESCRIPTION
In v1.6.0 specs (#7696) the mainnet config.yaml was updated to use Fulu.

- https://github.com/ethereum/consensus-specs/blob/v1.6.0/configs/mainnet.yaml#L57