### PR TITLE
VC: Add fallback mode for multiple beacon nodes.

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -115,6 +115,10 @@ type
     Poll = "poll"
     Event = "event"
 
+  BeaconNodeMode* {.pure.} = enum
+    BestScore = "bestscore"
+    Fallback = "fallback"
+
   Web3SignerUrl* = object
     url*: Uri
     provenBlockProperties*: seq[string] # empty if this is not a verifying Web3Signer
@@ -1056,6 +1060,12 @@ type
       defaultValue: @[defaultBeaconNodeUri]
       defaultValueDesc: $defaultBeaconNodeUri
       name: "beacon-node" .}: seq[Uri]
+
+    beaconNodeMode* {.
+      desc: "How validator client should operate multiple beacon nodes",
+      defaultValue: BeaconNodeMode.BestScore
+      defaultValueDesc: "Ask all beacon nodes and select the best response."
+      name: "beacon-node-mode" .}: BeaconNodeMode
 
     monitoringType* {.
       desc: "Enable block monitoring which are seen by beacon node (BETA)"

--- a/beacon_chain/validator_client/attestation_service.nim
+++ b/beacon_chain/validator_client/attestation_service.nim
@@ -76,7 +76,8 @@ proc serveAttestation(
       attestation = shortLog(atst)
     try:
       await vc.submitPoolAttestationsV2(
-        @[atst], consensusFork, ApiStrategyKind.First)
+        @[atst], consensusFork,
+        vc.getMode()[FnKind.submitPoolAttestations])
     except ValidatorApiError as exc:
       warn "Unable to publish attestation", reason = exc.getFailureReason()
       return false
@@ -155,7 +156,8 @@ proc serveAggregateAndProofV2*(
   let res =
     try:
       await vc.publishAggregateAndProofsV2(
-        @[signedProof], consensusFork, ApiStrategyKind.First)
+        @[signedProof], consensusFork,
+        vc.getMode()[FnKind.publishAggregateAndProofs])
     except ValidatorApiError as exc:
       warn "Unable to publish aggregated attestation",
             reason = exc.getFailureReason()
@@ -181,8 +183,10 @@ proc produceAndPublishAttestationsV2*(
   let
     vc = service.client
     fork = vc.forkAtEpoch(slot.epoch)
-    data = await vc.produceAttestationData(slot, CommitteeIndex(0),
-                                           ApiStrategyKind.Best)
+    data = await vc.produceAttestationData(
+      slot,
+      CommitteeIndex(0),
+      vc.getMode()[FnKind.produceAttestationData])
     registeredRes =
       vc.attachedValidators[].slashingProtection.withContext:
         var tmp: seq[RegisteredAttestation]
@@ -316,9 +320,10 @@ proc produceAndPublishAggregatesV2(
     block:
       let attestation =
         try:
-          await vc.getAggregatedAttestationV2(slot, attestationRoot,
-                                              committee_index,
-                                              ApiStrategyKind.Best)
+          await vc.getAggregatedAttestationV2(
+            slot, attestationRoot,
+            committee_index,
+            vc.getMode()[FnKind.getAggregatedAttestation])
         except ValidatorApiError as exc:
           warn "Unable to get aggregated attestation data", slot = slot,
                attestation_root = shortLog(attestationRoot),

--- a/beacon_chain/validator_client/block_service.nim
+++ b/beacon_chain/validator_client/block_service.nim
@@ -127,9 +127,10 @@ proc publishBlockV3(
   let
     maybeBlock =
       try:
-        await vc.produceBlockV3(slot, randaoReveal, graffiti,
-                                vc.config.builderBoostFactor,
-                                ApiStrategyKind.Best)
+        await vc.produceBlockV3(
+          slot, randaoReveal, graffiti,
+          vc.config.builderBoostFactor,
+          vc.getMode()[FnKind.produceBlock])
       except ValidatorApiError as exc:
         warn "Unable to retrieve block data", reason = exc.getFailureReason()
         return
@@ -185,13 +186,9 @@ proc publishBlockV3(
         res =
           try:
             debug "Sending blinded block"
-            if vc.isPastElectraFork(slot.epoch()):
-              await vc.publishBlindedBlockV2(
-                signedBlock, BroadcastValidationType.Gossip,
-                ApiStrategyKind.First)
-            else:
-              await vc.publishBlindedBlock(
-                signedBlock, ApiStrategyKind.First)
+            await vc.publishBlindedBlockV2(
+              signedBlock, BroadcastValidationType.Gossip,
+              vc.getMode()[FnKind.publishBlindedBlock])
           except ValidatorApiError as exc:
             warn "Unable to publish blinded block",
                  reason = exc.getFailureReason()
@@ -267,7 +264,7 @@ proc publishBlockV3(
             debug "Sending block"
             await vc.publishBlockV2(
               signedBlockContents, BroadcastValidationType.Gossip,
-              ApiStrategyKind.First)
+              vc.getMode()[FnKind.publishBlock])
           except ValidatorApiError as exc:
             warn "Unable to publish block", reason = exc.getFailureReason()
             return

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -176,6 +176,27 @@ type
     BrokenClock,        ## BN wall clock is broken or has significan offset.
     InternalError       ## BN reports internal error.
 
+  FnKind* {.pure.} = enum
+    getProposerDuties
+    getAttesterDuties
+    getSyncCommitteeDuties
+    getHeadBlockRoot
+    getValidators
+    produceAttestationData
+    submitPoolAttestations
+    getAggregatedAttestation
+    publishAggregateAndProofs
+    produceBlock
+    publishBlock
+    publishBlindedBlock
+    produceSyncCommitteeContribution
+    submitPoolSyncCommitteeSignature
+    publishContributionAndProofs
+    submitBeaconCommitteeSelections
+    submitSyncCommitteeSelections
+
+  VCBeaconNodeMode* = array[int(high(FnKind)) + 1, ApiStrategyKind]
+
   BeaconNodesCounters* = object
     data*: array[int(high(RestBeaconNodeStatus)) + 1, int]
 
@@ -311,6 +332,49 @@ const
     RestBeaconNodeStatus.BrokenClock,
     RestBeaconNodeStatus.InternalError
   }
+
+  BestScoreMode* = VCBeaconNodeMode([
+    ApiStrategyKind.First,     # getProposerDuties
+    ApiStrategyKind.First,     # getAttesterDuties
+    ApiStrategyKind.First,     # getSyncCommitteeDuties
+    ApiStrategyKind.Best,      # getHeadBlockRoot
+    ApiStrategyKind.First,     # getValidators
+    ApiStrategyKind.Best,      # produceAttestationData
+    ApiStrategyKind.First,     # submitPoolAttestations
+    ApiStrategyKind.Best,      # getAggregatedAttestation
+    ApiStrategyKind.First,     # publishAggregateAndProofs
+    ApiStrategyKind.Best,      # produceBlock
+    ApiStrategyKind.First,     # publishBlock
+    ApiStrategyKind.First,     # publishBlindedBlock
+    ApiStrategyKind.Best,      # produceSyncCommitteeContribution
+    ApiStrategyKind.First,     # submitPoolSyncCommitteeSignature
+    ApiStrategyKind.First,     # publishContributionAndProofs
+    ApiStrategyKind.Best,      # submitBeaconCommitteeSelections
+    ApiStrategyKind.Best       # submitSyncCommitteeSelections
+  ])
+
+  FallbackMode* = VCBeaconNodeMode([
+    ApiStrategyKind.Priority,  # getProposerDuties
+    ApiStrategyKind.Priority,  # getAttesterDuties
+    ApiStrategyKind.Priority,  # getSyncCommitteeDuties
+    ApiStrategyKind.Priority,  # getHeadBlockRoot
+    ApiStrategyKind.Priority,  # getValidators
+    ApiStrategyKind.Priority,  # produceAttestationData
+    ApiStrategyKind.Priority,  # submitPoolAttestations
+    ApiStrategyKind.Priority,  # getAggregatedAttestation
+    ApiStrategyKind.Priority,  # publishAggregateAndProofs
+    ApiStrategyKind.Priority,  # produceBlock
+    ApiStrategyKind.Priority,  # publishBlock
+    ApiStrategyKind.Priority,  # publishBlindedBlock
+    ApiStrategyKind.Priority,  # produceSyncCommitteeContribution
+    ApiStrategyKind.Priority,  # submitPoolSyncCommitteeSignature
+    ApiStrategyKind.Priority,  # publishContributionAndProofs
+    ApiStrategyKind.Priority,  # submitBeaconCommitteeSelections
+    ApiStrategyKind.Priority   # submitSyncCommitteeSelections
+  ])
+
+template `[]`*(vcs: VCBeaconNodeMode, index: FnKind): ApiStrategyKind =
+  vcs[int(index)]
 
 func SlotDuration*(vc: ValidatorClientRef): Duration =
   vc.timeParams.SLOT_DURATION
@@ -1669,6 +1733,13 @@ proc `+`*(slot: Slot, epochs: Epoch): Slot =
 func finish_slot*(epoch: Epoch): Slot =
   ## Return the last slot of ``epoch``.
   (epoch + 1).start_slot() - 1
+
+func getMode*(vc: ValidatorClientRef): VCBeaconNodeMode =
+  case vc.config.beaconNodeMode
+  of BeaconNodeMode.BestScore:
+    BestScoreMode
+  of BeaconNodeMode.Fallback:
+    FallbackMode
 
 proc getGraffitiBytes*(vc: ValidatorClientRef,
                        validator: AttachedValidator): GraffitiBytes =

--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -68,7 +68,7 @@ proc pollForValidatorIndices*(
   for idents in chunks(validatorIdents, ClientMaximumValidatorIds):
     let res =
       try:
-        await vc.getValidators(idents, ApiStrategyKind.First)
+        await vc.getValidators(idents, vc.getMode()[FnKind.getValidators])
       except ValidatorApiError as exc:
         warn "Unable to get head state's validator information",
               reason = exc.getFailureReason()
@@ -123,8 +123,9 @@ proc pollForAttesterDuties*(
               for chunk in indices.chunks(DutiesMaximumValidatorIds):
                 let res =
                   try:
-                    await vc.getAttesterDuties(epoch, chunk,
-                                               ApiStrategyKind.First)
+                    await vc.getAttesterDuties(
+                      epoch, chunk,
+                      vc.getMode()[FnKind.getAttesterDuties])
                   except ValidatorApiError as exc:
                     warn "Unable to get attester duties", epoch = epoch,
                          reason = exc.getFailureReason()
@@ -225,8 +226,9 @@ proc pollForSyncCommitteeDuties*(
         for chunk in indices.chunks(DutiesMaximumValidatorIds):
           let res =
             try:
-              await vc.getSyncCommitteeDuties(epoch, chunk,
-                                              ApiStrategyKind.First)
+              await vc.getSyncCommitteeDuties(
+                epoch, chunk,
+                vc.getMode()[FnKind.getSyncCommitteeDuties])
             except ValidatorApiError as exc:
               warn "Unable to get sync committee duties",
                    period = period, epoch = epoch,
@@ -506,8 +508,8 @@ proc pollForBeaconProposers*(
 
   if vc.attachedValidators[].count() != 0:
     try:
-      let res = await vc.getProposerDuties(currentEpoch,
-                                           ApiStrategyKind.First)
+      let res = await vc.getProposerDuties(
+        currentEpoch, vc.getMode()[FnKind.getProposerDuties])
       let
         dependentRoot = res.dependent_root
         duties = res.data

--- a/beacon_chain/validator_client/selection_proofs.nim
+++ b/beacon_chain/validator_client/selection_proofs.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/validator_client/selection_proofs.nim
+++ b/beacon_chain/validator_client/selection_proofs.nim
@@ -173,8 +173,8 @@ proc fillAttestationSelectionProofs*(
       let sresponse =
         try:
           # Query middleware for aggregated signatures.
-          await vc.submitBeaconCommitteeSelections(selections,
-                                                   ApiStrategyKind.Best)
+          await vc.submitBeaconCommitteeSelections(
+            selections, vc.getMode()[FnKind.submitBeaconCommitteeSelections])
         except ValidatorApiError as exc:
           warn "Unable to submit beacon committee selections",
                reason = exc.getFailureReason()
@@ -455,8 +455,8 @@ proc fillSyncCommitteeSelectionProofs*(
       let sresponse =
         try:
           # Query middleware for aggregated signatures.
-          await vc.submitSyncCommitteeSelections(selections,
-                                                 ApiStrategyKind.Best)
+          await vc.submitSyncCommitteeSelections(
+            selections, vc.getMode()[FnKind.submitSyncCommitteeSelections])
         except ValidatorApiError as exc:
           warn "Unable to submit sync committee selections",
                reason = exc.getFailureReason()

--- a/beacon_chain/validator_client/sync_committee_service.nim
+++ b/beacon_chain/validator_client/sync_committee_service.nim
@@ -69,7 +69,8 @@ proc serveSyncCommitteeMessage*(
 
   let res =
     try:
-      await vc.submitPoolSyncCommitteeSignature(message, ApiStrategyKind.First)
+      await vc.submitPoolSyncCommitteeSignature(
+        message, vc.getMode()[FnKind.submitPoolSyncCommitteeSignature])
     except ValidatorApiError as exc:
       warn "Unable to publish sync committee message",
            reason = exc.getFailureReason()
@@ -190,8 +191,8 @@ proc serveContributionAndProof*(
 
   let res =
     try:
-      await vc.publishContributionAndProofs(@[restSignedProof],
-                                            ApiStrategyKind.First)
+      await vc.publishContributionAndProofs(
+        @[restSignedProof], vc.getMode()[FnKind.publishContributionAndProofs])
     except ValidatorApiError as exc:
       warn "Unable to publish sync contribution",
            reason = exc.getFailureReason()
@@ -252,7 +253,8 @@ proc produceAndPublishContributions(
             if isNil(resMap[subCommitteeIdx]):
               let future =
                 vc.produceSyncCommitteeContribution(
-                  slot, subCommitteeIdx, beaconBlockRoot, ApiStrategyKind.Best)
+                  slot, subCommitteeIdx, beaconBlockRoot,
+                  vc.getMode()[FnKind.produceSyncCommitteeContribution])
               resMap[int(subCommitteeIdx)] = future
               resFutures.add(FutureBase(future))
       (resItems, resFutures, resMap)
@@ -373,7 +375,8 @@ proc publishSyncMessagesAndContributions(
   let beaconBlockRoot =
     block:
       try:
-        let res = await vc.getHeadBlockRoot(ApiStrategyKind.Best)
+        let res = await vc.getHeadBlockRoot(
+          vc.getMode()[FnKind.getHeadBlockRoot])
         if res.execution_optimistic.isNone():
           ## The `execution_optimistic` is missing from the response, we assume
           ## that the BN is unaware optimistic sync, so we consider the BN


### PR DESCRIPTION
Add "fallback" mode which will use first BN as primary and all other BNs will be used as fallbacks.
This mode is not enabled by default, but could be controlled via `--beacon-node-mode=fallback` option to VC.