### PR TITLE
Expose (json) log format, hide and deprecate obsolete options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       - name: Check copyright year
         if: ${{ !cancelled() }} && github.event_name == 'pull_request'
         run: |
-          excluded_files="config.yaml|config.nims|beacon_chain.nimble"
+          excluded_files="config.yaml|config.nims|beacon_chain.nimble|Makefile|Product.wxs"
           excluded_extensions="ans|bin|cfg|yml|json|json\\.template|md|png|service|ssz|tpl|txt|lock|nix|gitignore|envrc|sh"
 
           current_year=$(date +"%Y")

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ BASE_METRICS_PORT := 8008
 # WARNING: Use lazy assignment to allow CI to override.
 EXECUTOR_NUMBER ?= 0
 
-SEPOLIA_WEB3_URL := "--web3-url=https://rpc.sepolia.dev --web3-url=https://www.sepoliarpc.space"
-GNOSIS_WEB3_URLS := "--web3-url=https://rpc.gnosischain.com/"
+SEPOLIA_WEB3_URL := "--el=https://rpc.sepolia.dev --el=https://www.sepoliarpc.space"
+GNOSIS_WEB3_URLS := "--el=https://rpc.gnosischain.com/"
 
 VALIDATORS := 1
 CPU_LIMIT := 0

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -134,99 +134,75 @@ type
       name: "config-file" .}: Option[InputFile]
 
     logLevel* {.
-      desc: "Sets the log level for process and topics (e.g. \"DEBUG; TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none\")"
+      desc: "Log level for process and topics (e.g. \"DEBUG; TRACE:discv5,libp2p; REQUIRED:none; DISABLED:none\")"
       defaultValue: "INFO"
       name: "log-level" .}: string
 
-    logStdout* {.
-      hidden
-      desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
+    logFormat* {.
+      desc: "Choice of log format (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
       name: "log-format" .}: StdoutLogKind
 
-    logFile* {.
-      desc: "Specifies a path for the written JSON log file (deprecated)"
-      name: "log-file" .}: Option[OutFile]
-
     eth2Network* {.
-      desc: "The Eth2 network to join"
+      desc: "Consensus network to join (mainnet, hoodi, sepolia, custom/path)"
       defaultValueDesc: "mainnet"
       name: "network" .}: Option[string]
 
     dataDirFlag* {.
-      desc: "The directory where nimbus will store all blockchain data"
+      desc: "Directory for blockchain data including history, state and keys"
       abbr: "d"
       name: "data-dir" .}: Option[OutDir]
 
+    eraDirFlag* {.
+      desc: "Directory for era archive"
+      defaultValueDesc: "<data-dir>/era"
+      name: "era-dir" .}: Option[OutDir]
+
     validatorsDirFlag* {.
-      desc: "A directory containing validator keystores"
+      desc: "Directory for validator keystores"
       name: "validators-dir" .}: Option[InputDir]
 
-    verifyingWeb3Signers* {.
+    secretsDirFlag* {.
+      desc: "Directory for validator keystore passwords"
+      name: "secrets-dir" .}: Option[InputDir]
+
+    web3Signers* {.
       desc: "Remote Web3Signer URL that will be used as a source of validators"
+      name: "web3-signer-url" .}: seq[Uri]
+
+    verifyingWeb3Signers* {.
+      desc: "Verifying Web3Signer URL that will be used as a source of validators"
       name: "verifying-web3-signer-url" .}: seq[Uri]
 
     provenBlockProperties* {.
       desc: "The field path of a block property that will be sent for verification to the verifying Web3Signer (for example \".execution_payload.fee_recipient\")"
       name: "proven-block-property" .}: seq[string]
 
-    web3Signers* {.
-      desc: "Remote Web3Signer URL that will be used as a source of validators"
-      name: "web3-signer-url" .}: seq[Uri]
-
     web3signerUpdateInterval* {.
       desc: "Number of seconds between validator list updates"
       name: "web3-signer-update-interval"
       defaultValue: 3600 .}: Natural
 
-    secretsDirFlag* {.
-      desc: "A directory containing validator keystore passwords"
-      name: "secrets-dir" .}: Option[InputDir]
-
     walletsDirFlag* {.
       desc: "A directory containing wallet files"
       name: "wallets-dir" .}: Option[InputDir]
 
-    eraDirFlag* {.
-      hidden
-      desc: "A directory containing era files"
-      name: "era-dir" .}: Option[InputDir]
-
-    web3ForcePolling* {.
-      obsolete
-      name: "web3-force-polling" .}: Option[bool]
-
-    web3Urls* {.
-      desc: "One or more execution layer Engine API URLs"
-      name: "web3-url" .}: seq[EngineApiUrlConfigValue]
-
     elUrls* {.
-      desc: "One or more execution layer Engine API URLs"
+      desc: "Execution layer engine API URL"
+      longDesc: "Repeat --el=<url> to add multiple ELs, see https://nimbus.guide/eth1.html"
       name: "el" .}: seq[EngineApiUrlConfigValue]
 
     noEl* {.
-      defaultValue: false
-      desc: "Don't use an EL. The node will remain optimistically synced and won't be able to perform validator duties"
+      desc: "Run the consensus client without default and configured execution clients (validators will not work)"
       name: "no-el" .}: bool
-
-    optimistic* {.
-      obsolete # deprecated > 22.12
-      desc: "Run the node in optimistic mode, allowing it to optimistically sync without an execution client (flag deprecated, always on)"
-      name: "optimistic".}: Option[bool]
-
-    requireEngineAPI* {.
-      obsolete  # Deprecated > 22.9
-      desc: "Require Nimbus to be configured with an Engine API end-point after the Bellatrix fork epoch"
-      name: "require-engine-api-in-bellatrix" .}: Option[bool]
 
     nonInteractive* {.
       desc: "Do not display interactive prompts. Quit on missing configuration"
       name: "non-interactive" .}: bool
 
     netKeyFile* {.
-      desc: "Source of network (secp256k1) private key file " &
-            "(random|<path>)"
+      desc: "Source of network (secp256k1) private key file (random|<path>)"
       defaultValue: "random",
       name: "netkey-file" .}: string
 
@@ -270,6 +246,29 @@ type
     jwtSecret* {.
       desc: "A file containing the hex-encoded 256 bit secret key to be used for verifying/generating JWT tokens"
       name: "jwt-secret" .}: Option[InputFile]
+
+    logFile* {.
+      obsolete: "Logging to file has been deprecated since v1.5.3, see https://nimbus.guide/logging.html#logging-to-a-file"
+      name: "log-file" .}: Option[OutFile]
+
+    optimistic* {.
+      obsolete: "Optimistic mode automatically enabled since v22.12"
+      name: "optimistic".}: Option[bool]
+
+    # Hidden as of 26.1.0 to simplify the CLI help - while web3-url isn't going
+    # anywhere, it's easier to have just one value across all docs & help
+    web3Urls* {.
+      hidden
+      desc: "Superceded by --el as of v23.3.0"
+      name: "web3-url" .}: seq[EngineApiUrlConfigValue]
+
+    web3ForcePolling* {.
+      obsolete: "Not needed as of v23.3.1"
+      name: "web3-force-polling" .}: Option[bool]
+
+    requireEngineAPI* {.
+      obsolete: "Deprecated in v22.9"
+      name: "require-engine-api-in-bellatrix" .}: Option[bool]
 
     case cmd* {.
       command
@@ -369,15 +368,6 @@ type
         desc: "URL for obtaining the genesis state of the network (for networks without a built-in genesis state)"
         name: "genesis-state-url" .}: Option[Uri]
 
-      finalizedDepositTreeSnapshot* {.
-        obsolete
-        name: "finalized-deposit-tree-snapshot" .}: Option[InputFile]
-
-      finalizedCheckpointBlock* {.
-        obsolete
-        desc: "SSZ file specifying a recent finalized block"
-        name: "finalized-checkpoint-block" .}: Option[InputFile]
-
       nodeName* {.
         desc: "A name for this node that will appear in the logs. " &
               "If you set this to 'auto', a persistent automatically generated ID will be selected for each --data-dir folder"
@@ -441,37 +431,19 @@ type
         defaultValueDesc: ""
         name: "status-bar-contents" .}: string
 
-      rpcEnabled* {.
-        # Deprecated > 1.7.0
-        hidden
-        desc: "Deprecated for removal"
-        name: "rpc" .}: Option[bool]
-
-      rpcPort* {.
-        # Deprecated > 1.7.0
-        hidden
-        desc: "Deprecated for removal"
-        name: "rpc-port" .}: Option[Port]
-
-      rpcAddress* {.
-        # Deprecated > 1.7.0
-        hidden
-        desc: "Deprecated for removal"
-        name: "rpc-address" .}: Option[IpAddress]
-
       restEnabled* {.
-        desc: "Enable the REST server"
+        desc: "Enable the REST Beacon API server"
         defaultValue: false
         name: "rest" .}: bool
 
       restPort* {.
-        desc: "Port for the REST server"
+        desc: "Port for the REST Beacon API"
         defaultValue: defaultEth2RestPort
         defaultValueDesc: $defaultEth2RestPortDesc
         name: "rest-port" .}: Port
 
       restAddress* {.
-        desc: "Listening address of the REST server"
+        desc: "Listening address of the REST Beacon API"
         defaultValue: defaultAdminListenAddress
         defaultValueDesc: $defaultAdminListenAddressDesc
         name: "rest-address" .}: IpAddress
@@ -561,11 +533,6 @@ type
         defaultValue: LongRangeSyncMode.Lenient,
         name: "debug-long-range-sync".}: LongRangeSyncMode
 
-      inProcessValidators* {.
-        obsolete
-        desc: "Deprecated for removal"
-        name: "in-process-validators" .}: Option[bool]
-
       discv5Enabled* {.
         desc: "Enable Discovery v5"
         defaultValue: true
@@ -618,11 +585,6 @@ type
         desc: "Number of empty slots to process before considering the client out of sync. Defaults to the number of slots in 10 minutes"
         name: "sync-horizon" .}: Option[uint64]
 
-      terminalTotalDifficultyOverride* {.
-        obsolete
-        desc: "Deprecated for removal"
-        name: "terminal-total-difficulty-override" .}: Option[string]
-
       validatorMonitorAuto* {.
         desc: "Monitor validator activity automatically for validators active on this beacon node"
         defaultValue: true
@@ -639,14 +601,7 @@ type
 
       validatorMonitorTotals* {.
         obsolete: "Use --validator-monitor-details instead"
-        desc: "Deprecated in favour of --validator-monitor-details"
         name: "validator-monitor-totals" .}: Option[bool]
-
-      safeSlotsToImportOptimistically* {.
-        # Never unhidden or documented, and deprecated > 22.9.1
-        obsolete
-        desc: "Deprecated for removal"
-        name: "safe-slots-to-import-optimistically" .}: Option[uint16]
 
       # Same option as appears in Lighthouse and Prysm
       # https://lighthouse-book.sigmaprime.io/suggested-fee-recipient.html
@@ -694,6 +649,38 @@ type
         hidden
         desc: "Bandwidth estimate for the node (bits per second)"
         name: "debug-bandwidth-estimate" .}: Option[Natural]
+
+      rpcEnabled* {.
+        obsolete: "Superceded by REST API as of v1.7.0"
+        name: "rpc" .}: Option[bool]
+
+      rpcPort* {.
+        obsolete: "Superceded by REST API as of v1.7.0"
+        name: "rpc-port" .}: Option[Port]
+
+      rpcAddress* {.
+        obsolete: "Superceded by REST API as of v1.7.0"
+        name: "rpc-address" .}: Option[IpAddress]
+
+      finalizedDepositTreeSnapshot* {.
+        obsolete: "Deposit tree no longer used as of EIP-6110 / Electra / v25.6.0"
+        name: "finalized-deposit-tree-snapshot" .}: Option[InputFile]
+
+      finalizedCheckpointBlock* {.
+        obsolete: "Finalized checkpoint block no longer needed for checkpoint sync as of v24.1.0"
+        name: "finalized-checkpoint-block" .}: Option[InputFile]
+
+      inProcessValidators* {.
+        obsolete: "Superceded by web3signer as of v1.5.5"
+        name: "in-process-validators" .}: Option[bool]
+
+      terminalTotalDifficultyOverride* {.
+        obsolete: "TTD override obsoleted by successful merge"
+        name: "terminal-total-difficulty-override" .}: Option[string]
+
+      safeSlotsToImportOptimistically* {.
+        obsolete: "Removed in v22.9.1" # Never unhidden or documented
+        name: "safe-slots-to-import-optimistically" .}: Option[uint16]
 
     of BNStartUpCmd.wallets:
       case walletsCmd* {.command.}: WalletsCmd
@@ -867,11 +854,6 @@ type
         name: "state-id"
       .}: Option[string]
 
