### PR TITLE
Add option to light client to sync finality to engine API

### DIFF
--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -117,6 +117,11 @@ type LightClientConf* = object
     desc: "Recent trusted finalized block root to initialize light client from"
     name: "trusted-block-root" .}: Eth2Digest
 
+  syncLightClientFinality* {.
+    desc: "Whether the light client should including finality information when syncing execution layers"
+    defaultValue: false
+    name: "sync-light-client-finality" .}: bool
+
   # Execution layer
   web3Urls* {.
     desc: "One or more execution layer Engine API URLs"

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -179,12 +179,25 @@ proc main() {.noinline, raises: [CatchableError].} =
               not isSynced(bid.slot, beaconClock.currentSlot):
             return
 
+          let finalizedBlockHash =
+            if config.syncLightClientFinality:
+              let finalizedHeader = lightClient.finalizedHeader
+              withForkyHeader(finalizedHeader):
+                when lcDataFork >= LightClientDataFork.Capella:
+                  forkyHeader.execution.block_hash
+                else:
+                  ZERO_HASH
+            else:
+              ZERO_HASH
+
           withConsensusFork(consensusFork):
             when lcDataForkAtConsensusFork(consensusFork) == lcDataFork:
+              debug "Sending forkchoiceUpdated",
+                finalizedBlockHash = finalizedBlockHash
               optimisticFcuFut = elManager.forkchoiceUpdated(
                 headBlockHash = blockHash,
-                safeBlockHash = blockHash,  # stub value
-                finalizedBlockHash = ZERO_HASH,
+                safeBlockHash = finalizedBlockHash,  # justified not available
+                finalizedBlockHash = finalizedBlockHash,
                 payloadAttributes = Opt.none(consensusFork.PayloadAttributes))
               optimisticFcuFut.addCallback do (future: pointer):
                 optimisticFcuFut = nil


### PR DESCRIPTION
Enable the `nimbus_light_client` to sync the finalized block hash to the execution layers via startup flag `--sync-light-client-finality`.