### PR TITLE
fix: use correct committee validator bc1[1] for attestation2

### DIFF
--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -318,7 +318,7 @@ suite "Attestation pool electra processing" & preset():
       attestation1.loadSig, attestation1.startTime)
 
     pool[].addAttestation(
-      attestation2, @[bc0[1]], attestation2.aggregation_bits.len,
+      attestation2, @[bc1[1]], attestation2.aggregation_bits.len,
       attestation2.loadSig, attestation2.startTime)
 
     check cfg.process_slots(


### PR DESCRIPTION
Copy-paste bug: attestation2 created from committee bc1[1] was added to pool with validator from bc0[1] instead.
Test verifies cross-committee aggregation, so correct committee assignment is critical for test validity.

Reopen: https://github.com/status-im/nimbus-eth2/pull/7731