### PR TITLE
feat: quic transport support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,8 @@ local-testnet-minimal:
 		--fulu-fork-epoch 10000 \
 		--stop-at-epoch 6 \
 		--disable-htop \
-		--p2p-transport quic \
+		--debug-tcp false \
+		--debug-quic true \
 		--base-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \
 		--base-rest-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 30 )) \
 		--base-metrics-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 60 )) \
@@ -256,7 +257,8 @@ local-testnet-mainnet:
 		--fulu-fork-epoch 1 \
 		--stop-at-epoch 6 \
 		--disable-htop \
-		--p2p-transport mplex \
+		--debug-tcp true \
+		--debug-quic false \
 		--base-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \
 		--base-rest-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 30 )) \
 		--base-metrics-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 60 )) \

--- a/Makefile
+++ b/Makefile
@@ -486,7 +486,7 @@ nimbus_beacon_node: force_build_alone_tools
 
 GOERLI_TESTNETS_PARAMS := \
 	--tcp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
-	--tcp=true \
+	--debug-tcp=true \
 	--debug-quic=true \
 	--debug-quic-port=$$(( $(BASE_PORT) + $(NODE_ID) + 2000 )) \
 	--udp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \

--- a/Makefile
+++ b/Makefile
@@ -184,11 +184,13 @@ update: | update-common
 #
 # REST tests:
 # - --base-port (REST_TEST_BASE_PORT + 0)
-# - --base-rest-port (REST_TEST_BASE_PORT + 1)
-# - --base-metrics-port (REST_TEST_BASE_PORT + 2)
+# - debug-quic-port (REST_TEST_BASE_PORT + 1)
+# - --base-rest-port (REST_TEST_BASE_PORT + 2)
+# - --base-metrics-port (REST_TEST_BASE_PORT + 3)
 #
 # Local testnets (entire continuous range):
 # - --base-port + [0, --nodes + --light-clients)
+# - debug-quic-port uses (--base-port + 1) + [0, --nodes + --light-clients)
 # - --base-rest-port + [0, --nodes)
 # - --base-metrics-port + [0, --nodes)
 # - --base-vc-keymanager-port + [0, --nodes)
@@ -209,9 +211,9 @@ MAINNET_TESTNET_BASE_PORT := 26501
 restapi-test:
 	./tests/simulation/restapi.sh \
 		--data-dir resttest0_data \
-		--base-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 0 )) \
-		--base-rest-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 1 )) \
-		--base-metrics-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 3 + 2 )) \
+		--base-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 4 + 0 )) \
+		--base-rest-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 4 + 2 )) \
+		--base-metrics-port $$(( $(REST_TEST_BASE_PORT) + EXECUTOR_NUMBER * 4 + 3 )) \
 		--resttest-delay 30 \
 		--kill-old-processes
 
@@ -438,7 +440,7 @@ build/generate_makefile: tools/generate_makefile.nim | deps-common
 $(filter-out $(TOOLS_CORE_CUSTOMCOMPILE),$(TOOLS)): | build deps
 	+ for D in $(TOOLS_DIRS); do [ -e "$${D}/$@.nim" ] && TOOL_DIR="$${D}" && break; done && \
 		echo -e $(BUILD_MSG) "build/$@" && \
-		MAKE="$(MAKE)" V="$(V)" $(ENV_SCRIPT) scripts/compile_nim_program.sh $@ "$${TOOL_DIR}/$@.nim" $(NIM_PARAMS) && \
+		MAKE="$(MAKE)" V=1 $(ENV_SCRIPT) scripts/compile_nim_program.sh $@ "$${TOOL_DIR}/$@.nim" $(NIM_PARAMS) && \
 		echo -e $(BUILD_END_MSG) "build/$@"
 
 # Windows GitHub Actions CI runners, as of this writing, have around 8GB of RAM
@@ -486,6 +488,9 @@ nimbus_beacon_node: force_build_alone_tools
 
 GOERLI_TESTNETS_PARAMS := \
 	--tcp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
+	--tcp=true \
+	--debug-quic=true \
+	--debug-quic-port=$$(( $(BASE_PORT) + $(NODE_ID) + 1 )) \
 	--udp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
 	--metrics \
 	--metrics-port=$$(( $(BASE_METRICS_PORT) + $(NODE_ID) )) \

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ local-testnet-minimal:
 		--fulu-fork-epoch 10000 \
 		--stop-at-epoch 6 \
 		--disable-htop \
+		--p2p-transport quic \
 		--base-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \
 		--base-rest-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 30 )) \
 		--base-metrics-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 60 )) \
@@ -255,6 +256,7 @@ local-testnet-mainnet:
 		--fulu-fork-epoch 1 \
 		--stop-at-epoch 6 \
 		--disable-htop \
+		--p2p-transport mplex \
 		--base-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \
 		--base-rest-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 30 )) \
 		--base-metrics-port $$(( $(MAINNET_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 60 )) \

--- a/Makefile
+++ b/Makefile
@@ -184,13 +184,11 @@ update: | update-common
 #
 # REST tests:
 # - --base-port (REST_TEST_BASE_PORT + 0)
-# - debug-quic-port (REST_TEST_BASE_PORT + 1)
 # - --base-rest-port (REST_TEST_BASE_PORT + 2)
 # - --base-metrics-port (REST_TEST_BASE_PORT + 3)
 #
 # Local testnets (entire continuous range):
 # - --base-port + [0, --nodes + --light-clients)
-# - debug-quic-port uses (--base-port + 1) + [0, --nodes + --light-clients)
 # - --base-rest-port + [0, --nodes)
 # - --base-metrics-port + [0, --nodes)
 # - --base-vc-keymanager-port + [0, --nodes)
@@ -440,7 +438,7 @@ build/generate_makefile: tools/generate_makefile.nim | deps-common
 $(filter-out $(TOOLS_CORE_CUSTOMCOMPILE),$(TOOLS)): | build deps
 	+ for D in $(TOOLS_DIRS); do [ -e "$${D}/$@.nim" ] && TOOL_DIR="$${D}" && break; done && \
 		echo -e $(BUILD_MSG) "build/$@" && \
-		MAKE="$(MAKE)" V=1 $(ENV_SCRIPT) scripts/compile_nim_program.sh $@ "$${TOOL_DIR}/$@.nim" $(NIM_PARAMS) && \
+		MAKE="$(MAKE)" V="$(V)" $(ENV_SCRIPT) scripts/compile_nim_program.sh $@ "$${TOOL_DIR}/$@.nim" $(NIM_PARAMS) && \
 		echo -e $(BUILD_END_MSG) "build/$@"
 
 # Windows GitHub Actions CI runners, as of this writing, have around 8GB of RAM
@@ -490,7 +488,7 @@ GOERLI_TESTNETS_PARAMS := \
 	--tcp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
 	--tcp=true \
 	--debug-quic=true \
-	--debug-quic-port=$$(( $(BASE_PORT) + $(NODE_ID) + 1 )) \
+	--debug-quic-port=$$(( $(BASE_PORT) + $(NODE_ID) + 2000 )) \
 	--udp-port=$$(( $(BASE_PORT) + $(NODE_ID) )) \
 	--metrics \
 	--metrics-port=$$(( $(BASE_METRICS_PORT) + $(NODE_ID) )) \

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -823,17 +823,31 @@ type
           desc: "External IP address"
           name: "ip" .}: IpAddress
 
+        tcpExtEnabled* {.
+          hidden
+          desc: "Enable TCP transport"
+          defaultValue: true
+          name: "tcp" .}: bool
+
         tcpPortExt* {.
           desc: "External TCP port"
+          defaultValue: defaultEth2TcpPort
           name: "tcp-port" .}: Port
 
         udpPortExt* {.
           desc: "External UDP port"
           name: "udp-port" .}: Port
 
+        quicExtEnabled* {.
+          hidden
+          desc: "Enable QUIC transport"
+          defaultValue: false
+          name: "debug-quic" .}: bool
+
         quicPortExt* {.
           hidden
           desc: "External QUIC port"
+          defaultValue: defaultEth2QuicPort
           name: "debug-quic-port" .}: Port
 
         seqNumber* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -36,7 +36,7 @@ from consensus_object_pools/block_pools_types_light_client
 
 export
   uri, nat, enr,
-  defaultEth2TcpPort, enabledLogLevel,
+  defaultEth2TcpPort, defaultEth2QuicPort, enabledLogLevel,
   defs, parseCmdArg, completeCmdArg, network_metadata,
   el_conf, network,
   confTomlDefs, confTomlNet, confTomlUri, jsnet,
