### PR TITLE
Use confutils `obsolete` for deprecated beacon node conf options

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -194,7 +194,7 @@ type
       name: "era-dir" .}: Option[InputDir]
 
     web3ForcePolling* {.
-      hidden
+      obsolete
       name: "web3-force-polling" .}: Option[bool]
 
     web3Urls* {.
@@ -211,12 +211,12 @@ type
       name: "no-el" .}: bool
 
     optimistic* {.
-      hidden # deprecated > 22.12
+      obsolete # deprecated > 22.12
       desc: "Run the node in optimistic mode, allowing it to optimistically sync without an execution client (flag deprecated, always on)"
       name: "optimistic".}: Option[bool]
 
     requireEngineAPI* {.
-      hidden  # Deprecated > 22.9
+      obsolete  # Deprecated > 22.9
       desc: "Require Nimbus to be configured with an Engine API end-point after the Bellatrix fork epoch"
       name: "require-engine-api-in-bellatrix" .}: Option[bool]
 
@@ -370,11 +370,11 @@ type
         name: "genesis-state-url" .}: Option[Uri]
 
       finalizedDepositTreeSnapshot* {.
-        hidden
+        obsolete
         name: "finalized-deposit-tree-snapshot" .}: Option[InputFile]
 
       finalizedCheckpointBlock* {.
-        hidden
+        obsolete
         desc: "SSZ file specifying a recent finalized block"
         name: "finalized-checkpoint-block" .}: Option[InputFile]
 
@@ -562,7 +562,7 @@ type
         name: "debug-long-range-sync".}: LongRangeSyncMode
 
       inProcessValidators* {.
-        hidden
+        obsolete
         desc: "Deprecated for removal"
         name: "in-process-validators" .}: Option[bool]
 
@@ -619,7 +619,7 @@ type
         name: "sync-horizon" .}: Option[uint64]
 
       terminalTotalDifficultyOverride* {.
-        hidden
+        obsolete
         desc: "Deprecated for removal"
         name: "terminal-total-difficulty-override" .}: Option[string]
 
