### PR TITLE
Blob quarantine rewrite to get rid of busy loops.

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -113,6 +113,7 @@ AllTests-mainnet
 + database and memory overfill protection and pruning test                                   OK
 + database unload/load test                                                                  OK
 + overfill protection test                                                                   OK
++ overfill test [maximum number of blobs]                                                    OK
 + popSidecars()/hasSidecars() return []/true on block without blobs                          OK
 + pruneAfterFinalization() test                                                              OK
 + put() duplicate items should not affect counters                                           OK
@@ -171,11 +172,17 @@ AllTests-mainnet
 ```
 ## ColumnQuarantine data structure test suite  [Preset: mainnet]
 ```diff
-+ database and memory overfill protection and pruning test                                   OK
-+ database unload/load test                                                                  OK
-+ overfill protection test                                                                   OK
-+ pruneAfterFinalization() test                                                              OK
-+ put() duplicate items should not affect counters                                           OK
++ Empty in-memory scenario test [node]                                                       OK
++ Empty in-memory scenario test [supernode]                                                  OK
++ Mixed entries scenario test [node]                                                         OK
++ Mixed entries scenario test [supernode]                                                    OK
++ database and memory overfill protection and pruning test [node]                            OK
++ database unload/load test [node]                                                           OK
++ overfill protection test [node]                                                            OK
++ overfill test [node]                                                                       OK
++ overfill test [supernode]                                                                  OK
++ pruneAfterFinalization() test [node]                                                       OK
++ put() duplicate items should not affect counters [node]                                    OK
 + put()/fetchMissingSidecars/remove test [node]                                              OK
 + put()/fetchMissingSidecars/remove test [supernode]                                         OK
 + put()/hasSidecar(index, slot, proposer_index)/remove() test                                OK

--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -9,7 +9,7 @@
 
 import
   stew/bitops2,
-  std/[sets, tables, sequtils],
+  std/[sets, sequtils, strutils, lists],
   results, metrics,
   ../spec/[presets, helpers, column_map],
   ../beacon_chain_db_quarantine
@@ -47,10 +47,11 @@ type
       data: ref A
 
   RootTableRecord[A] = object
-    sidecars: seq[SidecarHolder[A]]
-    slot: Slot
+    blockRoot*: Eth2Digest
+    slot*: Slot
     unloaded: int
     count: int
+    sidecars: seq[SidecarHolder[A]]
 
   SidecarQuarantine[A, B] = object
     minEpochsForSidecarsRequests: uint64
@@ -61,9 +62,9 @@ type
     maxSidecarsPerBlockCount: int
     custodyColumns*: seq[ColumnIndex]
     custodyMap*: ColumnMap
-    roots: Table[Eth2Digest, RootTableRecord[A]]
-    memUsage: OrderedSet[Eth2Digest]
-    diskUsage: OrderedSet[Eth2Digest]
+    lastMemoryNode*: DoublyLinkedNode[RootTableRecord[A]]
+    roots: Table[Eth2Digest, DoublyLinkedNode[RootTableRecord[A]]]
+    list: DoublyLinkedList[RootTableRecord[A]]
     indexMap: seq[int]
     db: QuarantineDB
     onSidecarCallback*: B
@@ -109,14 +110,15 @@ func init[A, B](
     sidecars: newSeq[SidecarHolder[A]](q.maxSidecarsPerBlockCount),
     count: 0, unloaded: 0, slot: FAR_FUTURE_SLOT)
 
-func len*[A, B](quarantine: SidecarQuarantine[A, B]): int =
-  quarantine.memSidecarsCount + quarantine.diskSidecarsCount
-
-func lenMemory*[A, B](quarantine: SidecarQuarantine[A, B]): int =
-  quarantine.memSidecarsCount
-
-func lenDisk*[A, B](quarantine: SidecarQuarantine[A, B]): int =
-  quarantine.diskSidecarsCount
+func init[A, B](
+    t: typedesc[RootTableRecord],
+    q: SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest
+  ): RootTableRecord[A] =
+  RootTableRecord[A](
+    blockRoot: blockRoot,
+    sidecars: newSeq[SidecarHolder[A]](q.maxSidecarsPerBlockCount),
+    count: 0, unloaded: 0, slot: FAR_FUTURE_SLOT)
 
 func shortLog*[A, B](quarantine: SidecarQuarantine[A, B]): string =
   "[M:" & $quarantine.memSidecarsCount & "/" &
@@ -124,86 +126,34 @@ func shortLog*[A, B](quarantine: SidecarQuarantine[A, B]): string =
     $quarantine.diskSidecarsCount & "/" &
     $quarantine.maxDiskSidecarsCount & "]/" & $len(quarantine.roots)
 
-proc removeRoot[A, B](
-    quarantine: var SidecarQuarantine[A, B],
-    blockRoot: Eth2Digest
-) =
-  # This procedore removes all the sidecars associated with `blockRoot` from
-  # memory and from disk.
-  var
-    rootRecord: RootTableRecord[A]
-    sidecarsOnDisk = 0
+func len*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.memSidecarsCount + q.diskSidecarsCount
 
-  if quarantine.roots.pop(blockRoot, rootRecord):
-    for index in 0 ..< len(rootRecord.sidecars):
-      case rootRecord.sidecars[index].kind
-      of SidecarHolderKind.Empty:
-        discard
-      of SidecarHolderKind.Loaded:
-        rootRecord.sidecars[index].data = nil
-        dec(quarantine.memSidecarsCount)
-        blob_quarantine_memory_slots_occupied.set(
-          int64(quarantine.memSidecarsCount))
-      of SidecarHolderKind.Unloaded:
-        dec(quarantine.diskSidecarsCount)
-        blob_quarantine_database_slots_occupied.set(
-          int64(quarantine.diskSidecarsCount))
-        inc(sidecarsOnDisk)
+func lenMemory*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.memSidecarsCount
 
-    if sidecarsOnDisk > 0 and quarantine.maxMemSidecarsCount > 0:
-      quarantine.db.removeDataSidecars(A, blockRoot)
-      quarantine.diskUsage.excl(blockRoot)
+func lenDisk*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.diskSidecarsCount
 
-    quarantine.memUsage.excl(blockRoot)
+func size*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.maxMemSidecarsCount + q.maxDiskSidecarsCount
 
-proc remove*[A, B](
-    quarantine: var SidecarQuarantine[A, B],
-    blockRoot: Eth2Digest
-) =
-  ## Remove all the data columns or blobs related to the block root ``blockRoot`
-  ## from the quarantine ``quarantine``.
-  ##
-  ## Function do nothing, if ``blockRoot` is not part of the quarantine.
-  quarantine.removeRoot(blockRoot)
+func sizeMemory*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.maxMemSidecarsCount
 
