### PR TITLE
fix(network): remove redundant is_sync_committee_period check

### DIFF
--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -251,7 +251,7 @@ func nearSyncCommitteePeriod*(epoch: Epoch): Opt[uint64] =
     return Opt.some 0'u64
   let epochsBefore =
     EPOCHS_PER_SYNC_COMMITTEE_PERIOD - epoch.since_sync_committee_period_start()
-  if epoch.is_sync_committee_period() or epochsBefore <= SYNC_COMMITTEE_SUBNET_COUNT:
+  if epochsBefore <= SYNC_COMMITTEE_SUBNET_COUNT:
     return Opt.some epochsBefore
 
   Opt.none(uint64)


### PR DESCRIPTION
The is_sync_committee_period() check on line 254 was always false since line 250 already returns early when it's true. Removed dead code.