### PR TITLE
fix: make kurtosis sed call portable

### DIFF
--- a/run-kurtosis-check.sh
+++ b/run-kurtosis-check.sh
@@ -82,7 +82,7 @@ fi
 
 # Use sed to replace the el_image value in the file
 cat kurtosis-network-params.yml | envsubst > assertoor.yaml
-sed -i "s/cl_image: .*/cl_image: $new_cl_image/" assertoor.yaml
+sed -i'' -e "s/cl_image: .*/cl_image: $new_cl_image/" assertoor.yaml
 
 sudo kurtosis run \
   --enclave nimbus-localtestnet \


### PR DESCRIPTION
Before: sed: 1: "/tmp/assertoor-test-ori ...": command a expects \ followed by text
After: 17:      cl_image: test_image