### PR TITLE
Refactor conf with flatten

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -45,15 +45,10 @@ export
 declareGauge network_name, "network name", ["name"]
 
 const
-  # TODO: How should we select between IPv4 and IPv6
-  # Maybe there should be a config option for this.
-  defaultAdminListenAddress* = (static parseIpAddress("127.0.0.1"))
   defaultSigningNodeRequestTimeout* = 60
   defaultBeaconNode* = "http://127.0.0.1:" & $defaultEth2RestPort
   defaultBeaconNodeUri* = parseUri(defaultBeaconNode)
   defaultGasLimit* = 60_000_000
-  defaultAdminListenAddressDesc* = $defaultAdminListenAddress
-  defaultBeaconNodeDesc = $defaultBeaconNode
 
 when defined(windows):
   {.pragma: windowsOnly.}
@@ -305,13 +300,11 @@ type
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "tcp-port" .}: Port
 
       udpPort* {.
         desc: "Listening UDP port for node discovery"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "udp-port" .}: Port
 
       maxPeers* {.
@@ -403,21 +396,7 @@ type
         defaultValue: 0
         name: "stop-at-synced-epoch" .}: uint64
 
-      metricsEnabled* {.
-        desc: "Enable the metrics server"
-        defaultValue: false
-        name: "metrics" .}: bool
-
-      metricsAddress* {.
-        desc: "Listening address of the metrics server"
-        defaultValue: defaultAdminListenAddress
-        defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "metrics-address" .}: IpAddress
-
-      metricsPort* {.
-        desc: "Listening HTTP port of the metrics server"
-        defaultValue: 8008
-        name: "metrics-port" .}: Port
+      metrics* {.flatten.}: MetricsConf
 
       statusBarEnabled* {.
         posixOnly
@@ -445,13 +424,11 @@ type
       restPort* {.
         desc: "Port for the REST Beacon API"
         defaultValue: defaultEth2RestPort
-        defaultValueDesc: $defaultEth2RestPortDesc
         name: "rest-port" .}: Port
 
       restAddress* {.
         desc: "Listening address of the REST Beacon API"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "rest-address" .}: IpAddress
 
       restAllowedOrigin* {.
@@ -471,51 +448,9 @@ type
         desc: "The number of seconds to keep recently accessed states in memory"
         name: "rest-statecache-ttl" .}: Natural
 
-      restRequestTimeout* {.
-        defaultValue: 0
-        defaultValueDesc: "infinite"
-        desc: "The number of seconds to wait until complete REST request " &
-              "will be received"
-        name: "rest-request-timeout" .}: Natural
+      restApiConf* {.flatten.}: RestApiConf
 
-      restMaxRequestBodySize* {.
-        defaultValue: 16_384
-        desc: "Maximum size of REST request body (kilobytes)"
-        name: "rest-max-body-size" .}: Natural
-
-      restMaxRequestHeadersSize* {.
-        defaultValue: 128
-        desc: "Maximum size of REST request headers (kilobytes)"
-        name: "rest-max-headers-size" .}: Natural
-        ## NOTE: If you going to adjust this value please check value
-        ## ``ClientMaximumValidatorIds`` and comments in
-        ## `spec/eth2_apis/rest_types.nim`. This values depend on each other.
-
-      keymanagerEnabled* {.
-        desc: "Enable the REST keymanager API"
-        defaultValue: false
-        name: "keymanager" .}: bool
-
-      keymanagerPort* {.
-        desc: "Listening port for the REST keymanager API"
-        defaultValue: defaultEth2RestPort
-        defaultValueDesc: $defaultEth2RestPortDesc
-        name: "keymanager-port" .}: Port
-
-      keymanagerAddress* {.
-        desc: "Listening port for the REST keymanager API"
-        defaultValue: defaultAdminListenAddress
-        defaultValueDesc: $defaultAdminListenAddressDesc
-        name: "keymanager-address" .}: IpAddress
-
-      keymanagerAllowedOrigin* {.
-        desc: "Limit the access to the Keymanager API to a particular hostname " &
-              "(for CORS-enabled clients such as browsers)"
-        name: "keymanager-allow-origin" .}: Option[string]
-
-      keymanagerTokenFile* {.
-        desc: "A file specifying the authorization token required for accessing the keymanager API"
-        name: "keymanager-token-file" .}: Option[InputFile]
+      keyManagerApiConf* {.flatten.}: KeyManagerApiConf
 
       lightClientDataServe* {.
         desc: "Serve data for enabling light clients to stay in sync with the network"
@@ -789,7 +724,6 @@ type
         restUrlForExit* {.
           desc: "URL of the beacon node REST service"
           defaultValue: defaultBeaconNode
-          defaultValueDesc: $defaultBeaconNodeDesc
           name: "rest-url" .}: string
 
         printData* {.
@@ -855,7 +789,6 @@ type
       trustedNodeUrl* {.
         desc: "URL of the REST API to sync from"
         defaultValue: defaultBeaconNode
-        defaultValueDesc: $defaultBeaconNodeDesc
         name: "trusted-node-url"
       .}: string
 
@@ -948,23 +881,6 @@ type
       desc: "A directory containing validator keystore passwords"
       name: "secrets-dir" .}: Option[InputDir]
 
-    restRequestTimeout* {.
-      defaultValue: 0
-      defaultValueDesc: "infinite"
-      desc: "The number of seconds to wait until complete REST request " &
-            "will be received"
-      name: "rest-request-timeout" .}: Natural
-
-    restMaxRequestBodySize* {.
-      defaultValue: 16_384
-      desc: "Maximum size of REST request body (kilobytes)"
-      name: "rest-max-body-size" .}: Natural
-
-    restMaxRequestHeadersSize* {.
-      defaultValue: 64
-      desc: "Maximum size of REST request headers (kilobytes)"
-      name: "rest-max-headers-size" .}: Natural
-
     # Same option as appears in Lighthouse and Prysm
     # https://lighthouse-book.sigmaprime.io/suggested-fee-recipient.html
     # https://github.com/prysmaticlabs/prysm/pull/10312
@@ -977,47 +893,11 @@ type
       defaultValue: defaultGasLimit
       name: "suggested-gas-limit" .}: uint64
 
-    keymanagerEnabled* {.
-      desc: "Enable the REST keymanager API"
-      defaultValue: false
-      name: "keymanager" .}: bool
+    restApiConf* {.flatten.}: RestApiConf
 
-    keymanagerPort* {.
-      desc: "Listening port for the REST keymanager API"
-      defaultValue: defaultEth2RestPort
-      defaultValueDesc: $defaultEth2RestPortDesc
-      name: "keymanager-port" .}: Port
+    keyManagerApiConf* {.flatten.}: KeyManagerApiConf
 
-    keymanagerAddress* {.
-      desc: "Listening port for the REST keymanager API"
-      defaultValue: defaultAdminListenAddress
-      defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "keymanager-address" .}: IpAddress
-
-    keymanagerAllowedOrigin* {.
-      desc: "Limit the access to the Keymanager API to a particular hostname " &
-            "(for CORS-enabled clients such as browsers)"
-      name: "keymanager-allow-origin" .}: Option[string]
-
-    keymanagerTokenFile* {.
-      desc: "A file specifying the authorizition token required for accessing the keymanager API"
-      name: "keymanager-token-file" .}: Option[InputFile]
-
-    metricsEnabled* {.
-      desc: "Enable the metrics server"
-      defaultValue: false
-      name: "metrics" .}: bool
-
-    metricsAddress* {.
-      desc: "Listening address of the metrics server"
-      defaultValue: defaultAdminListenAddress
-      defaultValueDesc: $defaultAdminListenAddressDesc
-      name: "metrics-address" .}: IpAddress
-
-    metricsPort* {.
-      desc: "Listening HTTP port of the metrics server"
-      defaultValue: 8108
-      name: "metrics-port" .}: Port
+    metrics* {.flatten: (port: 8108).}: MetricsConf
 
     graffiti* {.
       desc: "The graffiti value that will appear in proposed blocks. " &
@@ -1134,13 +1014,11 @@ type
     bindPort* {.
       desc: "Port for the REST HTTP server"
       defaultValue: defaultEth2RestPort
-      defaultValueDesc: $defaultEth2RestPortDesc
       name: "bind-port" .}: Port
 
     bindAddress* {.
       desc: "Listening address of the REST HTTP server"
       defaultValue: defaultAdminListenAddress
-      defaultValueDesc: $defaultAdminListenAddressDesc
       name: "bind-address" .}: IpAddress
 
     tlsEnabled* {.

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -60,13 +60,11 @@ type LightClientConf* = object
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"
     defaultValue: defaultEth2TcpPort
-    defaultValueDesc: $defaultEth2TcpPortDesc
     name: "tcp-port" .}: Port
 
   udpPort* {.
     desc: "Listening UDP port for node discovery"
     defaultValue: defaultEth2TcpPort
-    defaultValueDesc: $defaultEth2TcpPortDesc
     name: "udp-port" .}: Port
 
   maxPeers* {.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1042,7 +1042,7 @@ proc init*(
                        config.restAllowedOrigin,
                        validateBeaconApiQueries,
                        nimbusAgentStr,
-                       config)
+                       config.restApiConf)
   else:
     nil
 
@@ -1098,7 +1098,7 @@ proc init*(
     validatorPool = newClone(ValidatorPool.init(
       slashingProtectionDB, config.doppelgangerDetection))
 
-    keymanagerInitResult = initKeymanagerServer(config, restServer)
+    keymanagerInitResult = initKeymanagerServer(config.keyManagerApiConf, config.restApiConf, restServer)
     keymanagerHost = if keymanagerInitResult.server != nil:
       newClone KeymanagerHost.init(
         validatorPool,
@@ -2830,7 +2830,7 @@ proc doRunBeaconNode(
   # we disable piggy-backing on other metrics here.
   setSystemMetricsAutomaticUpdate(false)
 
-  node.metricsServer = waitFor(config.initMetricsServer()).valueOr:
+  node.metricsServer = waitFor(initMetricsServer(config.metrics)).valueOr:
     return
 
   when not defined(windows):

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -14,13 +14,13 @@ import
   std/[cpuinfo, exitprocs, os, tables, terminal, typetraits],
 
   # Nimble packages
-  chronos, confutils, presto, toml_serialization, metrics,
+  chronos, confutils, confutils/std/net, presto, toml_serialization, metrics,
   chronicles, chronicles/helpers as chroniclesHelpers, chronicles/topics_registry,
   stew/io2, metrics/chronos_httpserver, taskpools,
 
   # Local modules
-  ./spec/keystore,
-  ./buildinfo
+  ./spec/[keystore, network],
+  ./[buildinfo, version]
 
 from ./spec/datatypes/base import SPEC_VERSION
 
@@ -35,6 +35,11 @@ when defaultChroniclesStream.outputs.type.arity == 2:
 
 export
   confutils, toml_serialization
+
+const
+  # TODO: How should we select between IPv4 and IPv6
+  # Maybe there should be a config option for this.
+  defaultAdminListenAddress* = (static parseIpAddress("127.0.0.1"))
 
 type
   StdoutLogKind* {.pure.} = enum
@@ -286,13 +291,35 @@ proc sleepAsync*(t: TimeDiff): Future[void] {.
   sleepAsync(nanoseconds(
     if t.nanoseconds < 0: 0'i64 else: t.nanoseconds))
 
+type
+  RestApiConf* = object
+    timeout* {.
+      defaultValue: 0
+      defaultValueDesc: "infinite"
+      desc: "The number of seconds to wait until complete REST request " &
+            "will be received"
+      name: "rest-request-timeout" .}: Natural
+
+    maxBodySize* {.
+      defaultValue: 16_384
+      desc: "Maximum size of REST request body (kilobytes)"
+      name: "rest-max-body-size" .}: Natural
+
+    maxHeadersSize* {.
+      defaultValue: 128
+      desc: "Maximum size of REST request headers (kilobytes)"
+      name: "rest-max-headers-size" .}: Natural
+      ## NOTE: If you going to adjust this value please check value
+      ## ``ClientMaximumValidatorIds`` and comments in
+      ## `spec/eth2_apis/rest_types.nim`. This values depend on each other.
+
 proc init*(T: type RestServerRef,
            ip: IpAddress,
            port: Port,
            allowedOrigin: Option[string],
            validateFn: PatternCallback,
            ident: string,
-           config: auto): T =
+           restApiConf: RestApiConf): T =
   let
     address = initTAddress(ip, port)
     serverFlags = {HttpServerFlags.QueryCommaSeparatedArray,
@@ -301,12 +328,12 @@ proc init*(T: type RestServerRef,
   # at least once per slot (12.seconds).
   let
     headersTimeout =
-      if config.restRequestTimeout == 0:
+      if restApiConf.timeout == 0:
         chronos.InfiniteDuration
       else:
-        seconds(int64(config.restRequestTimeout))
-    maxHeadersSize = config.restMaxRequestHeadersSize * 1024
-    maxRequestBodySize = config.restMaxRequestBodySize * 1024
+        seconds(int64(restApiConf.timeout))
+    maxHeadersSize = restApiConf.maxHeadersSize * 1024
+    maxRequestBodySize = restApiConf.maxBodySize * 1024
 
   let res = RestServerRef.new(RestRouter.init(validateFn, allowedOrigin),
                               address, serverFlags = serverFlags,
@@ -329,20 +356,51 @@ type
     server*: RestServerRef
     token*: string
 
+  KeyManagerApiConf* = object
+    enabled* {.
+      desc: "Enable the REST keymanager API"
+      defaultValue: false
+      name: "keymanager" .}: bool
+
+    port* {.
+      desc: "Listening port for the REST keymanager API"
+      defaultValue: defaultEth2RestPort
+      name: "keymanager-port" .}: Port
+
+    address* {.
+      desc: "Listening port for the REST keymanager API"
+      defaultValue: defaultAdminListenAddress
+      name: "keymanager-address" .}: IpAddress
+
+    allowedOrigin* {.
+      desc: "Limit the access to the Keymanager API to a particular hostname " &
+            "(for CORS-enabled clients such as browsers)"
+      name: "keymanager-allow-origin" .}: Option[string]
+
+    tokenFile* {.
+      desc: "A file specifying the authorization token required for accessing the keymanager API"
+      name: "keymanager-token-file" .}: Option[InputFile]
+
+# Copied from rest_key_management_api to avoid a circular dependency
+func validateKeymanagerApiQueries(key: string, value: string): int =
+  # There are no queries to validate
+  return 0
+
 proc initKeymanagerServer*(
-    config: auto,
-    existingRestServer: RestServerRef = nil): KeymanagerInitResult
-    {.raises: [].} =
+    keyManagerApiConf: KeyManagerApiConf,
+    restApiConf: RestApiConf,
+    existingRestServer: RestServerRef = nil
+): KeymanagerInitResult {.raises: [].} =
 
   var token: string
-  let keymanagerServer = if config.keymanagerEnabled:
-    if config.keymanagerTokenFile.isNone:
+  let keymanagerServer = if keyManagerApiConf.enabled:
+    if keyManagerApiConf.tokenFile.isNone:
       echo "To enable the Keymanager API, you must also specify " &
            "the --keymanager-token-file option."
       quit 1
 
     let
-      tokenFilePath = config.keymanagerTokenFile.get.string
+      tokenFilePath = keyManagerApiConf.tokenFile.get.string
       tokenFileReadRes = readAllChars(tokenFilePath)
 
     if tokenFileReadRes.isErr:
@@ -355,41 +413,53 @@ proc initKeymanagerServer*(
       fatal "The keymanager token should not be empty", tokenFilePath
       quit 1
 
-    when compiles(config.restPort):
-      if existingRestServer != nil and
-         config.restAddress == config.keymanagerAddress and
-        config.restPort == config.keymanagerPort:
-        existingRestServer
-      else:
-        RestServerRef.init(config.keymanagerAddress, config.keymanagerPort,
-                           config.keymanagerAllowedOrigin,
-                           validateKeymanagerApiQueries,
-                           nimbusAgentStr,
-                           config)
+    if existingRestServer != nil and
+        existingRestServer.server.address == initTAddress(keyManagerApiConf.address, keyManagerApiConf.port):
+      existingRestServer
     else:
-      RestServerRef.init(config.keymanagerAddress, config.keymanagerPort,
-                         config.keymanagerAllowedOrigin,
-                         validateKeymanagerApiQueries,
-                         nimbusAgentStr,
-                         config)
+      RestServerRef.init(
+        keyManagerApiConf.address,
+        keyManagerApiConf.port,
+        keyManagerApiConf.allowedOrigin,
+        validateKeymanagerApiQueries,
+        nimbusAgentStr,
+        restApiConf
+      )
   else:
     nil
 
   KeymanagerInitResult(server: keymanagerServer, token: token)
 
+type
+  MetricsConf* = object
+    enabled* {.
+      desc: "Enable the metrics server"
+      defaultValue: false
+      name: "metrics" .}: bool
+
+    address* {.
+      desc: "Listening address of the metrics server"
+      defaultValue: defaultAdminListenAddress
+      name: "metrics-address" .}: IpAddress
+
+    port* {.
+      desc: "Listening HTTP port of the metrics server"
+      defaultValue: 8008
+      name: "metrics-port" .}: Port
+
 proc initMetricsServer*(
-    config: auto
+    metrics: MetricsConf
 ): Future[Result[Opt[MetricsHttpServerRef], string]] {.
   async: (raises: [CancelledError]).} =
-  if config.metricsEnabled:
+  if metrics.enabled:
     let
-      metricsAddress = config.metricsAddress
-      metricsPort = config.metricsPort
-      url = "http://" & $metricsAddress & ":" & $metricsPort & "/metrics"
+      address = metrics.address
+      port = metrics.port
+      url = "http://" & $address & ":" & $port & "/metrics"
 
     info "Starting metrics HTTP server", url = url
 
-    let server = MetricsHttpServerRef.new($metricsAddress, metricsPort).valueOr:
+    let server = MetricsHttpServerRef.new($address, port).valueOr:
       fatal "Could not start metrics HTTP server",
             url = url, reason = error
       return err($error)

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -397,7 +397,7 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
 
   vc.beaconClock = await vc.initClock()
 
-  vc.metricsServer = (await vc.config.initMetricsServer()).valueOr:
+  vc.metricsServer = (await initMetricsServer(vc.config.metrics)).valueOr:
     raise newException(ValidatorClientError,
                        "Could not initialize metrics server")
 
@@ -419,7 +419,7 @@ proc asyncInit(vc: ValidatorClientRef): Future[ValidatorClientRef] {.
                        "Could not initialize local validators")
 
   let
-    keymanagerInitResult = initKeymanagerServer(vc.config, nil)
+    keymanagerInitResult = initKeymanagerServer(vc.config.keyManagerApiConf, vc.config.restApiConf, nil)
 
   func getCapellaForkVersion(): Opt[Version] =
     if vc.forkConfig.isNone():

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -42,11 +42,9 @@ const
     MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS
 
   defaultEth2TcpPort* = 9000
-  defaultEth2TcpPortDesc* = $defaultEth2TcpPort
 
   # This is not part of the spec! But it's port which Lighthouse uses
   defaultEth2RestPort* = 5052
-  defaultEth2RestPortDesc* = $defaultEth2RestPort
 
   enrAttestationSubnetsField* = "attnets"
   enrSyncSubnetsField* = "syncnets"

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -105,13 +105,11 @@ type
       bootstrapAddress* {.
         desc: "The public IP address that will be advertised as a bootstrap node for the testnet"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "bootstrap-address" .}: IpAddress
 
       bootstrapPort* {.
         desc: "The TCP/UDP port that will be used by the bootstrap node"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "bootstrap-port" .}: Port
 
       dataDir* {.
@@ -193,13 +191,11 @@ type
       enrAddress* {.
         desc: "The public IP address of that ENR"
         defaultValue: defaultAdminListenAddress
-        defaultValueDesc: $defaultAdminListenAddressDesc
         name: "enr-address" .}: IpAddress
 
       enrPort* {.
         desc: "The TCP/UDP port of that ENR"
         defaultValue: defaultEth2TcpPort
-        defaultValueDesc: $defaultEth2TcpPortDesc
         name: "enr-port" .}: Port
 
     of StartUpCommand.sendDeposits:


### PR DESCRIPTION
Changes:

- Pack metric opts into `MetricsConf`
- Pack keymanager opts into `keyManagerApiConf`
- Pack `restRequestTimeout`, `restMaxRequestBodySize`, `restMaxRequestHeadersSize` into `RestApiConf`. But this could be passed individually instead.
- Small initKeymanagerServer change to avoid passing rest opts.
- Clean up no longer needed `defaultValueDesc`
- Bumped nim-confutils to https://github.com/status-im/nim-confutils/pull/118

Beware this contains breaking changes; needs https://github.com/status-im/nimbus-eth1/pull/3848 to be merged after to solve them.