-      blockId* {.
-        hidden
-        desc: "Block id to sync to - this can be a block root, slot number, \"finalized\" or \"head\" (deprecated)"
-      .}: Option[string]
-
       lcTrustedBlockRoot* {.
         desc: "Recent trusted finalized block root to initialize light client from"
         name: "trusted-block-root" .}: Option[Eth2Digest]
@@ -882,13 +864,18 @@ type
         name: "backfill" .}: bool
 
       reindex* {.
-        desc: "Recreate historical state index at end of backfill, allowing full history access (requires full backfill)"
+        desc: "Recreate historical state index at end of backfill, allowing full history access starting from the given state id"
         defaultValue: false .}: bool
 
       downloadDepositSnapshot* {.
         desc: "Also try to download a snapshot of the deposit contract state"
         defaultValue: false
         name: "with-deposit-snapshot" .}: bool
+
+      blockId* {.
+        obsolete: "Block id not needed for checkpoint sync as of v24.1.0"
+        name: "block-id"
+      .}: Option[string]
 
   ValidatorClientConf* = object
     configFile* {.
@@ -900,16 +887,11 @@ type
       defaultValue: "INFO"
       name: "log-level" .}: string
 
-    logStdout* {.
-      hidden
-      desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
+    logFormat* {.
+      desc: "Choice of log format (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
       name: "log-format" .}: StdoutLogKind
-
-    logFile* {.
-      desc: "Specifies a path for the written JSON log file (deprecated)"
-      name: "log-file" .}: Option[OutFile]
 
     dataDirFlag* {.
       desc: "The directory where nimbus will store all blockchain data"
@@ -1012,18 +994,18 @@ type
       name: "keymanager-token-file" .}: Option[InputFile]
 
     metricsEnabled* {.
-      desc: "Enable the metrics server (BETA)"
+      desc: "Enable the metrics server"
       defaultValue: false
       name: "metrics" .}: bool
 
     metricsAddress* {.
-      desc: "Listening address of the metrics server (BETA)"
+      desc: "Listening address of the metrics server"
       defaultValue: defaultAdminListenAddress
       defaultValueDesc: $defaultAdminListenAddressDesc
       name: "metrics-address" .}: IpAddress
 
     metricsPort* {.
-      desc: "Listening HTTP port of the metrics server (BETA)"
+      desc: "Listening HTTP port of the metrics server"
       defaultValue: 8108
       name: "metrics-port" .}: Port
 
@@ -1072,6 +1054,10 @@ type
       defaultValue: BlockMonitoringType.Event
       name: "block-monitor-type".}: BlockMonitoringType
 
+    logFile* {.
+      obsolete: "Logging to file has been deprecated since v1.5.3, see https://nimbus.guide/logging.html#logging-to-a-file"
+      name: "log-file" .}: Option[OutFile]
+
   SigningNodeConf* = object
     configFile* {.
       desc: "Loads the configuration from a TOML file"
@@ -1082,18 +1068,19 @@ type
       defaultValue: "INFO"
       name: "log-level" .}: string
 
-    logStdout* {.
-      desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
+    logFormat* {.
+      desc: "Choice of log format (auto, colors, nocolors, json)"
       defaultValueDesc: "auto"
       defaultValue: StdoutLogKind.Auto
       name: "log-stdout" .}: StdoutLogKind
 
     logFile* {.
-      desc: "Specifies a path for the written JSON log file"
+      hidden
+      desc: "Specifies a path for the written JSON log file (deprecated)"
       name: "log-file" .}: Option[OutFile]
 
     eth2Network* {.
-      desc: "The Eth2 network to join"
+      desc: "Consensus network to join (mainnet, hoodi, sepolia, custom/path)"
       defaultValueDesc: "mainnet"
       name: "network" .}: Option[string]
 
@@ -1348,7 +1335,7 @@ proc walletsDir*(config: BeaconNodeConf): string =
 
 proc eraDir*(config: BeaconNodeConf): string =
   # The era directory should be shared between networks of the same type..
-  string config.eraDirFlag.get(InputDir(config.dataDir / "era"))
+  string config.eraDirFlag.get(OutDir(config.dataDir / "era"))
 
 {.push warning[ProveField]:off.}  # https://github.com/nim-lang/Nim/issues/22791
 func outWalletName*(config: BeaconNodeConf): Option[WalletName] =
@@ -1495,7 +1482,7 @@ proc loadJwtSecret(
     rng: var HmacDrbgContext,
     dataDir: string,
     jwtSecret: Opt[InputFile],
-    allowCreate: bool): Opt[seq[byte]] =
+    allowCreate: bool): Opt[JwtSharedKey] =
   # Some Web3 endpoints aren't compatible with JWT, but if explicitly chosen,
   # use it regardless.
   if jwtSecret.isSome or allowCreate:
@@ -1507,20 +1494,19 @@ proc loadJwtSecret(
 
     Opt.some secret.get
   else:
-    Opt.none seq[byte]
+    Opt.none JwtSharedKey
 
-func configJwtSecretOpt*(jwtSecret: Option[InputFile]): Opt[InputFile] =
-  if jwtSecret.isSome:
-    Opt.some jwtSecret.get
+func jwtSecretOpt*(config: BeaconNodeConf): Opt[InputFile] =
+  if config.jwtSecret.isSome:
+    Opt.some config.jwtSecret.get
   else:
     Opt.none InputFile
 
 proc loadJwtSecret*(
     rng: var HmacDrbgContext,
-    config: auto,
-    allowCreate: bool): Opt[seq[byte]] =
-  rng.loadJwtSecret(
-    string(config.dataDir), config.jwtSecret.configJwtSecretOpt, allowCreate)
+    config: BeaconNodeConf,
+    allowCreate: bool): Opt[JwtSharedKey] =
+  rng.loadJwtSecret(string(config.dataDir), config.jwtSecretOpt, allowCreate)
 
 proc engineApiUrls*(config: auto): seq[EngineApiUrl] =
   let elUrls = if config.noEl:
@@ -1530,8 +1516,7 @@ proc engineApiUrls*(config: auto): seq[EngineApiUrl] =
   else:
     config.elUrls
 
-  (elUrls & config.web3Urls).toFinalEngineApiUrls(
-    config.jwtSecret.configJwtSecretOpt)
+  (elUrls & config.web3Urls).toFinalEngineApiUrls(config.jwtSecretOpt)
 
 proc formatIt*(v: Option[IpAddress]): string =
   if v.isSome():

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1496,7 +1496,7 @@ proc loadJwtSecret(
   else:
     Opt.none JwtSharedKey
 
-func jwtSecretOpt*(config: BeaconNodeConf): Opt[InputFile] =
+func jwtSecretOpt*(config: auto): Opt[InputFile] =
   if config.jwtSecret.isSome:
     Opt.some config.jwtSecret.get
   else:

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -25,26 +25,20 @@ type LightClientConf* = object
     defaultValue: "INFO"
     name: "log-level" .}: string
 
-  logStdout* {.
-    hidden
-    desc: "Specifies what kind of logs should be written to stdout (auto, colors, nocolors, json)"
+  logFormat* {.
+    desc: "Choice of log format (auto, colors, nocolors, json)"
     defaultValueDesc: "auto"
     defaultValue: StdoutLogKind.Auto
     name: "log-format" .}: StdoutLogKind
 
-  logFile* {.
-    desc: "Specifies a path for the written Json log file (deprecated)"
-    name: "log-file" .}: Option[OutFile]
-
   # Storage
   dataDirFlag* {.
-    desc: "The directory where nimbus will store all blockchain data"
+    desc: "Directory where nimbus will store all blockchain data"
     abbr: "d"
     name: "data-dir" .}: Option[OutDir]
 
-  # Network
   eth2Network* {.
-    desc: "The Eth2 network to join"
+    desc: "Consensus network to join (mainnet, hoodi, sepolia, custom/path)"
     defaultValueDesc: "mainnet"
     name: "network" .}: Option[string]
 
@@ -119,20 +113,15 @@ type LightClientConf* = object
 
   syncLightClientFinality* {.
     desc: "Whether the light client should including finality information when syncing execution layers"
-    defaultValue: false
     name: "sync-light-client-finality" .}: bool
 
   # Execution layer
-  web3Urls* {.
-    desc: "One or more execution layer Engine API URLs"
-    name: "web3-url" .}: seq[EngineApiUrlConfigValue]
-
   elUrls* {.
-    desc: "One or more execution layer Engine API URLs"
+    desc: "Execution client engine API URL"
+    longDesc: "Repeat --el: to add multiple clients, see https://nimbus.guide/eth1.html"
     name: "el" .}: seq[EngineApiUrlConfigValue]
 
   noEl* {.
-    defaultValue: false
     desc: "Don't use an EL. The node will remain optimistically synced and won't be able to perform validator duties"
     name: "no-el" .}: bool
 
@@ -151,6 +140,17 @@ type LightClientConf* = object
     desc: "The wall-time epoch at which to exit the program. (for testing purposes)"
     defaultValue: 0
     name: "debug-stop-at-epoch" .}: uint64
