### PR TITLE
Bump nim-web3 and related changes

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -2305,7 +2305,7 @@ proc ETHReceiptsCreateFromJson(
     # Check fork consistency
     static: doAssert totalSerializedFields(ReceiptObject) == 17,
       "Only update this number once code is adjusted to check new fields!"
-    static: doAssert totalSerializedFields(LogObject) == 9,
+    static: doAssert totalSerializedFields(LogObject) == 10,
       "Only update this number once code is adjusted to check new fields!"
     let txType =
       case data.`type`.get(0.Quantity):


### PR DESCRIPTION
Note that this is not a blind increase of the number of fields. But no additional check can be done on that timestamp field as one would need access to the relevant header.

see change https://github.com/status-im/nim-web3/commit/6868584a2f473eb1da04d5a3a7270d8f6795acf0#diff-eaf5eeecddea56125909e7daaeee2ed63d867c91957a90539f5c4cabd2f58dbeR217-R220