@@ -302,11 +302,30 @@ type
         defaultValueDesc: "*"
         name: "listen-address" .}: Option[IpAddress]
 
+      tcpEnabled* {.
+        hidden
+        desc: "Enable TCP transport"
+        defaultValue: true
+        name: "tcp" .}: bool
+
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: $defaultEth2TcpPortDesc
         name: "tcp-port" .}: Port
+
+      quicEnabled* {.
+        hidden
+        desc: "Enable QUIC transport"
+        defaultValue: false
+        name: "debug-quic" .}: bool
+
+      quicPort* {.
+        hidden
+        desc: "Listening UDP port for Ethereum LibP2P traffic over QUIC"
+        defaultValue: defaultEth2QuicPort
+        defaultValueDesc: $defaultEth2QuicPortDesc
+        name: "debug-quic-port" .}: Port   
 
       udpPort* {.
         desc: "Listening UDP port for node discovery"
@@ -811,6 +830,11 @@ type
         udpPortExt* {.
           desc: "External UDP port"
           name: "udp-port" .}: Port
+
+        quicPortExt* {.
+          hidden
+          desc: "External QUIC port"
+          name: "debug-quic-port" .}: Port
 
         seqNumber* {.
           desc: "Record sequence number"

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -306,7 +306,7 @@ type
         hidden
         desc: "Enable TCP transport"
         defaultValue: true
-        name: "tcp" .}: bool
+        name: "debug-tcp" .}: bool
 
       tcpPort* {.
         desc: "Listening TCP port for Ethereum LibP2P traffic"
@@ -827,7 +827,7 @@ type
           hidden
           desc: "Enable TCP transport"
           defaultValue: true
-          name: "tcp" .}: bool
+          name: "debug-tcp" .}: bool
 
         tcpPortExt* {.
           desc: "External TCP port"

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -61,7 +61,7 @@ type LightClientConf* = object
     hidden
     desc: "Enable TCP transport"
     defaultValue: true
-    name: "tcp" .}: bool
+    name: "debug-tcp" .}: bool
 
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -57,11 +57,30 @@ type LightClientConf* = object
     desc: "Listening address for the Ethereum LibP2P and Discovery v5 traffic"
     name: "listen-address" .}: Option[IpAddress]
 
+  tcpEnabled* {.
+    hidden
+    desc: "Enable TCP transport"
+    defaultValue: true
+    name: "tcp" .}: bool
+
   tcpPort* {.
     desc: "Listening TCP port for Ethereum LibP2P traffic"
     defaultValue: defaultEth2TcpPort
     defaultValueDesc: $defaultEth2TcpPortDesc
     name: "tcp-port" .}: Port