-func getOldestInMemoryRoot[A, B](
-    quarantine: SidecarQuarantine[A, B]
-): Eth2Digest =
-  var oldestRoot: Eth2Digest
-  for blockRoot in quarantine.memUsage:
-    oldestRoot = blockRoot
-    break
-  oldestRoot
+func sizeDisk*[A, B](q: SidecarQuarantine[A, B]): int =
+  q.maxDiskSidecarsCount
 
-func getOldestOnDiskRoot[A, B](
-    quarantine: SidecarQuarantine[A, B]
-): Eth2Digest =
-  var oldestRoot: Eth2Digest
-  for blockRoot in quarantine.diskUsage:
-    oldestRoot = blockRoot
-    break
-  oldestRoot
-
-func fitsInMemory[A, B](quarantine: SidecarQuarantine[A, B], count: int): bool =
-  quarantine.memSidecarsCount + count <= quarantine.maxMemSidecarsCount
-
-func fitsOnDisk[A, B](quarantine: SidecarQuarantine[A, B], count: int): bool =
-  quarantine.diskSidecarsCount + count <= quarantine.maxDiskSidecarsCount
-
-proc pruneInMemoryRoot[A, B](quarantine: var SidecarQuarantine[A, B]) =
-  # Remove the all the blobs related to the oldest block root from the memory
-  # storage of quarantine ``quarantine``.
-  if len(quarantine.memUsage) == 0:
-    return
-  quarantine.remove(quarantine.getOldestInMemoryRoot())
-
-proc pruneOnDiskRoot[A, B](quarantine: var SidecarQuarantine[A, B]) =
-  # Remove the all the blobs related to the oldest block root from the disk
-  # storage of quarantine ``quarantine``.
-  # Returns `true` if oldest block root on disk is equal to `unloadRoot`.
-  if len(quarantine.diskUsage) == 0:
-    return
-  quarantine.remove(quarantine.getOldestOnDiskRoot())
+func unload[A](holder: var SidecarHolder[A]): ref A =
+  let res = holder.data
+  holder.data = nil
+  holder = SidecarHolder[A](
+    kind: SidecarHolderKind.Unloaded,
+    slot: holder.slot,
+    index: holder.index,
+    proposer_index: holder.proposer_index,
+  )
+  res
 
 func getIndex(quarantine: BlobQuarantine, index: BlobIndex): int =
   quarantine.indexMap[int(index)]
@@ -217,16 +167,183 @@ template slot(b: BlobSidecar|fulu.DataColumnSidecar): Slot =
 template proposer_index(b: BlobSidecar|fulu.DataColumnSidecar): uint64 =
   b.signed_block_header.message.proposer_index
 
-func unload[A](holder: var SidecarHolder[A]): ref A =
-  let res = holder.data
-  holder.data = nil
-  holder = SidecarHolder[A](
-    kind: SidecarHolderKind.Unloaded,
-    slot: holder.slot,
-    index: holder.index,
-    proposer_index: holder.proposer_index,
-  )
-  res
+proc removeNode[A, B](
+    quarantine: var SidecarQuarantine[A, B],
+    node: DoublyLinkedNode[RootTableRecord[A]],
+    databaseCount: int
+) =
+  # This procedore removes all the sidecars associated with ``node`` from
+  # memory, disk and data structures.
+  var sidecarsOnDisk = 0
+
+  let blockRoot = node[].value.blockRoot
+
+  for index in 0 ..< len(node[].value.sidecars):
+    case node[].value.sidecars[index].kind
+    of SidecarHolderKind.Empty:
+        discard
+    of SidecarHolderKind.Loaded:
+      node[].value.sidecars[index].data = nil
+      dec(quarantine.memSidecarsCount)
+      blob_quarantine_memory_slots_occupied.set(
+        int64(quarantine.memSidecarsCount))
+    of SidecarHolderKind.Unloaded:
+      dec(quarantine.diskSidecarsCount)
+      blob_quarantine_database_slots_occupied.set(
+        int64(quarantine.diskSidecarsCount))
+      inc(sidecarsOnDisk)
+
+  if (sidecarsOnDisk > 0) or (databaseCount > 0):
+    quarantine.db.removeDataSidecars(A, blockRoot)
+    if databaseCount > 0:
+      dec(quarantine.diskSidecarsCount, databaseCount)
+      blob_quarantine_database_slots_occupied.set(
+        int64(quarantine.diskSidecarsCount))
+
+  if quarantine.lastMemoryNode == node:
+    quarantine.lastMemoryNode = node.prev
+
+  quarantine.roots.del(blockRoot)
+  quarantine.list.remove(node)
+
+proc offloadRoot[A, B](
+    quarantine: var SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest
+) =
+  # This procedore offloads all the sidecars associated with `blockRoot` from
+  # memory to disk.
+
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
+    return
+
+  var res: seq[ref A]
+  for index in 0 ..< len(node[].value.sidecars):
+    if node[].value.sidecars[index].kind == SidecarHolderKind.Loaded:
+      res.add(node[].value.sidecars[index].unload())
+
+  if len(res) > 0:
+    quarantine.db.putDataSidecars(blockRoot, res)
+    dec(quarantine.memSidecarsCount, len(res))
+    inc(quarantine.diskSidecarsCount, len(res))
+    blob_quarantine_memory_slots_occupied.set(
+      int64(quarantine.memSidecarsCount))
+    blob_quarantine_database_slots_occupied.set(
+      int64(quarantine.diskSidecarsCount))
+    inc(node[].value.unloaded, len(res))
+
+func fitsInMemory[A, B](q: SidecarQuarantine[A, B], count: int): bool =
+  q.memSidecarsCount + count <= q.maxMemSidecarsCount
+
+func fitsInQuarantine[A, B](q: SidecarQuarantine[A, B], count: int): bool =
+  (q.memSidecarsCount + q.diskSidecarsCount + count) <=
+    (q.maxMemSidecarsCount + q.maxDiskSidecarsCount)
+
+proc ensureSidecarsFits[A, B](
+    q: var SidecarQuarantine[A, B],
+    count: int
+): Result[void, cstring] =
+  while not(q.fitsInQuarantine(count)):
+    # Pruning process.
+    let node = q.list.tail
+    if isNil(node):
+      return err("Tail node is nil")
+    q.removeNode(node, 0)
+
+  while not(q.fitsInMemory(count)):
+    # Offloading process
+    let node = q.lastMemoryNode
+    if isNil(node):
+      return err("Last memory node is nil")
+    q.offloadRoot(node[].value.blockRoot)
+    q.lastMemoryNode = node[].prev
+
+  ok()
+
+proc put*[A, B](
+    q: var SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest,
+    sidecars: openArray[ref A]
+) =
+  let
+    (node, missing) =
+      block:
+        let res = q.roots.getOrDefault(blockRoot)
+        if isNil(res):
+          (newDoublyLinkedNode(RootTableRecord.init(q, blockRoot)), true)
+        else:
+          (res, false)
+    newSidecarsCount =
+      block:
+        var res = 0
+        for sidecar in sidecars:
+          let index = q.getIndex(sidecar.index)
+          doAssert(index >= 0,
+            "Incorrect sidecar index " & $sidecar.index & " points to " &
+            $index)
+          if isEmpty(node[].value.sidecars[index]):
+            inc(res)
+        res
+
+  q.ensureSidecarsFits(newSidecarsCount).isOkOr:
+    return
+
+  for sidecar in sidecars:
+    let index = q.getIndex(sidecar.index)
+    if isEmpty(node[].value.sidecars[index]):
+      inc(node[].value.count)
+      node[].value.slot = sidecar[].slot()
+      node[].value.sidecars[index] =
+        SidecarHolder[A](
+          kind: SidecarHolderKind.Loaded,
+          slot: sidecar[].slot(),
+          index: uint64(sidecar[].index),
+          proposer_index: sidecar[].proposer_index(),
+          data: sidecar)
+
+  q.memSidecarsCount += newSidecarsCount
+  blob_quarantine_memory_slots_occupied.set(
+    int64(q.memSidecarsCount))
+
+  if missing:
+    # Add first
+    q.roots[blockRoot] = node
+    if isNil(q.list.head) and isNil(q.list.tail):
+      # In case when list empty, we could not use `prepend` operation.
+      q.list.add(node)
+    else:
+      q.list.prepend(node)
+  else:
+    # Move to first
+    q.list.remove(node)
+    if isNil(q.list.head) and isNil(q.list.tail):
+      # In case when list empty, we could not use `prepend` operation.
+      q.list.add(node)
+    else:
+      q.list.prepend(node)
+
+  if isNil(q.lastMemoryNode):
+    q.lastMemoryNode = node
+
+proc put*[A, B](
+    q: var SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest,
+    sidecar: ref A
+) =
+  q.put(blockRoot, [sidecar])
+
+proc remove*[A, B](
+    q: var SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest
+) =
+  ## Remove all the data columns or blobs related to the block root ``blockRoot`
+  ## from the quarantine ``q``.
+  ##
+  ## Function do nothing, if ``blockRoot` is not part of the quarantine.
+  let node = q.roots.getOrDefault(blockRoot)
+  if isNil(node):
+    return
+  q.removeNode(node, 0)
 
 func load[A](holder: var SidecarHolder[A], sidecar: ref A) =
   holder = SidecarHolder[A](
@@ -237,49 +354,11 @@ func load[A](holder: var SidecarHolder[A], sidecar: ref A) =
     data: sidecar
   )
 
