### PR TITLE
use fork aware deadline functions

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -295,7 +295,8 @@ proc process_block*(self: var ForkChoice,
   # Add proposer score boost if the block is timely
   let slot = self.checkpoints.time.slotOrZero(dag.timeParams)
   if slot == blck.slot and
-      self.checkpoints.time < slot.attestation_deadline(dag.timeParams) and
+      self.checkpoints.time < slot.attestation_deadline(
+        dag.timeParams, typeof(blck).kind) and
       self.checkpoints.proposer_boost_root == ZERO_HASH:
     self.checkpoints.proposer_boost_root = blckRef.root
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -546,8 +546,11 @@ proc processAttestation*(
     return errIgnore("Attestation before genesis")
 
   # Potential under/overflows are fine; would just create odd metrics and logs
-  let delay = wallTime -
-    attestation.data.slot.attestation_deadline(self.dag.timeParams)
+  let 
+    consensusFork =
+      self.dag.cfg.consensusForkAtEpoch(attestation.data.slot.epoch)
+    delay = wallTime - attestation.data.slot.attestation_deadline(
+      self.dag.timeParams, consensusFork)
   debug "Attestation received", delay
 
   let v = when attestation is phase0.Attestation:
@@ -614,7 +617,7 @@ proc processSignedAggregateAndProof*(
   # Potential under/overflows are fine; would just create odd logs
   let
     slot = signedAggregateAndProof.message.aggregate.data.slot
-    delay = wallTime - slot.aggregate_deadline(self.dag.timeParams)
+    delay = wallTime - slot.aggregate_deadline(self.dag.timeParams, fork)
   debug "Aggregate received", delay
 
   let v = await self.attestationPool.validateAggregate(

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -223,6 +223,32 @@ func sync_contribution_deadline*(
   s.start_beacon_time(timeParams) +
     timeParams.syncContributionSlotOffset
 
+# Gloas
+func attestation_deadline_gloas*(
+    s: Slot, timeParams: TimeParams): BeaconTime =
+  s.start_beacon_time(timeParams) +
+    timeParams.attestationSlotOffsetGloas
+
+func aggregate_deadline_gloas*(
+    s: Slot, timeParams: TimeParams): BeaconTime =
+  s.start_beacon_time(timeParams) +
+    timeParams.aggregateSlotOffsetGloas
+
+func sync_committee_message_deadline_gloas*(
+    s: Slot, timeParams: TimeParams): BeaconTime =
+  s.start_beacon_time(timeParams) +
+    timeParams.syncCommitteeMessageSlotOffsetGloas
+
+func sync_contribution_deadline_gloas*(
+    s: Slot, timeParams: TimeParams): BeaconTime =
+  s.start_beacon_time(timeParams) +
+    timeParams.syncContributionSlotOffsetGloas
+
+func payload_attestation_deadline*(
+    s: Slot, timeParams: TimeParams): BeaconTime =
+  s.start_beacon_time(timeParams) +
+    timeParams.payloadAttestationSlotOffset
+
 func light_client_finality_update_time*(
     s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams) +

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -583,3 +583,35 @@ func is_builder_payment_withdrawable*(
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-beta.0/specs/gloas/beacon-chain.md#new-is_parent_block_full
 func is_parent_block_full*(state: gloas.BeaconState): bool =
   state.latest_execution_payload_bid.block_hash == state.latest_block_hash
+
+func attestation_deadline*(
+    s: Slot, timeParams: TimeParams,
+    consensusFork: ConsensusFork): BeaconTime =
+  if consensusFork >= ConsensusFork.Gloas:
+    attestation_deadline_gloas(s, timeParams)
+  else:
+    attestation_deadline(s, timeParams)
+
+func aggregate_deadline*(
+    s: Slot, timeParams: TimeParams,
+    consensusFork: ConsensusFork): BeaconTime =
+  if consensusFork >= ConsensusFork.Gloas:
+    aggregate_deadline_gloas(s, timeParams)
+  else:
+    aggregate_deadline(s, timeParams)
+
+func sync_committee_message_deadline*(
+    s: Slot, timeParams: TimeParams,
+    consensusFork: ConsensusFork): BeaconTime =
+  if consensusFork >= ConsensusFork.Gloas:
+    sync_committee_message_deadline_gloas(s, timeParams)
+  else:
+    sync_committee_message_deadline(s, timeParams)
+
+func sync_contribution_deadline*(
+    s: Slot, timeParams: TimeParams,
+    consensusFork: ConsensusFork): BeaconTime =
+  if consensusFork >= ConsensusFork.Gloas:
+    sync_contribution_deadline_gloas(s, timeParams)
+  else:
+    sync_contribution_deadline(s, timeParams)

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -63,7 +63,8 @@ proc serveAttestation(
       raise exc
 
   logScope:
-    delay = vc.getDelay(attestationSlot.attestation_deadline(vc.timeParams))
+    delay = vc.getDelay(attestationSlot.attestation_deadline(
+      vc.timeParams, consensusFork))
 
   debug "Sending attestation"
 
@@ -92,7 +93,8 @@ proc serveAttestation(
       submitAttestation(attestation)
 
   if res:
-    let delay = vc.getDelay(attestationSlot.attestation_deadline(vc.timeParams))
+    let delay = vc.getDelay(attestationSlot.attestation_deadline(
+      vc.timeParams, consensusFork))
     beacon_attestations_sent.inc()
     beacon_attestation_sent_delay.observe(delay.toFloatSeconds())
     notice "Attestation published"
@@ -144,7 +146,7 @@ proc serveAggregateAndProofV2*(
         raiseAssert "Unsupported SignedAggregateAndProof"
 
   logScope:
-    delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams))
+    delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams, consensusFork))
 
   debug "Sending aggregated attestation", fork = consensusFork
 
@@ -258,8 +260,10 @@ proc produceAndPublishAttestationsV2*(
           else:
             inc(errored)
         (succeed, errored, failed)
-
-    delay = vc.getDelay(slot.attestation_deadline(vc.timeParams))
+    
+    consensusFork = vc.getConsensusFork(fork)
+    delay = vc.getDelay(slot.attestation_deadline(
+      vc.timeParams, consensusFork))
 
   debug "Attestation statistics", total = len(pendingAttestations),
         succeed = statistics[0], failed_to_deliver = statistics[1],
@@ -372,7 +376,10 @@ proc produceAndPublishAggregatesV2(
           inc(errored)
       (succeed, errored, failed)
 
-  let delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams))
+  let
+    consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+    delay = vc.getDelay(
+      slot.aggregate_deadline(vc.timeParams, consensusFork))
   debug "Aggregated attestation statistics", total = len(aggregates),
         succeed = statistics[0], failed_to_deliver = statistics[1],
         not_accepted = statistics[2], delay = delay, slot = slot,
@@ -387,7 +394,10 @@ proc publishAttestationsAndAggregatesV2(
     vc = service.client
 
   block:
-    let delay = vc.getDelay(slot.attestation_deadline(vc.timeParams))
+    let
+      consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+      delay = vc.getDelay(slot.attestation_deadline(
+        vc.timeParams, consensusFork))
     debug "Producing attestations", delay = delay, slot = slot,
                                     duties_count = len(duties)
 
@@ -402,14 +412,17 @@ proc publishAttestationsAndAggregatesV2(
       debug "Publish attestation request was interrupted"
       raise exc
 
-  let aggregateTime = vc.beaconClock.fromNow(
-    slot.aggregate_deadline(vc.timeParams))
+  let
+    consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+    aggregateTime = vc.beaconClock.fromNow(
+      slot.aggregate_deadline(vc.timeParams, consensusFork))
   if aggregateTime.inFuture:
     await sleepAsync(aggregateTime.offset)
 
   block:
     let
-      delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams))
+      delay = vc.getDelay(
+        slot.aggregate_deadline(vc.timeParams, consensusFork))
       dutiesByCommittee = getAttesterDutiesByCommittee(duties)
     debug "Producing aggregate and proofs", delay = delay
     var tasks: seq[Future[void].Raising([CancelledError])]

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -598,7 +598,7 @@ proc runBlockPollMonitor(service: BlockServiceRef,
     let
       currentTime = vc.beaconClock.now()
       afterSlot = currentTime.slotOrZero(vc.timeParams)
-      consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+      consensusFork = vc.getConsensusFork(vc.forkAtEpoch(afterSlot.epoch))
 
     if currentTime > afterSlot.attestation_deadline(
         vc.timeParams, consensusFork):

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -598,8 +598,10 @@ proc runBlockPollMonitor(service: BlockServiceRef,
     let
       currentTime = vc.beaconClock.now()
       afterSlot = currentTime.slotOrZero(vc.timeParams)
+      consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
 
-    if currentTime > afterSlot.attestation_deadline(vc.timeParams):
+    if currentTime > afterSlot.attestation_deadline(
+        vc.timeParams, consensusFork):
       # Attestation time already, lets wait for next slot.
       continue
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -879,6 +879,24 @@ proc getCurrentSlot*(vc: ValidatorClientRef): Opt[Slot] =
   else:
     Opt.none(Slot)
 
+proc getConsensusFork*(vc: ValidatorClientRef, fork: Fork): ConsensusFork =
+  doAssert(vc.forkConfig.isSome())
+  for key, value in vc.forkConfig.get().pairs():
+    if value.version == fork.current_version:
+      return key
+  raiseAssert "ForkConfig missing fork [" & $fork.current_version & "]"
+
+proc forkAtEpoch*(vc: ValidatorClientRef, epoch: Epoch): Fork =
+  # If schedule is present, it MUST not be empty.
+  doAssert(len(vc.forks) > 0)
+  var res: Fork
+  for item in vc.forks:
+    if item.epoch <= epoch:
+      res = item
+    else:
+      break
+  res
+
 proc getAttesterDutiesForSlot*(vc: ValidatorClientRef,
                                slot: Slot): seq[DutyAndProof] =
   ## Returns all `DutyAndProof` for the given `slot`.
@@ -903,7 +921,10 @@ proc getSyncCommitteeDutiesForSlot*(vc: ValidatorClientRef,
 proc getDurationToNextAttestation*(vc: ValidatorClientRef,
                                    slot: Slot): string =
   var minSlot = FAR_FUTURE_SLOT
-  let currentEpoch = slot.epoch()
+  let 
+    currentEpoch = slot.epoch()
+    consensusFork = vc.getConsensusFork(vc.forkAtEpoch(currentEpoch))
+
   for epoch in [currentEpoch, currentEpoch + 1'u64]:
     for key, item in vc.attesters:
       let duty = item.duties.getOrDefault(epoch, DefaultDutyAndProof)
@@ -916,7 +937,7 @@ proc getDurationToNextAttestation*(vc: ValidatorClientRef,
   if minSlot == FAR_FUTURE_SLOT:
     "<unknown>"
   else:
-    $(minSlot.attestation_deadline(vc.timeParams) -
+    $(minSlot.attestation_deadline(vc.timeParams, consensusFork) -
       slot.start_beacon_time(vc.timeParams))
 
 proc getDurationToNextBlock*(vc: ValidatorClientRef, slot: Slot): string =
@@ -978,24 +999,6 @@ proc getValidatorForDuties*(vc: ValidatorClientRef,
                             key: ValidatorPubKey, slot: Slot,
                             slashingSafe = false): Opt[AttachedValidator] =
   vc.attachedValidators[].getValidatorForDuties(key, slot, slashingSafe)
-
-proc forkAtEpoch*(vc: ValidatorClientRef, epoch: Epoch): Fork =
-  # If schedule is present, it MUST not be empty.
-  doAssert(len(vc.forks) > 0)
-  var res: Fork
-  for item in vc.forks:
-    if item.epoch <= epoch:
-      res = item
-    else:
-      break
-  res
-
-proc getConsensusFork*(vc: ValidatorClientRef, fork: Fork): ConsensusFork =
-  doAssert(vc.forkConfig.isSome())
-  for key, value in vc.forkConfig.get().pairs():
-    if value.version == fork.current_version:
-      return key
-  raiseAssert "ForkConfig missing fork [" & $fork.current_version & "]"
 
 proc isPastElectraFork*(vc: ValidatorClientRef, epoch: Epoch): bool =
   doAssert(len(vc.forks) > 0)
@@ -1492,12 +1495,13 @@ proc waitForBlock*(
         shortLog(blocks[0])
       else:
         "[" & blocks.mapIt(shortLog(it)).join(", ") & "]"
+    consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
 
   debug "Block proposal awaited", duration = dur,
         block_root = blockRoot
 
   try:
-    await waitAfterBlockCutoff(vc.beaconClock, slot)
+    await waitAfterBlockCutoff(vc.beaconClock, slot, consensusFork)
   except CancelledError as exc:
     let dur = Moment.now() - startTime
     debug "Waiting for block cutoff was interrupted", duration = dur

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -37,6 +37,7 @@ proc serveSyncCommitteeMessage*(
     vc = service.client
     startTime = Moment.now()
     fork = vc.forkAtEpoch(slot.epoch)
+    currentFork = vc.getConsensusFork(fork)
     genesisValidatorsRoot = vc.beaconGenesis.genesis_validators_root
     vindex = duty.validator_index
     validator = vc.getValidatorForDuties(
@@ -63,7 +64,8 @@ proc serveSyncCommitteeMessage*(
 
   debug "Sending sync committee message",
         delay = vc.getDelay(
-          message.slot.sync_committee_message_deadline(vc.timeParams))
+          message.slot.sync_committee_message_deadline(
+            vc.timeParams, currentFork))
 
   let res =
     try:
@@ -78,7 +80,8 @@ proc serveSyncCommitteeMessage*(
 
   let
     delay = vc.getDelay(
-      message.slot.sync_committee_message_deadline(vc.timeParams))
+      message.slot.sync_committee_message_deadline(
+        vc.timeParams, currentFork))
     dur = Moment.now() - startTime
 
   if res:
@@ -133,7 +136,9 @@ proc produceAndPublishSyncCommitteeMessages(
       (succeed, errored, failed)
 
   let
-    delay = vc.getDelay(slot.attestation_deadline(vc.timeParams))
+    consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+    delay = vc.getDelay(slot.attestation_deadline(
+      vc.timeParams, consensusFork))
     dur = Moment.now() - startTime
 
   debug "Sync committee message statistics",
@@ -154,6 +159,7 @@ proc serveContributionAndProof*(
     slot = proof.contribution.slot
     genesisRoot = vc.beaconGenesis.genesis_validators_root
     fork = vc.forkAtEpoch(slot.epoch)
+    consensusFork = vc.getConsensusFork(fork)
 
   logScope:
     validator = validatorLog(validator)
@@ -176,7 +182,8 @@ proc serveContributionAndProof*(
       res.get()
 
   debug "Sending sync contribution",
-        delay = vc.getDelay(slot.sync_contribution_deadline(vc.timeParams))
+        delay = vc.getDelay(slot.sync_contribution_deadline(
+          vc.timeParams, consensusFork))
 
   let restSignedProof = RestSignedContributionAndProof.init(
     proof, signature)
@@ -328,7 +335,8 @@ proc produceAndPublishContributions(
           (succeed, errored, failed)
 
     let
-      delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams))
+      consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+      delay = vc.getDelay(slot.aggregate_deadline(vc.timeParams, consensusFork))
       dur = Moment.now() - startTime
 
     debug "Sync message contribution statistics",
@@ -355,8 +363,10 @@ proc publishSyncMessagesAndContributions(
     slot = slot
 
   block:
-    let delay = vc.getDelay(
-      slot.sync_committee_message_deadline(vc.timeParams))
+    let 
+      currentFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+      delay = vc.getDelay(
+        slot.sync_committee_message_deadline(vc.timeParams, currentFork))
     debug "Producing sync committee messages", delay = delay,
           duties_count = len(duties)
 
@@ -396,15 +406,19 @@ proc publishSyncMessagesAndContributions(
     return
 
   let currentTime = vc.beaconClock.now()
-  if slot.sync_contribution_deadline(vc.timeParams) > currentTime:
+  let consensusFork = vc.getConsensusFork(vc.forkAtEpoch(slot.epoch))
+  if slot.sync_contribution_deadline(
+      vc.timeParams, consensusFork) > currentTime:
     let waitDur = nanoseconds((
-      slot.sync_contribution_deadline(vc.timeParams) - currentTime).nanoseconds)
+      slot.sync_contribution_deadline(
+        vc.timeParams, consensusFork) - currentTime).nanoseconds)
     # Sleeping until `sync_contribution_deadline`.
     debug "Waiting for sync contribution deadline", wait_time = waitDur
     await sleepAsync(waitDur)
 
   block:
-    let delay = vc.getDelay(slot.sync_contribution_deadline(vc.timeParams))
+    let delay = vc.getDelay(
+      slot.sync_contribution_deadline(vc.timeParams, consensusFork))
     debug "Producing contribution and proofs", delay = delay
 
   try:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1237,8 +1237,10 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   head = newHead
 
   # The latest point in time when we'll be sending out attestations
-  let attestationCutoff = node.beaconClock.fromNow(
-    slot.attestation_deadline(node.dag.timeParams))
+  let
+    consensusFork = node.dag.cfg.consensusForkAtEpoch(slot.epoch)
+    attestationCutoff = node.beaconClock.fromNow(
+      slot.attestation_deadline(node.dag.timeParams, consensusFork))
   if attestationCutoff.inFuture:
     debug "Waiting to send attestations",
       head = shortLog(head),
@@ -1247,7 +1249,8 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
     # Wait either for the block or the attestation cutoff time to arrive
     if await node.consensusManager[].expectBlock(slot)
         .withTimeout(attestationCutoff.offset):
-      await waitAfterBlockCutoff(node.beaconClock, slot, Opt.some(head))
+      await waitAfterBlockCutoff(
+        node.beaconClock, slot, consensusFork, Opt.some(head))
 
     # Time passed - we might need to select a new head in that case
     node.consensusManager[].updateHead(slot)
@@ -1270,7 +1273,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
     node.dag.timeParams.aggregateSlotOffset ==
     node.dag.timeParams.syncContributionSlotOffset, "Timing change?")
   let aggregateCutoff = node.beaconClock.fromNow(
-    slot.aggregate_deadline(node.dag.timeParams))
+    slot.aggregate_deadline(node.dag.timeParams, consensusFork))
   if aggregateCutoff.inFuture:
     debug "Waiting to send aggregate attestations",
       aggregateCutoff = shortLog(aggregateCutoff.offset)

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -248,7 +248,9 @@ proc routeAttestation*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = attestation.data.slot
-    delay = sendTime - slot.attestation_deadline(router[].dag.timeParams)
+    currentFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = sendTime - slot.attestation_deadline(
+      router[].dag.timeParams, currentFork)
     res = await router[].network.broadcastAttestation(subnet_id, attestation)
 
   if res.isOk():
@@ -321,7 +323,9 @@ proc routeSignedAggregateAndProof*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = proof.message.aggregate.data.slot
-    delay = sendTime - slot.aggregate_deadline(router[].dag.timeParams)
+    currentFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay =
+     sendTime - slot.aggregate_deadline(router[].dag.timeParams, currentFork)
     res = await router[].network.broadcastAggregateAndProof(proof)
 
   if res.isOk():
@@ -356,8 +360,9 @@ proc routeSyncCommitteeMessage*(
 
   let
     sendTime = router[].processor.getCurrentBeaconTime()
-    delay = sendTime -
-      msg.slot.sync_committee_message_deadline(router[].dag.timeParams)
+    currentFork = router[].dag.cfg.consensusForkAtEpoch(msg.slot.epoch)
+    delay = sendTime - msg.slot.sync_committee_message_deadline(
+      router[].dag.timeParams, currentFork)
 
     res = await router[].network.broadcastSyncCommitteeMessage(
       msg, subcommitteeIdx)
@@ -479,7 +484,9 @@ proc routeSignedContributionAndProof*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = msg.message.contribution.slot
-    delay = sendTime - slot.sync_contribution_deadline(router[].dag.timeParams)
+    currentFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = sendTime -
+      slot.sync_contribution_deadline(router[].dag.timeParams, currentFork)
 
   let res = await router[].network.broadcastSignedContributionAndProof(msg)
   if res.isOk():

--- a/beacon_chain/validators/validator_duties.nim
+++ b/beacon_chain/validators/validator_duties.nim
@@ -53,6 +53,7 @@ func toSingleAttestation*(
     signature: signature)
 
 proc waitAfterBlockCutoff*(clock: BeaconClock, slot: Slot,
+                           consensusFork: ConsensusFork,
                            head: Opt[BlockRef] = Opt.none(BlockRef))
                            {.async: (raises: [CancelledError]).} =
   # The expected block arrived (or expectBlock was called again which
@@ -75,7 +76,8 @@ proc waitAfterBlockCutoff*(clock: BeaconClock, slot: Slot,
   let
     extraDelay = nanos(clock.timeParams.attestationSlotOffset.nanoseconds div 2)
     afterBlockCutoff = clock.fromNow(min(
-      clock.now(), slot.attestation_deadline(clock.timeParams)) + extraDelay)
+      clock.now(), 
+      slot.attestation_deadline(clock.timeParams, consensusFork)) + extraDelay)
 
   if afterBlockCutoff.inFuture:
     if head.isSome():

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -172,8 +172,9 @@ cli do(
       syncCommittee = @(dag.syncCommitteeParticipants(slot + 1))
       genesis_validators_root = dag.genesis_validators_root
       fork = dag.forkAtEpoch(slot.epoch)
-      messagesTime = slot.attestation_deadline(cfg.timeParams)
-      contributionsTime = slot.sync_contribution_deadline(cfg.timeParams)
+      consensusFork = dag.cfg.consensusForkAtEpoch(slot.epoch)
+      messagesTime = slot.attestation_deadline(cfg.timeParams, consensusFork)
+      contributionsTime = slot.sync_contribution_deadline(cfg.timeParams, consensusFork)
 
     var aggregators: seq[Aggregator]
 


### PR DESCRIPTION
use fork-aware timing system for Gloas. 
Deadlines should use correct timing based on the active consensus fork.