+
+  quicEnabled* {.
+    hidden
+    desc: "Enable QUIC transport"
+    defaultValue: false
+    name: "debug-quic" .}: bool
+
+  quicPort* {.
+    hidden
+    desc: "Listening UDP port for Ethereum LibP2P traffic over QUIC"
+    defaultValue: defaultEth2QuicPort
+    defaultValueDesc: $defaultEth2QuicPortDesc
+    name: "debug-quic-port" .}: Port
 
   udpPort* {.
     desc: "Listening UDP port for node discovery"

--- a/beacon_chain/networking/eth2_discovery.nim
+++ b/beacon_chain/networking/eth2_discovery.nim
@@ -84,7 +84,7 @@ proc loadBootstrapFile*(bootstrapFile: string,
 
 proc new*(T: type Eth2DiscoveryProtocol,
           config: BeaconNodeConf | LightClientConf,
-          enrIp: Opt[IpAddress], enrTcpPort, enrUdpPort: Opt[Port],
+          enrIp: Opt[IpAddress], enrTcpPort, enrQuicPort, enrUdpPort: Opt[Port],
           pk: PrivateKey,
           enrFields: openArray[(string, seq[byte])], rng: ref HmacDrbgContext):
           T =
@@ -108,8 +108,8 @@ proc new*(T: type Eth2DiscoveryProtocol,
     else:
       Opt.none(IpAddress)
 
-  newProtocol(pk, enrIp, enrTcpPort, enrUdpPort, enrFields, bootstrapEnrs,
-    bindPort = config.udpPort, bindIp = listenAddress,
+  newProtocol(pk, enrIp, enrTcpPort, enrUdpPort, enrQuicPort, enrFields,
+    bootstrapEnrs, bindPort = config.udpPort, bindIp = listenAddress,
     enrAutoUpdate = config.enrAutoUpdate, rng = rng)
 
 func isCompatibleForkId*(discoveryForkId: ENRForkID, peerForkId: ENRForkID): bool =

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1343,10 +1343,10 @@ template udpEndPoint(address, port): auto =
   MultiAddress.init(address, udpProtocol, port)
 
 template quicEndPoint(address, port): auto =
-  try:
-    MultiAddress.init(address, udpProtocol, port) & MultiAddress.init("/quic-v1").tryGet()
-  except LPError:
-    raiseAssert "invalid quic address"
+  concat(
+    MultiAddress.init(address, udpProtocol, port),
+    MultiAddress.init("/quic-v1").expect("valid address")).expect(
+      "valid quic address")
 
 func toPeerAddr*(r: enr.TypedRecord,
                  peerAddrProto: openArray[PeerAddrProto]): Result[PeerAddr, cstring] =
@@ -1487,7 +1487,7 @@ proc connectWorker(node: Eth2Node, index: int) {.async: (raises: [CancelledError
 
 func toPeerAddr(node: Node): Result[PeerAddr, cstring] =
   let nodeRecord = TypedRecord.fromRecord(node.record)
-  let peerAddr = ? nodeRecord.toPeerAddr(@[PeerAddrProto.TCP, PeerAddrProto.QUIC])
+  let peerAddr = ? nodeRecord.toPeerAddr([PeerAddrProto.TCP, PeerAddrProto.QUIC])
   ok(peerAddr)
 
 proc trimConnections(node: Eth2Node, count: int) =
@@ -2000,7 +2000,7 @@ proc start*(node: Eth2Node) {.async: (raises: [CancelledError]).} =
     notice "Discovery disabled; trying bootstrap nodes",
       nodes = node.discovery.bootstrapRecords.len
     for enr in node.discovery.bootstrapRecords:
-      let pa = TypedRecord.fromRecord(enr).toPeerAddr(@[PeerAddrProto.TCP, PeerAddrProto.QUIC])
+      let pa = TypedRecord.fromRecord(enr).toPeerAddr([PeerAddrProto.TCP, PeerAddrProto.QUIC])
       if pa.isOk():
         await node.connQueue.addLast(pa.get())
   node.peerPingerHeartbeatFut = node.peerPingerHeartbeat()
@@ -2451,7 +2451,7 @@ proc createEth2Node*(
                 warn "Failed to parse direct peer address, skipping", enr=s, err = error
                 return err("Invalid direct peer")
               typedEnr = TypedRecord.fromRecord(enr)
-              peerAddress = toPeerAddr(typedEnr, @[PeerAddrProto.TCP, PeerAddrProto.QUIC]).get()
+              peerAddress = toPeerAddr(typedEnr, [PeerAddrProto.TCP, PeerAddrProto.QUIC]).get()
             (peerAddress.peerId, peerAddress.addrs[0])
           elif s.startsWith("/"):
             parseFullAddress(s).valueOr:

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -10,7 +10,7 @@
 import
   # Std lib
   std/[typetraits, os, sequtils, strutils, algorithm, math, tables, macrocache],
-
+  lsquic/lsquic_ffi,
   # Status libs
   results,
   stew/[leb128, endians2, byteutils, io2, bitops2],
@@ -235,6 +235,13 @@ type
 
   NetRes*[T] = Result[T, Eth2NetworkingError]
     ## This is type returned from all network requests
+    ## 
+  
+  PeerAddrProto* {.pure.} = enum
+    TCP
+    UDP
+    QUIC
+
 
 const
   clientId* = "Nimbus beacon node " & fullVersionStr
@@ -1041,7 +1048,7 @@ proc doMakeEth2Request(
     res
   except CancelledError as exc:
     raise exc
-  except LPStreamError:
+  except LPStreamError as exc:
     peer.updateScore(PeerScorePoorRequest)
     neterr BrokenConnection
   finally:
@@ -1185,7 +1192,7 @@ proc handleIncomingStream(network: Eth2Node,
     of Disconnecting, Disconnected, None:
       # We got incoming stream request while disconnected or disconnecting.
       debug "Got incoming request from disconnected peer", peer = peer,
-           message = msgName
+           message = msgName, state=peer.connectionState
       return
     of Connecting:
       # We got incoming stream request while handshake is not yet finished,
@@ -1330,8 +1337,20 @@ proc handleIncomingStream(network: Eth2Node,
     await noCancel conn.closeWithEOF()
     releasePeer(peer)
 
+template tcpEndPoint(address, port): auto =
+  MultiAddress.init(address, tcpProtocol, port)
+
+template udpEndPoint(address, port): auto =
+  MultiAddress.init(address, udpProtocol, port)
+
+template quicEndPoint(address, port): auto =
+  try:
+    MultiAddress.init(address, udpProtocol, port) & MultiAddress.init("/quic-v1").tryGet()
+  except LPError:
+    raiseAssert "invalid quic address"
+
 func toPeerAddr*(r: enr.TypedRecord,
-                 proto: IpTransportProtocol): Result[PeerAddr, cstring] =
+                 peerAddrProto: seq[PeerAddrProto]): Result[PeerAddr, cstring] =
   if not r.secp256k1.isSome:
     return err("enr: no secp256k1 key in record")
 
@@ -1342,42 +1361,61 @@ func toPeerAddr*(r: enr.TypedRecord,
 
   var addrs = newSeq[MultiAddress]()
 
-  case proto
-  of tcpProtocol:
-    if r.ip.isSome and r.tcp.isSome:
-      let ip = IpAddress(
-        family: IpAddressFamily.IPv4,
-        address_v4: r.ip.get)
-      addrs.add MultiAddress.init(ip, tcpProtocol, Port r.tcp.get)
+  for proto in peerAddrProto:
+    case proto
+    of PeerAddrProto.TCP:
+      if r.ip.isSome and r.tcp.isSome:
+        let ip = IpAddress(
+          family: IpAddressFamily.IPv4,
+          address_v4: r.ip.get)
+        addrs.add tcpEndPoint(ip, Port r.tcp.get)
 
-    if r.ip6.isSome:
-      let ip = IpAddress(
-        family: IpAddressFamily.IPv6,
-        address_v6: r.ip6.get)
-      if r.tcp6.isSome:
-        addrs.add MultiAddress.init(ip, tcpProtocol, Port r.tcp6.get)
-      elif r.tcp.isSome:
-        addrs.add MultiAddress.init(ip, tcpProtocol, Port r.tcp.get)
-      else:
-        discard
+      if r.ip6.isSome:
+        let ip = IpAddress(
+          family: IpAddressFamily.IPv6,
+          address_v6: r.ip6.get)
+        if r.tcp6.isSome:
+          addrs.add tcpEndPoint(ip, Port r.tcp6.get)
+        elif r.tcp.isSome:
+          addrs.add tcpEndPoint(ip, Port r.tcp.get)
+        else:
+          discard
 
-  of udpProtocol:
-    if r.ip.isSome and r.udp.isSome:
-      let ip = IpAddress(
-        family: IpAddressFamily.IPv4,
-        address_v4: r.ip.get)
-      addrs.add MultiAddress.init(ip, udpProtocol, Port r.udp.get)
+    of PeerAddrProto.UDP:
+      if r.ip.isSome and r.udp.isSome:
+        let ip = IpAddress(
+          family: IpAddressFamily.IPv4,
+          address_v4: r.ip.get)
+        addrs.add udpEndPoint(ip, Port r.udp.get)
 
-    if r.ip6.isSome:
-      let ip = IpAddress(
-        family: IpAddressFamily.IPv6,
-        address_v6: r.ip6.get)
-      if r.udp6.isSome:
-        addrs.add MultiAddress.init(ip, udpProtocol, Port r.udp6.get)
-      elif r.udp.isSome:
-        addrs.add MultiAddress.init(ip, udpProtocol, Port r.udp.get)
-      else:
-        discard
+      if r.ip6.isSome:
+        let ip = IpAddress(
+          family: IpAddressFamily.IPv6,
+          address_v6: r.ip6.get)
+        if r.udp6.isSome:
+          addrs.add udpEndPoint(ip, Port r.udp6.get)
+        elif r.udp.isSome:
+          addrs.add udpEndPoint(ip, Port r.udp.get)
+        else:
+          discard
+
+    of PeerAddrProto.QUIC:
+      if r.ip.isSome and r.quic.isSome:
+        let ip = IpAddress(
+            family: IpAddressFamily.IPv4,
+            address_v4: r.ip.get)
+        addrs.add quicEndPoint(ip, Port r.quic.get)
+
+      if r.ip6.isSome:
+        let ip = IpAddress(
+          family: IpAddressFamily.IPv6,
+          address_v6: r.ip6.get)
+        if r.quic6.isSome:
+          addrs.add quicEndPoint(ip, Port r.quic6.get)
+        elif r.quic.isSome:
+          addrs.add quicEndPoint(ip, Port r.quic.get)
+        else:
+          discard
 
   if addrs.len == 0:
     return err("enr: no addresses in record")
@@ -1450,7 +1488,7 @@ proc connectWorker(node: Eth2Node, index: int) {.async: (raises: [CancelledError
 
 func toPeerAddr(node: Node): Result[PeerAddr, cstring] =
   let nodeRecord = TypedRecord.fromRecord(node.record)
-  let peerAddr = ? nodeRecord.toPeerAddr(tcpProtocol)
+  let peerAddr = ? nodeRecord.toPeerAddr(@[PeerAddrProto.TCP, PeerAddrProto.QUIC])
   ok(peerAddr)
 
 proc trimConnections(node: Eth2Node, count: int) =
@@ -1843,7 +1881,7 @@ proc new(T: type Eth2Node,
          forkDigests: ref ForkDigests, getBeaconTime: GetBeaconTimeFn,
          initialNextForkDigest: ForkDigest,
          switch: Switch, pubsub: GossipSub,
-         ip: Opt[IpAddress], tcpPort, udpPort: Opt[Port],
+         ip: Opt[IpAddress], tcpPort, quicPort, udpPort: Opt[Port],
          privKey: keys.PrivateKey, discovery: bool,
          directPeers: DirectPeers, announcedAddresses: openArray[MultiAddress],
          rng: ref HmacDrbgContext): T =
@@ -1878,7 +1916,7 @@ proc new(T: type Eth2Node,
     forkDigests: forkDigests,
     getBeaconTime: getBeaconTime,
     discovery: Eth2DiscoveryProtocol.new(
-      config, ip, tcpPort, udpPort, privKey,
+      config, ip, tcpPort, quicPort, udpPort, privKey,
       {
         enrForkIdField: SSZ.encode(enrForkId),
         enrAttestationSubnetsField: SSZ.encode(metadata.attnets),
@@ -1939,7 +1977,7 @@ proc startListening*(node: Eth2Node) {.async.} =
   try:
     await node.switch.start()
   except CatchableError as exc:
-    fatal "Failed to start LibP2P transport. TCP port may be already in use",
+    fatal "Failed to start LibP2P transport. TCP/QUIC port may be already in use",
           exc = exc.msg
     quit 1
 
@@ -1963,7 +2001,7 @@ proc start*(node: Eth2Node) {.async: (raises: [CancelledError]).} =
     notice "Discovery disabled; trying bootstrap nodes",
       nodes = node.discovery.bootstrapRecords.len
     for enr in node.discovery.bootstrapRecords:
-      let pa = TypedRecord.fromRecord(enr).toPeerAddr(tcpProtocol)
+      let pa = TypedRecord.fromRecord(enr).toPeerAddr(@[PeerAddrProto.TCP, PeerAddrProto.QUIC])
       if pa.isOk():
         await node.connQueue.addLast(pa.get())
   node.peerPingerHeartbeatFut = node.peerPingerHeartbeat()
@@ -2237,9 +2275,6 @@ proc peerTrimmerHeartbeat(node: Eth2Node) {.async: (raises: [CancelledError]).} 
 func asEthKey*(key: PrivateKey): keys.PrivateKey =
   keys.PrivateKey(key.skkey)
 
-template tcpEndPoint(address, port): auto =
-  MultiAddress.init(address, tcpProtocol, port)
-
 func initNetKeys(privKey: PrivateKey): NetKeyPair =
   let pubKey = privKey.getPublicKey().expect("working public key from random")
   NetKeyPair(seckey: privKey, pubkey: pubKey)
@@ -2336,7 +2371,7 @@ func gossipId(
 proc newBeaconSwitch(
     config: BeaconNodeConf | LightClientConf,
     seckey: PrivateKey,
-    address: MultiAddress,
+    addresses: seq[MultiAddress],
     rng: ref HmacDrbgContext,
 ): Result[Switch, string] =
   let service: Service = WildcardAddressResolverService.new()
@@ -2344,17 +2379,23 @@ proc newBeaconSwitch(
   var sb = SwitchBuilder.new()
   # Order of multiplexers matters, the first will be default
   try:
-    ok sb
+    sb = sb
     .withPrivateKey(seckey)
-    .withAddress(address)
+    .withAddresses(addresses)
     .withRng(rng)
     .withNoise()
-    .withMplex(chronos.minutes(5), chronos.minutes(5))
     .withMaxConnections(config.maxPeers)
     .withAgentVersion(config.agentString)
-    .withTcpTransport({ServerFlags.ReuseAddr})
     .withServices(@[service])
-    .build()
+
+    if config.tcpEnabled: 
+      sb = sb.withMplex(chronos.minutes(5), chronos.minutes(5))
+             .withTcpTransport({ServerFlags.ReuseAddr})
+
+    if config.quicEnabled:
+      sb = sb.withQuicTransport()
+        
+    ok sb.build()
   except LPError as exc:
     err(exc.msg)
 
@@ -2378,18 +2419,28 @@ proc createEth2Node*(
       else:
         getAutoAddress(Port(0)).toIpAddress()
 
+  var ports = @[(port: config.udpPort, protocol: PortProtocol.UDP)]
+
+  if config.tcpEnabled:
+    ports.add((port: config.tcpPort, protocol: PortProtocol.TCP))
+
+  if config.quicEnabled:
+    ports.add((port: config.quicPort, protocol: PortProtocol.UDP))
+
+  let
     (extIp, extPorts) = setupAddress(
       config.nat,
       listenAddress,
-      @[
-        (port: config.udpPort, protocol: PortProtocol.UDP),
-        (port: config.tcpPort, protocol: PortProtocol.TCP),
-      ],
+      ports,
       clientId,
     )
-
     extUdpPort = extPorts[0].toPort()
-    extTcpPort = extPorts[1].toPort()
+    extTcpPort = if config.tcpEnabled: extPorts[1].toPort() else: Opt.none(Port)
+    extQuicPort =
+      if config.quicEnabled:
+        extPorts[if config.tcpEnabled: 2 else: 1].toPort()
+      else:
+        Opt.none(Port)
 
     directPeers = block:
       var res: DirectPeers
@@ -2401,7 +2452,7 @@ proc createEth2Node*(
                 warn "Failed to parse direct peer address, skipping", enr=s, err = error
                 return err("Invalid direct peer")
               typedEnr = TypedRecord.fromRecord(enr)
-              peerAddress = toPeerAddr(typedEnr, tcpProtocol).get()
+              peerAddress = toPeerAddr(typedEnr, @[PeerAddrProto.TCP, PeerAddrProto.QUIC]).get()
             (peerAddress.peerId, peerAddress.addrs[0])
           elif s.startsWith("/"):
             parseFullAddress(s).valueOr:
@@ -2414,10 +2465,18 @@ proc createEth2Node*(
         info "Adding privileged direct peer", peerId, address
       res
 
-    hostAddress = tcpEndPoint(listenAddress, config.tcpPort)
-    announcedAddresses =
-      if extIp.isNone() or extTcpPort.isNone(): @[]
-      else: @[tcpEndPoint(extIp.get(), extTcpPort.get())]
+  var hostAddress = newSeq[MultiAddress]()
+  var announcedAddresses = newSeq[MultiAddress]()
+
+  if config.tcpEnabled:
+    hostAddress.add(tcpEndPoint(listenAddress, config.tcpPort))
+    if not(extIp.isNone() or extTcpPort.isNone()):
+      announcedAddresses.add(tcpEndPoint(extIp.get(), extTcpPort.get()))
+
+  if config.quicEnabled:
+    hostAddress.add(quicEndPoint(listenAddress, config.quicPort))
+    if not(extIp.isNone() or extQuicPort.isNone()):
+      announcedAddresses.add(quicEndPoint(extIp.get(), extQuicPort.get()))
 
   debug "Initializing networking", hostAddress,
                                    network_public_key = netKeys.pubkey,
@@ -2496,7 +2555,7 @@ proc createEth2Node*(
 
   let node = Eth2Node.new(
     config, cfg, enrForkId, discoveryForkId, forkDigests, getBeaconTime, initialNextForkDigest, switch, pubsub, extIp,
-    extTcpPort, extUdpPort, netKeys.seckey.asEthKey,
+    extTcpPort, extQuicPort, extUdpPort, netKeys.seckey.asEthKey,
     discovery = config.discv5Enabled, directPeers, announcedAddresses,
     rng = rng)
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -10,7 +10,7 @@
 import
   # Std lib
   std/[typetraits, os, sequtils, strutils, algorithm, math, tables, macrocache],
-  lsquic/lsquic_ffi,
+
   # Status libs
   results,
   stew/[leb128, endians2, byteutils, io2, bitops2],
@@ -235,7 +235,6 @@ type
 
   NetRes*[T] = Result[T, Eth2NetworkingError]
     ## This is type returned from all network requests
-    ## 
   
   PeerAddrProto* {.pure.} = enum
     TCP
@@ -1048,7 +1047,7 @@ proc doMakeEth2Request(
     res
   except CancelledError as exc:
     raise exc
-  except LPStreamError as exc:
+  except LPStreamError:
     peer.updateScore(PeerScorePoorRequest)
     neterr BrokenConnection
   finally:
@@ -1192,7 +1191,7 @@ proc handleIncomingStream(network: Eth2Node,
     of Disconnecting, Disconnected, None:
       # We got incoming stream request while disconnected or disconnecting.
       debug "Got incoming request from disconnected peer", peer = peer,
-           message = msgName, state=peer.connectionState
+           message = msgName
       return
     of Connecting:
       # We got incoming stream request while handshake is not yet finished,
@@ -1350,7 +1349,7 @@ template quicEndPoint(address, port): auto =
     raiseAssert "invalid quic address"
 
 func toPeerAddr*(r: enr.TypedRecord,
-                 peerAddrProto: seq[PeerAddrProto]): Result[PeerAddr, cstring] =
+                 peerAddrProto: openArray[PeerAddrProto]): Result[PeerAddr, cstring] =
   if not r.secp256k1.isSome:
     return err("enr: no secp256k1 key in record")
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -12,7 +12,6 @@ import
   std/[os, random, strutils, terminal, times],
   chronos, chronicles,
   metrics, metrics/chronos_httpserver,
-  lsquic/lsquic_ffi,
   stew/[byteutils, io2],
   kzg4844/kzg,
   eth/enr/enr,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -12,6 +12,7 @@ import
   std/[os, random, strutils, terminal, times],
   chronos, chronicles,
   metrics, metrics/chronos_httpserver,
+  lsquic/lsquic_ffi,
   stew/[byteutils, io2],
   kzg4844/kzg,
   eth/enr/enr,
@@ -2865,9 +2866,9 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
       config.seqNumber,
       netKeys.seckey.asEthKey,
       Opt.some(config.ipExt),
-      Opt.some(config.tcpPortExt),
+      if config.tcpEnabled: Opt.some(config.tcpPortExt) else: Opt.none(Port),
       Opt.some(config.udpPortExt),
-      Opt.none(Port),
+      if config.quicEnabled: Opt.some(config.quicPortExt) else: Opt.none(Port),
       fieldPairs).expect("Record within size limits")
 
     echo record.toURI()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2865,9 +2865,9 @@ proc doRecord(config: BeaconNodeConf, rng: var HmacDrbgContext) {.
       config.seqNumber,
       netKeys.seckey.asEthKey,
       Opt.some(config.ipExt),
-      if config.tcpEnabled: Opt.some(config.tcpPortExt) else: Opt.none(Port),
+      if config.tcpExtEnabled: Opt.some(config.tcpPortExt) else: Opt.none(Port),
       Opt.some(config.udpPortExt),
-      if config.quicEnabled: Opt.some(config.quicPortExt) else: Opt.none(Port),
+      if config.quicExtEnabled: Opt.some(config.quicPortExt) else: Opt.none(Port),
       fieldPairs).expect("Record within size limits")
 
     echo record.toURI()

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -120,7 +120,7 @@ proc getLastSeenAddress(node: BeaconNode, id: PeerId): string =
 proc getDiscoveryAddresses(node: BeaconNode): seq[string] =
   let
     typedRec = TypedRecord.fromRecord(node.network.enrRecord())
-    peerAddr = typedRec.toPeerAddr(udpProtocol).valueOr:
+    peerAddr = typedRec.toPeerAddr(@[PeerAddrProto.UDP]).valueOr:
       return default(seq[string])
     maddress = MultiAddress.init(multiCodec("p2p"), peerAddr.peerId).valueOr:
       return default(seq[string])

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -120,7 +120,7 @@ proc getLastSeenAddress(node: BeaconNode, id: PeerId): string =
 proc getDiscoveryAddresses(node: BeaconNode): seq[string] =
   let
     typedRec = TypedRecord.fromRecord(node.network.enrRecord())
-    peerAddr = typedRec.toPeerAddr(@[PeerAddrProto.UDP]).valueOr:
+    peerAddr = typedRec.toPeerAddr([PeerAddrProto.UDP]).valueOr:
       return default(seq[string])
     maddress = MultiAddress.init(multiCodec("p2p"), peerAddr.peerId).valueOr:
       return default(seq[string])

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -44,6 +44,9 @@ const
   defaultEth2TcpPort* = 9000
   defaultEth2TcpPortDesc* = $defaultEth2TcpPort
 
+  defaultEth2QuicPort* = 9001
+  defaultEth2QuicPortDesc* = $defaultEth2QuicPort
+
   # This is not part of the spec! But it's port which Lighthouse uses
   defaultEth2RestPort* = 5052
   defaultEth2RestPortDesc* = $defaultEth2RestPort
@@ -53,6 +56,7 @@ const
   enrCustodyGroupCountField* = "cgc"
   enrNextForkDigestField* = "nfd"
   enrForkIdField* = "eth2"
+  quicField* = "quic"
 
 template eth2Prefix(forkDigest: ForkDigest): string =
   "/eth2/" & $forkDigest & "/"

--- a/config.nims
+++ b/config.nims
@@ -67,6 +67,11 @@ if defined(limitStackUsage):
   # stack size of each function.
   switch("passC", "-fstack-usage -Werror=stack-usage=1048576")
   switch("passL", "-fstack-usage -Werror=stack-usage=1048576")
+  
+  # QUIC does variable stack allocations
+  put("lsquic_enc_sess_ietf.always", "-fno-lto -Wno-stack-usage")
+  put("lsquic_handshake.always", "-fno-lto -Wno-stack-usage")
+  put("lsquic_hkdf.always", "-fno-lto -Wno-stack-usage")
 
 if defined(windows):
   # disable timestamps in Windows PE headers - https://wiki.debian.org/ReproducibleBuilds/TimestampsInPEBinaries

--- a/docker/dist/README.md.tpl
+++ b/docker/dist/README.md.tpl
@@ -42,7 +42,7 @@ To connect to mainnet with default options:
 The script will forward all supplied options to the beacon node executable:
 
 ```bash
-./run-mainnet-beacon-node.sh --log-level=DEBUG --tcp-port=9050
+./run-mainnet-beacon-node.sh --log-level=DEBUG --tcp-port=9050 --debug-quic=true --debug-quic-port=9051
 ```
 
 To monitor the Eth1 validator deposit contract, you'll need to pair

--- a/docker/dist/README.md.tpl
+++ b/docker/dist/README.md.tpl
@@ -42,7 +42,7 @@ To connect to mainnet with default options:
 The script will forward all supplied options to the beacon node executable:
 
 ```bash
-./run-mainnet-beacon-node.sh --log-level=DEBUG --tcp-port=9050 --debug-quic=true --debug-quic-port=9051
+./run-mainnet-beacon-node.sh --log-level=DEBUG --tcp-port=9050
 ```
 
 To monitor the Eth1 validator deposit contract, you'll need to pair

--- a/docker/dist/binaries/docker-compose-example1.yml
+++ b/docker/dist/binaries/docker-compose-example1.yml
@@ -15,11 +15,12 @@ services:
     ports:
       - 9000:9000/tcp
       - 9000:9000/udp
+      - 9001:9001/udp
       - 127.0.0.1:5052:5052/tcp
       - 127.0.0.1:8008:8008/tcp
     volumes:
       - ./data:/home/user/nimbus-eth2/build/data
-    # you need to make sure that port 9000 is accesible from outside; no automagic port forwarding here
+    # you need to make sure that ports 9000/9001 are accesible from outside; no automagic port forwarding here
     command: >-
       --network=hoodi
       --data-dir=/home/user/nimbus-eth2/build/data/shared_hoodi_0
@@ -28,6 +29,9 @@ services:
       --log-level=info
       --tcp-port=9000
       --udp-port=9000
+      --tcp=true
+      --debug-quic=false
+      --debug-quic-port=9001
       --rest
       --rest-address=0.0.0.0
       --rest-port=5052

--- a/docker/dist/binaries/docker-compose-example1.yml
+++ b/docker/dist/binaries/docker-compose-example1.yml
@@ -15,12 +15,11 @@ services:
     ports:
       - 9000:9000/tcp
       - 9000:9000/udp
-      - 9001:9001/udp
       - 127.0.0.1:5052:5052/tcp
       - 127.0.0.1:8008:8008/tcp
     volumes:
       - ./data:/home/user/nimbus-eth2/build/data
-    # you need to make sure that ports 9000/9001 are accesible from outside; no automagic port forwarding here
+    # you need to make sure that ports 9000/9001 are accessible from outside; no automagic port forwarding here
     command: >-
       --network=hoodi
       --data-dir=/home/user/nimbus-eth2/build/data/shared_hoodi_0
@@ -29,9 +28,6 @@ services:
       --log-level=info
       --tcp-port=9000
       --udp-port=9000
-      --tcp=true
-      --debug-quic=false
-      --debug-quic-port=9001
       --rest
       --rest-address=0.0.0.0
       --rest-port=5052

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -54,6 +54,18 @@ type
       desc: "The Eth2 network preset to use"
       name: "network" }: Option[string]
 
+    tcpEnabled* {.
+      hidden
+      desc: "Enable TCP transport"
+      defaultValue: true
+      name: "tcp" .}: bool
+
+    quicEnabled* {.
+      hidden
+      desc: "Enable QUIC transport"
+      defaultValue: false
+      name: "debug-quic" .}: bool
+
     case cmd* {.command.}: StartUpCommand
     of StartUpCommand.deployDepositContract:
       discard
@@ -108,12 +120,25 @@ type
         defaultValueDesc: $defaultAdminListenAddressDesc
         name: "bootstrap-address" .}: IpAddress
 
-      bootstrapPort* {.
-        desc: "The TCP/UDP port that will be used by the bootstrap node"
+      bootstrapTcpPort* {.
+        desc: "The TCP port that will be used by the bootstrap node"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: $defaultEth2TcpPortDesc
-        name: "bootstrap-port" .}: Port
+        name: "bootstrap-tcp-port" .}: Port
 
+      bootstrapUdpPort* {.
+        desc: "The UDP port that will be used by the bootstrap node"
+        defaultValue: defaultEth2TcpPort
+        defaultValueDesc: $defaultEth2TcpPortDesc
+        name: "bootstrap-udp-port" .}: Port
+
+      bootstrapQuicPort* {.
+        hidden
+        desc: "The QUIC UDP port that will be used by the bootstrap node"
+        defaultValue: defaultEth2QuicPort
+        defaultValueDesc: $defaultEth2QuicPortDesc
+        name: "debug-bootstrap-quic-port" .}: Port
+ 
       dataDir* {.
         desc: "Nimbus data directory where the keys of the bootstrap node will be placed"
         name: "data-dir" .}: OutDir
@@ -196,12 +221,25 @@ type
         defaultValueDesc: $defaultAdminListenAddressDesc
         name: "enr-address" .}: IpAddress
 
-      enrPort* {.
+      enrTcpPort* {.
         desc: "The TCP/UDP port of that ENR"
         defaultValue: defaultEth2TcpPort
         defaultValueDesc: $defaultEth2TcpPortDesc
-        name: "enr-port" .}: Port
+        name: "enr-tcp-port" .}: Port
 
+      enrUdpPort* {.
+        desc: "The UDP port of that ENR"
+        defaultValue: defaultEth2TcpPort
+        defaultValueDesc: $defaultEth2TcpPortDesc
+        name: "enr-udp-port" .}: Port
+
+      enrQuicPort* {.
+        hidden
+        desc: "The QUIC UDP port of that ENR"
+        defaultValue: defaultEth2QuicPort
+        defaultValueDesc: $defaultEth2QuicPortDesc
+        name: "debug-enr-quic-port" .}: Port
+ 
     of StartUpCommand.sendDeposits:
       depositsFile* {.
         desc: "A LaunchPad deposits file"
@@ -307,7 +345,7 @@ proc createEnr(rng: var HmacDrbgContext,
                cfg: RuntimeConfig,
                forkId: seq[byte],
                address: IpAddress,
-               port: Port): enr.Record
+               tcpPort: Opt[Port], udpPort: Port, quicPort: Opt[Port]): enr.Record
                {.raises: [CatchableError].} =
   type MetaData = altair.MetaData
   let
@@ -319,9 +357,9 @@ proc createEnr(rng: var HmacDrbgContext,
       1, # sequence number
       networkKeys.seckey.asEthKey,
       Opt.some(address),
-      Opt.some(port),
-      Opt.some(port),
-      Opt.none(Port),
+      tcpPort,
+      Opt.some(udpPort),
+      quicPort,
       [
         toFieldPair(enrForkIdField, forkId),
         toFieldPair(enrAttestationSubnetsField, SSZ.encode(netMetadata.attnets))
@@ -428,7 +466,10 @@ proc doCreateTestnet*(config: CliConfig,
       enr =
         createEnr(rng, string config.dataDir, string config.netKeyFile,
           config.netKeyInsecurePassword, cfg, SSZ.encode(forkId),
-          config.bootstrapAddress, config.bootstrapPort)
+          config.bootstrapAddress, 
+          if config.tcpEnabled: Opt.some(config.bootstrapTcpPort) else: Opt.none(Port),
+          config.bootstrapUdpPort, 
+          if config.quicEnabled: Opt.some(config.bootstrapQuicPort) else: Opt.none(Port))
     writeFile(bootstrapFile, enr.toURI)
     echo "Wrote ", bootstrapFile
 
@@ -472,7 +513,10 @@ when isMainModule:
       enr =
         createEnr(rng, string config.enrDataDir, string config.enrNetKeyFile,
           config.enrNetKeyInsecurePassword, cfg, forkIdField,
-          config.enrAddress, config.enrPort)
+          config.enrAddress, 
+          if config.tcpEnabled: Opt.some(config.enrTcpPort) else: Opt.none(Port),
+          config.enrUdpPort,
+          if config.quicEnabled: Opt.some(config.enrQuicPort) else: Opt.none(Port))
     stderr.writeLine(enr.toURI)
 
   proc deployContract(web3: Web3, code: seq[byte]): Future[ReceiptObject] {.async.} =

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -43,7 +43,7 @@ CURL_BINARY="$(command -v curl)" || { echo "Curl not installed. Aborting."; exit
 JQ_BINARY="$(command -v jq)" || { echo "jq not installed. Aborting."; exit 1; }
 
 OPTS="ht:n:d:g"
-LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:"
+LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:,p2p-transport:"
 
 # default values
 BINARIES=""
@@ -55,6 +55,7 @@ USE_PAYLOAD_BUILDER="false"
 : ${PAYLOAD_BUILDER_HOST:=127.0.0.1}
 : ${PAYLOAD_BUILDER_PORT:=4888}
 LOG_LEVEL="DEBUG; TRACE:networking"
+P2P_TRANSPORT="both"
 BASE_PORT="9000"
 BASE_REMOTE_SIGNER_PORT="6000"
 BASE_REMOTE_SIGNER_METRICS_PORT="6100"
@@ -138,6 +139,8 @@ CI run: $(basename "$0") --disable-htop -- --verify-finalization
                               and validator clients, with all beacon nodes being paired up
                               with a corresponding validator client)
   --log-level                 set the log level (default: "${LOG_LEVEL}")
+  --p2p-transport             P2P transport to use: mplex, quic, or both
+                              (default: "${P2P_TRANSPORT}")
   --reuse-existing-data-dir   instead of deleting and recreating the data dir, keep it and reuse everything we can from it
   --reuse-binaries            don't (re)build the binaries we need and don't delete them at the end (speeds up testing)
   --timeout                   timeout in seconds (default: ${TIMEOUT_DURATION} - no timeout)
@@ -231,6 +234,10 @@ while true; do
       ;;
     --log-level)
       LOG_LEVEL="$2"
+      shift 2
+      ;;
+    --p2p-transport)
+      P2P_TRANSPORT="$2"
       shift 2
       ;;
     --base-port)
@@ -354,6 +361,25 @@ if [[ -n "${ETH2_DOCKER_IMAGE}" ]]; then
     false
   fi
 fi
+
+case "${P2P_TRANSPORT}" in
+  mplex)
+    P2P_TCP_ENABLED="true"
+    P2P_QUIC_ENABLED="false"
+    ;;
+  quic)
+    P2P_TCP_ENABLED="false"
+    P2P_QUIC_ENABLED="true"
+    ;;
+  both)
+    P2P_TCP_ENABLED="true"
+    P2P_QUIC_ENABLED="true"
+    ;;
+  *)
+    echo "Invalid --p2p-transport value: ${P2P_TRANSPORT}. Expected one of: mplex, quic, both."
+    exit 1
+    ;;
+esac
 
 # when sourcing env.sh, it will try to execute $@, so empty it
 EXTRA_ARGS="$@"
@@ -857,8 +883,8 @@ done
   --bootstrap-address=127.0.0.1 \
   --bootstrap-tcp-port=$(( BASE_PORT + BOOTSTRAP_NODE - 1 )) \
   --bootstrap-udp-port=$(( BASE_PORT + BOOTSTRAP_NODE - 1 )) \
-  --tcp=true \
-  --debug-quic=true \
+  --tcp=${P2P_TCP_ENABLED} \
+  --debug-quic=${P2P_QUIC_ENABLED} \
   --debug-bootstrap-quic-port=$(( BASE_PORT + 2000 + BOOTSTRAP_NODE - 1 )) \
   --netkey-file=$CONTAINER_BOOTSTRAP_NETWORK_KEYFILE \
   --insecure-netkey-password=true \
@@ -875,8 +901,8 @@ DIRECTPEER_ENR=$(
     --data-dir="$CONTAINER_DATA_DIR/node$DIRECTPEER_NODE" \
     --bootstrap-enr="$CONTAINER_DATA_DIR/bootstrap_nodes.txt" \
     --enr-address=127.0.0.1 \
-    --tcp=true \
-    --debug-quic=true \
+    --tcp=${P2P_TCP_ENABLED} \
+    --debug-quic=${P2P_QUIC_ENABLED} \
     --enr-tcp-port=$(( BASE_PORT + DIRECTPEER_NODE - 1 )) \
     --enr-udp-port=$(( BASE_PORT + DIRECTPEER_NODE - 1 )) \
     --debug-enr-quic-port=$(( BASE_PORT + 2000 + DIRECTPEER_NODE - 1 )) \
@@ -1093,8 +1119,8 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
     --config-file="${CLI_CONF_FILE}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE - 1 )) \
     --udp-port=$(( BASE_PORT + NUM_NODE - 1 )) \
-    --tcp=true \
-    --debug-quic=true \
+    --debug-tcp=${P2P_TCP_ENABLED} \
+    --debug-quic=${P2P_QUIC_ENABLED} \
     --debug-quic-port=$(( BASE_PORT + 2000 + NUM_NODE - 1 )) \
     --max-peers=$(( NUM_NODES + LC_NODES - 1 )) \
     --data-dir="${CONTAINER_NODE_DATA_DIR}" \
@@ -1205,8 +1231,8 @@ if [ "$LC_NODES" -ge "1" ]; then
       --bootstrap-node="${LC_BOOTSTRAP_NODE}" \
       --tcp-port=$(( TCP_PORT )) \
       --udp-port=$(( UDP_PORT ))  \
-      --tcp=true \
-      --debug-quic=true \
+      --debug-tcp=${P2P_TCP_ENABLED} \
+      --debug-quic=${P2P_QUIC_ENABLED} \
       --debug-quic-port=$(( QUIC_PORT )) \
       --max-peers=$(( NUM_NODES + LC_NODES - 1 )) \
       --nat="extip:127.0.0.1" \

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -43,7 +43,7 @@ CURL_BINARY="$(command -v curl)" || { echo "Curl not installed. Aborting."; exit
 JQ_BINARY="$(command -v jq)" || { echo "jq not installed. Aborting."; exit 1; }
 
 OPTS="ht:n:d:g"
-LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:,p2p-transport:"
+LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:,debug-tcp:,debug-quic:"
 
 # default values
 BINARIES=""
@@ -55,7 +55,8 @@ USE_PAYLOAD_BUILDER="false"
 : ${PAYLOAD_BUILDER_HOST:=127.0.0.1}
 : ${PAYLOAD_BUILDER_PORT:=4888}
 LOG_LEVEL="DEBUG; TRACE:networking"
-P2P_TRANSPORT="both"
+P2P_TCP_ENABLED="true"
+P2P_QUIC_ENABLED="false"
 BASE_PORT="9000"
 BASE_REMOTE_SIGNER_PORT="6000"
 BASE_REMOTE_SIGNER_METRICS_PORT="6100"
@@ -139,8 +140,8 @@ CI run: $(basename "$0") --disable-htop -- --verify-finalization
                               and validator clients, with all beacon nodes being paired up
                               with a corresponding validator client)
   --log-level                 set the log level (default: "${LOG_LEVEL}")
-  --p2p-transport             P2P transport to use: mplex, quic, or both
-                              (default: "${P2P_TRANSPORT}")
+  --debug-tcp                 enable TCP transport: true or false (default: ${P2P_TCP_ENABLED})
+  --debug-quic                enable QUIC transport: true or false (default: ${P2P_QUIC_ENABLED})
   --reuse-existing-data-dir   instead of deleting and recreating the data dir, keep it and reuse everything we can from it
   --reuse-binaries            don't (re)build the binaries we need and don't delete them at the end (speeds up testing)
   --timeout                   timeout in seconds (default: ${TIMEOUT_DURATION} - no timeout)
@@ -236,8 +237,12 @@ while true; do
       LOG_LEVEL="$2"
       shift 2
       ;;
-    --p2p-transport)
-      P2P_TRANSPORT="$2"
+    --debug-tcp)
+      P2P_TCP_ENABLED="$2"
+      shift 2
+      ;;
+    --debug-quic)
+      P2P_QUIC_ENABLED="$2"
       shift 2
       ;;
     --base-port)
@@ -362,21 +367,18 @@ if [[ -n "${ETH2_DOCKER_IMAGE}" ]]; then
   fi
 fi
 
-case "${P2P_TRANSPORT}" in
-  mplex)
-    P2P_TCP_ENABLED="true"
-    P2P_QUIC_ENABLED="false"
-    ;;
-  quic)
-    P2P_TCP_ENABLED="false"
-    P2P_QUIC_ENABLED="true"
-    ;;
-  both)
-    P2P_TCP_ENABLED="true"
-    P2P_QUIC_ENABLED="true"
-    ;;
+case "${P2P_TCP_ENABLED}" in
+  true|false) ;;
   *)
-    echo "Invalid --p2p-transport value: ${P2P_TRANSPORT}. Expected one of: mplex, quic, both."
+    echo "Invalid --debug-tcp value: ${P2P_TCP_ENABLED}. Expected true or false."
+    exit 1
+    ;;
+esac
+
+case "${P2P_QUIC_ENABLED}" in
+  true|false) ;;
+  *)
+    echo "Invalid --debug-quic value: ${P2P_QUIC_ENABLED}. Expected true or false."
     exit 1
     ;;
 esac

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1194,7 +1194,8 @@ if [ "$LC_NODES" -ge "1" ]; then
     fi
 
     TCP_PORT=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 ))
-    QUIC_PORT=$(( TCP_PORT + 1000 ))
+    UDP_PORT=$(( TCP_PORT ))
+    QUIC_PORT=$(( TCP_PORT + 2000 ))
 
     ./build/nimbus_light_client \
       --log-level="${LOG_LEVEL}" \
@@ -1202,11 +1203,11 @@ if [ "$LC_NODES" -ge "1" ]; then
       --data-dir="${LC_DATA_DIR}" \
       --network="${CONTAINER_DATA_DIR}" \
       --bootstrap-node="${LC_BOOTSTRAP_NODE}" \
-      --tcp-port=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 )) \
-      --udp-port=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 )) \
+      --tcp-port=$(( TCP_PORT )) \
+      --udp-port=$(( UDP_PORT ))  \
       --tcp=true \
       --debug-quic=true \