-proc unloadRoot[A, B](quarantine: var SidecarQuarantine[A, B]) =
-  doAssert(len(quarantine.memUsage) > 0)
-
-  if quarantine.maxDiskSidecarsCount == 0:
-    # Disk storage is disabled, so we use should prune memory storage instead.
-    quarantine.pruneInMemoryRoot()
-    return
-
-  let blockRoot = quarantine.getOldestInMemoryRoot()
-
-  # There's some condition whereby `quarantine.roots` becomes desynced with
-  # `quarantine.diskUsage`, such that `removeRoot` functions as a no-op and
-  # the `fitsOnDisk/pruneOnDiskRoot` becomes an infinite loop. Pending some
-  # more principled/correct approach, kludge around this.
-  var retries = 0
-
-  quarantine.roots.withValue(blockRoot, record):
-    while not(quarantine.fitsOnDisk(record[].count)):
-      quarantine.pruneOnDiskRoot()
-      inc retries
-      if retries > 10:
-        break
-
-    var res: seq[ref A]
-    for index in 0 ..< len(record[].sidecars):
-      if record[].sidecars[index].kind == SidecarHolderKind.Loaded:
-        res.add(record[].sidecars[index].unload())
-        dec(quarantine.memSidecarsCount)
-        inc(quarantine.diskSidecarsCount)
-        blob_quarantine_memory_slots_occupied.set(
-          int64(quarantine.memSidecarsCount))
-        blob_quarantine_database_slots_occupied.set(
-          int64(quarantine.diskSidecarsCount))
-        inc(record[].unloaded)
-
-    quarantine.memUsage.excl(blockRoot)
-    if len(res) > 0:
-      quarantine.db.putDataSidecars(blockRoot, res)
-      quarantine.diskUsage.incl(blockRoot)
-
-proc loadRoot[A, B](quarantine: var SidecarQuarantine[A, B],
-                    blockRoot: Eth2Digest,
-                    record: var RootTableRecord[A]) =
+proc loadRoot[A, B](
+    quarantine: var SidecarQuarantine[A, B],
+    blockRoot: Eth2Digest,
+    record: var RootTableRecord[A]
+) =
   for sidecar in quarantine.db.sidecars(A, blockRoot):
     let index = quarantine.getIndex(sidecar.index)
     doAssert(index >= 0,
@@ -289,89 +368,10 @@ proc loadRoot[A, B](quarantine: var SidecarQuarantine[A, B],
       "but it is `" & $record.sidecars[index].kind & "`")
     record.sidecars[index].load(newClone(sidecar))
     dec(record.unloaded)
+    inc(quarantine.memSidecarsCount)
 
   doAssert(record.unloaded == 0,
     "Record's unloaded count should be zero, but it is " & $record.unloaded)
-
-proc put[A, B](
-    record: var RootTableRecord[A],
-    blockRoot: Eth2Digest,
-    q: var SidecarQuarantine[A, B],
-    sidecars: openArray[ref A]
-) =
-  if record.count == 0:
-    q.memUsage.incl(blockRoot)
-
-  for sidecar in sidecars:
-    # Sidecar should pass validation before being added to quarantine,
-    # so we assume that
-    # 1. sidecar.index is < MAX_BLOBS_PER_BLOCK for `deneb` and.
-    # 2. sidecar.index is < MAX_BLOBS_PER_BLOCK_ELECTRA for `electra`.
-    # 3. sidecar.index is in custody columns set for `fulu`.
-    let index = q.getIndex(sidecar.index)
-    doAssert(index >= 0,
-      "Incorrect sidecar index " & $sidecar.index & " points to " & $index)
-
-    if isEmpty(record.sidecars[index]):
-      inc(q.memSidecarsCount)
-      blob_quarantine_memory_slots_occupied.set(int64(q.memSidecarsCount))
-      inc(record.count)
-      record.slot = sidecar[].slot()
-
-      record.sidecars[index] = SidecarHolder[A](
-        kind: SidecarHolderKind.Loaded,
-        slot: sidecar[].slot(),
-        index: uint64(sidecar[].index),
-        proposer_index: sidecar[].proposer_index(),
-        data: sidecar
-      )
-
-proc put*[A, B](
-    quarantine: var SidecarQuarantine[A, B],
-    blockRoot: Eth2Digest,
-    sidecar: ref A
-) =
-  ## Function adds blob or data column sidecar associated with block root
-  ## ``blockRoot`` to the quarantine ``quarantine``.
-  while not(quarantine.fitsInMemory(1)):
-    # FIFO if full. For example, sync manager and request manager can race to
-    # put blobs in at the same time, so one gets blob insert -> block resolve
-    # -> blob insert sequence, which leaves garbage blobs.
-    #
-    # This also therefore automatically garbage-collects otherwise valid garbage
-    # blobs which are correctly signed, point to either correct block roots or a
-    # block root which isn't ever seen, and then are for any reason simply never
-    # used.
-    quarantine.unloadRoot()
-
-  let rootRecord = RootTableRecord.init(quarantine)
-  quarantine.roots.mgetOrPut(blockRoot, rootRecord).put(
-    blockRoot, quarantine, [sidecar])
-
-proc put*[A, B](
-    quarantine: var SidecarQuarantine[A, B],
-    blockRoot: Eth2Digest,
-    sidecars: openArray[ref A]
-) =
-  ## Function adds number of blobs or data columns sidecars associated to single
-  ## block with root ``blockRoot`` to the quarantine ``quarantine``.
-  if len(sidecars) == 0:
-    return
-
-  while not(quarantine.fitsInMemory(len(sidecars))):
-    # FIFO if full. For example, sync manager and request manager can race to
-    # put blobs in at the same time, so one gets blob insert -> block resolve
-    # -> blob insert sequence, which leaves garbage blobs.
-    #
-    # This also therefore automatically garbage-collects otherwise valid garbage
-    # blobs which are correctly signed, point to either correct block roots or a
-    # block root which isn't ever seen, and then are for any reason simply never
-    # used.
-    quarantine.unloadRoot()
-
-  let rootRecord = RootTableRecord.init(quarantine)
-  quarantine.roots.mgetOrPut(blockRoot, rootRecord).put(
-    blockRoot, quarantine, sidecars)
 
 template hasSidecarImpl(
     blockRoot: Eth2Digest,
@@ -379,14 +379,14 @@ template hasSidecarImpl(
     proposerIndex: uint64,
     sidecarIndex: typed
 ): bool =
-  let rootRecord = quarantine.roots.getOrDefault(blockRoot)
-  if rootRecord.count == 0:
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return false
   let index = quarantine.getIndex(index)
-  if (index == -1) or rootRecord.sidecars[index].isEmpty():
+  if (index == -1) or node[].value.sidecars[index].isEmpty():
     return false
-  if (rootRecord.sidecars[index].proposer_index != proposer_index) or
-     (rootRecord.sidecars[index].slot != slot):
+  if (node[].value.sidecars[index].proposer_index != proposer_index) or
+     (node[].value.sidecars[index].slot != slot):
     return false
   true
 
@@ -394,11 +394,11 @@ template hasSidecarImpl(
     blockRoot: Eth2Digest,
     sidecarIndex: typed
 ): bool =
-  let rootRecord = quarantine.roots.getOrDefault(blockRoot)
-  if rootRecord.count == 0:
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return false
   let index = quarantine.getIndex(sidecarIndex)
-  (index != -1) and not rootRecord.sidecars[index].isEmpty()
+  (index != -1) and not node[].value.sidecars[index].isEmpty()
 
 func hasSidecar*(
     quarantine: BlobQuarantine,
@@ -440,12 +440,11 @@ func hasSidecars*(
   if len(blck.message.body.blob_kzg_commitments) == 0:
     return true
 
-  let record = quarantine.roots.getOrDefault(blockRoot)
-  if record.count == 0:
-    # block root not found.
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return false
 
-  if record.count < len(blck.message.body.blob_kzg_commitments):
+  if node[].value.count < len(blck.message.body.blob_kzg_commitments):
     # Quarantine does not hold enough blob sidecars.
     return false
   true
@@ -460,9 +459,8 @@ func hasSidecars*(
   if len(blck.message.body.blob_kzg_commitments) == 0:
     return true
 
-  let record = quarantine.roots.getOrDefault(blockRoot)
-  if len(record.sidecars) == 0:
-    # block root not found, record.sidecars sequence was not initialized.
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return false
 
   let
@@ -473,7 +471,7 @@ func hasSidecars*(
       else:
         len(quarantine.custodyColumns)
 
-  if record.count < columnsCount:
+  if node[].value.count < columnsCount:
     # Quarantine does not hold enough column sidecars.
     return false
   true
@@ -511,30 +509,30 @@ proc popSidecars*(
     quarantine.remove(blockRoot)
     return Opt.some(default(seq[ref BlobSidecar]))
 
-  var record = quarantine.roots.getOrDefault(blockRoot)
-  if len(record.sidecars) == 0:
-    # block root not found, record.sidecars sequence was not initialized.
+  var node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return Opt.none(seq[ref BlobSidecar])
 
-  if record.count < sidecarsCount:
+  if node[].value.count < sidecarsCount:
     # Quarantine does not hold enough blob sidecars.
     return Opt.none(seq[ref BlobSidecar])
 
-  if record.unloaded > 0:
+  let databaseCount = node[].value.unloaded
+  if databaseCount > 0:
     # Quarantine unloaded some blobs to disk, we should load it back.
-    quarantine.loadRoot(blockRoot, record)
+    quarantine.loadRoot(blockRoot, node[].value)
 
   var sidecars: seq[ref BlobSidecar]
   for bindex in 0 ..< len(blck.message.body.blob_kzg_commitments):
     let index = quarantine.getIndex(BlobIndex(bindex))
-    doAssert(record.sidecars[index].isLoaded(),
+    doAssert(node[].value.sidecars[index].isLoaded(),
       "Record should only have loaded values, but it is `" &
-        $record.sidecars[index].kind & "`")
-    sidecars.add(record.sidecars[index].data)
+        $node[].value.sidecars[index].kind & "`")
+    sidecars.add(node[].value.sidecars[index].data)
 
   # popSidecars() should remove all the artifacts from the quarantine in both
   # memory and disk.
-  quarantine.removeRoot(blockRoot)
+  quarantine.removeNode(node, databaseCount)
 
   Opt.some(sidecars)
 
@@ -546,9 +544,8 @@ proc popSidecars*(
   ## If some of the column sidecars are missing Opt.none() is returned.
   ## Note: Blocks should be checked for sidecars count first, otherwise
   ## result of this function would be always Opt.none().
-  var record = quarantine.roots.getOrDefault(blockRoot)
-  if len(record.sidecars) == 0:
-    # block root not found, record.sidecars sequence was not allocated.
+  var node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
     return Opt.none(seq[ref fulu.DataColumnSidecar])
 
   let
@@ -559,17 +556,18 @@ proc popSidecars*(
       else:
         len(quarantine.custodyColumns)
 
-  if record.count < columnsCount:
+  if node[].value.count < columnsCount:
     # Quarantine does not hold enough column sidecars.
     return Opt.none(seq[ref fulu.DataColumnSidecar])
 
-  if record.unloaded > 0:
+  let databaseCount = node[].value.unloaded
+  if databaseCount > 0:
     # Quarantine unloaded some blobs to disk, we should load it back.
-    quarantine.loadRoot(blockRoot, record)
+    quarantine.loadRoot(blockRoot, node[].value)
 
   var sidecars: seq[ref fulu.DataColumnSidecar]
   if supernode:
-    for sidecar in record.sidecars:
+    for sidecar in node[].value.sidecars:
       # Supernode could have some of the columns not filled.
       if not(sidecar.isEmpty()):
         doAssert(sidecar.isLoaded(),
@@ -585,17 +583,17 @@ proc popSidecars*(
   else:
     for cindex in quarantine.custodyColumns:
       let index = quarantine.getIndex(cindex)
-      doAssert(record.sidecars[index].isLoaded(),
+      doAssert(node[].value.sidecars[index].isLoaded(),
         "Record should only have loaded values, but it is `" &
-          $record.sidecars[index].kind & "`")
-      sidecars.add(record.sidecars[index].data)
+          $node[].value.sidecars[index].kind & "`")
+      sidecars.add(node[].value.sidecars[index].data)
 
     doAssert(len(sidecars) == len(quarantine.custodyColumns),
       "Incorrect amount of sidecars in record for node - " & $len(sidecars))
 
   # popSidecars() should remove all the artifacts from the quarantine in both
   # memory and disk.
-  quarantine.removeRoot(blockRoot)
+  quarantine.removeNode(node, databaseCount)
 
   Opt.some(sidecars)
 
@@ -614,17 +612,18 @@ func fetchMissingSidecars*(
   ## Function returns sequence of BlobIdentifiers for blobs which are missing
   ## for block root ``blockRoot`` and block ``blck``.
   var res: seq[BlobIdentifier]
-  let record = quarantine.roots.getOrDefault(blockRoot)
+  let
+    node = quarantine.roots.getOrDefault(blockRoot)
+    commitmentsCount = len(blck.message.body.blob_kzg_commitments)
 
-  let commitmentsCount = len(blck.message.body.blob_kzg_commitments)
-  if (commitmentsCount == 0) or (record.count == commitmentsCount):
-    # Fast-path if ``blck`` does not have any blobs or if quarantine's record
-    # holds enough blobs.
+  if commitmentsCount == 0:
+    return res
+  if not(isNil(node)) and (node[].value.count == commitmentsCount):
     return res
 
   for bindex in 0 ..< commitmentsCount:
     let index = quarantine.getIndex(BlobIndex(bindex))
-    if len(record.sidecars) == 0 or record.sidecars[index].isEmpty():
+    if isNil(node) or node[].value.sidecars[index].isEmpty():
       res.add(BlobIdentifier(block_root: blockRoot, index: BlobIndex(bindex)))
   res
 
@@ -636,17 +635,18 @@ func getMissingSidecarIndices*(
   ## Function returns sequence of BlobIndex for blobs which are missing for
   ## block root ``blockRoot`` and block ``blck``.
   var res: seq[BlobIndex]
-  let record = quarantine.roots.getOrDefault(blockRoot)
+  let
+    node = quarantine.roots.getOrDefault(blockRoot)
+    commitmentsCount = len(blck.message.body.blob_kzg_commitments)
 
-  let commitmentsCount = len(blck.message.body.blob_kzg_commitments)
-  if (commitmentsCount == 0) or (record.count == commitmentsCount):
-    # Fast-path if ``blck`` does not have any blobs or if quarantine's record
-    # holds enough blobs.
+  if commitmentsCount == 0:
+    return res
+  if not(isNil(node)) and (node[].value.count == commitmentsCount):
     return res
 
   for bindex in 0 ..< commitmentsCount:
     let index = quarantine.getIndex(BlobIndex(bindex))
-    if len(record.sidecars) == 0 or record.sidecars[index].isEmpty():
+    if isNil(node) or node[].value.sidecars[index].isEmpty():
       res.add(BlobIndex(bindex))
   res
 
@@ -663,7 +663,8 @@ func fetchMissingSidecars*(
   ## Note: If there is no missing columns - DataColumnByRootIdentifier.indices
   ## array will be empty.
   var res: ColumnMap
-  let record = quarantine.roots.getOrDefault(blockRoot)
+
+  let node = quarantine.roots.getOrDefault(blockRoot)
 
   if len(blck.message.body.blob_kzg_commitments) == 0:
     # Fast-path if block does not have any columns
@@ -687,7 +688,7 @@ func fetchMissingSidecars*(
         len(quarantine.custodyColumns)
 
   if supernode:
-    if len(record.sidecars) == 0:
+    if isNil(node):
       for column in peerMap.items():
         if len(res) > columnsCount:
           # We don't need to request more than (NUMBER_OF_COLUMNS div 2)
@@ -695,7 +696,7 @@ func fetchMissingSidecars*(
           break
         res.incl(column)
     else:
-      if record.count > columnsCount:
+      if node[].value.count > columnsCount:
         # We already have enough columns for reconstruction.
         return
           DataColumnsByRootIdentifier(
@@ -703,21 +704,21 @@ func fetchMissingSidecars*(
             indices: DataColumnIndices(default(seq[ColumnIndex])))
 
       for column in peerMap.items():
-        if record.count + len(res) > columnsCount:
+        if node[].value.count + len(res) > columnsCount:
           # We don't need to request more than (NUMBER_OF_COLUMNS div 2)
           # columns.
           break
         let index = quarantine.getIndex(column)
-        if (index == -1) or record.sidecars[index].isEmpty():
+        if (index == -1) or node[].value.sidecars[index].isEmpty():
           res.incl(column)
   else:
-    if len(record.sidecars) == 0:
+    if isNil(node):
       for column in (peerMap and quarantine.custodyMap).items():
         res.incl(column)
     else:
       for column in (peerMap and quarantine.custodyMap).items():
         let index = quarantine.getIndex(column)
-        if (index == -1) or (record.sidecars[index].isEmpty()):
+        if (index == -1) or (node[].value.sidecars[index].isEmpty()):
           res.incl(column)
 
   DataColumnsByRootIdentifier(
@@ -742,21 +743,25 @@ func getMissingColumnsMap*(
     blck: fulu.SignedBeaconBlock | gloas.SignedBeaconBlock,
 ): ColumnMap =
   var res: ColumnMap
-  let record = quarantine.roots.getOrDefault(blockRoot)
+  let node = quarantine.roots.getOrDefault(blockRoot)
+
   if len(blck.message.body.blob_kzg_commitments) == 0:
     # Fast-path if block does not have any columns
     return res
   if (len(quarantine.custodyColumns) == NUMBER_OF_COLUMNS):
-    if len(record.sidecars) > NUMBER_OF_COLUMNS div 2:
-      return res
-    for index in 0 ..< NUMBER_OF_COLUMNS:
-      if (len(record.sidecars) == 0) or record.sidecars[index].isEmpty():
+    if isNil(node):
+      for index in 0 ..< NUMBER_OF_COLUMNS:
         res.incl(ColumnIndex(index))
+    else:
+      if len(node[].value.sidecars) > NUMBER_OF_COLUMNS div 2:
+        return res
+      for index in 0 ..< NUMBER_OF_COLUMNS:
+        if node[].value.sidecars[index].isEmpty():
+          res.incl(ColumnIndex(index))
   else:
     for column in quarantine.custodyMap.items():
       let index = quarantine.getIndex(column)
-      if (len(record.sidecars) == 0) or (index == -1) or
-         record.sidecars[index].isEmpty():
+      if isNil(node) or (index == -1) or node[].value.sidecars[index].isEmpty():
         res.incl(column)
   res
 
@@ -791,13 +796,13 @@ proc pruneAfterFinalization*(
         epoch
     epochSlot = (startEpoch + 1).start_slot()
 
-  var rootsToRemove: seq[Eth2Digest]
-  for mkey, mrecord in quarantine.roots.mpairs():
-    if (mrecord.count > 0) and (mrecord.slot < epochSlot):
-      rootsToRemove.add(mkey)
+  var nodes: seq[DoublyLinkedNode[RootTableRecord[BlobSidecar]]]
+  for node in quarantine.list.nodes():
+    if (node[].value.count > 0) and (node[].value.slot < epochSlot):
+      nodes.add(node)
 
-  for root in rootsToRemove:
-    quarantine.removeRoot(root)
+  for node in nodes:
+    quarantine.removeNode(node, 0)
 
 proc pruneAfterFinalization*(
     quarantine: var ColumnQuarantine,
@@ -819,13 +824,13 @@ proc pruneAfterFinalization*(
         epoch
     epochSlot = (startEpoch + 1).start_slot()
 
-  var rootsToRemove: seq[Eth2Digest]
-  for mkey, mrecord in quarantine.roots.mpairs():
-    if (mrecord.count > 0) and (mrecord.slot < epochSlot):
-      rootsToRemove.add(mkey)
+  var nodes: seq[DoublyLinkedNode[RootTableRecord[fulu.DataColumnSidecar]]]
+  for node in quarantine.list.nodes():
+    if (node[].value.count > 0) and (node[].value.slot < epochSlot):
+      nodes.add(node)
 
-  for root in rootsToRemove:
-    quarantine.removeRoot(root)
+  for node in nodes:
+    quarantine.removeNode(node, 0)
 
 template onBlobSidecarCallback*(
     quarantine: BlobQuarantine
@@ -868,6 +873,7 @@ proc init*(
     diskSidecarsCount: 0,
     indexMap: indexMap,
     onSidecarCallback: onBlobSidecarCallback,
+    list: initDoublyLinkedList[RootTableRecord[BlobSidecar]](),
     db: database
   )
 
@@ -907,6 +913,7 @@ proc init*(
     indexMap: indexMap,
     custodyColumns: @custodyColumns,
     custodyMap: ColumnMap.init(custodyColumns),
+    list: initDoublyLinkedList[RootTableRecord[fulu.DataColumnSidecar]](),
     db: database,
     onSidecarCallback: onDataColumnSidecarCallback
   )

--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -47,8 +47,8 @@ type
       data: ref A
 
   RootTableRecord[A] = object
-    blockRoot*: Eth2Digest
-    slot*: Slot
+    blockRoot: Eth2Digest
+    slot: Slot
     unloaded: int
     count: int
     sidecars: seq[SidecarHolder[A]]
@@ -62,7 +62,7 @@ type
     maxSidecarsPerBlockCount: int
     custodyColumns*: seq[ColumnIndex]
     custodyMap*: ColumnMap
-    lastMemoryNode*: DoublyLinkedNode[RootTableRecord[A]]
+    lastMemoryNode: DoublyLinkedNode[RootTableRecord[A]]
     roots: Table[Eth2Digest, DoublyLinkedNode[RootTableRecord[A]]]
     list: DoublyLinkedList[RootTableRecord[A]]
     indexMap: seq[int]

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -8,14 +8,14 @@
 {.push raises: [].}
 {.used.}
 
-import std/sequtils, stew/endians2,
+import stew/endians2, std/sequtils,
        kzg4844/kzg,
        unittest2,
        ./testutil,
        ../beacon_chain/[beacon_chain_db, beacon_chain_db_quarantine],
        ../beacon_chain/spec/datatypes/[deneb, electra, fulu],
        ../beacon_chain/spec/[presets, helpers],
-       ../beacon_chain/consensus_object_pools/blob_quarantine
+       ../beacon_chain/consensus_object_pools/blob_quarantine_lru
 
 func genBlockRoot(index: int): Eth2Digest =
   var res: Eth2Digest
@@ -105,11 +105,13 @@ func compareSidecarsByValue(
     a, b: openArray[ref BlobSidecar|ref fulu.DataColumnSidecar]
 ): bool =
   if len(a) != len(b):
+    debugEcho "Length not equal"
     return false
   if len(a) == 0:
     return true
   for i in 0 ..< len(a):
     if a[i][] != b[i][]:
+      debugEcho "data not equal"
       return false
   true
 
@@ -757,7 +759,7 @@ suite "BlobQuarantine data structure test suite " & preset():
       bq = BlobQuarantine.init(cfg, quarantine, 2, nil)
       sidecars: seq[tuple[sidecar: ref BlobSidecar, blockRoot: Eth2Digest]]
 
-    let maxSidecars = int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA * SLOTS_PER_EPOCH) * 3
+    let maxSidecars = maxSidecars(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
     for i in 0 ..< maxSidecars:
       let
         index = i mod int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
@@ -909,6 +911,62 @@ suite "BlobQuarantine data structure test suite " & preset():
       len(bq) == len(sidecars) - int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA) + 1
       lenDisk(bq) == 0
       quarantine.sidecarsCount(typedesc[BlobSidecar]) == 0
+
+  test "overfill test [maximum number of blobs]":
+    var
+      bq = BlobQuarantine.init(cfg, quarantine, 2, nil)
+      sidecars: seq[tuple[sidecar: ref BlobSidecar, blockRoot: Eth2Digest]]
+
+    let maximumSidecars = bq.size * 2
+
+    for i in 0 ..< maximumSidecars:
+      let
+        index = i mod int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
+        slot = i div int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA) + 100
+        blockRoot = genBlockRoot(slot)
+        sidecar = newClone(genBlobSidecar(index, slot, i, proposer_index = i))
+      sidecars.add((sidecar, blockRoot))
+
+    for item in sidecars:
+      bq.put(item.blockRoot, item.sidecar)
+
+    # At this stage only last sidecars in range
+    # [maxSidecars - quarantine.size, maxSidecars] should be present in
+    # quarantine.
+    let
+      startPosition = maximumSidecars - bq.size()
+
+    for i in startPosition ..< maximumSidecars:
+      let
+        item =
+          sidecars[i]
+        index =
+          item.sidecar[].index
+        slot =
+          item.sidecar[].signed_block_header.message.slot
+        proposerIndex =
+          item.sidecar[].signed_block_header.message.proposer_index
+
+      check:
+        bq.hasSidecar(
+          blockRoot = item.blockRoot, slot = slot,
+          proposer_index = proposerIndex, index = index) == true
+
+    for i in 0 ..< startPosition:
+      let
+        item =
+          sidecars[i]
+        index =
+          item.sidecar[].index
+        slot =
+          item.sidecar[].signed_block_header.message.slot
+        proposerIndex =
+          item.sidecar[].signed_block_header.message.proposer_index
+
+      check:
+        bq.hasSidecar(
+          blockRoot = item.blockRoot, slot = slot,
+          proposer_index = proposerIndex, index = index) == false
 
   test "database and memory overfill protection and pruning test":
     var
@@ -1570,7 +1628,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
     bq.remove(broot2)
     check len(bq) == 0
 
-  test "overfill protection test":
+  test "overfill protection test [node]":
     let
       custodyColumns =
         [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
@@ -1691,7 +1749,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
           index = sidecars[j].sidecar[].index
         ) == false
 
-  test "put() duplicate items should not affect counters":
+  test "put() duplicate items should not affect counters [node]":
     let
       custodyColumns =
         [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
@@ -1759,7 +1817,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
     bq.remove(broot1)
     check len(bq) == 0
 
-  test "pruneAfterFinalization() test":
+  test "pruneAfterFinalization() test [node]":
     let
       custodyColumns =
         [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
@@ -1873,7 +1931,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
           genBlockRoot(item.root), Slot(item.slot),
           uint64(item.proposer_index), BlobIndex(item.index)) == false
 
-  test "database unload/load test":
+  test "database unload/load test [node]":
     let
       custodyColumns =
         [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
@@ -2040,7 +2098,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       lenDisk(bq) == 0
       quarantine.sidecarsCount(typedesc[fulu.DataColumnSidecar]) == 0
 
-  test "database and memory overfill protection and pruning test":
+  test "database and memory overfill protection and pruning test [node]":
     let
       custodyColumns =
         [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
@@ -2201,3 +2259,342 @@ suite "ColumnQuarantine data structure test suite " & preset():
     check:
       len(bq) == 0
       quarantine.sidecarsCount(typedesc[fulu.DataColumnSidecar]) == 0
+
+  const ColumnsVectors = [
+    ("node", [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))),
+    ("supernode", supernodeColumns())
+  ]
+
+  for cvec in ColumnsVectors:
+    test "overfill test [" & cvec[0] & "]":
+      let custodyColumns = cvec[1]
+      var
+        bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 2, nil)
+        sidecars: seq[tuple[sidecar: ref fulu.DataColumnSidecar,
+                            blockRoot: Eth2Digest]]
+
+      let maximumSidecars = bq.size * 2
+
+      for i in 0 ..< maximumSidecars:
+        let
+          index = i mod len(custodyColumns)
+          slot = i div len(custodyColumns) + 100
+          blockRoot = genBlockRoot(slot)
+          sidecar = newClone(genDataColumnSidecar(int(custodyColumns[index]),
+            slot, proposer_index = i))
+        sidecars.add((sidecar, blockRoot))
+
+      for item in sidecars:
+        bq.put(item.blockRoot, item.sidecar)
+
+      # At this stage only last sidecars in range
+      # [maxSidecars - quarantine.size, maxSidecars] should be present in
+      # quarantine.
+      let
+        startPosition = maximumSidecars - bq.size()
+
+      for i in startPosition ..< maximumSidecars:
+        let
+          item =
+            sidecars[i]
+          slot =
+            item.sidecar[].signed_block_header.message.slot
+          proposerIndex =
+            item.sidecar[].signed_block_header.message.proposer_index
+          index =
+            item.sidecar[].index
+
+        check:
+          bq.hasSidecar(
+            blockRoot = item.blockRoot, slot = slot,
+            proposer_index = proposerIndex, index = index) == true
+
+      for i in 0 ..< startPosition:
+        let
+          item =
+            sidecars[i]
+          slot =
+            item.sidecar[].signed_block_header.message.slot
+          proposerIndex =
+            item.sidecar[].signed_block_header.message.proposer_index
+          index =
+            item.sidecar[].index
+
+        check:
+          bq.hasSidecar(
+            blockRoot = item.blockRoot, slot = slot,
+            proposer_index = proposerIndex, index = index) == false
+
+    test "Empty in-memory scenario test [" & cvec[0] & "]":
+      let custodyColumns = cvec[1]
+      var
+        bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 2, nil)
+        sidecars: seq[tuple[sidecar: ref fulu.DataColumnSidecar,
+                            blockRoot: Eth2Digest]]
+
+      let size = bq.sizeMemory * 2
+        # full size of quarantine is bq.sizeMemory + bq.sizeMemory * 2
+      for i in 0 ..< size:
+        let
+          index = i mod len(custodyColumns)
+          slot = i div len(custodyColumns) + 100
+          blockRoot = genBlockRoot(slot)
+          sidecar = newClone(genDataColumnSidecar(int(custodyColumns[index]),
+            slot, proposer_index = i))
+        sidecars.add((sidecar, blockRoot))
+
+      for item in sidecars:
+        bq.put(item.blockRoot, item.sidecar)
+
+      check:
+        bq.lenMemory() == bq.sizeMemory()
+        bq.lenDisk() == bq.sizeMemory()
+
+      # At this stage we have full in memory store and partially filled disk store
+
+      for i in bq.sizeMemory ..< size:
+        let blockRoot = sidecars[i].blockRoot
+        bq.remove(blockRoot)
+
+      # At this stage we removed all the in-memory roots.
+      check:
+        bq.lenMemory() == 0
+        bq.lenDisk() == bq.sizeMemory()
+
+      var
+        sidecars2: seq[tuple[sidecar: ref fulu.DataColumnSidecar,
+                             blockRoot: Eth2Digest]]
+
+      for i in 0 ..< len(custodyColumns):
+        let
+          index = i mod len(custodyColumns)
+          slot = i div len(custodyColumns) + 1000000
+          blockRoot = genBlockRoot(slot)
+          sidecar = newClone(genDataColumnSidecar(int(custodyColumns[index]),
+            slot, proposer_index = i))
+        sidecars2.add((sidecar, blockRoot))
+
+      # Now we should be able to add new columns to in-memory storage.
+      for item in sidecars2:
+        bq.put(item.blockRoot, item.sidecar)
+
+      check:
+        bq.lenMemory() == len(custodyColumns)
+        bq.lenDisk() == bq.sizeMemory()
+
+    test "Mixed entries scenario test [" & cvec[0] & "]":
+      let custodyColumns = cvec[1]
+      var
+        bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 2, nil)
+        sidecars: seq[tuple[sidecar: ref fulu.DataColumnSidecar,
+                            blockRoot: Eth2Digest]]
+
+      let maximumSidecars = bq.size * 2
+
+      for i in 0 ..< maximumSidecars:
+        let
+          index = i mod len(custodyColumns)
+          slot = i div len(custodyColumns) + 100
+          blockRoot = genBlockRoot(slot)
+          sidecar = newClone(genDataColumnSidecar(int(custodyColumns[index]),
+            slot, proposer_index = i))
+        sidecars.add((sidecar, blockRoot))
+
+      case cvec[0]
+      of "node":
+        # Add only first 3 sidecars for first block
+        for i in 0 ..< 3:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add only first 5 sidecars for second block
+        for i in 8 ..< 13:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add all other sidecars
+        for item in sidecars.toOpenArray(16, bq.sizeMemory - 1):
+          bq.put(item.blockRoot, item.sidecar)
+      of "supernode":
+        # Add only 64 sidecars for first block.
+        for i in 0 ..< 64:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add only 64 sidecars for second block.
+        for i in 128 ..< 192:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add all other sidecars
+        for item in sidecars.toOpenArray(256, bq.sizeMemory - 1):
+          bq.put(item.blockRoot, item.sidecar)
+
+      check:
+        bq.lenMemory() == bq.sizeMemory() - len(custodyColumns)
+
+      # Adding last block which could fit in memory
+      block:
+        let offset = bq.sizeMemory()
+        for i in 0 ..< len(custodyColumns):
+          let item = sidecars[offset + i]
+          bq.put(item.blockRoot, item.sidecar)
+
+      check:
+        bq.lenMemory() == bq.sizeMemory()
+
+      # Adding block which should overfill memory storage and our two non-100%
+      # filled blocks should be offloaded to disk.
+      block:
+        let offset = bq.sizeMemory() + len(custodyColumns)
+        for i in 0 ..< len(custodyColumns):
+          let item = sidecars[offset + i]
+          bq.put(item.blockRoot, item.sidecar)
+
+      check:
+        bq.lenMemory() == bq.sizeMemory()
+        bq.lenDisk() == len(custodyColumns)
+
+      # Checking columns are in place.
+      case cvec[0]
+      of "node":
+        for i in [0, 1, 2, 8, 9, 10, 11, 12]:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == true
+        for i in [3, 4, 5, 6, 7, 13, 14, 15]:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == false
+      of "supernode":
+        for i in 0 ..< 64:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == true
+
+        for i in 128 ..< 192:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == true
+
+        for i in 64 ..< 128:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == false
+
+        for i in 192 ..< 256:
+          check:
+            bq.hasSidecar(
+              sidecars[i].blockRoot,
+              sidecars[i].sidecar[].signed_block_header.message.slot,
+              sidecars[i].sidecar[].signed_block_header.message.proposer_index,
+              sidecars[i].sidecar[].index
+            ) == false
+
+      let
+        commitments = [
+          genKzgCommitment(1), genKzgCommitment(2), genKzgCommitment(3)
+        ]
+        block1 = genFuluSignedBeaconBlock(
+          sidecars[0].blockRoot, commitments)
+        block2 = genFuluSignedBeaconBlock(
+          sidecars[0 + len(custodyColumns)].blockRoot, commitments)
+
+      # Both blocks should be incomplete.
+      check:
+        bq.hasSidecars(block1) == false
+        bq.hasSidecars(block2) == false
+
+      case cvec[0]
+      of "node":
+        # Add last 5 sidecars for first block
+        for i in 3 ..< 8:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add last 3 sidecars for second block
+        for i in 13 ..< 16:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+      of "supernode":
+        # Add last 64 sidecars for first block.
+        for i in 64 ..< 128:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+        # Add last 64 sidecars for second block.
+        for i in 192 ..< 256:
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+
+      check:
+        bq.lenMemory() == bq.sizeMemory()
+        bq.lenDisk() == len(custodyColumns) * 2
+        bq.hasSidecars(block1) == true
+        bq.hasSidecars(block2) == true
+
+      let sidecars1 = bq.popSidecars(sidecars[0].blockRoot)
+      check:
+        sidecars1.isSome() == true
+      case cvec[0]
+      of "node":
+        check:
+          bq.lenMemory() == bq.sizeMemory() - 5
+          bq.lenDisk() == len(custodyColumns) * 2 - 3
+      of "supernode":
+        check:
+          bq.lenMemory() == bq.sizeMemory() - 64
+          bq.lenDisk() == len(custodyColumns) * 2 - 64
+
+      let sidecars2 = bq.popSidecars(sidecars[len(custodyColumns)].blockRoot)
+
+      check:
+        sidecars2.isSome() == true
+        bq.lenMemory() == bq.sizeMemory() - len(custodyColumns)
+        bq.lenDisk() == len(custodyColumns) * 2 - len(custodyColumns)
+
+      let
+        expect1 =
+          case cvec[0]
+          of "node":
+            let
+              start = 0
+              finish = len(custodyColumns)
+            sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
+          of "supernode":
+            # In case of super node quarantine returns
+            # NUMBER_OF_COLUMNS div 2 + 1 columns which is enough for
+            # rebuild.
+            let
+              start = 0
+              finish = len(custodyColumns) div 2 + 1
+            sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
+          else:
+            raiseAssert "inaccessible"
+        expect2 =
+          case cvec[0]
+          of "node":
+            let
+              start = len(custodyColumns)
+              finish = start + len(custodyColumns)
+            sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
+          of "supernode":
+            # In case of super node quarantine returns
+            # NUMBER_OF_COLUMNS div 2 + 1 columns which is enough for
+            # rebuild.
+            let
+              start = len(custodyColumns)
+              finish = start + len(custodyColumns) div 2 + 1
+            sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
+          else:
+            raiseAssert "inaccessible"
+
+      check:
+        compareSidecarsByValue(sidecars1.get(), expect1) == true
+        compareSidecarsByValue(sidecars2.get(), expect2) == true

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -15,7 +15,7 @@ import stew/endians2, std/sequtils,
        ../beacon_chain/[beacon_chain_db, beacon_chain_db_quarantine],
        ../beacon_chain/spec/datatypes/[deneb, electra, fulu],
        ../beacon_chain/spec/[presets, helpers],
-       ../beacon_chain/consensus_object_pools/blob_quarantine_lru
+       ../beacon_chain/consensus_object_pools/blob_quarantine
 
 func genBlockRoot(index: int): Eth2Digest =
   var res: Eth2Digest


### PR DESCRIPTION
This PR removes `CountTable` usage, it uses `DoublyLinkedList` instead and so, there could not be inconsistency between data stored in `CountTables` and in `roots` table. Now `roots` table only holds references to nodes of `DoublyLinkedList`. 