### PR TITLE
Add Gloas data column sidecar support to block production/proposal

### DIFF
--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -267,10 +267,10 @@ proc assemble_data_column_sidecars*(
     signed_beacon_block: gloas.SignedBeaconBlock,
     blobs: seq[KzgBlob], kzg_commitments: deneb.KzgCommitments,
     cell_proofs: seq[KzgProof]): seq[gloas.DataColumnSidecar] =
-  var sidecars = newSeqOfCap[gloas.DataColumnSidecar](CELLS_PER_EXT_BLOB)
-
   if kzg_commitments.len == 0 or blobs.len == 0:
-    return sidecars
+    return static(default(seq[gloas.DataColumnSidecar]))
+
+  var sidecars = newSeqOfCap[gloas.DataColumnSidecar](CELLS_PER_EXT_BLOB)
 
   if blobs.len != kzg_commitments.len:
     return sidecars

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -273,13 +273,9 @@ proc assemble_data_column_sidecars*(
     return sidecars
 
   if blobs.len != kzg_commitments.len:
-    warn "Blob count mismatch with commitments",
-      blobs = blobs.len, commitments = kzg_commitments.len
     return sidecars
 
   if cell_proofs.len != blobs.len * CELLS_PER_EXT_BLOB:
-    warn "Cell proofs count mismatch",
-      expected = blobs.len * CELLS_PER_EXT_BLOB, actual = cell_proofs.len
     return sidecars
 
   var

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -208,63 +208,112 @@ proc recover_cells_and_proofs_parallel*(
   ok(res)
 
 proc assemble_data_column_sidecars*(
-    signed_beacon_block: fulu.SignedBeaconBlock | gloas.SignedBeaconBlock,
+    signed_beacon_block: fulu.SignedBeaconBlock,
     blobs: seq[KzgBlob], cell_proofs: seq[KzgProof]): seq[fulu.DataColumnSidecar] =
   template blck(): auto = signed_beacon_block.message
   var sidecars = newSeqOfCap[fulu.DataColumnSidecar](CELLS_PER_EXT_BLOB)
 
-  when signed_beacon_block is gloas.SignedBeaconBlock:
-    debugGloasComment "kzg_commitments removed from beaconblock in gloas"
+  template kzg_commitments: untyped =
+    signed_beacon_block.message.body.blob_kzg_commitments
+  if kzg_commitments.len == 0:
     return sidecars
-  else:
-    template kzg_commitments: untyped =
-      signed_beacon_block.message.body.blob_kzg_commitments
-    if kzg_commitments.len == 0:
-      return sidecars
-    let
-      beacon_block_header =
-        BeaconBlockHeader(
-          slot: blck.slot,
-          proposer_index: blck.proposer_index,
-          parent_root: blck.parent_root,
-          state_root: blck.state_root,
-          body_root: hash_tree_root(blck.body))
+  let
+    beacon_block_header =
+      BeaconBlockHeader(
+        slot: blck.slot,
+        proposer_index: blck.proposer_index,
+        parent_root: blck.parent_root,
+        state_root: blck.state_root,
+        body_root: hash_tree_root(blck.body))
 
-      signed_beacon_block_header =
-        SignedBeaconBlockHeader(
-          message: beacon_block_header,
-          signature: signed_beacon_block.signature)
+    signed_beacon_block_header =
+      SignedBeaconBlockHeader(
+        message: beacon_block_header,
+        signature: signed_beacon_block.signature)
 
+  var
+    cells = newSeq[CellBytes](blobs.len)
+    proofs = newSeq[ProofBytes](blobs.len)
+
+  for i in 0 ..< blobs.len:
+    cells[i] = computeCells(blobs[i]).get
+    let proofElem = addr proofs[i]
+    staticFor j, 0 ..< CELLS_PER_EXT_BLOB:
+      assign(proofElem[][j], cell_proofs[i * CELLS_PER_EXT_BLOB + j])
+
+  for columnIndex in 0..<CELLS_PER_EXT_BLOB:
     var
-      cells = newSeq[CellBytes](blobs.len)
-      proofs = newSeq[ProofBytes](blobs.len)
+      column = newSeqOfCap[KzgCell](blobs.len)
+      kzgProofOfColumn = newSeqOfCap[KzgProof](blobs.len)
+    for rowIndex in 0..<blobs.len:
+      column.add(cells[rowIndex][columnIndex])
+      kzgProofOfColumn.add(proofs[rowIndex][columnIndex])
 
-    for i in 0 ..< blobs.len:
-      cells[i] = computeCells(blobs[i]).get
-      let proofElem = addr proofs[i]
-      staticFor j, 0 ..< CELLS_PER_EXT_BLOB:
-        assign(proofElem[][j], cell_proofs[i * CELLS_PER_EXT_BLOB + j])
+    var sidecar = fulu.DataColumnSidecar(
+      index: ColumnIndex(columnIndex),
+      column: DataColumn.init(column),
+      kzg_commitments: blck.body.blob_kzg_commitments,
+      kzg_proofs: deneb.KzgProofs.init(kzgProofOfColumn),
+      signed_block_header: signed_beacon_block_header)
+    blck.body.build_proof(
+      KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX.GeneralizedIndex,
+      sidecar.kzg_commitments_inclusion_proof).expect("Valid gindex")
+    sidecars.add(sidecar)
 
-    for columnIndex in 0..<CELLS_PER_EXT_BLOB:
-      var
-        column = newSeqOfCap[KzgCell](blobs.len)
-        kzgProofOfColumn = newSeqOfCap[KzgProof](blobs.len)
-      for rowIndex in 0..<blobs.len:
-        column.add(cells[rowIndex][columnIndex])
-        kzgProofOfColumn.add(proofs[rowIndex][columnIndex])
+  sidecars
 
-      var sidecar = fulu.DataColumnSidecar(
-        index: ColumnIndex(columnIndex),
-        column: DataColumn.init(column),
-        kzg_commitments: blck.body.blob_kzg_commitments,
-        kzg_proofs: deneb.KzgProofs.init(kzgProofOfColumn),
-        signed_block_header: signed_beacon_block_header)
-      blck.body.build_proof(
-        KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX.GeneralizedIndex,
-        sidecar.kzg_commitments_inclusion_proof).expect("Valid gindex")
-      sidecars.add(sidecar)
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/builder.md#modified-get_data_column_sidecars
+proc assemble_data_column_sidecars*(
+    signed_beacon_block: gloas.SignedBeaconBlock,
+    blobs: seq[KzgBlob], kzg_commitments: deneb.KzgCommitments,
+    cell_proofs: seq[KzgProof]): seq[gloas.DataColumnSidecar] =
+  var sidecars = newSeqOfCap[gloas.DataColumnSidecar](CELLS_PER_EXT_BLOB)
 
-    sidecars
+  if kzg_commitments.len == 0 or blobs.len == 0:
+    return sidecars
+
+  if blobs.len != kzg_commitments.len:
+    warn "Blob count mismatch with commitments",
+      blobs = blobs.len, commitments = kzg_commitments.len
+    return sidecars
+
+  if cell_proofs.len != blobs.len * CELLS_PER_EXT_BLOB:
+    warn "Cell proofs count mismatch",
+      expected = blobs.len * CELLS_PER_EXT_BLOB, actual = cell_proofs.len
+    return sidecars
+
+  var
+    cells = newSeq[CellBytes](blobs.len)
+    proofs = newSeq[ProofBytes](blobs.len)
+
+  for i in 0 ..< blobs.len:
+    cells[i] = computeCells(blobs[i]).get
+    let proofElem = addr proofs[i]
+    staticFor j, 0 ..< CELLS_PER_EXT_BLOB:
+      assign(proofElem[][j], cell_proofs[i * CELLS_PER_EXT_BLOB + j])
+
+  template beacon_block_root: untyped = signed_beacon_block.root
+
+  for columnIndex in 0 ..< CELLS_PER_EXT_BLOB:
+    var
+      column = newSeqOfCap[KzgCell](blobs.len)
+      kzgProofOfColumn = newSeqOfCap[KzgProof](blobs.len)
+
+    for rowIndex in 0..<blobs.len:
+      column.add(cells[rowIndex][columnIndex])
+      kzgProofOfColumn.add(proofs[rowIndex][columnIndex])
+
+    let sidecar = gloas.DataColumnSidecar(
+      index: ColumnIndex(columnIndex),
+      column: DataColumn.init(column),
+      kzg_commitments: kzg_commitments,
+      kzg_proofs: deneb.KzgProofs.init(kzgProofOfColumn),
+      slot: signed_beacon_block.message.slot,
+      beacon_block_root: beacon_block_root
+    )
+    sidecars.add(sidecar)
+
+  sidecars
 
 proc assemble_partial_data_column_sidecars*(
     signed_beacon_block: fulu.SignedBeaconBlock,

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -578,13 +578,11 @@ proc proposeBlockAux(
 
   when consensusFork >= ConsensusFork.Gloas:
     let sidecarsOpt =
-      if engineBid[].eps.blobsBundle.commitments.len > 0:
-        Opt.some(signedBlock.assemble_data_column_sidecars(
-          engineBid[].eps.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it)),
-          engineBid[].eps.blobsBundle.commitments,
-          @(engineBid[].eps.blobsBundle.proofs.mapIt(kzg.KzgProof(it)))
-        ))
-      else: Opt.none(seq[gloas.DataColumnSidecar])
+      Opt.some(signedBlock.assemble_data_column_sidecars(
+        engineBid[].eps.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it)),
+        engineBid[].eps.blobsBundle.commitments,
+        @(engineBid[].eps.blobsBundle.proofs.mapIt(kzg.KzgProof(it)))
+      ))
   elif consensusFork == ConsensusFork.Fulu:
     let sidecarsOpt =
       Opt.some(signedBlock.assemble_data_column_sidecars(

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -407,8 +407,10 @@ proc proposeBlockAux(
 
     engineBid =
       when consensusFork == ConsensusFork.Gloas:
-        debugGloasComment "when need to getExecutionPayload/getPayload"
-        default(Opt[EngineBid[gloas.ExecutionPayloadForSigning]])
+        # Fetch only engine payload for now
+        await node.getExecutionPayload(
+          consensusFork, head, state, validator_index, validator.pubkey
+        )
       elif consensusFork >= ConsensusFork.Electra:
         # Fetch both builder and engine payloads then use the better one to
         # make a block
@@ -574,11 +576,16 @@ proc proposeBlockAux(
       message: engineBlock.blck, signature: signature, root: blockRoot
     )
 
-  when consensusFork == ConsensusFork.Gloas:
-    # using noSidecars for Phase0 -> Capella blocks for now
-    let sidecarsOpt = Opt.none(seq[gloas.DataColumnSidecar])
-  elif consensusFork >= ConsensusFork.Fulu and
-      consensusFork < ConsensusFork.Gloas:
+  when consensusFork >= ConsensusFork.Gloas:
+    let sidecarsOpt =
+      if engineBid[].eps.blobsBundle.commitments.len > 0:
+        Opt.some(signedBlock.assemble_data_column_sidecars(
+          engineBid[].eps.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it)),
+          engineBid[].eps.blobsBundle.commitments,
+          @(engineBid[].eps.blobsBundle.proofs.mapIt(kzg.KzgProof(it)))
+        ))
+      else: Opt.none(seq[gloas.DataColumnSidecar])
+  elif consensusFork == ConsensusFork.Fulu:
     let sidecarsOpt =
       Opt.some(signedBlock.assemble_data_column_sidecars(
         engineBlock.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it)),
@@ -590,6 +597,7 @@ proc proposeBlockAux(
           engineBlock.blobsBundle.proofs,
           engineBlock.blobsBundle.blobs))
   else:
+    # using noSidecars for Phase0 -> Capella blocks for now
     const sidecarsOpt = noSidecarsAtFork
 
   let
@@ -613,6 +621,9 @@ proc proposeBlockAux(
     validator = shortLog(validator)
 
   beacon_blocks_proposed.inc()
+
+  debugGloasComment ""
+  # TODO: broadcast signed envelope
 
   newBlockRef.get()
 


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/builder.md#constructing-the-datacolumnsidecars
This adds Gloas specific `assemble_data_column_sidecars` overload and acccepts `kzg_commitments` as explicit parameter (from blobs bundle, not beacon block body) and uses `beacon_block_root` and `slot` fields instead of `signed_block_header`.
Also, it removes inclusion proofs as commitments are no longer in the block body for Gloas