-      --debug-quic-port=$(( BASE_PORT + 2000 + NUM_NODES + NUM_LC - 1 )) \
+      --debug-quic-port=$(( QUIC_PORT )) \
       --max-peers=$(( NUM_NODES + LC_NODES - 1 )) \
       --nat="extip:127.0.0.1" \
       --trusted-block-root="${LC_TRUSTED_BLOCK_ROOT}" \

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -421,6 +421,16 @@ kill_by_port() {
         exit 1
       fi
     done
+    for PID in $(lsof -n -i udp:${PORT} -t); do
+      echo -n "Found old process using UDP port ${PORT}, with PID ${PID}. "
+      if [[ "${KILL_OLD_PROCESSES}" == "1" ]]; then
+        echo "Killing it."
+        kill -SIGKILL "${PID}" || true
+      else
+        echo "Aborting."
+        exit 1
+      fi
+    done
   done
 }
 
@@ -497,7 +507,7 @@ if [[ "${OS}" != "windows" ]]; then
 
   # Stop Nimbus CL nodes
   for NUM_NODE in $(seq 1 $NUM_NODES); do
-    for PORT in $(( BASE_PORT + NUM_NODE - 1 )) $(( BASE_METRICS_PORT + NUM_NODE - 1)) $(( BASE_REST_PORT + NUM_NODE - 1)); do
+    for PORT in $(( BASE_PORT + NUM_NODE - 1 )) $(( BASE_PORT + 2000 + NUM_NODE - 1 )) $(( BASE_METRICS_PORT + NUM_NODE - 1)) $(( BASE_REST_PORT + NUM_NODE - 1)); do
       PORTS_TO_KILL+=("${PORT}")
     done
   done