+
+  logFile* {.
+    obsolete: "Logging to file has been deprecated since v1.5.3, see https://nimbus.guide/logging.html#logging-to-a-file"
+    name: "log-file" .}: Option[OutFile]
+
+  # Hidden as of 26.1.0 to simplify the CLI help - new setups should use --el
+  # which is equivalent and present as of 23.3.0
+  web3Urls* {.
+    hidden
+    desc: "Superceded by --el"
+    name: "web3-url" .}: seq[EngineApiUrlConfigValue]
 
 proc defaultDataDir*(config: LightClientConf): string =
   defaultDataDir("", config.eth2Network.shortNetworkName())

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -32,7 +32,7 @@ type
 
   EngineApiUrl* = object
     url: string
-    jwtSecret: Opt[seq[byte]]
+    jwtSecret: Opt[JwtSharedKey]
     roles: EngineApiRoles
 
   EngineApiUrlConfigValue* = object
@@ -52,14 +52,14 @@ chronicles.formatIt EngineApiUrl:
 
 proc init*(T: type EngineApiUrl,
            url: string,
-           jwtSecret = Opt.none seq[byte],
+           jwtSecret = Opt.none JwtSharedKey,
            roles = defaultEngineApiRoles): T =
   T(url: url, jwtSecret: jwtSecret, roles: roles)
 
 func url*(engineUrl: EngineApiUrl): string =
   engineUrl.url
 
-func jwtSecret*(engineUrl: EngineApiUrl): Opt[seq[byte]] =
+func jwtSecret*(engineUrl: EngineApiUrl): Opt[JwtSharedKey] =
   engineUrl.jwtSecret
 
 func roles*(engineUrl: EngineApiUrl): EngineApiRoles =
@@ -170,12 +170,12 @@ func getDefaultEngineApiUrl*(x: Option[InputFile]): EngineApiUrlConfigValue =
         some defaultJwtSecret)
 
 proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
-                 confJwtSecret: Opt[seq[byte]]): Result[EngineApiUrl, cstring] =
+                 confJwtSecret: Opt[JwtSharedKey]): Result[EngineApiUrl, cstring] =
   if confValue.jwtSecret.isSome and confValue.jwtSecretFile.isSome:
     return err "The options `jwtSecret` and `jwtSecretFile` should not be specified together"
 
   let jwtSecret = if confValue.jwtSecret.isSome:
-    Opt.some(? parseJwtTokenValue(confValue.jwtSecret.get))
+    Opt.some(? parseJwtSharedKey(confValue.jwtSecret.get))
   elif confValue.jwtSecretFile.isSome:
     Opt.some(? loadJwtSecretFile(confValue.jwtSecretFile.get))
   else:
@@ -189,7 +189,7 @@ proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
     jwtSecret = jwtSecret,
     roles = confValue.roles.get(defaultEngineApiRoles))
 
-proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[seq[byte]] =
+proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[JwtSharedKey] =
   if jwtSecret.isSome:
     let res = loadJwtSecretFile(jwtSecret.get)
     if res.isOk:
@@ -198,7 +198,7 @@ proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[seq[byte]] =
       fatal "Failed to load JWT secret file", err = res.error
       quit 1
   else:
-    Opt.none seq[byte]
+    Opt.none JwtSharedKey
 
 proc toFinalEngineApiUrls*(elUrls: seq[EngineApiUrlConfigValue],
                            confJwtSecret: Opt[InputFile]): seq[EngineApiUrl] =

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -18,12 +18,12 @@ import
   kzg4844/[kzg_abi, kzg],
   stew/objects,
   # Local modules:
-  ../spec/forks,
+  ../spec/[engine_authentication, forks],
   ../networking/network_metadata,
   "."/[el_conf, engine_api_conversions]
 
 from std/sequtils import anyIt, filterIt, mapIt
-from std/times import getTime, inSeconds, initTime, `-`
+from std/times import getTime, toUnix
 from std/typetraits import distinctBase
 from ../spec/engine_authentication import getSignedIatToken
 from ../spec/state_transition_block import kzg_commitment_to_versioned_hash
@@ -278,16 +278,15 @@ func hasJwtSecret(m: ELManager): bool =
 func isConnected(connection: ELConnection): bool =
   connection.web3.isSome
 
-func getJsonRpcRequestHeaders(jwtSecret: Opt[seq[byte]]):
-    auto =
+func getJsonRpcRequestHeaders(jwtSecret: Opt[JwtSharedKey]): auto =
   if jwtSecret.isSome:
     let secret = jwtSecret.get
-    (proc(): seq[(string, string)] =
+    proc(): seq[(string, string)] =
       # https://www.rfc-editor.org/rfc/rfc6750#section-6.1.1
-      @[("Authorization", "Bearer " & getSignedIatToken(
-        secret, (getTime() - initTime(0, 0)).inSeconds))])
+      @[("Authorization", "Bearer " & getSignedIatToken(secret, getTime().toUnix()))]
   else:
