### PR TITLE
Only check isomorphism of types in debug compiles

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -9,6 +9,7 @@
 
 import
   std/[json, sequtils, times],
+  stew/objects,
   eth/common/eth_types_rlp,
   eth/common/keys,
   eth/p2p/discoveryv5/random2,
@@ -957,7 +958,7 @@ proc ETHLightClientHeaderCopyExecutionHash(
   root.toUnmanagedPtr()
 
 type ExecutionPayloadHeader =
-  typeof(default(lcDataFork.LightClientHeader).execution)
+  typeof(declval(lcDataFork.LightClientHeader).execution)
 
 func ETHLightClientHeaderGetExecution(
     header: ptr lcDataFork.LightClientHeader

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -865,10 +865,10 @@ static:
   doAssert supportsCopyMem(Eth2Digest)
   doAssert ATTESTATION_SUBNET_COUNT <= high(distinctBase SubnetId)
 
-func getSizeofSig(X: type, n: int = 0): seq[(string, int, int)] {.compileTime.} =
-  for name, value in default(ptr X)[].fieldPairs:
+func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
+  for name, value in x.fieldPairs:
     when value is tuple|object:
-      result.add getSizeofSig(typeof(value), n + 1)
+      result.add getSizeofSig(value, n + 1)
     # TrustedSig and ValidatorSig differ in that they have otherwise identical
     # fields where one is "blob" and the other is "data". They're structurally
     # isomorphic, regardless. Grandfather that exception in, but in general it
@@ -887,17 +887,19 @@ template isomorphicCast*[T](x: auto): T =
 
   static: doAssert (T is ref) == (U is ref)
   when T is ref:
-    type
-      TT = pointerBase(T)
-      UU = pointerBase(U)
-    static:
-      doAssert sizeof(TT) == sizeof(UU)
-      doAssert getSizeofSig(T) == getSizeofSig(U)
+    when defined(debug):
+      type
+        TT = pointerBase(T)
+        UU = pointerBase(U)
+      static:
+        doAssert sizeof(TT) == sizeof(UU)
+        doAssert getSizeofSig(TT()) == getSizeofSig(UU())
     cast[T](x)
   else:
-    static:
-      doAssert getSizeofSig(T) == getSizeofSig(U)
-      doAssert sizeof(T) == sizeof(U)
+    when defined(debug): # 10s+ compile time due to `default(T)` and `replace`!
+      static:
+        doAssert sizeof(T) == sizeof(U)
+        doAssert getSizeofSig(T()) == getSizeofSig(U())
     cast[ptr T](unsafeAddr x)[]
 
 func prune*(cache: var StateCache, epoch: Epoch) =

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -865,7 +865,7 @@ static:
   doAssert supportsCopyMem(Eth2Digest)
   doAssert ATTESTATION_SUBNET_COUNT <= high(distinctBase SubnetId)
 
-func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
+func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] {.compileTime.} =
   for name, value in x.fieldPairs:
     when value is tuple|object:
       result.add getSizeofSig(value, n + 1)
@@ -884,19 +884,22 @@ func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] =
 template isomorphicCast*[T](x: auto): T =
   # Each of these pairs of types has ABI-compatible memory representations.
   type U = typeof(x)
+
   static: doAssert (T is ref) == (U is ref)
   when T is ref:
-    type
-      TT = typeof default(typeof T)[]
-      UU = typeof default(typeof U)[]
-    static:
-      doAssert sizeof(TT) == sizeof(UU)
-      doAssert getSizeofSig(TT()) == getSizeofSig(UU())
+    when defined(debug):
+      type
+        TT = typeof default(typeof T)[]
+        UU = typeof default(typeof U)[]
+      static:
+        doAssert sizeof(TT) == sizeof(UU)
+        doAssert getSizeofSig(TT()) == getSizeofSig(UU())
     cast[T](x)
   else:
-    static:
-      doAssert getSizeofSig(T()) == getSizeofSig(U())
-      doAssert sizeof(T) == sizeof(U)
+    when defined(debug): # 10s+ compile time due to `default(T)` and `replace`!
+      static:
+        doAssert getSizeofSig(T()) == getSizeofSig(U())
+        doAssert sizeof(T) == sizeof(U)
     cast[ptr T](unsafeAddr x)[]
 
 func prune*(cache: var StateCache, epoch: Epoch) =

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -865,10 +865,10 @@ static:
   doAssert supportsCopyMem(Eth2Digest)
   doAssert ATTESTATION_SUBNET_COUNT <= high(distinctBase SubnetId)
 
-func getSizeofSig(x: auto, n: int = 0): seq[(string, int, int)] {.compileTime.} =
-  for name, value in x.fieldPairs:
+func getSizeofSig(X: type, n: int = 0): seq[(string, int, int)] {.compileTime.} =
+  for name, value in default(ptr X)[].fieldPairs:
     when value is tuple|object:
-      result.add getSizeofSig(value, n + 1)
+      result.add getSizeofSig(typeof(value), n + 1)
     # TrustedSig and ValidatorSig differ in that they have otherwise identical
     # fields where one is "blob" and the other is "data". They're structurally
     # isomorphic, regardless. Grandfather that exception in, but in general it
@@ -887,19 +887,17 @@ template isomorphicCast*[T](x: auto): T =
 
   static: doAssert (T is ref) == (U is ref)
   when T is ref:
-    when defined(debug):
-      type
-        TT = typeof default(typeof T)[]
-        UU = typeof default(typeof U)[]
-      static:
-        doAssert sizeof(TT) == sizeof(UU)
-        doAssert getSizeofSig(TT()) == getSizeofSig(UU())
+    type
+      TT = pointerBase(T)
+      UU = pointerBase(U)
+    static:
+      doAssert sizeof(TT) == sizeof(UU)
+      doAssert getSizeofSig(T) == getSizeofSig(U)
     cast[T](x)
   else:
-    when defined(debug): # 10s+ compile time due to `default(T)` and `replace`!
-      static:
-        doAssert getSizeofSig(T()) == getSizeofSig(U())
-        doAssert sizeof(T) == sizeof(U)
+    static:
+      doAssert getSizeofSig(T) == getSizeofSig(U)
+      doAssert sizeof(T) == sizeof(U)
     cast[ptr T](unsafeAddr x)[]
 
 func prune*(cache: var StateCache, epoch: Epoch) =

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -43,10 +43,12 @@
 import
   chronicles,
   results,
+  stew/objects,
   ../extras,
-  "."/[
-    beaconstate, eth2_merkleization, forks, helpers, signatures,
-    state_transition_block, state_transition_epoch, validator]
+  ./[
+    beaconstate, eth2_merkleization, forks, helpers, signatures, state_transition_block,
+    state_transition_epoch, validator,
+  ]
 
 export results, extras, state_transition_block
 
@@ -377,7 +379,7 @@ proc makeBeaconBlockWithRewards*(
   ## the block is to be created.
   type
     MaybeBlindedBeaconBlock = consensusFork.BeaconBlock(type(execution_payload))
-    MaybeBlindedBlockBody = typeof(default(MaybeBlindedBeaconBlock).body)
+    MaybeBlindedBlockBody = typeof(declval(MaybeBlindedBeaconBlock).body)
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/validator.md#preparing-for-a-beaconblock
   var blck = MaybeBlindedBeaconBlock(


### PR DESCRIPTION
The VM is slow at instantiating large types like the beacon state at compile time, hence it takes >10s to perform this check.

A macro similar to nim-serialization could be developed instead to replace `fieldPairs` which here is only used to reason about type, but still needs an actual instance.