@@ -845,7 +855,11 @@ done
   --output-genesis="$CONTAINER_DATA_DIR/genesis.ssz" \
   --output-bootstrap-file="$CONTAINER_DATA_DIR/bootstrap_nodes.txt" \
   --bootstrap-address=127.0.0.1 \
-  --bootstrap-port=$(( BASE_PORT + BOOTSTRAP_NODE - 1 )) \
+  --bootstrap-tcp-port=$(( BASE_PORT + BOOTSTRAP_NODE - 1 )) \
+  --bootstrap-udp-port=$(( BASE_PORT + BOOTSTRAP_NODE - 1 )) \
+  --tcp=true \
+  --debug-quic=true \
+  --debug-bootstrap-quic-port=$(( BASE_PORT + 2000 + BOOTSTRAP_NODE - 1 )) \
   --netkey-file=$CONTAINER_BOOTSTRAP_NETWORK_KEYFILE \
   --insecure-netkey-password=true \
   --genesis-time=$GENESIS_TIME \
@@ -861,7 +875,11 @@ DIRECTPEER_ENR=$(
     --data-dir="$CONTAINER_DATA_DIR/node$DIRECTPEER_NODE" \
     --bootstrap-enr="$CONTAINER_DATA_DIR/bootstrap_nodes.txt" \
     --enr-address=127.0.0.1 \
-    --enr-port=$(( BASE_PORT + DIRECTPEER_NODE - 1 )) \
+    --tcp=true \
+    --debug-quic=true \
+    --enr-tcp-port=$(( BASE_PORT + DIRECTPEER_NODE - 1 )) \
+    --enr-udp-port=$(( BASE_PORT + DIRECTPEER_NODE - 1 )) \
+    --debug-enr-quic-port=$(( BASE_PORT + 2000 + DIRECTPEER_NODE - 1 )) \
     --enr-netkey-file=$DIRECTPEER_NETWORK_KEYFILE \
     --insecure-netkey-password=true 2>&1 > /dev/null
 )
