### PR TITLE
bump: update nim-ssz-serialization

### DIFF
--- a/docker/dist/entry_point.sh
+++ b/docker/dist/entry_point.sh
@@ -111,15 +111,6 @@ elif [[ "${PLATFORM}" == "macOS_arm64" ]]; then
   ${CC} --version
   echo
 
-  # Patch hashtree to not use -fno-integrated-as for macOS arm64
-  # osxcross doesn't have an arm64 GNU assembler, so we must use clang's integrated assembler
-  # See: https://developer.apple.com/forums/thread/717267
-  HASHTREE_ABI="vendor/nim-ssz-serialization/vendor/hashtree/hashtree_abi.nim"
-  if [[ -f "${HASHTREE_ABI}" ]]; then
-    echo "Patching ${HASHTREE_ABI} to use integrated assembler for macOS arm64..."
-    sed -i 's/defined(linux) or defined(macosx)/defined(linux)/g' "${HASHTREE_ABI}"
-  fi
-
   make \
     -j$(nproc) \
     USE_LIBBACKTRACE=0 \


### PR DESCRIPTION
After updating hashtree and nim-ssz-serialization we can get rid of the patch here

https://github.com/status-im/nimbus-eth2/blob/207a8220d525190fa1b5223ddf8004f0df523741/docker/dist/entry_point.sh#L114-L121

depends on:
- [x] https://github.com/status-im/nim-ssz-serialization/pull/139
- [x] https://github.com/status-im/nim-ssz-serialization/pull/142
- [x] https://github.com/OffchainLabs/hashtree/pull/58