### PR TITLE
Use `debug` instead of `hidden` in debug conf options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             nimflags-extra: --mm:refc
           - target:
               os: linux
-            builder: ['self-hosted','ubuntu-22.04']
+            builder: ['ubuntu-22.04']
           - target:
               os: macos
               cpu: arm64
@@ -193,7 +193,7 @@ jobs:
 
   devbuild:
     name: "Developer builds"
-    runs-on: ['self-hosted','ubuntu-22.04']
+    runs-on: ['ubuntu-22.04']
     steps:
       - name: Fix nim cache conflicts
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
             nimflags-extra: --mm:refc
           - target:
               os: linux
-            builder: ['ubuntu-22.04']
+            builder: ['self-hosted','ubuntu-22.04']
           - target:
               os: macos
               cpu: arm64
@@ -193,7 +193,7 @@ jobs:
 
   devbuild:
     name: "Developer builds"
-    runs-on: ['ubuntu-22.04']
+    runs-on: ['self-hosted','ubuntu-22.04']
     steps:
       - name: Fix nim cache conflicts
         run: |

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -242,7 +242,7 @@ type
       name: "subscribe-all-subnets" .}: bool
 
     debugPeerdasSupernode* {.
-      hidden
+      debug
       defaultValue: false,
       name: "debug-peerdas-supernode" .}: bool
 
@@ -397,13 +397,13 @@ type
         name: "verify-finalization" .}: bool
 
       stopAtEpoch* {.
-        hidden
+        debug
         desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "debug-stop-at-epoch" .}: uint64
 
       stopAtSyncedEpoch* {.
-        hidden
+        debug
         desc: "The synced epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "stop-at-synced-epoch" .}: uint64
@@ -557,7 +557,7 @@ type
         name: "light-client-data-max-periods" .}: Option[uint64]
 
       longRangeSync* {.
-        hidden
+        debug
         desc: "Enable long-range syncing (genesis sync)",
         defaultValue: LongRangeSyncMode.Lenient,
         name: "debug-long-range-sync".}: LongRangeSyncMode
@@ -601,7 +601,7 @@ type
       #     `--debug-invalidate-block-root` flag present until finality has
       #     advanced beyond the problematic chain segment
       invalidBlockRoots* {.
-        hidden
+        debug
         desc: "List of beacon block roots that, if the EL responds with SYNCING/ACCEPTED, are treated as if their execution payload was INVALID"
         name: "debug-invalidate-block-root" .}: seq[Eth2Digest]
 
@@ -685,14 +685,14 @@ type
         name: "history".}: HistoryMode
 
       trustedSetupFile* {.
-        hidden
+        debug
         desc: "Alternative EIP-4844 trusted setup file"
         defaultValue: none(string)
         defaultValueDesc: "Baked in trusted setup"
         name: "debug-trusted-setup-file" .}: Option[string]
 
       bandwidthEstimate* {.
-        hidden
+        debug
         desc: "Bandwidth estimate for the node (bits per second)"
         name: "debug-bandwidth-estimate" .}: Option[Natural]
 
@@ -1035,6 +1035,7 @@ type
       name: "graffiti" .}: Option[GraffitiBytes]
 
     stopAtEpoch* {.
+      debug
       desc: "A positive epoch selects the epoch at which to stop"
       defaultValue: 0
       name: "debug-stop-at-epoch" .}: uint64

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -403,7 +403,7 @@ type
         name: "debug-stop-at-epoch" .}: uint64
 
       stopAtSyncedEpoch* {.
-        debug
+        hidden
         desc: "The synced epoch at which to exit the program. (for testing purposes)"
         defaultValue: 0
         name: "stop-at-synced-epoch" .}: uint64

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1035,7 +1035,6 @@ type
       name: "graffiti" .}: Option[GraffitiBytes]
 
     stopAtEpoch* {.
-      debug
       desc: "A positive epoch selects the epoch at which to stop"
       defaultValue: 0
       name: "debug-stop-at-epoch" .}: uint64

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -141,13 +141,13 @@ type LightClientConf* = object
     name: "jwt-secret" .}: Option[InputFile]
 
   bandwidthEstimate* {.
-    hidden
+    debug
     desc: "Bandwidth estimate for the node (bits per second)"
     name: "debug-bandwidth-estimate" .}: Option[Natural]
 
   # Testing
   stopAtEpoch* {.
-    hidden
+    debug
     desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
     defaultValue: 0
     name: "debug-stop-at-epoch" .}: uint64

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -26,6 +26,8 @@ nimbus_beacon_node [OPTIONS]... command
 
 The following options are available:
 
+     --help                    Show this help message and exit. Available arguments: debug.
+     --version                 Show program's version and exit.
      --config-file             Loads the configuration from a TOML file.
      --log-level               Sets the log level for process and topics (e.g. "DEBUG; TRACE:discv5,libp2p;
                                REQUIRED:none; DISABLED:none") [=INFO].


### PR DESCRIPTION
Changes:

- Change `debug-` prefixed conf options from `hidden` to `debug`. They will show when setting `--help:debug`

Note there are more `hidden` options. I only changed the ones that have `debug-` prefix.

Bump confutils:

- https://github.com/status-im/nim-confutils/pull/126
- https://github.com/status-im/nim-confutils/pull/127
- https://github.com/status-im/nim-confutils/pull/128