@@ -1075,6 +1093,9 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
     --config-file="${CLI_CONF_FILE}" \
     --tcp-port=$(( BASE_PORT + NUM_NODE - 1 )) \
     --udp-port=$(( BASE_PORT + NUM_NODE - 1 )) \
+    --tcp=true \
+    --debug-quic=true \
+    --debug-quic-port=$(( BASE_PORT + 2000 + NUM_NODE - 1 )) \
     --max-peers=$(( NUM_NODES + LC_NODES - 1 )) \
     --data-dir="${CONTAINER_NODE_DATA_DIR}" \
     ${BOOTSTRAP_ARG} \
@@ -1172,6 +1193,9 @@ if [ "$LC_NODES" -ge "1" ]; then
       WEB3_ARG+=("--el=http://127.0.0.1:${GETH_AUTH_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
     fi
 
+    TCP_PORT=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 ))
+    QUIC_PORT=$(( TCP_PORT + 1000 ))
+
     ./build/nimbus_light_client \
       --log-level="${LOG_LEVEL}" \
       --log-format="json" \
@@ -1180,6 +1204,9 @@ if [ "$LC_NODES" -ge "1" ]; then
       --bootstrap-node="${LC_BOOTSTRAP_NODE}" \
       --tcp-port=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 )) \
       --udp-port=$(( BASE_PORT + NUM_NODES + NUM_LC - 1 )) \
