### PR TITLE
ci: use m4 host

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -10,7 +10,7 @@ library 'status-jenkins-lib@v1.9.2'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */
-  agent { label 'macos && aarch64 && !macm4-01' }
+  agent { label 'macos && aarch64' }
 
   parameters {
     choice(


### PR DESCRIPTION
we can start using this host again after clang has been downgraded to 20.x

fixes: https://github.com/status-im/infra-ci/issues/226