### PR TITLE
fix: remove incorrect BeaconState type from EpochInfo functions

### DIFF
--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -673,13 +673,13 @@ func get_flag_index_reward*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/altair/beacon-chain.md#get_flag_index_deltas
 func get_unslashed_participating_increment*(
-    info: altair.EpochInfo | bellatrix.BeaconState,
+    info: altair.EpochInfo,
     flag_index: TimelyFlag): uint64 =
   info.balances.previous_epoch[flag_index] div EFFECTIVE_BALANCE_INCREMENT.Gwei
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/altair/beacon-chain.md#get_flag_index_deltas
 func get_active_increments*(
-    info: altair.EpochInfo | bellatrix.BeaconState): uint64 =
+    info: altair.EpochInfo): uint64 =
   info.balances.current_epoch div EFFECTIVE_BALANCE_INCREMENT.Gwei
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#get_flag_index_deltas


### PR DESCRIPTION
The type constraint `altair.EpochInfo | bellatrix.BeaconState` in get_unslashed_participating_increment and get_active_increments was wrong.

These functions access info.balances.previous_epoch[flag_index] and info.balances.current_epoch, which only exist on EpochInfo's UnslashedParticipatingBalances type. BeaconState.balances is a HashList[Gwei, ...] with no such fields - passing it would fail to compile.

Removed bellatrix.BeaconState from the type union since it was never valid and all call sites use altair.EpochInfo anyway.