### PR TITLE
EthJson Rpc flavor

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -15,7 +15,6 @@ import
   eth/p2p/discoveryv5/random2,
   eth/rlp,
   eth/trie/ordered_trie,
-  json_rpc/jsonmarshal,
   secp256k1,
   web3/[engine_api_types, eth_api_types, conversions],
   ../el/engine_api_conversions,
@@ -1088,10 +1087,10 @@ proc ETHExecutionBlockHeaderCreateFromJson(
   ## See:
   ## * https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash
   let data = try:
-    # a direct parameter like JrpcConv.decode($blockHeaderJson, BlockObject)
+    # a direct parameter like EthJson.decode($blockHeaderJson, BlockObject)
     # will cause premature garbage collector kick in.
     let jsonBytes = $blockHeaderJson
-    JrpcConv.decode(jsonBytes, BlockObject)
+    EthJson.decode(jsonBytes, BlockObject)
   except SerializationError:
     return nil
   if data == nil:
@@ -1580,10 +1579,10 @@ proc ETHTransactionsCreateFromJson(
   ## See:
   ## * https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_getblockbyhash
   var datas = try:
-    # a direct parameter like JrpcConv.decode($transactionsJson, seq[TransactionObject])
+    # a direct parameter like EthJson.decode($transactionsJson, seq[TransactionObject])
     # will cause premature garbage collector kick in.
     let jsonBytes = $transactionsJson
-    JrpcConv.decode(jsonBytes, seq[TransactionObject])
+    EthJson.decode(jsonBytes, seq[TransactionObject])
   except SerializationError:
     return nil
 
@@ -1596,7 +1595,7 @@ proc ETHTransactionsCreateFromJson(
       return nil
 
     # Check fork consistency
-    static: doAssert totalSerializedFields(TransactionObject) == 23,
+    static: doAssert totalSerializedFields(TransactionObject) == 24,
       "Only update this number once code is adjusted to check new fields!"
     let txType =
       case data.`type`.get(0.Quantity):
@@ -2389,10 +2388,10 @@ proc ETHReceiptsCreateFromJson(
   ## See:
   ## * https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionreceipt
   var datas = try:
-    # a direct parameter like JrpcConv.decode($receiptsJson, seq[ReceiptObject])
+    # a direct parameter like EthJson.decode($receiptsJson, seq[ReceiptObject])
     # will cause premature garbage collector kick in.
     let jsonBytes = $receiptsJson
-    JrpcConv.decode(jsonBytes, seq[ReceiptObject])
+    EthJson.decode(jsonBytes, seq[ReceiptObject])
   except SerializationError:
     return nil
   if datas.len != ETHTransactionsGetCount(transactions):

--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -11,7 +11,7 @@ import
   std/[json, options, times],
   chronos, bearssl/rand, chronicles, confutils, stint, json_serialization,
   web3, eth/common/keys, eth/p2p/discoveryv5/random2,
-  stew/[io2, byteutils], json_rpc/jsonmarshal,
+  stew/[io2, byteutils],
   ../beacon_chain/conf,
   ../beacon_chain/el/el_manager,
   ../beacon_chain/networking/eth2_network,
@@ -418,7 +418,7 @@ proc doCreateTestnet*(config: CliConfig,
 
     try:
       let blockAsJson = genesisBlockContents.get
-      genesisBlock = JrpcConv.decode(blockAsJson, BlockObject)
+      genesisBlock = EthJson.decode(blockAsJson, BlockObject)
     except CatchableError as err:
       error "Failed to load the genesis block from json",
             err = err.msg

--- a/research/fakeee.nim
+++ b/research/fakeee.nim
@@ -17,75 +17,76 @@ import
   chronicles
 
 proc setupEngineAPI*(server: RpcServer) =
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_newpayloadv1
-  # cannot use `params` as param name. see https:#github.com/status-im/nim-json-rpc/issues/128
-  server.rpc("engine_newPayloadV1") do(payload: ExecutionPayloadV1) -> PayloadStatusV1:
-    info "engine_newPayloadV1",
-      number = $(distinctBase payload.blockNumber), hash = payload.blockHash
+  server.rpc(EthJson):
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_newpayloadv1
+    # cannot use `params` as param name. see https:#github.com/status-im/nim-json-rpc/issues/128
+    proc engine_newPayloadV1(payload: ExecutionPayloadV1): PayloadStatusV1 =
+      info "engine_newPayloadV1",
+        number = $(distinctBase payload.blockNumber), hash = payload.blockHash
 
-    return PayloadStatusV1(
-      status: PayloadExecutionStatus.syncing,
-    )
+      return PayloadStatusV1(
+        status: PayloadExecutionStatus.syncing,
+      )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_newpayloadv2
-  server.rpc("engine_newPayloadV2") do(payload: ExecutionPayloadV2) -> PayloadStatusV1:
-    info "engine_newPayloadV2", payload
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_newpayloadv2
+    proc engine_newPayloadV2(payload: ExecutionPayloadV2): PayloadStatusV1 =
+      info "engine_newPayloadV2", payload
 
-    return PayloadStatusV1(
-      status: PayloadExecutionStatus.syncing,
-    )
+      return PayloadStatusV1(
+        status: PayloadExecutionStatus.syncing,
+      )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_getpayloadv1
-  server.rpc("engine_getPayloadV1") do(payloadId: Bytes8) -> ExecutionPayloadV1:
-    info "engine_getPayloadV1",
-      id = payloadId.toHex
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_getpayloadv1
+    proc engine_getPayloadV1(payloadId: Bytes8): ExecutionPayloadV1 {.raises: [ApplicationError].} =
+      info "engine_getPayloadV1",
+        id = payloadId.toHex
 
-    raise (ref ApplicationError)(
-      code: engineApiUnknownPayload,
-      msg: "Unknown payload"
-    )
+      raise (ref ApplicationError)(
+        code: engineApiUnknownPayload,
+        msg: "Unknown payload"
+      )
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_forkchoiceupdatedv1
-  server.rpc("engine_forkchoiceUpdatedV1") do(
-      update: ForkchoiceStateV1,
-      payloadAttributes: Opt[PayloadAttributesV1]) -> ForkchoiceUpdatedResponse:
-    info "engine_forkchoiceUpdatedV1",
-      update,
-      payloadAttributes
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#engine_forkchoiceupdatedv1
+    proc engine_forkchoiceUpdatedV1(
+        update: ForkchoiceStateV1,
+        payloadAttributes: Opt[PayloadAttributesV1]): ForkchoiceUpdatedResponse =
+      info "engine_forkchoiceUpdatedV1",
+        update,
+        payloadAttributes
 
-    return ForkchoiceUpdatedResponse(
-      payloadStatus: PayloadStatusV1(
-      status: PayloadExecutionStatus.syncing))
+      return ForkchoiceUpdatedResponse(
+        payloadStatus: PayloadStatusV1(
+        status: PayloadExecutionStatus.syncing))
 
-  # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_forkchoiceupdatedv2
-  server.rpc("engine_forkchoiceUpdatedV2") do(
-      forkchoiceState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV2]) -> ForkchoiceUpdatedResponse:
-    info "engine_forkchoiceUpdatedV2",
-      forkchoiceState, payloadAttributes
+    # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#engine_forkchoiceupdatedv2
+    proc engine_forkchoiceUpdatedV2(
+        forkchoiceState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV2]): ForkchoiceUpdatedResponse =
+      info "engine_forkchoiceUpdatedV2",
+        forkchoiceState, payloadAttributes
 
-    return ForkchoiceUpdatedResponse(
-      payloadStatus: PayloadStatusV1(
-      status: PayloadExecutionStatus.syncing))
+      return ForkchoiceUpdatedResponse(
+        payloadStatus: PayloadStatusV1(
+        status: PayloadExecutionStatus.syncing))
 
-  server.rpc("eth_getBlockByNumber") do(
-      quantityTag: string, fullTransactions: bool) -> JsonString:
-    info "eth_getBlockByNumber", quantityTag, fullTransactions
+    proc eth_getBlockByNumber(
+        quantityTag: string, fullTransactions: bool): JsonString =
+      info "eth_getBlockByNumber", quantityTag, fullTransactions
 
-    return if quantityTag == "latest":
-      JrpcConv.encode(BlockObject(number: 1000.Quantity)).JsonString
-    else:
-      "{}".JsonString
+      return if quantityTag == "latest":
+        EthJson.encode(BlockObject(number: 1000.Quantity)).JsonString
+      else:
+        "{}".JsonString
 
-  server.rpc("eth_getBlockByHash") do(
-      data: string, fullTransactions: bool) -> BlockObject:
-    info "eth_getBlockByHash", data = toHex(data), fullTransactions
+    proc eth_getBlockByHash(
+        data: string, fullTransactions: bool): BlockObject =
+      info "eth_getBlockByHash", data = toHex(data), fullTransactions
 
-    return BlockObject(number: 1000.Quantity)
+      return BlockObject(number: 1000.Quantity)
 
-  server.rpc("eth_chainId") do() -> UInt256:
-    info "eth_chainId"
+    proc eth_chainId(): UInt256 =
+      info "eth_chainId"
 
-    return 1.u256
+      return 1.u256
 
 when isMainModule:
   let server = newRpcHttpServer(

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -78,7 +78,7 @@ proc createMockEngineState*(
 
 proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
   ## Setup a mock execution engine API on the RPC server
-  server.rpc("engine_newPayloadV4") do(
+  server.rpc("engine_newPayloadV4", EthJson) do(
     payload: ExecutionPayloadV3,
     expectedBlobVersionedHashes: Opt[seq[Hash32]],
     parentBeaconBlockRoot: Opt[Hash32],
@@ -96,7 +96,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
       status: PayloadExecutionStatus.valid, latestValidHash: Opt.some(payload.blockHash)
     )
 
-  server.rpc("engine_newPayloadV5") do(
+  server.rpc("engine_newPayloadV5", EthJson) do(
     payload: ExecutionPayloadV4,
     expectedBlobVersionedHashes: Opt[seq[Hash32]],
     parentBeaconBlockRoot: Opt[Hash32],
@@ -114,7 +114,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
       status: PayloadExecutionStatus.valid, latestValidHash: Opt.some(payload.blockHash)
     )
 
-  server.rpc("engine_forkchoiceUpdatedV3") do(
+  server.rpc("engine_forkchoiceUpdatedV3", EthJson) do(
     fcState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV3]
   ) -> ForkchoiceUpdatedResponse:
     inc state.forkchoiceCallCount
@@ -138,7 +138,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
           Opt.none(Bytes8),
     )
 
-  server.rpc("engine_forkchoiceUpdatedV4") do(
+  server.rpc("engine_forkchoiceUpdatedV4", EthJson) do(
     fcState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV4]
   ) -> ForkchoiceUpdatedResponse:
     inc state.forkchoiceV4CallCount
@@ -162,7 +162,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
           Opt.none(Bytes8),
     )
 
-  server.rpc("engine_getPayloadV4") do(payloadId: Bytes8) -> GetPayloadV4Response:
+  server.rpc("engine_getPayloadV4", EthJson) do(payloadId: Bytes8) -> GetPayloadV4Response:
     inc state.getPayloadCallCount
     if state.responseDelay > 0.milliseconds:
       await sleepAsync(state.responseDelay)
@@ -173,7 +173,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
 
     return GetPayloadV4Response()
 
-  server.rpc("engine_getPayloadV6") do(payloadId: Bytes8) -> GetPayloadV6Response:
+  server.rpc("engine_getPayloadV6", EthJson) do(payloadId: Bytes8) -> GetPayloadV6Response:
     inc state.getPayloadV6CallCount
     if state.responseDelay > 0.milliseconds:
       await sleepAsync(state.responseDelay)
@@ -184,7 +184,7 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
 
     return GetPayloadV6Response()
 
-  server.rpc("eth_chainId") do() -> UInt256:
+  server.rpc("eth_chainId", EthJson) do() -> UInt256:
     inc state.chainIdCallCount
     if state.responseDelay > 0.milliseconds:
       await sleepAsync(state.responseDelay)


### PR DESCRIPTION
Changes:

- Use `EthJson` instead of `JrpcConv` format flavor
- Remove `json_rpc/jsonmarshal` imports
- Bump nim-web3:
  - https://github.com/status-im/nim-web3/pull/247
  - https://github.com/status-im/nim-web3/pull/248
  - https://github.com/status-im/nim-web3/pull/249
  - https://github.com/status-im/nim-web3/pull/237

Pending:

- https://github.com/status-im/nim-json-rpc/pull/259
- https://github.com/status-im/nim-web3/pull/237

Note: `rpc` context adds an indentation level; if reviewing in github, turn on "Hide whitespace" config in the tool bar.