+      --tcp=true \
+      --debug-quic=true \
+      --debug-quic-port=$(( BASE_PORT + 2000 + NUM_NODES + NUM_LC - 1 )) \
       --max-peers=$(( NUM_NODES + LC_NODES - 1 )) \
       --nat="extip:127.0.0.1" \
       --trusted-block-root="${LC_TRUSTED_BLOCK_ROOT}" \

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -62,7 +62,7 @@ fi
 
 TCP_PORT=$(( BASE_P2P_PORT + NODE_ID ))
 UDP_PORT=$(( TCP_PORT ))
-QUIC_PORT=$(( TCP_PORT + 1 ))
+QUIC_PORT=$(( TCP_PORT + 2000 ))
 
 # Allow the binary to receive signals directly.
 exec ${WINPTY} build/${NBC_BINARY} \

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -70,7 +70,7 @@ exec ${WINPTY} build/${NBC_BINARY} \
   --data-dir="${DATA_DIR}" \
   --tcp-port=${TCP_PORT} \
   --udp-port=${UDP_PORT} \
-  --tcp=true \
+  --debug-tcp=true \
   --debug-quic=false \
   --debug-quic-port=${QUIC_PORT} \
   --rest \

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -60,12 +60,19 @@ if [[ "$WEB3_URL" != "" ]]; then
   WEB3_URL_ARG="--el=${WEB3_URL}"
 fi
 
