### PR TITLE
fix: remove unreachable condition in deposit processing

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -761,8 +761,6 @@ proc process_operations(
         # Otherwise wraps because unsigned; Python spec semantics would result in
         # negative difference, which would be impossible for len(...) to match.
         if state.eth1_deposit_index < eth1_deposit_index_limit:
-          if eth1_deposit_index_limit < state.eth1_deposit_index:
-            return err("eth1_deposit_index_limit < state.eth1_deposit_index")
           min(
             MAX_DEPOSITS, eth1_deposit_index_limit - state.eth1_deposit_index)
         else:


### PR DESCRIPTION
Remove dead code in process_operations for Electra fork. The inner check `eth1_deposit_index_limit < state.eth1_deposit_index` can never be true because it's inside a block where we already verified the opposite condition `state.eth1_deposit_index < eth1_deposit_index_limit`