### PR TITLE
fix: check ELECTRA_FORK_EPOCH for electraHeaders instead of DENEB

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -584,7 +584,7 @@ proc new*(T: type BeaconChainDB,
         else:
           "",
       electraHeaders:
-        if cfg.DENEB_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        if cfg.ELECTRA_FORK_EPOCH != FAR_FUTURE_EPOCH:
           "lc_electra_headers"
         else:
           "",


### PR DESCRIPTION
electraHeaders table was created when DENEB_FORK_EPOCH was set, not ELECTRA_FORK_EPOCH.
Copy-paste error from denebHeaders condition above.