### PR TITLE
ci: block macm4-01 for investigation

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -10,7 +10,7 @@ library 'status-jenkins-lib@v1.9.2'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
-  agent { label 'macos && aarch64' }
+  agent { label 'macos && aarch64 && !macm4-01' }
 
   parameters {
     choice(


### PR DESCRIPTION
blocks `macm4-01` till we complete investigating why nimbus-eth2 builds are failing on this new host.