+TCP_PORT=$(( BASE_P2P_PORT + NODE_ID ))
+UDP_PORT=$(( TCP_PORT ))
+QUIC_PORT=$(( TCP_PORT + 1 ))
+
 # Allow the binary to receive signals directly.
 exec ${WINPTY} build/${NBC_BINARY} \
   --network=${NETWORK} \
   --data-dir="${DATA_DIR}" \
-  --tcp-port=$(( ${BASE_P2P_PORT} + ${NODE_ID} )) \
-  --udp-port=$(( ${BASE_P2P_PORT} + ${NODE_ID} )) \
+  --tcp-port=${TCP_PORT} \
+  --udp-port=${UDP_PORT} \
+  --tcp=true \
+  --debug-quic=false \
+  --debug-quic-port=${QUIC_PORT} \
   --rest \
   --rest-port=$(( ${BASE_REST_PORT} + ${NODE_ID} )) \
   --metrics \

--- a/tests/simulation/restapi.sh
+++ b/tests/simulation/restapi.sh
@@ -142,7 +142,7 @@ fi
 
 # kill lingering processes from a previous run
 if [[ "${HAVE_LSOF}" == "1" ]]; then
-  for PORT in ${BASE_PORT} ${BASE_METRICS_PORT} ${BASE_REST_PORT}; do
+  for PORT in ${BASE_PORT} $((BASE_PORT + 2000)) ${BASE_METRICS_PORT} ${BASE_REST_PORT}; do
     for PID in $(lsof -n -i tcp:${PORT} -sTCP:LISTEN -t); do
       echo -n "Found old process listening on port ${PORT}, with PID ${PID}. "
       if [[ "${KILL_OLD_PROCESSES}" == "1" ]]; then
@@ -151,6 +151,16 @@ if [[ "${HAVE_LSOF}" == "1" ]]; then
       else
 	echo "Aborting."
 	exit 1
+      fi
+    done
+    for PID in $(lsof -n -i udp:${PORT} -t); do
+      echo -n "Found old process using UDP port ${PORT}, with PID ${PID}. "
+      if [[ "${KILL_OLD_PROCESSES}" == "1" ]]; then
+        echo "Killing it."
+        kill -9 ${PID} || true
+      else
+        echo "Aborting."
+        exit 1
       fi
     done
   done
@@ -222,6 +232,8 @@ echo "Creating testnet genesis..."
 ${LOCAL_TESTNET_SIMULATION_BIN} \
   createTestnet \
   --data-dir="${TEST_DIR}" \
+  --tcp=true \
+  --debug-quic=true \
   --deposits-file="${DEPOSITS_FILE}" \
   --total-validators="${NUM_VALIDATORS}" \
   --output-genesis="${SNAPSHOT_FILE}" \
@@ -240,6 +252,9 @@ rm -rf "${TEST_DIR}/db" "${TEST_DIR}/validators/slashing_protection.sqlite3"
 ${NIMBUS_BEACON_NODE_BIN} \
   --tcp-port=${BASE_PORT} \
   --udp-port=${BASE_PORT} \
+  --tcp=true \
+  --debug-quic=false \
+  --debug-quic-port=$((BASE_PORT + 2000)) \
   --log-level=${LOG_LEVEL:-DEBUG} \
   --network="${TEST_DIR}" \
   --data-dir="${TEST_DIR}" \

--- a/tests/simulation/restapi.sh
+++ b/tests/simulation/restapi.sh
@@ -252,7 +252,7 @@ rm -rf "${TEST_DIR}/db" "${TEST_DIR}/validators/slashing_protection.sqlite3"
 ${NIMBUS_BEACON_NODE_BIN} \
   --tcp-port=${BASE_PORT} \
   --udp-port=${BASE_PORT} \
-  --tcp=true \
+  --debug-tcp=true \
   --debug-quic=false \
   --debug-quic-port=$((BASE_PORT + 2000)) \
   --log-level=${LOG_LEVEL:-DEBUG} \

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -344,7 +344,7 @@ proc initBeaconNode(basePort: int): Future[BeaconNode] {.async: (raises: []).} =
             @[
               "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
               "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
-              "--tcp=true",
+              "--debug-tcp=true",
               "--debug-quic=true",
               "--debug-quic-port=" & $(basePort + PortKind.PeerToPeer.ord + 2000),
               "--discv5=off",

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -344,6 +344,9 @@ proc initBeaconNode(basePort: int): Future[BeaconNode] {.async: (raises: []).} =
             @[
               "--tcp-port=" & $(basePort + PortKind.PeerToPeer.ord),
               "--udp-port=" & $(basePort + PortKind.PeerToPeer.ord),
+              "--tcp=true",
+              "--debug-quic=true",
+              "--debug-quic-port=" & $(basePort + PortKind.PeerToPeer.ord + 2000),
               "--discv5=off",
               "--network=" & dataDir,
               "--data-dir=" & nodeDataDir,


### PR DESCRIPTION
Adds  QUIC transport support to Nimbus beacon node while keeping TCP as the default transport.

- add hidden CLI/config flags for enabling QUIC and selecting QUIC ports on beacon nodes and light clients
- extend ENR creation and parsing to carry QUIC endpoints alongside existing TCP/UDP fields
- update peer address handling so discovered/bootstrap peers can be dialed over TCP or QUIC
- modifies the libp2p switch setup to bind and advertise multiple transport addresses
- update local testnet tooling, scripts, docker examples, and tests to allocate and pass QUIC ports
- bump the vendored `nim-libp2p` dependency and relax stack-usage flags for relevant `lsquic` objects

## Notes

- QUIC is still hidden behind `--debug-quic`; existing TCP behavior remains unchanged by default
- this PR is mainly transport/address plumbing plus dev/test tooling updates, not a change to the default networking mode