### PR TITLE
introduce light supernodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -720,6 +720,7 @@ test_libnimbus_lc: libnimbus_lc.a
 				--std=c17 -flto \
 				-pedantic -pedantic-errors \
 				-Wall -Wextra -Werror -Wno-maybe-uninitialized \
+				-Wno-stringop-overflow \
 				-Wno-unsafe-buffer-usage -Wno-unknown-warning-option \
 				-o build/test_libnimbus_lc \
 				beacon_chain/libnimbus_lc/test_libnimbus_lc.c \

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -253,7 +253,7 @@ type
 
     lightSupernode* {.
       defaultValue: false,
-      desc: "Subscribe to the first half of column subnets, therefore custodying half the columns than a usual supernode"
+      desc: "Subscribe to the first half of column subnets"
       name: "light-supernode" .}: bool
 
     slashingDbKind* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -251,6 +251,11 @@ type
       desc: "Subscribe to all column subnets, thereby becoming a PeerDAS supernode"
       name: "peerdas-supernode" .}: bool
 
+    lightSupernode* {.
+      defaultValue: false,
+      desc: "Subscribe to the first half of column subnets, therefore custodying half the columns than a usual supernode"
+      name: "light-supernode" .}: bool
+
     slashingDbKind* {.
       hidden
       defaultValue: SlashingDbKind.v2

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -417,9 +417,12 @@ proc initFullNode(
     blobQuarantine = newClone(BlobQuarantine.init(
       dag.cfg, dag.db.getQuarantineDB(), 10, onBlobSidecarAdded))
     supernode = node.config.peerdasSupernode or node.config.debugPeerdasSupernode
+    lightSupernode = node.config.lightSupernode
     localCustodyGroups =
       if supernode:
         dag.cfg.NUMBER_OF_CUSTODY_GROUPS
+      elif lightSupernode:
+        dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2
       else:
         dag.cfg.CUSTODY_REQUIREMENT
     custodyColumns =
@@ -1294,9 +1297,13 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   subnets + node.getNextSyncCommitteeSubnets(epoch)
 
 func readCustodyGroupSubnets(node: BeaconNode): uint64 =
-  let vcus_count = node.dataColumnQuarantine.custodyColumns.lenu64
+  let
+    custodyGroups = node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
+    vcus_count = node.dataColumnQuarantine.custodyColumns.lenu64
   if node.config.peerdasSupernode or node.config.debugPeerdasSupernode:
-    node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
+    custodyGroups
+  elif node.config.lightSupernode:
+    custodyGroups div 2
   elif vcus_count > node.dag.cfg.CUSTODY_REQUIREMENT:
     vcus_count
   else:
@@ -1304,10 +1311,19 @@ func readCustodyGroupSubnets(node: BeaconNode): uint64 =
 
 proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
   let
+    custody_groups = node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
     forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
     targetSubnets = node.readCustodyGroupSubnets()
-    custody = node.dag.cfg.get_custody_groups(
-      node.network.nodeId, targetSubnets.uint64)
+    custody =
+      if node.config.lightSupernode:
+        # Light supernode serves only half of the custody groups
+        var res = newSeqOfCap[CustodyIndex](custody_groups div 2)
+        for i in 0..<custody_groups div 2:
+          res.add CustodyIndex(i)
+        res
+      else:
+        node.dag.cfg.get_custody_groups(
+        node.network.nodeId, targetSubnets.uint64)
 
   for i in custody:
     let topic = getDataColumnSidecarTopic(forkDigest, i)
@@ -1736,6 +1752,9 @@ proc reconstructDataColumns(node: BeaconNode, slot: Slot) =
   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-beta.0/specs/fulu/das-core.md#reconstruction-and-cross-seeding
   # "If the node obtains 50%+ of all the columns, it SHOULD reconstruct the
   # full data matrix via the recover_matrix helper."
+  if node.config.lightSupernode:
+    return
+
   if node.dataColumnQuarantine.custodyColumns.lenu64 <
       node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2:
     return
@@ -2014,6 +2033,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
   if (not node.config.peerdasSupernode) and
      (not node.config.debugPeerdasSupernode) and
+     (not node.config.lightSupernode) and
      node.dataColumnQuarantine[].len == 0 and
      node.attachedValidatorBalanceTotal > 0.Gwei:
     # Detect new validator custody at the last slot of every epoch

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1766,6 +1766,10 @@ proc reconstructDataColumns(node: BeaconNode, slot: Slot) =
       node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2:
     return
 
+  # Currently, this logic is broken
+  if true:
+    return
+
   logScope:
     slot = slot
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -426,8 +426,15 @@ proc initFullNode(
       else:
         dag.cfg.CUSTODY_REQUIREMENT
     custodyColumns =
-      dag.cfg.resolve_columns_from_custody_groups(
-        node.network.nodeId, localCustodyGroups)
+      if node.config.lightSupernode:
+        # Just the first half of custody columns
+        var res: HashSet[ColumnIndex]
+        for i in 0..<dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2:
+          res.incl ColumnIndex(i)
+        res
+      else:
+        dag.cfg.resolve_columns_from_custody_groups(
+          node.network.nodeId, localCustodyGroups)
 
   var sortedColumns = custodyColumns.toSeq()
   sort(sortedColumns)

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -50,6 +50,7 @@ The following options are available:
      --agent-string            Node agent string which is used as identifier in network [=nimbus].
      --subscribe-all-subnets   Subscribe to all subnet topics when gossiping [=false].
      --peerdas-supernode       Subscribe to all column subnets, thereby becoming a PeerDAS supernode [=false].
+     --light-supernode         Subscribe to the first half of column subnets [=false].
      --num-threads             Number of worker threads ("0" = use as many threads as there are CPU cores
                                available) [=0].
      --jwt-secret              A file containing the hex-encoded 256 bit secret key to be used for
@@ -112,7 +113,6 @@ The following options are available:
      --light-client-data-import-mode  Which classes of light client data to import. Must be one of: none, only-new,
                                full (slow startup), on-demand (may miss validator duties) [=only-new].
      --light-client-data-max-periods  Maximum number of sync committee periods to retain light client data.
-     --light-supernode         Subscribe to the first half of column subnets [=false].
      --in-process-validators   Disable the push model (the beacon node tells a signing process with the private
                                keys of the validators what to sign and when) and load the validators in the
                                beacon node itself [=true].

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -112,6 +112,7 @@ The following options are available:
      --light-client-data-import-mode  Which classes of light client data to import. Must be one of: none, only-new,
                                full (slow startup), on-demand (may miss validator duties) [=only-new].
      --light-client-data-max-periods  Maximum number of sync committee periods to retain light client data.
+     --light-supernode         Subscribe to only the first half of total column subnets.
      --in-process-validators   Disable the push model (the beacon node tells a signing process with the private
                                keys of the validators what to sign and when) and load the validators in the
                                beacon node itself [=true].

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -112,7 +112,7 @@ The following options are available:
      --light-client-data-import-mode  Which classes of light client data to import. Must be one of: none, only-new,
                                full (slow startup), on-demand (may miss validator duties) [=only-new].
      --light-client-data-max-periods  Maximum number of sync committee periods to retain light client data.
-     --light-supernode         Subscribe to only the first half of total column subnets.
+     --light-supernode         Subscribe to the first half of column subnets [=false].
      --in-process-validators   Disable the push model (the beacon node tells a signing process with the private
                                keys of the validators what to sign and when) and load the validators in the
                                beacon node itself [=true].


### PR DESCRIPTION
Light supernodes would effectively custody always the first half columns of the total columns gossiped through the network per slot. The rationale being having an added advantage of not having to reconstruct columns every slot, and still be able to serve blobs via the beaconAPI to L2s.

This avoids the added cost of CPU load when the BN tries to reconstruct columns, however it should have similar bandwidth requirements to how we work supernodes today.

To enable launch your BN with `--light-supernode` set to `true`.