### PR TITLE
fix ImplicitDefaultValue warning

### DIFF
--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -603,7 +603,7 @@ proc routeBlsToExecutionChange*(
 proc routePayloadAttestationMessage*(
     router: ref MessageRouter,
     message: PayloadAttestationMessage,
-    checkSignature, checkValidator: bool = true):
+    checkSignature = true, checkValidator = true):
     Future[SendResult] {.async: (raises: [CancelledError]).} =
   block:
     let res = await router.processor.processPayloadAttestationMessage(

--- a/config.nims
+++ b/config.nims
@@ -172,6 +172,7 @@ if canEnableDebuggingSymbols:
 switch("warningAsError", "BareExcept:on")
 switch("warningAsError", "CaseTransition:on")
 switch("warningAsError", "CStringConv:on")
+switch("warningAsError", "ImplicitDefaultValue:on")
 switch("warningAsError", "UnusedImport:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")


### PR DESCRIPTION
```
nimbus-eth2/beacon_chain/validators/message_router.nim(606, 5) Warning: checkSignature, checkValidator all have default value 'true', this may be unintentional, either use ';' (semicolon) or explicitly write each default value [ImplicitDefaultValue]
```