### PR TITLE
fix: correct operand order in doppelganger stale check

### DIFF
--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -340,7 +340,7 @@ proc doppelgangerChecked*(validator: AttachedValidator, epoch: Epoch) =
         validator = shortLog(validator), check, epoch
       return
 
-    if check - epoch > 1:
+    if epoch - check > 1:
       debug "Doppelganger stale check",
         validator = shortLog(validator), check, epoch
 


### PR DESCRIPTION
Fix swapped operands in `doppelgangerChecked()`. The condition `check - epoch > 1`  was incorrect since `check <= epoch` at that point, causing uint64 underflow.
Changed to `epoch - check > 1` to match the identical logic in `doppelgangerActivity()`.