-    (proc(): seq[(string, string)] = @[])
+    proc(): seq[(string, string)] =
+      @[]
 
 proc newWeb3*(engineUrl: EngineApiUrl): Future[Web3] =
   newWeb3(engineUrl.url,
@@ -1239,7 +1238,7 @@ func `$`(x: BlockObject): string =
   $(x.number) & " [" & $(x.hash) & "]"
 
 proc testWeb3Provider*(
-    web3Url: Uri, jwtSecret: Opt[seq[byte]]
+    web3Url: Uri, jwtSecret: Opt[JwtSharedKey]
 ) {.async: (raises: [CatchableError]).} =
 
   stdout.write "Establishing web3 connection..."

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -25,7 +25,6 @@ import
 from std/sequtils import anyIt, filterIt, mapIt
 from std/times import getTime, toUnix
 from std/typetraits import distinctBase
-from ../spec/engine_authentication import getSignedIatToken
 from ../spec/state_transition_block import kzg_commitment_to_versioned_hash
 
 export

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -234,7 +234,7 @@ proc loadChainDag(
       else: nil
   dag = ChainDAGRef.init(
     cfg, db, validatorMonitor, chainDagFlags, config.eraDir,
-    vanityLogs = getVanityLogs(detectTTY(config.logStdout)),
+    vanityLogs = getVanityLogs(detectTTY(config.logFormat)),
     lcDataConfig = LightClientDataConfig(
       serve: config.lightClientDataServe,
       importMode: config.lightClientDataImportMode,

--- a/beacon_chain/nimbus_binary_common.nim
+++ b/beacon_chain/nimbus_binary_common.nim
@@ -200,7 +200,10 @@ proc obsoleteCmdOpt*(ConfType: type object, opt, msg: string) =
 
 template loggerSetup(ConfType: type): untyped =
   proc (config: ConfType) {.raises: [], gcsafe.} =
-    setupLogging(config.logLevel, config.logStdout, config.logFile)
+    when compiles(config.logFile):
+      setupLogging(config.logLevel, config.logFormat, config.logFile)
+    else:
+      setupLogging(config.logLevel, config.logFormat)
 
 proc loadWithBanners*(
     ConfType: type,

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -23,7 +23,7 @@ export rand, results
 
 const jwtSecretFile* = "jwt.hex"
 
-# https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
+# https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/authentication.md#key-distribution
 # 256-bit shared key
 type
   JwtSharedKey* = array[32, byte]
@@ -35,7 +35,7 @@ func base64urlEncode(x: string): string =
   Base64Url.encode(x.toOpenArrayByte(0, x.high()))
 
 func getIatToken*(time: int64): string =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#jwt-claims
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/authentication.md#jwt-claims
   # "Required: `iat` (issued-at) claim. The execution layer client **SHOULD**
   # only accept `iat` timestamps which are within +-60 seconds from the current
   # time."
@@ -48,7 +48,7 @@ func getIatToken*(time: int64): string =
   &"""{{"iat":{time}}}"""
 
 func getSignedToken*(key: JwtSharedKey, payload: string): string =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#jwt-specifications
+  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/authentication.md#jwt-specifications
   # "The execution layer client **MUST** support at least the following `alg`
   # `HMAC + SHA256` (`HS256`)"
 
@@ -100,7 +100,7 @@ proc checkJwtSecret*(
     # token, valid for the duration of the execution, and store the
     # hex-encoded secret as a jwt.hex file on the filesystem.
     #
-    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/authentication.md#key-distribution
     let jwtSecretPath = dataDir / jwtSecretFile
 
     if fileExists(jwtSecretPath):

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -53,15 +53,12 @@ func getSignedToken*(key: JwtSharedKey, payload: string): string =
   # `HMAC + SHA256` (`HS256`)"
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
-  const jwsProtectedHeader = base64urlEncode("""{"typ":"JWT","alg":"HS256"}""") & "."
+  # base64urlEncode("""{"typ":"JWT","alg":"HS256"}""") & "."
+  const jwsProtectedHeader = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
   # Sanity check
-  static:
-    doAssert jwsProtectedHeader == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
   let signingInput = jwsProtectedHeader & base64urlEncode(payload)
 
-  signingInput & "." & Base64Url.encode(
-    sha256.hmac(distinctBase key, signingInput).data
-  )
+  signingInput & "." & Base64Url.encode(sha256.hmac(key, signingInput).data)
 
 func getSignedIatToken*(key: JwtSharedKey, time: int64): string =
   getSignedToken(key, getIatToken(time))

--- a/beacon_chain/spec/engine_authentication.nim
+++ b/beacon_chain/spec/engine_authentication.nim
@@ -8,28 +8,33 @@
 {.push raises: [].}
 
 import
-  chronicles, confutils/defs,
+  std/[strformat, typetraits],
+  stew/[arrayops, base64],
   bearssl/rand,
+  chronicles,
+  confutils/defs,
   nimcrypto/[hmac, utils, sha2],
   results,
   stew/byteutils
 
-from std/base64 import encode
-from std/json import JsonNode, `$`, `%*`
-from std/os import `/`
-from std/strutils import replace
+from std/os import `/`, fileExists
 
 export rand, results
 
-const
-  JWT_SECRET_LEN = 32
+const jwtSecretFile* = "jwt.hex"
 
-func base64urlEncode(x: auto): string =
+# https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
+# 256-bit shared key
+type
+  JwtSharedKey* = array[32, byte]
+  Rng* = proc(v: var openArray[byte]) {.raises: [], gcsafe.}
+
+func base64urlEncode(x: string): string =
   # The only strings this gets are internally generated, and don't have
   # encoding quirks.
-  base64.encode(x, safe = true).replace("=", "")
+  Base64Url.encode(x.toOpenArrayByte(0, x.high()))
 
-func getIatToken*(time: int64): JsonNode =
+func getIatToken*(time: int64): string =
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#jwt-claims
   # "Required: `iat` (issued-at) claim. The execution layer client **SHOULD**
   # only accept `iat` timestamps which are within +-60 seconds from the current
@@ -40,51 +45,52 @@ func getIatToken*(time: int64): JsonNode =
   #
   # https://pyjwt.readthedocs.io/en/stable/usage.html#issued-at-claim-iat shows
   # an example of an iat claim: {"iat": 1371720939}
-  %* {"iat": time}
+  &"""{{"iat":{time}}}"""
 
-func getSignedToken*(key: openArray[byte], payload: string): string =
+func getSignedToken*(key: JwtSharedKey, payload: string): string =
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#jwt-specifications
   # "The execution layer client **MUST** support at least the following `alg`
   # `HMAC + SHA256` (`HS256`)"
 
   # https://datatracker.ietf.org/doc/html/rfc7515#appendix-A.1.1
-  const jwsProtectedHeader =
-    base64urlEncode($ %* {"typ": "JWT", "alg": "HS256"}) & "."
-  # In theory, std/json might change how it encodes, and it doesn't per-se
-  # matter but can also simply specify the base64-encoded form directly if
-  # useful, since it's never checked here on its own.
-  static: doAssert jwsProtectedHeader == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
+  const jwsProtectedHeader = base64urlEncode("""{"typ":"JWT","alg":"HS256"}""") & "."
+  # Sanity check
+  static:
+    doAssert jwsProtectedHeader == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9."
   let signingInput = jwsProtectedHeader & base64urlEncode(payload)
 
-  signingInput & "." & base64urlEncode(sha256.hmac(key, signingInput).data)
+  signingInput & "." & Base64Url.encode(
+    sha256.hmac(distinctBase key, signingInput).data
+  )
 
-func getSignedIatToken*(key: openArray[byte], time: int64): string =
-  getSignedToken(key, $getIatToken(time))
+func getSignedIatToken*(key: JwtSharedKey, time: int64): string =
+  getSignedToken(key, getIatToken(time))
 
-func parseJwtTokenValue*(input: string): Result[seq[byte], cstring] =
+func parseJwtSharedKey*(input: string): Result[JwtSharedKey, cstring] =
   # Secret JWT key is parsed in constant time using nimcrypto:
   # https://github.com/cheatfate/nimcrypto/pull/44
-  let secret = utils.fromHex(input)
-  if secret.len == JWT_SECRET_LEN:
-    ok(secret)
-  else:
-    err("The JWT secret should be 256 bits and hex-encoded")
-
-proc loadJwtSecretFile*(jwtSecretFile: InputFile): Result[seq[byte], cstring] =
   try:
-    let lines = readLines(string jwtSecretFile, 1)
+    let secret = utils.fromHex(input)
+    if secret.len == sizeof(JwtSharedKey):
+      ok(JwtSharedKey.initCopyFrom(secret))
+    else:
+      err("The JWT secret should be 256 bits and hex-encoded")
+  except ValueError:
+    err("invalid JWT hex string")
+
+proc loadJwtSecretFile*(input: InputFile): Result[JwtSharedKey, cstring] =
+  try:
+    let lines = readLines(string input, 1)
     if lines.len > 0:
-      parseJwtTokenValue(lines[0])
+      parseJwtSharedKey(lines[0])
     else:
       err("The JWT token file should not be empty")
   except IOError:
     err("couldn't open specified JWT secret file")
-  except ValueError:
-    err("invalid JWT hex string")
 
 proc checkJwtSecret*(
-    rng: var HmacDrbgContext, dataDir: string, jwtSecret: Opt[InputFile]):
-    Result[seq[byte], cstring] =
+    rng: Rng, dataDir: string, jwtSecret: Opt[InputFile]
+): Result[JwtSharedKey, cstring] =
   # If such a parameter is given, but the file cannot be read, or does not
   # contain a hex-encoded key of 256 bits, the client should treat this as an
   # error: either abort the startup, or show error and continue without
@@ -92,22 +98,40 @@ proc checkJwtSecret*(
   if jwtSecret.isNone:
     # If such a parameter is not given, the client SHOULD generate such a
     # token, valid for the duration of the execution, and store the
-    # hex-encoded secret as a jwt.hex file on the filesystem. This file can
-    # then be used to provision the counterpart client.
+    # hex-encoded secret as a jwt.hex file on the filesystem.
     #
     # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.3/src/engine/authentication.md#key-distribution
-    const jwtSecretFilename = "jwt.hex"
-    let jwtSecretPath = dataDir / jwtSecretFilename
+    let jwtSecretPath = dataDir / jwtSecretFile
 
-    let newSecret = rng.generateBytes(JWT_SECRET_LEN)
+    if fileExists(jwtSecretPath):
+      # According to the spec:
+      # "This file can then be used to provision the counterpart client."
+      # Since writing the file is implicit, it stands to reason to interpret the
+      # above as reading being implicit too - when execution and consensus
+      # clients share the same directory, this allows the setup to "just work".
+      return loadJwtSecretFile(InputFile jwtSecretPath)
+    var newSecret: JwtSharedKey
+    rng(distinctBase newSecret)
     try:
-      writeFile(jwtSecretPath, newSecret.to0xHex())
+      writeFile(jwtSecretPath, distinctBase(newSecret).to0xHex())
     except IOError as exc:
       # Allow continuing to run, though this is effectively fatal for a merge
       # client using authentication. This keeps it lower-risk initially.
-      warn "Could not write JWT secret to data directory",
-        jwtSecretPath,
-        err = exc.msg
+      warn "Could not write JWT secret to data directory", jwtSecretPath, err = exc.msg
+
+    notice "JWT secret generated", jwtSecretPath
+
     return ok(newSecret)
 
   loadJwtSecretFile(jwtSecret.get)
+
+proc checkJwtSecret*(
+    rng: var HmacDrbgContext, dataDir: string, jwtSecret: Opt[InputFile]
+): Result[JwtSharedKey, cstring] =
+  let rng = addr rng
+  checkJwtSecret(
+    proc(v: var openArray[byte]) =
+      rng[].generate(v),
+    dataDir,
+    jwtSecret,
+  )

--- a/docker/dist/README.md.tpl
+++ b/docker/dist/README.md.tpl
@@ -70,5 +70,5 @@ The `hoodi` testnet runs on
 build/nimbus_beacon_node \
     --network=hoodi \
     --data-dir=build/data/shared_hoodi_0 \
-    --web3-url="ws://localhost:8545"
+    --el="ws://localhost:8545"
 ```

--- a/docker/dist/binaries/docker-compose-example1.yml
+++ b/docker/dist/binaries/docker-compose-example1.yml
@@ -23,7 +23,7 @@ services:
     command: >-
       --network=hoodi
       --data-dir=/home/user/nimbus-eth2/build/data/shared_hoodi_0
-      --web3-url=wss://hoodi.infura.io/ws/v3/YOUR_TOKEN
+      --el=wss://hoodi.infura.io/ws/v3/YOUR_TOKEN
       --nat=extip:YOUR_EXTERNAL_IP
       --log-level=info
       --tcp-port=9000

--- a/docs/the_nimbus_book/mkdocs.yml
+++ b/docs/the_nimbus_book/mkdocs.yml
@@ -43,6 +43,7 @@ plugins:
   - redirects:
       redirect_maps:
         'el-light-client.md': 'consensus-light-client.md'
+  - search
 
 markdown_extensions:
   - admonition

--- a/docs/the_nimbus_book/src/build.md
+++ b/docs/the_nimbus_book/src/build.md
@@ -1,6 +1,6 @@
 # Build from source
 
-Building Nimbus from source ensures that all hardware-specific optimizations are turned on.
+Building Nimbus from source creates a binary specifically optimized for the hardware that you're running on.
 The build process itself is simple and fully automated, but may take a few minutes.
 
 !!! note "Nim"
@@ -28,9 +28,6 @@ To build the Nimbus beacon node and its dependencies, run:
 make -j4 nimbus_beacon_node
 ```
 
-!!! tip
-    Omit `-j4` on systems with 4GB of memory or less.
-
 This step can take several minutes.
 After it has finished, you can check if the installation was successful by running:
 
@@ -41,7 +38,11 @@ build/nimbus_beacon_node --help
 If you see the command-line options, your installation was successful!
 Otherwise, don't hesitate to reach out to us in the `#helpdesk` channel of [our discord](https://discord.gg/j3nYBUeEad).
 
+!!! tip "Low memory systems"
+    Omit `-j4` on systems with 12GB of memory or less.
 
+!!! tip "Portable builds"
+    To make the build portable, such that in can run on other hardware than the build machine, run `make -j4 NIMFLAGS=-d:disableMarchNative nimbus_beacon_node` instead
 
 ## Keeping Nimbus updated
 

--- a/docs/the_nimbus_book/src/consensus-light-client.md
+++ b/docs/the_nimbus_book/src/consensus-light-client.md
@@ -93,7 +93,7 @@ To start the consensus light client, run the following commands (inserting your 
     TRUSTED_BLOCK_ROOT=0x1234567890123456789012345678901234567890123456789012345678901234
     JWTSECRET=path/to/execution/client/jwt.hex
     build/nimbus_light_client \
-        --web3-url=http://127.0.0.1:8551 --jwt-secret="$JWTSECRET" \
+        --el=http://127.0.0.1:8551 --jwt-secret="$JWTSECRET" \
         --trusted-block-root=$TRUSTED_BLOCK_ROOT
     ```
 
@@ -102,7 +102,7 @@ To start the consensus light client, run the following commands (inserting your 
     TRUSTED_BLOCK_ROOT=0x1234567890123456789012345678901234567890123456789012345678901234
     JWTSECRET=path/to/execution/client/jwt.hex
     build/nimbus_light_client --network=hoodi \
-        --web3-url=http://127.0.0.1:8551 --jwt-secret="$JWTSECRET" \
+        --el=http://127.0.0.1:8551 --jwt-secret="$JWTSECRET" \
         --trusted-block-root=$TRUSTED_BLOCK_ROOT
     ```
 
@@ -144,8 +144,7 @@ INF 2022-11-21 18:04:03.982+01:00 New LC optimistic header                   opt
 
 !!! note
     The [light client protocol](https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/altair/light-client/sync-protocol.md) depends on consensus layer (CL) full nodes to serve additional data.
-    As this is a new protocol, not all implementations are supporting it yet.
-    Therefore, it may take several minutes to discover supporting peers, during which no log messages may be produced.
+    Since not all consensus clients serve the light client data, it may take several minutes to discover supporting peers, during which no log messages may be produced.
 
 === "Geth"
 

--- a/docs/the_nimbus_book/src/eth1.md
+++ b/docs/the_nimbus_book/src/eth1.md
@@ -73,15 +73,17 @@ The `--el` option informs the beacon node how to connect to the execution client
 
 !!! info
     By default, the execution client accepts connections on the localhost interface (`127.0.0.1`), with default authenticated RPC port `8551`.
+
     When the `--el` option is not explicitly specified, Nimbus will assume that the execution client is running on the same machine with such default settings.
 
 Once started, the execution client will create a file containing a JWT secret token.
 The token file is needed for Nimbus to authenticate itself with the execution client and perform trusted operations.
-You will need to pass the path to the token file to Nimbus together with the web3 URL.
+You will need to pass the path to the token file to Nimbus together with the execution layer URL.
 
 === "Mainnet"
     ```sh
     ./run-mainnet-beacon-node.sh \
+        --data-dir=build/data/mainnet \
         --el=http://127.0.0.1:8551 \
         --jwt-secret=/tmp/jwtsecret
     ```
@@ -90,7 +92,7 @@ You will need to pass the path to the token file to Nimbus together with the web
     ```sh
     build/nimbus_beacon_node \
         --network=hoodi \
-        --data-dir=build/data/shared_hoodi_0 \
+        --data-dir=build/data/hoodi \
         --el=http://127.0.0.1:8551 \
         --jwt-secret=/tmp/jwtsecret
     ```
@@ -127,9 +129,6 @@ You will need to pass the path to the token file to Nimbus together with the web
 
     Follow [Besu upgrade instructions](https://besu.hyperledger.org/public-networks/how-to/upgrade-node).
 
-
-
-
 ## Advanced setups
 
 ### Running multiple execution clients
@@ -144,22 +143,25 @@ To enable this mode, just specify multiple URLs through the `--el` option when s
     --jwt-secret=/tmp/jwtsecret
 ```
 
+If the servers have different JWT secrets, they can be specified on the command line:
+
+```sh
+./run-mainnet-beacon-node.sh \
+    --el=http://127.0.0.1:8551/#jwt-secret-file=/tmp/jwt.hex
+    --el=ws://other:8551#jwt-secret=d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3
+```
+
 !!! tip
-    You can use a different secret for each connection by specifying `jwt-secret` or `jwt-secret-file` as a query parameter in the anchor section of the URL (e.g. `http://127.0.0.1:8551/#jwt-secret=0x12345...` or `http://127.0.0.1:8551/#jwt-secret-file=/tmp/jwtsecret`).
-    If you use a [TOML config file](./options.md#configuration-files), you can also use the following, more natural, syntax:
+    If you use a [TOML config file](./options.md#configuration-files), you can also use the following syntax:
 
     ```toml
-    data-dir = "my-data-dir"
-    rest = true
-    ...
-
     [[el]]
     url = "http://127.0.0.1:8551"
-    jwt-secret-file="/path/to/jwt/file"
+    jwt-secret-file="/tmp/jwt.hex"
 
     [[el]]
     url = "http://192.168.1.2:8551"
-    jwt-secret = ""
+    jwt-secret = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
     ```
 
 As long as any of execution clients remains operational and fully synced, Nimbus will keep performing all validator duties.

--- a/docs/the_nimbus_book/src/execution-client.md
+++ b/docs/the_nimbus_book/src/execution-client.md
@@ -7,7 +7,13 @@
 
     If you're looking for information about setting up an execution client for validator duties or any other production usage, see the [execution clients guide](./eth1.md).
 
-The Nimbus execution client is a light-weight implementation of the Ethereum execution protocol. Paired with a [beacon node](./quick-start.md) or [consensus light client](./consensus-light-client.md), it provides access to Ethereum blockchain for dapps and users alike via the standard [Web3 API](https://ethereum.github.io/execution-apis/api-documentation/).
+The Nimbus execution client is a light-weight implementation of the Ethereum execution protocol.
+
+It provides access to the Ethereum blockchain for dapps and users alike via the standard [Web3 API](https://ethereum.github.io/execution-apis/api-documentation/).
+
+This document describes how to pair the execution client with an external beacon node.
+
+The execution client can also run as part of the [unified node](https://github.com/status-im/nimbus-eth1/pull/3646), without a separate beacon node process.
 
 ## Building from source
 
@@ -25,18 +31,20 @@ cd nimbus-eth1
 To build the Nimbus execution client and its dependencies, make sure you have [all prerequisites](./install.md) and then run:
 
 ```sh
-make -j4 nimbus_execution_client
+make -j4 nimbus
 ```
 
 This may take a few minutes.
 
-When the process finishes, the `nimbus_execution_client` executables can be found in the `build` subdirectory.
+When the process finishes, the `nimbus` executable can be found in the `build` subdirectory.
 
 ## Syncing using era files
 
 Syncing Nimbus requires a set of `era1` and `era` files. These can be generated from a `geth` and `nimbus` consensus client respectively or downloaded from a third-party repository.
 
 In addition to the era files themselves, you will need at least 200GB of free space on a fast SSD in your data directory, as set by the `--data-dir` command line option.
+
+When using Nimbus for both execution client and beacon node, the nodes can share the same data directory.
 
 !!! info "`era` file downloading"
     `era` and `era1` files for testing purposes could at the time of writing be found here - these sources may or may not be available:
@@ -49,11 +57,6 @@ In addition to the era files themselves, you will need at least 200GB of free sp
         * https://hoodi.era.nimbus.team/
 
         The Hoodi network does not have `era1` files since it never operated as a proof-of-work chain
-
-    === "Holesky"
-        * https://holesky.era.nimbus.team/
-
-        The Holesky network does not have `era1` files since it never operated as a proof-of-work chain
 
     === "Sepolia"
         * https://sepolia.era.nimbus.team/
@@ -111,23 +114,17 @@ See the [era file guide](./era-store.md) for more information.
         Performing a full sync of mainnet from era files takes several days - its speed varies greatly depending on hardware. Use one of the testnets to get started more quickly!
 
     ```sh
-    build/nimbus_execution_client --data-dir=build/mainnet import
+    build/nimbus executionClient --data-dir=build/mainnet import
     ```
-
 
 === "Hoodi"
     ```sh
-    build/nimbus_execution_client --network=hoodi --data-dir=build/hoodi import
-    ```
-
-=== "Holesky"
-    ```sh
-    build/nimbus_execution_client --network=holesky --data-dir=build/holesky import
+    build/nimbus executionClient --network=hoodi --data-dir=build/hoodi import
     ```
 
 === "Sepolia"
     ```sh
-    build/nimbus_execution_client --network=sepolia --data-dir=build/sepolia import
+    build/nimbus executionClient --network=sepolia --data-dir=build/sepolia import
     ```
 
 ## Launch the client
@@ -140,23 +137,21 @@ During startup, a `jwt.hex` file will be placed in the data directory containing
 
 === "Mainnet"
     ```sh
-    build/nimbus_execution_client --data-dir=build/mainnet --engine-api
+    build/nimbus executionClient --data-dir=build/mainnet --engine-api
     ```
 
 === "Hoodi"
     ```sh
-    build/nimbus_execution_client --network=hoodi --data-dir=build/hoodi --engine-api
-    ```
-
-=== "Holesky"
-    ```sh
-    build/nimbus_execution_client --network=holesky --data-dir=build/holesky --engine-api
+    build/nimbus executionClient --network=hoodi --data-dir=build/hoodi --engine-api
     ```
 
 === "Sepolia"
     ```sh
-    build/nimbus_execution_client --network=sepolia --data-dir=build/sepolia --engine-api
+    build/nimbus executionClient --network=sepolia --data-dir=build/sepolia --engine-api
     ```
+
+!!! tip "Unified node"
+    Nimbus also supports running Ethereum as a single process, in the [unified node](https://github.com/status-im/nimbus-eth1/pull/3646)
 
 ## Optionally quickstart with a pre-synced database
 
@@ -168,10 +163,10 @@ If you want to skip the era file import and start with a pre-synced database, yo
 
 ```sh
 # Download the pre-synced database
-wget https://eth1-db.nimbus.team/mainnet-static-vid-keyed.tar.gz
+wget https://eth1-db.nimbus.team/mainnet-latest.tar.gz
 
 # Extract the database into the data directory
-tar -xzf mainnet-static-vid-keyed.tar.gz
+tar -xzf mainnet-latest.tar.gz
 ```
 
 This will extract the pre-synced database into the current directory, which you can then use as your data directory.
@@ -191,11 +186,6 @@ This method of syncing loads blocks from the consensus node and passes them to t
 === "Hoodi"
     ```sh
     ./build/nrpc sync --network=hoodi --beacon-api=http://localhost:5052 --el-engine-api=http://localhost:8550 --jwt-secret=build/hoodi/jwt.hex
-    ```
-
-=== "Holesky"
-    ```sh
-    ./build/nrpc sync --network=holesky --beacon-api=http://localhost:5052 --el-engine-api=http://localhost:8550 --jwt-secret=build/holesky/jwt.hex
     ```
 
 === "Sepolia"

--- a/docs/the_nimbus_book/src/faq.md
+++ b/docs/the_nimbus_book/src/faq.md
@@ -7,7 +7,6 @@
 Check our [system requirements](./hardware.md) and [how to prepare your machine](./install.md).
 Note that it is also possible to [run Nimbus on Raspberry Pi](./pi-guide.md).
 
-
 ### I'm currently using Prysm / Lighthouse / Teku, how do I migrate to Nimbus?
 
 See our [migration guide](./migration.md).
@@ -81,8 +80,7 @@ We recommend you to do a [trusted node sync](./trusted-node-sync.md), which take
 
 ### How can I automate running my beacon node?
 
-You can set up a systemd service.
-See [our systemd guide](./beacon-node-systemd.md).
+See our [systemd guide](./beacon-node-systemd.md).
 
 ### Folder Permissions
 
@@ -99,15 +97,11 @@ The following errors are a sign of this:
 
 See the [data directory page](./data-dir.md#permissions) for instructions on how to fix this.
 
-
-
-
-
 ## Networking
 
 ### How can I improve my peer count?
 
-See [the networking guide](./networking.md).
+See our [networking guide](./networking.md).
 
 ### How do I fix the discovered new external address warning log?
 
@@ -123,9 +117,6 @@ If this doesn't fix the problem, the next thing to do is to check your external 
 Note that Nimbus `TCP` and `UDP` ports are both set to `9000` by default.
 
 See [here](./networking.md#set-up-port-forwarding) for how to set up port forwarding.
-
-
-
 
 
 
@@ -162,14 +153,12 @@ In other words: to keep them honest, their actions need to have financial conseq
 
 ### How much ETH does a validator need to stake?
 
-Before a validator can start to secure the network, they need to stake **32 ETH**.
+Before a validator can start to secure the network, they need to stake at least **32 ETH**.
 This forms the validator's initial balance.
 
 ### Is there any advantage to having more than 32 ETH at stake?
 
-No, there is no advantage to having more than 32 ETH staked.
-
-Limiting the maximum stake to 32 ETH encourages decentralization of power as it prevents any single validator from having an excessively large vote on the state of the chain.
+As of the [Electra hard fork](https://eips.ethereum.org/EIPS/eip-7251), you can stake more than 32 ETH and gain voting weight and rewards proportionally. The minimal amount to stake remains at 32 ETH.
 
 !!! note ""
     Remember that a validator’s vote is weighted by the amount it has at stake.

--- a/docs/the_nimbus_book/src/hoodi.md
+++ b/docs/the_nimbus_book/src/hoodi.md
@@ -72,7 +72,7 @@ If you come across any issues, please [report them here](https://github.com/stat
     ```sh
     nimbus-eth2/build/nimbus_beacon_node \
         --network=hoodi \
-        --web3-url=http://127.0.0.1:8551 \
+        --el=http://127.0.0.1:8551 \
         --rest \
         --metrics \
         --jwt-secret="/opt/jwtsecret" \

--- a/docs/the_nimbus_book/src/index.md
+++ b/docs/the_nimbus_book/src/index.md
@@ -20,10 +20,9 @@ Our companion project [fluffy](https://github.com/status-im/nimbus-eth1/tree/mas
 * [External block builder](./external-block-builder.md) (PBS / mev-boost) support with execution client fallback
 * [Consensus light client](./consensus-light-client.md) for running an execution client without a full beacon node
 
-
 ## Design goals
 
-One of our most important design goals is an application architecture that makes it **simple to embed Nimbus into other software.**
+One of our most important design goals is an application architecture that makes it **simple to run and simple to embed into other software.**
 
 Another goal is to **minimize reliance on third-party software.**
 
@@ -31,11 +30,9 @@ A third one is for the application binary to be as **lightweight as possible in 
 
 ### Integration with Status
 
-<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I can&#39;t wait to run Nimbus straight from Status Desktop <a href="https://twitter.com/hashtag/hyped?src=hash&amp;ref_src=twsrc%5Etfw">#hyped</a></p>&mdash; JARRAÐ HOPΞ (@jarradhope) <a href="https://twitter.com/jarradhope/status/1293473249347555334?ref_src=twsrc%5Etfw">August 12, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<blockquote class="twitter-tweet"><p lang="en" dir="ltr">I can&#39;t wait to run Nimbus straight from Status Desktop <a href="https://twitter.com/hashtag/hyped?src=hash&amp;ref_src=twsrc%5Etfw">#hyped</a></p>&mdash; JARRAÐ HOPΞ (@jarradhope)</a></blockquote>
 
-As part of our first design goal, our primary objective here is for Nimbus to be tightly integrated into the [Status messaging app](https://status.im/).
-
-Our dream is for you to be able to run and monitor your validator straight from Status desktop.
+As part of our design goals, a primary objective is for Nimbus to be tightly integrated into the [Status messaging app](https://status.im/), driving forward the light client requirements to make that possible.
 
 ## Book contents
 
@@ -54,10 +51,7 @@ Join us on [Status](https://join.status.im/nimbus-general) and [Discord](https:/
 
 ## Donate
 
-If you'd like to contribute to Nimbus development:
-
-* Our donation address is [`0xDeb4A0e8d9a8dB30a9f53AF2dCc9Eb27060c6557`](https://etherscan.io/address/0xDeb4A0e8d9a8dB30a9f53AF2dCc9Eb27060c6557)
-* We're also listed on [GitCoin](https://gitcoin.co/grants/137/nimbus-2)
+We welcome contribution to [`0xDeb4A0e8d9a8dB30a9f53AF2dCc9Eb27060c6557`](https://etherscan.io/address/0xDeb4A0e8d9a8dB30a9f53AF2dCc9Eb27060c6557) - the funds there help sustain and support for the long term.
 
 ## Stay updated
 

--- a/docs/the_nimbus_book/src/install.md
+++ b/docs/the_nimbus_book/src/install.md
@@ -1,15 +1,17 @@
 # Prepare your machine
 
-The Nimbus beacon node runs on Linux, macOS, Windows, and Android.
+Nimbus runs on Linux, macOS, Windows, and Android.
+
+You can install Nimbus either using precompiled binaries or build from source.
 
 ## System requirements
 
-Check that your machine matches the [minimal system requirements](./hardware.md).
+Check that your machine matches the [minimal system requirements](./hardware.md). The operating system must be a version supported by its vendor.
 
 ## Build prerequisites
 
 !!! tip
-    If you are planning to use the precompiled binaries, you can skip this section and go straight to the [binaries](./binaries.md)!
+    If you are planning to use the precompiled binaries, you can skip straight to the [time section](#time)!
 
 When building from source, you will need additional build dependencies to be installed:
 

--- a/docs/the_nimbus_book/src/log-rotate.md
+++ b/docs/the_nimbus_book/src/log-rotate.md
@@ -71,7 +71,7 @@ The final step is to redirect logs to `rotatelogs` using a pipe when starting Ni
 ```bash
 build/nimbus_beacon_node \
   --network=hoodi \
-  --web3-url="$WEB3URL" \
+  --el="$WEB3_URL" \
   --data-dir=$DATADIR 2>&1 | rotatelogs -L "$DATADIR/nbc_bn.log" -p "/path/to/rotatelogs-compress.sh" -D -f -c "$DATADIR/log/nbc_bn_%Y%m%d%H%M%S.log" 3600
 ```
 

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -29,23 +29,24 @@ The following options are available:
      --help                    Show this help message and exit.
      --version                 Show program's version and exit.
      --config-file             Loads the configuration from a TOML file.
-     --log-level               Sets the log level for process and topics (e.g. "DEBUG; TRACE:discv5,libp2p;
+     --log-level               Log level for process and topics (e.g. "DEBUG; TRACE:discv5,libp2p;
                                REQUIRED:none; DISABLED:none") [=INFO].
-     --log-file                Specifies a path for the written JSON log file (deprecated).
-     --network                 The Eth2 network to join [=mainnet].
- -d, --data-dir                The directory where nimbus will store all blockchain data.
-     --validators-dir          A directory containing validator keystores.
-     --verifying-web3-signer-url  Remote Web3Signer URL that will be used as a source of validators.
+     --log-format              Choice of log format (auto, colors, nocolors, json) [=auto].
+     --network                 Consensus network to join (mainnet, hoodi, sepolia, custom/path) [=mainnet].
+ -d, --data-dir                Directory for blockchain data including history, state and keys.
+     --era-dir                 Directory for era archive [=<data-dir>/era].
+     --validators-dir          Directory for validator keystores.
+     --secrets-dir             Directory for validator keystore passwords.
+     --web3-signer-url         Remote Web3Signer URL that will be used as a source of validators.
+     --verifying-web3-signer-url  Verifying Web3Signer URL that will be used as a source of validators.
      --proven-block-property   The field path of a block property that will be sent for verification to the
                                verifying Web3Signer (for example ".execution_payload.fee_recipient").
-     --web3-signer-url         Remote Web3Signer URL that will be used as a source of validators.
      --web3-signer-update-interval  Number of seconds between validator list updates [=3600].
-     --secrets-dir             A directory containing validator keystore passwords.
      --wallets-dir             A directory containing wallet files.
-     --web3-url                One or more execution layer Engine API URLs.
-     --el                      One or more execution layer Engine API URLs.
-     --no-el                   Don't use an EL. The node will remain optimistically synced and won't be able to
-                               perform validator duties [=false].
+     --el                      Execution layer engine API URL.
+                               Repeat --el=<url> to add multiple ELs, see https://nimbus.guide/eth1.html.
+     --no-el                   Run the consensus client without default and configured execution clients
+                               (validators will not work).
      --non-interactive         Do not display interactive prompts. Quit on missing configuration.
      --netkey-file             Source of network (secp256k1) private key file (random|<path>) [=random].
      --insecure-netkey-password  Use pre-generated INSECURE password for network private key file [=false].
@@ -92,9 +93,9 @@ The following options are available:
      --metrics-port            Listening HTTP port of the metrics server [=8008].
      --status-bar              Display a status bar at the bottom of the terminal screen [=true].
      --status-bar-contents     Textual template for the contents of the status bar.
-     --rest                    Enable the REST server [=false].
-     --rest-port               Port for the REST server [=5052].
-     --rest-address            Listening address of the REST server [=127.0.0.1].
+     --rest                    Enable the REST Beacon API server [=false].
+     --rest-port               Port for the REST Beacon API [=5052].
+     --rest-address            Listening address of the REST Beacon API [=127.0.0.1].
      --rest-allow-origin       Limit the access to the REST API to a particular hostname (for CORS-enabled
                                clients such as browsers).
      --rest-statecache-size    The maximum number of recently accessed states that are kept in memory. Speeds
@@ -151,7 +152,7 @@ All command line options can also be provided in a [TOML](https://toml.io/en/)
 config file specified through the `--config-file` flag.
 Within the config file, you need to use the long names of all options.
 Please note that certain options
-such as `web3-url`, `bootstrap-node`, `direct-peer`, and `validator-monitor-pubkey`
+such as `el`, `bootstrap-node`, `direct-peer`, and `validator-monitor-pubkey`
 can be supplied more than once on the command line: in the TOML file, you need
 to supply them as arrays.
 
@@ -169,7 +170,7 @@ Here is an example config file illustrating all of the above:
     ```toml
     # Comments look like this
     doppelganger-detection = true
-    web3-url = ["http://127.0.0.1:8551"]
+    el = ["http://127.0.0.1:8551"]
     num-threads = 0
 
     [trustedNodeSync]

--- a/docs/the_nimbus_book/src/pi-guide.md
+++ b/docs/the_nimbus_book/src/pi-guide.md
@@ -413,9 +413,6 @@ INF 2023-10-01 11:25:37.073+01:00 Generating new networking key
 ...
 NTC 2023-10-01 11:25:45.267+00:00 Local validator attached                   tid=22009 file=validator_pool.nim:33 pubkey=95e3cbe88c71ab2d0e3053b7b12ead329a37e9fb8358bdb4e56251993ab68e46b9f9fa61035fe4cf2abf4c07dfad6c45 validator=95e3cbe8
 ...
-NTC 2023-10-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
-NTC 2023-10-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
-...
 INF 2023-10-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
 INF 2023-10-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014
 ```

--- a/docs/the_nimbus_book/src/quick-start.md
+++ b/docs/the_nimbus_book/src/quick-start.md
@@ -68,7 +68,7 @@ cd nimbus-eth2
     ```sh
     # Start a mainnet node
     ./run-mainnet-beacon-node.sh \
-        --web3-url=http://127.0.0.1:8551 \
+        --el=http://127.0.0.1:8551 \
         --jwt-secret=/tmp/jwtsecret
     ```
 
@@ -78,14 +78,14 @@ cd nimbus-eth2
     build/nimbus_beacon_node \
         --network=hoodi \
         --data-dir=build/data/shared_hoodi_0 \
-        --web3-url=http://127.0.0.1:8551 \
+        --el=http://127.0.0.1:8551 \
         --jwt-secret=/tmp/jwtsecret
     ```
 
 Once the beacon node starts, you'll see it logging information to the console, like so:
 
 ```sh
-INF 2022-07-19 15:42:58.145+02:00 Launching beacon node                      topics="beacnde" version=v22.10.1-97a1cdc4-stateofus ...
+INF 2022-07-19 15:42:58.145+02:00 Launching beacon node       topics="beacnde" version=v22.10.1-97a1cdc4-stateofus ...
 ```
 
 Congratulations!

--- a/docs/the_nimbus_book/src/run-a-validator.md
+++ b/docs/the_nimbus_book/src/run-a-validator.md
@@ -1,4 +1,4 @@
-# Validating
+# Validator
 
 Once your beacon node is [running](./quick-start.md), the next step is to set up a validator.
 
@@ -7,7 +7,7 @@ This is a simple, safe and efficient way to get started.
 
 !!! tip "Separate validator client"
 
-    While not needed, advanced users may want to use a [separate validator client](./validator-client.md) instead.
+    Running a [separate validator client](./validator-client.md) allows advanced setups such as connecting to multiple beacon nodes or running on separate machines.
 
 
 
@@ -179,12 +179,12 @@ You can set up a separate address or reuse the address from which you funded you
 
 ### 2. (Re)start the node
 
-Press `Ctrl-c` to stop the beacon node if it's running, then use the same command as before to run it again, this time adding the `--suggested-fee-recipient` option in addition to `--web3-url`:
+Press `Ctrl-c` to stop the beacon node if it's running, then use the same command as before to run it again, this time adding the `--suggested-fee-recipient` option in addition to `--el`:
 
 === "Mainnet"
     ```sh
     ./run-mainnet-beacon-node.sh \
-        --web3-url=http://127.0.0.1:8551 \
+        --el=http://127.0.0.1:8551 \
         --suggested-fee-recipient=0x...
     ```
 
@@ -193,7 +193,7 @@ Press `Ctrl-c` to stop the beacon node if it's running, then use the same comman
     build/nimbus_beacon_node \
         --network=hoodi \
         --data-dir=build/data/shared_hoodi_0 \
-        --web3-url=http://127.0.0.1:8551 \
+        --el=http://127.0.0.1:8551 \
         --suggested-fee-recipient=0x...
     ```
 

--- a/docs/the_nimbus_book/src/start-syncing.md
+++ b/docs/the_nimbus_book/src/start-syncing.md
@@ -11,12 +11,12 @@ Syncing starts automatically when you start your node, and may take **several ho
 If you are planning to become a validator, you should ensure that your beacon node is [completely synced](./keep-an-eye.md#keep-track-of-your-syncing-progress) before submitting your deposit; otherwise, you might miss attestations, proposal duties and sync committee duties until it has finished syncing.
 
 !!! note
-    You need need to run an execution client (**web3 provider**) together with the beacon node.
-    See [here](./eth1.md) for instructions on how to do so.
+    You need need to run an [execution client](./eth1.md) together with the beacon node.
 
 ## Networks
 
 Using Nimbus, you can connect either to a testnet or mainnet.
+
 Mainnet is the main Ethereum network where real assets are at stake, while testnets are used by users and developers alike to test their node and setup before committing real assets.
 
 If this is the first time you're setting up your node, it is recommended you run it on a testnet first.
@@ -37,8 +37,13 @@ Later, when everything is working, you can easily switch to mainnet.
     To start syncing the Ethereum beacon chain mainnet, run:
 
     ```
-    ./run-mainnet-beacon-node.sh
+    build/nimbus_beacon_node \
+        --network=hoodi \
+        --data-dir=build/data/shared_mainnet_0
     ```
+
+!!! note ""
+    Each network needs to have its own data directory (`--data-dir`)!
 
 ## Log output
 
@@ -50,9 +55,6 @@ INF 2023-10-01 11:25:33.487+01:00 Launching beacon node
 INF 2023-10-01 11:25:34.556+01:00 Loading block dag from database            topics="beacnde" tid=19985314 path=build/data/shared_hoodi_0/db
 INF 2023-10-01 11:25:35.921+01:00 Block dag initialized
 INF 2023-10-01 11:25:37.073+01:00 Generating new networking key
-...
-NTC 2023-10-01 11:25:59.512+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3836397 depositsProcessed=106147
-NTC 2023-10-01 11:26:02.574+00:00 Eth1 sync progress                         topics="eth1" tid=21914 blockNumber=3841412 depositsProcessed=106391
 ...
 INF 2023-10-01 11:26:31.000+00:00 Slot start                                 topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:505 lastSlot=96566 scheduledSlot=96567 beaconTime=1w6d9h53m24s944us774ns peers=7 head=b54486c4:96563 headEpoch=3017 finalized=2f5d12e4:96479 finalizedEpoch=3014
 INF 2023-10-01 11:26:36.285+00:00 Slot end                                   topics="beacnde" tid=21815 file=nimbus_beacon_node.nim:593 slot=96567 nextSlot=96568 head=b54486c4:96563 headEpoch=3017 finalizedHead=2f5d12e4:96479 finalizedEpoch=3014

--- a/docs/the_nimbus_book/src/validator-client.md
+++ b/docs/the_nimbus_book/src/validator-client.md
@@ -1,9 +1,5 @@
 # Run a separate validator client
 
-!!! warning
-    Some features of the validator client, such as the metrics server, are currently in BETA and details may change in response to community feedback.
-    Please consult the `--help` screen for more details.
-
 By default, Nimbus integrates the validator client into the main beacon node process — this is a simple, safe and efficient way to run a validator.
 
 Advanced users may wish to run validators in a separate process, allowing more flexible deployment strategies.

--- a/installer/windows/Product.wxs
+++ b/installer/windows/Product.wxs
@@ -50,7 +50,7 @@
         Id="CommandArgs"
         After="InstallFiles"
         Sequence='execute'
-        Value="--run-as-service --network=\&quot;[NETWORK]\&quot; --web3-url=\&quot;[WURL]\&quot; --data-dir=\&quot;[%APPDATA]\Nimbus\BeaconNode\&quot; --log-file=\&quot;[%APPDATA]\Nimbus\BeaconNode\Nimbus.log\&quot;" />
+        Value="--run-as-service --network=\&quot;[NETWORK]\&quot; --el=\&quot;[WURL]\&quot; --data-dir=\&quot;[%APPDATA]\Nimbus\BeaconNode\&quot; --log-file=\&quot;[%APPDATA]\Nimbus\BeaconNode\Nimbus.log\&quot;" />
     <CustomAction
         Id="SCEdit"
         Directory="INSTALLFOLDER"

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1006,7 +1006,7 @@ CONTAINER_BOOTSTRAP_ENR="${CONTAINER_DATA_DIR}/node${BOOTSTRAP_NODE}/beacon_node
 #./build/ncli_testnet sendDeposits \
 #  --deposits-file="$DEPOSITS_FILE" \
 #  --min-delay=$MIN_DEPOSIT_SENDING_DELAY --max-delay=$MAX_DEPOSIT_SENDING_DELAY \
-#  --web3-url="$MAIN_WEB3_URL" \
+#  --el="$MAIN_WEB3_URL" \
 #  --deposit-contract=$DEPOSIT_CONTRACT_ADDRESS > "$DATA_DIR/log_deposit_maker.txt" 2>&1 &
 
 for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
@@ -1114,11 +1114,11 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
 
   WEB3_ARG=()
   if [ "${RUN_NIMBUS_ETH1}" == "1" ]; then
-    WEB3_ARG+=("--web3-url=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODE - 1 ))]}")
+    WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODE - 1 ))]}")
   fi
 
   if [ "${RUN_GETH}" == "1" ]; then
-    WEB3_ARG+=("--web3-url=http://127.0.0.1:${GETH_AUTH_RPC_PORTS[$((NUM_NODE - 1))]}")
+    WEB3_ARG+=("--el=http://127.0.0.1:${GETH_AUTH_RPC_PORTS[$((NUM_NODE - 1))]}")
   fi
 
   if [ ${#WEB3_ARG[@]} -eq 0 ]; then # check if the array is empty
@@ -1247,11 +1247,11 @@ if [ "$LC_NODES" -ge "1" ]; then
 
     WEB3_ARG=()
     if [ "${RUN_NIMBUS_ETH1}" == "1" ]; then
-      WEB3_ARG+=("--web3-url=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
+      WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
     fi
 
     if [ "${RUN_GETH}" == "1" ]; then
-      WEB3_ARG+=("--web3-url=http://127.0.0.1:${GETH_AUTH_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
+      WEB3_ARG+=("--el=http://127.0.0.1:${GETH_AUTH_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
     fi
 
     ./build/nimbus_light_client \

--- a/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
+++ b/scripts/package_src/nimbus_beacon_node/image/lib/systemd/system/nimbus_beacon_node.service
@@ -67,5 +67,5 @@ ExecStart=/usr/bin/nimbus_beacon_node \
   --udp-port=${UDP_PORT} \
   --rest=${REST_ENABLED} --rest-port=${REST_PORT} \
   --metrics=${METRICS_ENABLED} --metrics-port=${METRICS_PORT} \
-  --web3-url=${WEB3_URL} \
+  --el=${WEB3_URL} \
   --jwt-secret=${JWT_SECRET}

--- a/scripts/run-beacon-node.sh
+++ b/scripts/run-beacon-node.sh
@@ -57,7 +57,7 @@ fi
 
 WEB3_URL_ARG=""
 if [[ "$WEB3_URL" != "" ]]; then
-  WEB3_URL_ARG="--web3-url=${WEB3_URL}"
+  WEB3_URL_ARG="--el=${WEB3_URL}"
 fi
 
 # Allow the binary to receive signals directly.

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -45,7 +45,7 @@ suite "EL Configuration":
 
     let
       url1Final1 = url1.toFinalUrl(Opt.some validJwtToken)
-      url1Final2 = url1.toFinalUrl(Opt.none seq[byte])
+      url1Final2 = url1.toFinalUrl(Opt.none JwtSharedKey)
 
     check:
       url1Final1.isOk

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -31,7 +31,7 @@ proc loadExampleConfig(
       sources.addConfigFileContent(Toml, content))
 
 const
-  validJwtToken = parseJwtTokenValue(
+  validJwtToken = parseJwtSharedKey(
     "aa95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098cc").get
 
 suite "EL Configuration":

--- a/tests/test_engine_authentication.nim
+++ b/tests/test_engine_authentication.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_engine_authentication.nim
+++ b/tests/test_engine_authentication.nim
@@ -39,38 +39,36 @@ suite "engine API authentication":
       $getIatToken(3339327695) == "{\"iat\":3339327695}"
 
   test "HS256 JWS signing":
-    let secret = mapIt("secret", byte(it))
+    let secret = parseJwtSharedKey("0x16bb0c58f546a90d2fcfe295f50dd4e60aaa48ecd5d61a4569765d1b77784d34").expect("valid key")
     check:
       # https://pyjwt.readthedocs.io/en/stable/usage.html#encoding-decoding-tokens-with-hs256
-      # The pyjwt version I have swaps the order of the fields in the header, so creates this
-      # different result from their website. Both are valid, and RFC 7515 has another example
-      # of a slightly different ordering/whitespace combination. It just has to decode as the
-      # same JSON, semantically.
-      getSignedToken(secret, "{\"some\":\"payload\"}") == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoicGF5bG9hZCJ9.Joh1R2dYzkRvDkqv3sygm5YyK8Gi4ShZqbhK2gxcs2U"
+      getSignedToken(secret, "{\"some\":\"payload\"}") == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzb21lIjoicGF5bG9hZCJ9.Ku0XnrSVRMgWutypu6KXgLiiMFJc_viVGJRhbxRP_AU"
 
   test "HS256 JWS iat token signing":
-    let secret = mapIt("secret", byte(it))
+    let secret = parseJwtSharedKey("0x16bb0c58f546a90d2fcfe295f50dd4e60aaa48ecd5d61a4569765d1b77784d34").expect("valid key")
     # https://pyjwt.readthedocs.io/en/stable/usage.html
-    # >>> for i in [0, 1, 2, 14, 60, 95, 487, 529, 2669, 6082, 6234, 230158, 675817, 695159, 19257188, 52639657, 71947005, 1169144470, 29316
-    #...   print('      getSignedIatToken(secret, %d) == "%s"'%(i, jwt.encode({"iat": i}, "secret", algorithm="HS256")))
+      # sort_keys=False ensures that the header is encoded in the same order as we use
+    # >>> secret = bytes.fromhex("16bb0c58f546a90d2fcfe295f50dd4e60aaa48ecd5d61a4569765d1b77784d34")
+    # >>> for i in [0, 1, 2, 14, 60, 95, 487, 529, 2669, 6082, 6234, 230158, 675817, 695159, 19257188, 52639657, 71947005, 1169144470, 2931679730, 3339327695]:
+    #...   print('      getSignedIatToken(secret, %d) == "%s"'%(i, jwt.encode({"iat": i}, secret, algorithm="HS256", sort_keys=False)))
     check:
-      getSignedIatToken(secret, 0) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjB9.BA9VRUphKugikQmUzIL-6kyi9Wa1IWeli25hY8n5w7M"
-      getSignedIatToken(secret, 1) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.SjP9sSFaSm1pgnnVtx-M7Bq06xoenJUJldFRn1HpB5g"
-      getSignedIatToken(secret, 2) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjJ9.VA2Qo_m1MtT_DXiNt06UFcFTxEd90GjggsJC1H2XL2U"
-      getSignedIatToken(secret, 14) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0fQ.I7YMwh9o23qr5iK6YSgflG3nCCtzJFoSSMDTXSMJoZ4"
-      getSignedIatToken(secret, 60) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYwfQ.3-5HWzbM9ICMADiXshOKdBVP2RsWKdpcaw1uK_x0B-w"
-      getSignedIatToken(secret, 95) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjk1fQ.mERclea8y-SjN6qAZFWoXKydrLTgnzHNgvJ87zbYc8k"
-      getSignedIatToken(secret, 487) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjQ4N30.Z6xuP1n4vUOqKgMdCQrDREOoBVSfvUlXcNzw5B-BA8k"
-      getSignedIatToken(secret, 529) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjUyOX0.VSWpcLQEp_fdGZGjAHvYFYAyfc8Pzt3V-hRZUngMf8Y"
-      getSignedIatToken(secret, 2669) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjI2Njl9.jeBC5FfU6amVKGmCqZxUHSqumd8AYEa-mnk0V_QNBn4"
-      getSignedIatToken(secret, 6082) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYwODJ9.Ua9q9HTc1jv8S5_Lpg0w-mFV293rrrtXnS7jUhH8pxE"
-      getSignedIatToken(secret, 6234) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYyMzR9.8nSB6zb4zrAcH1vW5OcOt1ru1RkuLRTFLVv1VQW8BS0"
-      getSignedIatToken(secret, 230158) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjIzMDE1OH0.IwjEyz0__xlp1bMitC5YmEIR0emGgqin7Bknm9pDrYM"
-      getSignedIatToken(secret, 675817) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjY3NTgxN30.mKhib1fJ0KQy8X8T0xPN89DZootODNlBXOIksdVnmf4"
-      getSignedIatToken(secret, 695159) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjY5NTE1OX0.KJClqQMaEVnFksdScc_SprEWqpxDtFUrXxZCsALqkpk"
-      getSignedIatToken(secret, 19257188) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE5MjU3MTg4fQ.Q_BssigyQGRDkV9ysGcGKIzEEXMpVpv0t4Bx4pf7lr4"
-      getSignedIatToken(secret, 52639657) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjUyNjM5NjU3fQ.O0cI2U_kEW1MbWyXcAh146mRU2CwzMNegAQit_1-TNU"
-      getSignedIatToken(secret, 71947005) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjcxOTQ3MDA1fQ.pQwPWxMHzWGvTTfRfWKiGX8qEI2NcZbnB3ruh4Wcftg"
-      getSignedIatToken(secret, 1169144470) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjExNjkxNDQ0NzB9.5JS0pVVh1g8hxO_PDQpwCvFnh1tdRtodpALXU1xol4I"
-      getSignedIatToken(secret, 2931679730) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjI5MzE2Nzk3MzB9.0ZR8DiVy6Y_pOleGC9Ti3M8ShtH5hyCBhceO1C2OTj0"
-      getSignedIatToken(secret, 3339327695) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjMzMzkzMjc2OTV9.ZRYaNrsvcIzppVeNorYUgEmVXcwOOQbqPlCQcoAaO4k"
+      getSignedIatToken(secret, 0) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjB9.QGNQ2NmP9yWCTc1myLyj5xBgNX7GvJsZOMRS0ope_Qw"
+      getSignedIatToken(secret, 1) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjF9.nwzloKy77j4wyEeq05b7sCIILNrwOymg1M9dtvJvD20"
+      getSignedIatToken(secret, 2) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjJ9.Tm-rxRRO2ycmteuSkiciE-KScKCiyqnjaQXuMauPKtE"
+      getSignedIatToken(secret, 14) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE0fQ.wDcw2rZsiT2AP2LMXE-8vEz7aoztVUM4b6wDbuE1UU8"
+      getSignedIatToken(secret, 60) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYwfQ.K8OKg3ZxujDiULWlkierZILEhvHiNyr9zAQzo6_xmRo"
+      getSignedIatToken(secret, 95) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjk1fQ.yhZWklNsK3JYvzMB867MD89y-czjXfXVdqNZ4G8fKKA"
+      getSignedIatToken(secret, 487) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjQ4N30.e0D__OXkjno8Hm35vW1DY19CStV4_PEVfkrA8JzvTws"
+      getSignedIatToken(secret, 529) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjUyOX0.6howC0fIcvcGRHbaU-U-AXhwnokXIdQA4lRGmiW5OWc"
+      getSignedIatToken(secret, 2669) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjI2Njl9.2qs8jX7nWwqrgi6v4zEeRGGHvRACp3BBzDMP5IHP8G0"
+      getSignedIatToken(secret, 6082) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYwODJ9.XLWfpPZSS91setVUWPgiQhfkNH67mMZXu6_MxvugQ0A"
+      getSignedIatToken(secret, 6234) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjYyMzR9.a19HeRfVbGmDVQqAJIlNWiOoNJ9o51QT_01fZq6JA_M"
+      getSignedIatToken(secret, 230158) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjIzMDE1OH0.aQDRym5vA0jZ1nbfD01jqx7XxGPlZxhvmxLhvuWRf4E"
+      getSignedIatToken(secret, 675817) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjY3NTgxN30.IOXXc58UmxVsL9am113vmJ7EHwavVYYllrruQMJoMSc"
+      getSignedIatToken(secret, 695159) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjY5NTE1OX0.uzUWhm9_sl0TZI0LN57Ay8MW8loY8EwM1oNPzCPOio0"
+      getSignedIatToken(secret, 19257188) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE5MjU3MTg4fQ.D42LqNic0gsmarnL0l1XP5ylBwMqYT7pGr_6wZhvcPM"
+      getSignedIatToken(secret, 52639657) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjUyNjM5NjU3fQ.Xg4Ipcs3xu4O8McyDswIld7ROZM73DY73ryc1vWGMZI"
+      getSignedIatToken(secret, 71947005) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjcxOTQ3MDA1fQ.4C10E4Il-cmNAmU2sGKkAQfgoSJO4ReTvGiCzo0KzYU"
+      getSignedIatToken(secret, 1169144470) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjExNjkxNDQ0NzB9.eYSTnh6mqN_0wVyqj1biL9QwLGxr1l51IDMHTKizqmo"
+      getSignedIatToken(secret, 2931679730) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjI5MzE2Nzk3MzB9.Mljj-2-BhxFXkkROuvU7_DMtoVROiE-iOMnPR5uyZA0"
+      getSignedIatToken(secret, 3339327695) == "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjMzMzkzMjc2OTV9.C_9IaA1RM6jMKhUqr8S7rvFD2OkYOT2xjx_DR4CPFX4"

--- a/tests/test_engine_authentication.nim
+++ b/tests/test_engine_authentication.nim
@@ -9,7 +9,6 @@
 {.used.}
 
 import
-  std/sequtils,
   unittest2,
   ../beacon_chain/spec/engine_authentication
 

--- a/tests/test_engine_authentication.nim
+++ b/tests/test_engine_authentication.nim
@@ -9,7 +9,7 @@
 {.used.}
 
 import
-  std/[json, sequtils],
+  std/sequtils,
   unittest2,
   ../beacon_chain/spec/engine_authentication
 

--- a/tests/test_keystore_management.nim
+++ b/tests/test_keystore_management.nim
@@ -9,7 +9,7 @@
 {.used.}
 
 import
-  std/[os, options, json, typetraits, uri, algorithm],
+  std/[os, json, typetraits, uri, algorithm],
   unittest2, chronos, chronicles, stint, json_serialization,
   blscurve,
   libp2p/crypto/crypto as lcrypto,


### PR DESCRIPTION
The `json` log format is documented in the guide but did not, until now, appear in the `--help` text.

Take the opportunity to clean up the options and docs:

* prefer `--el=<url>` throughout (`--web3-url` remains as an availble and equivalent name but no longer appears in `--help`)
* expose `--era` option that is used to distribute historical/archived blocks on the beacon network
* document when options were obsoleted and provide migration docs where reasonable
* If `jwt.hex` exists in the data directory, use it when starting the node - when running Nimbus as both execution and beacon client sharing a data directory, this "just works" since one of them will write while the other reads the file.
* Simplify JWT implmenentation by hardcoding some of the JSON messages
* Add a search bar to the docs (didn't we have one before??)
* Use the unified binary in the execution client docs
* Note that you can now stake more than 32 ETH per validator
* Remove obsolete gitcoin donation link
* Remove BETA tag for validator client metrics - no significant changes are currently planned