@@ -638,13 +638,13 @@ type
         name: "validator-monitor-details" .}: bool
 
       validatorMonitorTotals* {.
-        hidden
+        obsolete: "Use --validator-monitor-details instead"
         desc: "Deprecated in favour of --validator-monitor-details"
         name: "validator-monitor-totals" .}: Option[bool]
 
       safeSlotsToImportOptimistically* {.
         # Never unhidden or documented, and deprecated > 22.9.1
-        hidden
+        obsolete
         desc: "Deprecated for removal"
         name: "safe-slots-to-import-optimistically" .}: Option[uint16]
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2862,20 +2862,6 @@ proc doRunBeaconNode(
   if config.rpcEnabled.isSome:
     warn "Nimbus's JSON-RPC server has been removed. This includes the --rpc, --rpc-port, and --rpc-address configuration options. https://nimbus.guide/rest-api.html shows how to enable and configure the REST Beacon API server which replaces it."
 
-  template ignoreDeprecatedOption(option: untyped): untyped =
-    if config.option.isSome:
-      warn "Ignoring deprecated configuration option", option = config.option.get
-
-  ignoreDeprecatedOption requireEngineAPI
-  ignoreDeprecatedOption safeSlotsToImportOptimistically
-  ignoreDeprecatedOption terminalTotalDifficultyOverride
-  ignoreDeprecatedOption optimistic
-  ignoreDeprecatedOption validatorMonitorTotals
-  ignoreDeprecatedOption web3ForcePolling
-  ignoreDeprecatedOption finalizedDepositTreeSnapshot
-  ignoreDeprecatedOption finalizedCheckpointBlock
-  ignoreDeprecatedOption inProcessValidators
-
   # Trusted setup is needed for Cancun+ blocks and is shared between threads,
   # so it needs to be initalized from the main thread before anything else tries
   # to use it
@@ -3040,11 +3026,12 @@ proc main*() {.noinline, raises: [CatchableError].} =
   const copyright =
     "Copyright (c) 2019-" & compileYear & " Status Research & Development GmbH"
 
-  var config = BeaconNodeConf.loadWithBanners(clientId, copyright, [specBanner]).valueOr:
+  var config = BeaconNodeConf.loadWithBanners(
+    clientId, copyright, [specBanner], setupLogger = true
+  ).valueOr:
     writePanicLine error # Logging not yet set up
     quit QuitFailure
 
-  setupLogging(config.logLevel, config.logStdout, config.logFile)
   setupFileLimits()
 
   if not (checkAndCreateDataDir(string(config.dataDir))):

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -192,12 +192,23 @@ proc setupTaskpool*(numThreads: int): Taskpool =
 
   taskpool
 
+proc obsoleteCmdOpt*(ConfType: type object, opt, msg: string) =
+  if msg.len == 0:
+    warn "Ignoring deprecated configuration option", opt
+  else:
+    warn "Ignoring deprecated configuration option", opt, msg
+
+template loggerSetup(ConfType: type): untyped =
+  proc (config: ConfType) {.raises: [], gcsafe.} =
+    setupLogging(config.logLevel, config.logStdout, config.logFile)
+
 proc loadWithBanners*(
     ConfType: type,
     helpBanner, copyright: string,
     versions: openArray[string],
     ignoreUnknown = false,
     environment: openArray[string] = [],
+    setupLogger = false
 ): Result[ConfType, string] =
   let
     version =
@@ -227,6 +238,7 @@ proc loadWithBanners*(
           if config.configFile.isSome:
             sources.addConfigFile(Toml, config.configFile.get)
         ,
+        loggerSetup = if setupLogger: loggerSetup(ConfType) else: nil
       )
     except CatchableError as exc:
       # Logging not configured yet!

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -32,11 +32,11 @@ proc main() {.noinline, raises: [CatchableError].} =
     copyright =
       "Copyright (c) 2022-" & compileYear & " Status Research & Development GmbH"
 
-  var config = LightClientConf.loadWithBanners(banner, copyright, [specBanner]).valueOr:
+  var config = LightClientConf.loadWithBanners(
+    banner, copyright, [specBanner], setupLogger = true
+  ).valueOr:
     writePanicLine error # Logging not yet set up
     quit QuitFailure
-
-  setupLogging(config.logLevel, config.logStdout, config.logFile)
 
   notice "Launching light client",
     version = fullVersionStr, cmdParams = commandLineParams(), config

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -500,11 +500,11 @@ proc main() {.noinline, raises: [CatchableError].} =
     copyright =
       "Copyright (c) 2021-" & compileYear & " Status Research & Development GmbH"
 
-  let config = SigningNodeConf.loadWithBanners(banner, copyright, [specBanner]).valueOr:
+  let config = SigningNodeConf.loadWithBanners(
+    banner, copyright, [specBanner], setupLogger = true
+  ).valueOr:
     writePanicLine error # Logging not yet set up
     quit QuitFailure
-
-  setupLogging(config.logLevel, config.logStdout, config.logFile)
 
   waitFor runSigningNode(config)
 

--- a/beacon_chain/nimbus_validator_client.nim
+++ b/beacon_chain/nimbus_validator_client.nim
@@ -646,7 +646,9 @@ proc main() {.noinline, raises: [CatchableError].} =
       "Copyright (c) 2020-" & compileYear & " Status Research & Development GmbH"
 
   let
-    config = ValidatorClientConf.loadWithBanners(banner, copyright, [specBanner]).valueOr:
+    config = ValidatorClientConf.loadWithBanners(
+      banner, copyright, [specBanner], setupLogger = true
+    ).valueOr:
       writePanicLine error # Logging not yet set up
       quit QuitFailure
 
@@ -654,7 +656,6 @@ proc main() {.noinline, raises: [CatchableError].} =
     # and avoid using system resources (such as urandom) after that
     rng = HmacDrbgContext.new()
 
-  setupLogging(config.logLevel, config.logStdout, config.logFile)
   setupFileLimits()
 
   waitFor runValidatorClient(config, rng)

--- a/beacon_chain/winservice.nim
+++ b/beacon_chain/winservice.nim
@@ -148,12 +148,12 @@ when defined(windows):
         reportServiceStatus(SERVICE_STOPPED, ERROR_INVALID_PARAMETER, 0)
         quit QuitFailure
 
-      var config = loadWithBanners(argConfigType, argHelpBanner, argCopyright,
-                                   argVersions, false, environment).valueOr:
+      var config = loadWithBanners(
+        argConfigType, argHelpBanner, argCopyright,
+        argVersions, false, environment, setupLogger = true
+      ).valueOr:
         reportServiceStatus(SERVICE_STOPPED, ERROR_BAD_CONFIGURATION, 0)
         quit QuitFailure
-
-      setupLogging(config.logLevel, config.logStdout, config.logFile)
 
       try:
         argEntryPoint(config)

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -26,6 +26,8 @@ nimbus_beacon_node [OPTIONS]... command
 
 The following options are available:
 
+     --help                    Show this help message and exit.
+     --version                 Show program's version and exit.
      --config-file             Loads the configuration from a TOML file.
      --log-level               Sets the log level for process and topics (e.g. "DEBUG; TRACE:discv5,libp2p;
                                REQUIRED:none; DISABLED:none") [=INFO].


### PR DESCRIPTION
Changes:

- `obsoleteCmdOpt` overload to output obsolete/deprecated options. Keep using chronicles (otherwise the default write to stderr would be used).
- Pass confutils `load` callback to setup chronicles before outputting deprecation warnings. Adds `setupLogger` param to `loadWithBanners` .

Output example:

```text
WRN 2025-12-23 20:17:44.631-03:00 Ignoring deprecated configuration option   topics="beacnde" opt=web3-force-polling
INF 2025-12-23 20:17:44.632-03:00 Launching beacon node                      topics="beacnde" version=v25[...]
```

Bump confutils:

- https://github.com/status-im/nim-confutils/pull/135
- https://github.com/status-im/nim-confutils/pull/136
- https://github.com/status-im/nim-confutils/pull/126
- https://github.com/status-im/nim-confutils/pull/127
- https://github.com/status-im/nim-confutils/pull/128
