### PR TITLE
Simplify era-based node startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Nimbus-eth2 is an extremely efficient consensus layer (eth2) client implementati
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Documentation](#documentation)
+- [Quickly test your tooling against Nimbus](#quickly-test-your-tooling-against-nimbus)
+- [Migrate from another client](#migrate-from-another-client)
 - [Related projects](#related-projects)
 - [Donations](#donations)
 - [Branch guide](#branch-guide)
@@ -43,8 +45,6 @@ The [Quickstart](https://nimbus.guide/quick-start.html) in particular will help 
 * http://unstable.mainnet.beacon-api.nimbus.team/
 * http://testing.hoodi.beacon-api.nimbus.team/
 * http://unstable.hoodi.beacon-api.nimbus.team/
-* http://testing.holesky.beacon-api.nimbus.team/
-* http://unstable.holesky.beacon-api.nimbus.team/
 * http://unstable.sepolia.beacon-api.nimbus.team/
 
 Note that right now these are very much unstable testing instances. They may be unresponsive at times - so **please do not rely on them for validating**. We may also disable them at any time.
@@ -56,14 +56,15 @@ This [guide](https://nimbus.guide/migration.html) will take you through the basi
 
 ## Related projects
 
-* [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/): Nimbus for Ethereum 1
-* [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/tree/v1.3.0/#stable-specifications): Consensus specification that this project implements
+* [status-im/nimbus-eth1](https://github.com/status-im/nimbus-eth1/): Nimbus execution client
+* [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/tree/master/#stable-specifications): Consensus specification that this project implements
 
 You can check where the beacon chain fits in the Ethereum ecosystem in our Two-Point-Oh series: https://our.status.im/tag/two-point-oh/
 
 ## Donations
 
 If you'd like to contribute to Nimbus development, our donation address is [`0x70E47C843E0F6ab0991A3189c28F2957eb6d3842`](https://etherscan.io/address/0x70E47C843E0F6ab0991A3189c28F2957eb6d3842)
+
 ## Branch guide
 
 * `stable` - latest stable release - **this branch is recommended for most users**

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -680,10 +680,11 @@ proc new*(T: type BeaconChainDB,
       SqStoreRef.init("", "test", readOnly = readOnly, inMemory = true).expect(
         "working database (out of memory?)")
     else:
-      if (let res = secureCreatePath(dir); res.isErr):
-        fatal "Failed to create create database directory",
-          path = dir, err = ioErrorMsg(res.error)
-        quit 1
+      if not readOnly:
+        secureCreatePath(dir).isOkOr:
+          fatal "Failed to create create database directory",
+            path = dir, err = ioErrorMsg(error)
+          quit 1
 
       SqStoreRef.init(
         dir, "nbc", readOnly = readOnly, manualCheckpoint = true).expectDb()

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -17,7 +17,7 @@ import
   metrics, metrics/chronos_httpserver,
 
   # Local modules
-  "."/[beacon_clock, beacon_chain_db, conf, light_client, version],
+  ./[beacon_clock, beacon_chain_db, conf, light_client, version],
   ./gossip_processing/[eth2_processor, block_processor, optimistic_processor],
   ./networking/eth2_network,
   ./el/el_manager,
@@ -180,3 +180,26 @@ proc getPayloadBuilderClient*(
   RestClientRef.new(payloadBuilderAddress.get, flags = flags,
                     socketFlags = socketFlags,
                     userAgent = nimbusAgentStr)
+
+func init*(T: type EventBus): T =
+  T(
+    headQueue: newAsyncEventQueue[HeadChangeInfoObject](),
+    blocksQueue: newAsyncEventQueue[EventBeaconBlockObject](),
+    blockGossipQueue: newAsyncEventQueue[EventBeaconBlockGossipObject](),
+    phase0AttestQueue: newAsyncEventQueue[phase0.Attestation](),
+    singleAttestQueue: newAsyncEventQueue[SingleAttestation](),
+    exitQueue: newAsyncEventQueue[SignedVoluntaryExit](),
+    blsToExecQueue: newAsyncEventQueue[SignedBLSToExecutionChange](),
+    propSlashQueue: newAsyncEventQueue[ProposerSlashing](),
+    phase0AttSlashQueue: newAsyncEventQueue[phase0.AttesterSlashing](),
+    electraAttSlashQueue: newAsyncEventQueue[electra.AttesterSlashing](),
+    blobSidecarQueue: newAsyncEventQueue[BlobSidecarInfoObject](),
+    columnSidecarQueue: newAsyncEventQueue[DataColumnSidecarInfoObject](),
+    finalQueue: newAsyncEventQueue[FinalizationInfoObject](),
+    reorgQueue: newAsyncEventQueue[ReorgInfoObject](),
+    contribQueue: newAsyncEventQueue[SignedContributionAndProof](),
+    finUpdateQueue: newAsyncEventQueue[RestVersioned[ForkedLightClientFinalityUpdate]](),
+    optUpdateQueue:
+      newAsyncEventQueue[RestVersioned[ForkedLightClientOptimisticUpdate]](),
+    optFinHeaderUpdateQueue: newAsyncEventQueue[ForkedLightClientHeader](),
+  )

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -638,6 +638,10 @@ type
         defaultValue: HistoryMode.Prune
         name: "history".}: HistoryMode
 
+      reindexBN* {.
+        desc: "Reindex historical states for archive access"
+        name: "reindex".}: bool
+
       trustedSetupFile* {.
         hidden
         desc: "Alternative EIP-4844 trusted setup file"

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -236,6 +236,14 @@ func getBlockIdAtSlot*(dag: ChainDAGRef, slot: Slot): Opt[BlockSlotId] =
   tryWithState dag.epochRefState
   tryWithState dag.clearanceState
 
+  if uint64(slot) < dag.frontfillBlocks.lenu64:
+    for i in 0 ..< int(slot):
+      let root = dag.frontfillBlocks[int(slot) - i]
+      if not root.isZero():
+        return Opt.some BlockSlotId.init(
+          BlockId(slot: Slot(int(slot) - i), root: root), slot
+        )
+
   # Fallback to database, this only works for backfilled blocks
   let finlow = dag.db.finalizedBlocks.low.expect("at least tailRef written")
   if slot >= finlow:
@@ -1009,8 +1017,6 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
            vanityLogs = default(VanityLogs),
            lcDataConfig = default(LightClientDataConfig)): ChainDAGRef =
-  cfg.checkForkConsistency()
-
   doAssert updateFlags - {strictVerification} == {},
     "Other flags not supported in ChainDAG"
 
@@ -1279,6 +1285,13 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
     # Here, we'll build up the slot->root mapping in memory for the range of
     # blocks from genesis to backfill, if possible.
+    # Due to how era files are constructed, the block that was last applied to
+    # the era state is not part of the era file itself - in order to have a
+    # "full" block history, we must therefore backfill it from p2p, even if it's
+    # not strictly needed to validate the _next_ block that builds on this state.
+    # TODO consider setting the head to the block _before_ this last state -
+    #      this will ensure that we download the missing block as part of
+    #      regular syncing instead of waiting for backfill.
     for bid in dag.era.getBlockIds(
         historical_roots, historical_summaries, Slot(0), Eth2Digest()):
       # If backfill has not yet started, the backfill slot itself also needs
@@ -2589,14 +2602,10 @@ proc updateHead*(
 proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): Result[void, cstring] =
   ## Lightweight check to see if it is likely that the given database has been
   ## initialized
-  let
-    tailBlockRoot = db.getTailBlock()
-  if not tailBlockRoot.isSome():
+  let tailBlockRoot = db.getTailBlock().valueOr:
     return err("Tail block root missing")
 
-  let
-    tailBlock = db.getBlockId(tailBlockRoot.get())
-  if not tailBlock.isSome():
+  if db.getBlockId(tailBlockRoot).isNone():
     return err("Tail block information missing")
 
   ok()
@@ -2752,7 +2761,7 @@ func aggregateAll*(
 func needsBackfill*(dag: ChainDAGRef): bool =
   dag.backfill.slot > dag.horizon
 
-proc rebuildIndex*(dag: ChainDAGRef) =
+proc rebuildIndex*(dag: ChainDAGRef, cancel: proc(): bool {.raises: [], gcsafe.}) =
   ## After a checkpoint sync, we lack intermediate states to replay from - this
   ## function rebuilds them so that historical replay can take place again
   ## TODO the pruning of junk states could be moved to a separate function that
@@ -2763,7 +2772,6 @@ proc rebuildIndex*(dag: ChainDAGRef) =
     roots = dag.db.loadStateRoots()
     historicalRoots = getStateField(dag.headState, historical_roots).asSeq()
     historicalSummaries = dag.headState.historical_summaries.asSeq()
-
   var
     canonical = newSeq[Eth2Digest](
       (dag.finalizedHead.slot.epoch + EPOCHS_PER_STATE_SNAPSHOT - 1) div
@@ -2775,8 +2783,6 @@ proc rebuildIndex*(dag: ChainDAGRef) =
   for k, v in roots:
     if k[0] >= dag.finalizedHead.slot:
       continue # skip newer stuff
-    if k[0] < dag.backfill.slot:
-      continue # skip stuff for which we have no blocks
 
     if not isFinalizedStateSnapshot(k[0]):
       # `tail` will move at the end of the process, so we won't need any
@@ -2798,9 +2804,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
 
     canonical[k[0].epoch div EPOCHS_PER_STATE_SNAPSHOT] = v
 
-  let
-    state = (ref ForkedHashedBeaconState)()
-
+  let state = (ref ForkedHashedBeaconState)()
   var
     cache: StateCache
     info: ForkedEpochInfo
@@ -2811,13 +2815,13 @@ proc rebuildIndex*(dag: ChainDAGRef) =
   # zero root whenever a particular state is missing - this way, if there's
   # partial progress or gaps, they will be dealt with correctly
   for i, state_root in canonical.mpairs():
-    let
-      slot = Epoch(i * EPOCHS_PER_STATE_SNAPSHOT).start_slot
+    if cancel():
+      return
 
-    if slot < dag.backfill.slot:
-      # TODO if we have era files, we could try to load blocks from them at
-      #      this point
-      # TODO if we don't do the above, we can of course compute the starting `i`
+    let slot = Epoch(i * EPOCHS_PER_STATE_SNAPSHOT).start_slot
+
+    if slot < dag.backfill.slot and uint64(slot) > dag.frontfillBlocks.lenu64:
+      reset(tailBid) # No unbroken history!
       continue
 
     if tailBid.isNone():
@@ -2850,8 +2854,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
       states += 1
       continue
 
-    let
-      startSlot = Epoch((i - 1) * EPOCHS_PER_STATE_SNAPSHOT).start_slot
+    let startSlot = Epoch((i - 1) * EPOCHS_PER_STATE_SNAPSHOT).start_slot
 
     info "Recreating state snapshot",
       slot, startStateRoot = canonical[i - 1],  startSlot

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -835,7 +835,7 @@ proc sendGetBlobsV2*(
     err()
 
 proc sendGetBlobsV3*(
-    m: ElManager,
+    m: ELManager,
     blck: fulu.SignedBeaconBlock
 ): Future[Opt[seq[Opt[BlobAndProofV2]]]] {.async: (raises: [CancelledError]).} =
   if m.elConnections.len == 0:

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -265,10 +265,13 @@ type EraPath* = tuple[era: Era, path: string]
 iterator eras*(_: type EraFile, cfg: RuntimeConfig, eraDir: string): EraPath =
   ## Iterate over all era files available in the given directory.
   ## Entries may appear out of order and are not necessarily valid era files.
-  for f in walkFiles(eraDir / "*.era"):
-    let era = Era.fromEraFile(cfg, io2.splitPath(f).tail).valueOr:
-      continue
-    yield (era, f)
+  try:
+    for f in walkFiles(eraDir / "*.era"):
+      let era = Era.fromEraFile(cfg, io2.splitPath(f).tail).valueOr:
+        continue
+      yield (era, f)
+  except OsError: # On windows only ...
+    discard
 
 proc genesis*(_: type EraFile, cfg: RuntimeConfig, eraDir: string): Opt[EraPath] =
   ## Find the genesis era file (era 0) in the given directory.

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -72,7 +72,7 @@ proc open*(_: type EraFile, name: string): Result[EraFile, string] =
   reset(f)
   ok res
 
-proc close(f: EraFile) =
+proc close*(f: EraFile) =
   if f.handle.isSome():
     discard closeFile(f.handle.get())
     reset(f.handle)
@@ -260,6 +260,35 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
       return err("Invalid block signature")
 
   ok(getStateRoot(state[]))
+
+type EraPath* = tuple[era: Era, path: string]
+iterator eras*(_: type EraFile, cfg: RuntimeConfig, eraDir: string): EraPath =
+  ## Iterate over all era files available in the given directory.
+  ## Entries may appear out of order and are not necessarily valid era files.
+  for f in walkFiles(eraDir / "*.era"):
+    let era = Era.fromEraFile(cfg, io2.splitPath(f).tail).valueOr:
+      continue
+    yield (era, f)
+
+proc genesis*(_: type EraFile, cfg: RuntimeConfig, eraDir: string): Opt[EraPath] =
+  ## Find the genesis era file (era 0) in the given directory.
+  for e in EraFile.eras(cfg, eraDir):
+    if e.era == 0:
+      return Opt.some(e)
+
+  Opt.none(EraPath)
+
+proc latest*(_: type EraFile, cfg: RuntimeConfig, eraDir: string): Opt[EraPath] =
+  ## Find the most recent era file in the given directory, if any.
+  var latest: EraPath
+
+  for e in EraFile.eras(cfg, eraDir):
+    if e.era > latest[0]:
+      latest = e
+  if latest[1].len > 0:
+    Opt.some(latest)
+  else:
+    Opt.none(EraPath)
 
 proc getEraFile(
     db: EraDB, historical_roots: openArray[Eth2Digest],
@@ -530,3 +559,6 @@ when isMainModule:
     f = EraFile.open(dbPath & "/mainnet-00001-40cf2f3c.era").expect(
       "opening works")
   doAssert f.verify(cfg).isOk()
+
+  for x in EraFile.eras(cfg, dbPath):
+    echo x

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -8,7 +8,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/os,
+  std/[os, uri],
   stew/byteutils, stew/shims/macros,
   chronicles,
   eth/common/eth_types_json_serialization,
@@ -64,7 +64,7 @@ type
     of BakedIn:
       networkName*: string
     of BakedInUrl:
-      url*: string
+      url*: Uri
       digest*: Eth2Digest
 
   Eth2NetworkMetadata* = object
@@ -153,6 +153,8 @@ proc loadEth2NetworkMetadata*(
         readBootEnr(bootstrapNodesPath) &
         readBootEnr(bootEnrPath))
 
+    runtimeConfig.checkForkConsistency()
+
     ok Eth2NetworkMetadata(
       eth1Network: eth1Network,
       cfg: runtimeConfig,
@@ -160,7 +162,7 @@ proc loadEth2NetworkMetadata*(
       genesis:
         if downloadGenesisFrom.isSome:
           GenesisMetadata(kind: BakedInUrl,
-                          url: downloadGenesisFrom.get.url,
+                          url: parseUri downloadGenesisFrom.get.url,
                           digest: downloadGenesisFrom.get.digest)
         elif useBakedInGenesis.isSome:
           GenesisMetadata(kind: BakedIn, networkName: useBakedInGenesis.get)

--- a/beacon_chain/networking/network_metadata_downloads.nim
+++ b/beacon_chain/networking/network_metadata_downloads.nim
@@ -22,7 +22,10 @@ type
   DigestMismatchError* = object of CatchableError
 
 proc downloadFile(url: Uri): Future[seq[byte]] {.async.} =
-  var httpSession = HttpSessionRef.new()
+  let httpSession = HttpSessionRef.new()
+  defer:
+    await httpSession.closeWait()
+
   let response = await httpSession.fetch(url)
   if response[0] == 200:
     return response[1]
@@ -31,16 +34,23 @@ proc downloadFile(url: Uri): Future[seq[byte]] {.async.} =
       msg: "Unexpected status code " & $response[0] & " when fetching " & $url,
       status: response[0])
 
-proc fetchGenesisBytes*(
-    metadata: Eth2NetworkMetadata,
-    genesisStateUrlOverride = none(Uri)): Future[seq[byte]] {.async.} =
+proc fetchGenesisState*(
+    metadata: Eth2NetworkMetadata, genesisStateUrlOverride = none(Uri)
+): Future[ref ForkedHashedBeaconState] {.async.} =
+  ## Fetch and parse the genesis beacon state from the configured source, which
+  ## may include downloading it.
   case metadata.genesis.kind
   of NoGenesis:
-    raiseAssert "fetchGenesisBytes should be called only when metadata.hasGenesis is true"
+    raiseAssert "fetchGenesisState should be called only when metadata.hasGenesis is true"
   of BakedIn:
-    result = @(metadata.genesis.bakedBytes)
+    try:
+      newClone(
+        readSszForkedHashedBeaconState(metadata.cfg, metadata.genesis.bakedBytes)
+      )
+    except SerializationError as err:
+      raiseAssert "Invalid baked-in state: " & err.msg
   of BakedInUrl:
-    result = await downloadFile(genesisStateUrlOverride.get(parseUri metadata.genesis.url))
+    var tmp = await downloadFile(genesisStateUrlOverride.get(metadata.genesis.url))
     # Under the built-in default URL, we serve a snappy-encoded BeaconState in order
     # to reduce the size of the downloaded file with roughly 50% (this precise ratio
     # depends on the number of validator records). The user is still free to provide
@@ -49,21 +59,21 @@ proc fetchGenesisBytes*(
     # Since a SSZ-encoded BeaconState will start with a LittleEndian genesis time
     # (64 bits) while a snappy framed stream will always start with a fixed header
     # that will decoded as a timestamp with the value 5791996851603375871 (year 2153).
-    #
-    # TODO: A more complete solution will implement compression on the HTTP level,
-    #       by relying on the Content-Encoding header to determine the compression
-    #       algorithm. The detection method used here will not interfere with such
-    #       an implementation and it may remain useful when dealing with misconfigured
-    #       HTTP servers.
-    if result.isSnappyFramedStream:
-      result = decodeFramed(result)
-    let state = newClone(readSszForkedHashedBeaconState(metadata.cfg, result))
+    if tmp.isSnappyFramedStream:
+      tmp = decodeFramed(tmp)
+
+    let state = newClone(readSszForkedHashedBeaconState(metadata.cfg, tmp))
     withState(state[]):
       if forkyState.root != metadata.genesis.digest:
         raise (ref DigestMismatchError)(
-          msg: "The downloaded genesis state cannot be verified (checksum mismatch)")
+          msg: "The downloaded genesis state cannot be verified (checksum mismatch)"
+        )
+    state
   of UserSuppliedFile:
-    result = readAllBytes(metadata.genesis.path).tryGet()
+    var tmp: seq[byte]
+    io2.readFile(metadata.genesis.path, tmp).tryGet()
+
+    newClone(readSszForkedHashedBeaconState(metadata.cfg, tmp))
 
 proc sourceDesc*(metadata: GenesisMetadata): string =
   case metadata.kind
@@ -72,13 +82,6 @@ proc sourceDesc*(metadata: GenesisMetadata): string =
   of BakedIn:
     metadata.networkName
   of BakedInUrl:
-    metadata.url
+    $metadata.url
   of UserSuppliedFile:
     metadata.path
-
-when isMainModule:
-  let hoodiMetadata = getMetadataForNetwork("hoodi")
-  io2.writeFile(
-    "hoodi-genesis.ssz",
-    waitFor hoodiMetadata.fetchGenesisBytes()
-  ).expect("success")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -28,7 +28,7 @@ import
   ./sync/[sync_protocol, light_client_protocol, sync_overseer, validator_custody],
   ./validators/[keystore_management, beacon_validators],
   ./[
-    beacon_node, beacon_node_light_client, buildinfo, deposits,
+    beacon_node, beacon_node_light_client, buildinfo, deposits, era_db,
     nimbus_binary_common, process_state, statusbar, trusted_node_sync, wallets]
 
 from std/algorithm import sort
@@ -62,43 +62,211 @@ declareGauge sync_committee_active,
 declareCounter db_checkpoint_seconds,
   "Time spent checkpointing the database to clear the WAL file"
 
+proc readState(
+    cfg: RuntimeConfig, bytes: openArray[byte]
+): Opt[ref ForkedHashedBeaconState] =
+  try:
+    ok newClone readSszForkedHashedBeaconState(cfg, bytes)
+  except CatchableError as err:
+    error "Failed to decode state, check that you're on the same `--network`!",
+      size = bytes.len, digest = eth2digest(bytes), err = err.msg
+    Opt.none(ref ForkedHashedBeaconState)
+
+proc readFileState(cfg: RuntimeConfig, path: string): Opt[ref ForkedHashedBeaconState] =
+  ## Read and decode a beacon state from a file path.
+  ## Returns nil if file cannot be read, otherwise decodes the SSZ content.
+  debug "Reading state", path
+  var tmp: seq[byte]
+  io2.readFile(path, tmp).isOkOr:
+    error "Could not read state", path, err = error.ioErrorMsg
+    return Opt.none(ref ForkedHashedBeaconState)
+
+  readState(cfg, tmp)
+
+proc readEraState(cfg: RuntimeConfig, file: EraPath): Opt[ref ForkedHashedBeaconState] =
+  ## Extract and decode a beacon state from an era file - unlike the helpers in
+  ## EraDB, this function does not validate that the era file corresponds to
+  ## a particular history, as identified by summaries.
+  ##
+  ## If the Era file is corrup
+  debug "Reading era state", file
+  let ef = EraFile.open(file.path).valueOr:
+    error "Could not open era file", file, error
+    return Opt.none(ref ForkedHashedBeaconState)
+
+  defer:
+    ef.close()
+
+  var tmp: seq[byte]
+
+  ef.getStateSSZ(file.era.start_slot(), tmp).isOkOr:
+    fatal "Could not read state, era file corrupt?", file, error
+    return Opt.none(ref ForkedHashedBeaconState)
+
+  readState(cfg, tmp)
+
 proc fetchGenesisState(
     metadata: Eth2NetworkMetadata,
+    eraDir: string,
     genesisState = none(InputFile),
-    genesisStateUrl = none(Uri)
-): Future[ref ForkedHashedBeaconState] {.async: (raises: []).} =
-  let genesisBytes =
-    if metadata.genesis.kind != BakedIn and genesisState.isSome:
-      let res = io2.readAllBytes(genesisState.get.string)
-      res.valueOr:
-        error "Failed to read genesis state file", err = res.error.ioErrorMsg
-        quit 1
-    elif metadata.hasGenesis:
-      try:
-        if metadata.genesis.kind == BakedInUrl:
-          info "Obtaining genesis state",
-               sourceUrl = $genesisStateUrl
-                 .get(parseUri metadata.genesis.url)
-        await metadata.fetchGenesisBytes(genesisStateUrl)
-      except CatchableError as err:
-        error "Failed to obtain genesis state",
-              source = metadata.genesis.sourceDesc,
-              err = err.msg
-        quit 1
-    else:
-      @[]
+    genesisStateUrl = none(Uri),
+): Future[Opt[ref ForkedHashedBeaconState]] {.async: (raises: []).} =
+  ## Load the genesis state from any of the given sources with a preference for
+  ## local files (in the case that only an URL/digest pair is baked into the
+  ## binary)
+  ##
+  ## Returns `none` if the era source is broken and `Opt.some nil` when no
+  ## genesis state is available.
 
-  if genesisBytes.len > 0:
+  if metadata.genesis.kind != BakedIn and genesisState.isSome:
+    readFileState(metadata.cfg, genesisState.get().string)
+  elif (let eraFile = EraFile.genesis(metadata.cfg, eraDir); eraFile.isSome):
+    readEraState(metadata.cfg, eraFile[])
+  elif metadata.hasGenesis:
     try:
-      newClone readSszForkedHashedBeaconState(metadata.cfg, genesisBytes)
+      if metadata.genesis.kind == BakedInUrl:
+        info "Downloading genesis state",
+          sourceUrl = $genesisStateUrl.get(metadata.genesis.url)
+      ok await metadata.fetchGenesisState(genesisStateUrl)
     except CatchableError as err:
-      error "Invalid genesis state",
-            size = genesisBytes.len,
-            digest = eth2digest(genesisBytes),
-            err = err.msg
-      quit 1
+      error "Failed to obtain genesis state",
+        source = metadata.genesis.sourceDesc, err = err.msg
+      Opt.none(ref ForkedHashedBeaconState)
   else:
-    nil
+    Opt.some default(ref ForkedHashedBeaconState)
+
+proc fetchCheckpointState(
+    metadata: Eth2NetworkMetadata, eraDir: string, file: Option[InputFile]
+): Opt[ref ForkedHashedBeaconState] =
+  ## Load a checkpoint state from file or era database.
+  if file.isSome:
+    readFileState(metadata.cfg, file.get().string)
+  elif (let eraFile = EraFile.latest(metadata.cfg, eraDir); eraFile.isSome):
+    readEraState(metadata.cfg, eraFile[])
+  else:
+    Opt.some default(ref ForkedHashedBeaconState)
+
+proc setupDatabase(
+    config: BeaconNodeConf, metadata: Eth2NetworkMetadata
+): Future[Opt[BeaconChainDB]] {.async: (raises: [CancelledError]).} =
+  # Open the database and initialize it with genesis/checkpoint if it wasn't
+  # setup before - fails if the data sources we use are broken
+  let db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
+
+  if ChainDAGRef.isInitialized(db).isOk():
+    if config.finalizedCheckpointState.isSome:
+      error "A database already exists, cannot start from given checkpoint",
+        dataDir = config.dataDir
+      return Opt.none(BeaconChainDB)
+    return ok db
+
+  # We need at least one state to initialize the database - this can be the
+  # genesis state which is a special case of a checkpoint state at slot 0.
+  #
+  # While a checkpoint state from any epoch slot is sufficient for launching
+  # the client, we'll try to add the genesis state to the database as well.
+  var
+    checkpointState =
+      ?fetchCheckpointState(metadata, config.eraDir, config.finalizedCheckpointState)
+    genesisState =
+      if not checkpointState.isNil and
+          getStateField(checkpointState[], slot) == GENESIS_SLOT:
+        checkpointState
+      else:
+        ?await fetchGenesisState(
+          metadata, config.eraDir, config.genesisState, config.genesisStateUrl
+        )
+
+  if config.externalBeaconApiUrl.isSome():
+    # When using an external beacon api, require that the checkpoint state is
+    # verified with the light client by always using a verified sync target
+    let syncTarget =
+      if config.trustedBlockRoot.isSome:
+        Opt.some TrustedNodeSyncTarget.fromTrustedBlockRoot(
+          config.trustedBlockRoot.get()
+        )
+      elif config.trustedStateRoot.isSome:
+        Opt.some TrustedNodeSyncTarget.fromStateId(
+          config.trustedStateRoot.get().data.to0xHex()
+        )
+      elif metadata.cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH and not genesisState.isNil:
+        # Sync can be bootstrapped from the genesis block root
+        let genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
+        notice "Neither `--trusted-block-root` nor `--trusted-state-root` " &
+          "provided with `--external-beacon-api-url`, " &
+          "falling back to genesis block root",
+          externalBeaconApiUrl = config.externalBeaconApiUrl.get,
+          trustedBlockRoot = config.trustedBlockRoot,
+          trustedStateRoot = config.trustedStateRoot,
+          genesisBlockRoot = $genesisBlockRoot
+        Opt.some TrustedNodeSyncTarget.fromTrustedBlockRoot(genesisBlockRoot)
+      else:
+        Opt.none TrustedNodeSyncTarget
+
+    if syncTarget.isSome():
+      let tmp = await fetchCheckpointState(
+        metadata.cfg, config.externalBeaconApiUrl.get(), syncTarget[], genesisState
+      )
+
+      if checkpointState != nil and tmp != nil:
+        # Special case: we loaded a checkpoint state (for example from era
+        # files) and then the remote beacon api gave us a newer one!
+        if getStateField(tmp[], slot) > getStateField(checkpointState[], slot):
+          checkpointState = tmp
+    else:
+      warn "Ignoring `--external-beacon-api-url`, neither " &
+        "`--trusted-block-root` nor `--trusted-state-root` provided",
+        externalBeaconApiUrl = config.externalBeaconApiUrl.get,
+        trustedBlockRoot = config.trustedBlockRoot,
+        trustedStateRoot = config.trustedStateRoot
+
+  if genesisState.isNil and checkpointState.isNil:
+    fatal "No database and no genesis snapshot found. Please supply a genesis.ssz " &
+      "with the network configuration"
+    return Opt.none(BeaconChainDB)
+
+  if not genesisState.isNil and config.longRangeSync == LongRangeSyncMode.Light:
+    let
+      genesisTime = getStateField(genesisState[], genesis_time)
+      beaconClock = BeaconClock.init(metadata.cfg.timeParams, genesisTime).valueOr:
+        fatal "Invalid genesis time in genesis state", genesisTime
+        return Opt.none(BeaconChainDB)
+      currentSlot = beaconClock.currentSlot
+      checkpoint = Checkpoint(
+        epoch: epoch(getStateField(genesisState[], slot)),
+        root: getStateField(genesisState[], latest_block_header).state_root,
+      )
+
+    if not is_within_weak_subjectivity_period(
+      metadata.cfg, currentSlot, genesisState[], checkpoint
+    ):
+      # We do support any network which starts from Altair or later fork.
+      if metadata.cfg.ALTAIR_FORK_EPOCH != GENESIS_EPOCH:
+        fatal WeakSubjectivityLogMessage,
+          current_slot = currentSlot, altair_fork_epoch = metadata.cfg.ALTAIR_FORK_EPOCH
+        return Opt.none(BeaconChainDB)
+
+  if not genesisState.isNil and not checkpointState.isNil:
+    if getStateField(genesisState[], genesis_validators_root) !=
+        getStateField(checkpointState[], genesis_validators_root):
+      fatal "Checkpoint state does not match genesis - check the --network parameter",
+        rootFromGenesis = getStateField(genesisState[], genesis_validators_root),
+        rootFromCheckpoint = getStateField(checkpointState[], genesis_validators_root)
+      return Opt.none(BeaconChainDB)
+
+  # Always store genesis state if we have it - this allows reindexing and
+  # answering genesis queries
+  if not genesisState.isNil:
+    ChainDAGRef.preInit(db, genesisState[])
+
+  if not checkpointState.isNil:
+    if genesisState.isNil or
+        getStateField(checkpointState[], slot) != getStateField(genesisState[], slot):
+      ChainDAGRef.preInit(db, checkpointState[])
+
+  doAssert ChainDAGRef.isInitialized(db).isOk(), "preInit should have initialized db"
+
+  ok db
 
 proc doRunTrustedNodeSync(
     db: BeaconChainDB,
@@ -111,33 +279,21 @@ proc doRunTrustedNodeSync(
     backfill: bool,
     reindex: bool,
     genesisState: ref ForkedHashedBeaconState,
-) {.async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError], raw: true).} =
   let syncTarget =
     if stateId.isSome:
       if trustedBlockRoot.isSome:
-        warn "Ignoring `trustedBlockRoot`, `stateId` is set",
-          stateId, trustedBlockRoot
-      TrustedNodeSyncTarget(
-        kind: TrustedNodeSyncKind.StateId,
-        stateId: stateId.get)
+        warn "Ignoring `trustedBlockRoot`, `stateId` is set", stateId, trustedBlockRoot
+      TrustedNodeSyncTarget.fromStateId(stateId.get)
     elif trustedBlockRoot.isSome:
-      TrustedNodeSyncTarget(
-        kind: TrustedNodeSyncKind.TrustedBlockRoot,
-        trustedBlockRoot: trustedBlockRoot.get)
+      TrustedNodeSyncTarget.fromTrustedBlockRoot(trustedBlockRoot.get)
     else:
-      TrustedNodeSyncTarget(
-        kind: TrustedNodeSyncKind.StateId,
-        stateId: "finalized")
+      TrustedNodeSyncTarget.fromStateId("finalized")
 
-  await db.doTrustedNodeSync(
-    metadata.cfg,
-    databaseDir,
-    eraDir,
-    restUrl,
-    syncTarget,
-    backfill,
-    reindex,
-    genesisState)
+  db.doTrustedNodeSync(
+    metadata.cfg, databaseDir, eraDir, restUrl, syncTarget, backfill, reindex,
+    genesisState,
+  )
 
 func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
   case stdoutKind
@@ -751,41 +907,6 @@ proc init*(
   if ProcessState.stopIt(notice("Shutting down", reason = it)):
     return Opt.none(BeaconNode)
 
-  var genesisState: ref ForkedHashedBeaconState = nil
-
-  template cfg: auto = metadata.cfg
-
-  if not(isDir(config.databaseDir)):
-    # If database directory missing, we going to use genesis state to check
-    # for weak_subjectivity_period.
-    genesisState =
-      await fetchGenesisState(
-        metadata, config.genesisState, config.genesisStateUrl)
-    let
-      genesisTime = getStateField(genesisState[], genesis_time)
-      beaconClock = BeaconClock.init(
-          metadata.cfg.timeParams, genesisTime).valueOr:
-        fatal "Invalid genesis time in genesis state", genesisTime
-        return Opt.none(BeaconNode)
-      currentSlot = beaconClock.currentSlot
-      checkpoint = Checkpoint(
-        epoch: epoch(getStateField(genesisState[], slot)),
-        root: getStateField(genesisState[], latest_block_header).state_root)
-
-    notice "Genesis state information",
-           genesis_fork = genesisState.kind,
-           is_post_altair = (cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH)
-
-    if config.longRangeSync == LongRangeSyncMode.Light:
-      if not is_within_weak_subjectivity_period(metadata.cfg, currentSlot,
-                                                genesisState[], checkpoint):
-        # We do support any network which starts from Altair or later fork.
-        let metadata = config.loadEth2Network()
-        if metadata.cfg.ALTAIR_FORK_EPOCH != GENESIS_EPOCH:
-          fatal WeakSubjectivityLogMessage, current_slot = currentSlot,
-                altair_fork_epoch = metadata.cfg.ALTAIR_FORK_EPOCH
-          return Opt.none(BeaconNode)
-
   if metadata.genesis.kind == BakedIn:
     if config.genesisState.isSome:
       warn "The --genesis-state option has no effect on networks with built-in genesis state"
@@ -793,151 +914,7 @@ proc init*(
     if config.genesisStateUrl.isSome:
       warn "The --genesis-state-url option has no effect on networks with built-in genesis state"
 
-  let
-    eventBus = EventBus(
-      headQueue: newAsyncEventQueue[HeadChangeInfoObject](),
-      blocksQueue: newAsyncEventQueue[EventBeaconBlockObject](),
-      blockGossipQueue: newAsyncEventQueue[EventBeaconBlockGossipObject](),
-      phase0AttestQueue: newAsyncEventQueue[phase0.Attestation](),
-      singleAttestQueue: newAsyncEventQueue[SingleAttestation](),
-      exitQueue: newAsyncEventQueue[SignedVoluntaryExit](),
-      blsToExecQueue: newAsyncEventQueue[SignedBLSToExecutionChange](),
-      propSlashQueue: newAsyncEventQueue[ProposerSlashing](),
-      phase0AttSlashQueue: newAsyncEventQueue[phase0.AttesterSlashing](),
-      electraAttSlashQueue: newAsyncEventQueue[electra.AttesterSlashing](),
-      blobSidecarQueue: newAsyncEventQueue[BlobSidecarInfoObject](),
-      columnSidecarQueue: newAsyncEventQueue[DataColumnSidecarInfoObject](),
-      finalQueue: newAsyncEventQueue[FinalizationInfoObject](),
-      reorgQueue: newAsyncEventQueue[ReorgInfoObject](),
-      contribQueue: newAsyncEventQueue[SignedContributionAndProof](),
-      finUpdateQueue: newAsyncEventQueue[
-        RestVersioned[ForkedLightClientFinalityUpdate]](),
-      optUpdateQueue: newAsyncEventQueue[
-        RestVersioned[ForkedLightClientOptimisticUpdate]](),
-      optFinHeaderUpdateQueue: newAsyncEventQueue[ForkedLightClientHeader]())
-    db = BeaconChainDB.new(config.databaseDir, cfg, inMemory = false)
-
-  if config.externalBeaconApiUrl.isSome and ChainDAGRef.isInitialized(db).isErr:
-    let trustedBlockRoot =
-      if config.trustedStateRoot.isSome or config.trustedBlockRoot.isSome:
-        config.trustedBlockRoot
-      elif cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH:
-        # Sync can be bootstrapped from the genesis block root
-        if genesisState.isNil:
-          genesisState = await fetchGenesisState(
-            metadata, config.genesisState, config.genesisStateUrl)
-        if not genesisState.isNil:
-          let genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
-          notice "Neither `--trusted-block-root` nor `--trusted-state-root` " &
-            "provided with `--external-beacon-api-url`, " &
-            "falling back to genesis block root",
-            externalBeaconApiUrl = config.externalBeaconApiUrl.get,
-            trustedBlockRoot = config.trustedBlockRoot,
-            trustedStateRoot = config.trustedStateRoot,
-            genesisBlockRoot = $genesisBlockRoot
-          some genesisBlockRoot
-        else:
-          none[Eth2Digest]()
-      else:
-        none[Eth2Digest]()
-    if config.trustedStateRoot.isNone and trustedBlockRoot.isNone:
-      warn "Ignoring `--external-beacon-api-url`, neither " &
-        "`--trusted-block-root` nor `--trusted-state-root` provided",
-        externalBeaconApiUrl = config.externalBeaconApiUrl.get,
-        trustedBlockRoot = config.trustedBlockRoot,
-        trustedStateRoot = config.trustedStateRoot
-    else:
-      if genesisState.isNil:
-        genesisState = await fetchGenesisState(
-          metadata, config.genesisState, config.genesisStateUrl)
-      await db.doRunTrustedNodeSync(
-        metadata,
-        config.databaseDir,
-        config.eraDir,
-        config.externalBeaconApiUrl.get,
-        config.trustedStateRoot.map do (x: Eth2Digest) -> string:
-          x.data.to0xHex(),
-        trustedBlockRoot,
-        backfill = false,
-        reindex = false,
-        genesisState)
-
-  let checkpointState = if config.finalizedCheckpointState.isSome:
-    let checkpointStatePath = config.finalizedCheckpointState.get.string
-    let tmp = try:
-      newClone(readSszForkedHashedBeaconState(
-        cfg, readAllBytes(checkpointStatePath).tryGet()))
-    except SszError as err:
-      fatal "Checkpoint state loading failed",
-            err = formatMsg(err, checkpointStatePath)
-      return Opt.none(BeaconNode)
-    except CatchableError as err:
-      fatal "Failed to read checkpoint state file", err = err.msg
-      return Opt.none(BeaconNode)
-
-    if not getStateField(tmp[], slot).is_epoch:
-      fatal "--finalized-checkpoint-state must point to a state for an epoch slot",
-        slot = getStateField(tmp[], slot)
-      return Opt.none(BeaconNode)
-    tmp
-  else:
-    nil
-
-  let engineApiUrls = config.engineApiUrls
-
-  if engineApiUrls.len == 0:
-    notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
-
-  var networkGenesisValidatorsRoot = metadata.bakedGenesisValidatorsRoot
-
-  if not ChainDAGRef.isInitialized(db).isOk():
-    genesisState =
-      if not checkpointState.isNil and
-          getStateField(checkpointState[], slot) == 0:
-        checkpointState
-      else:
-        if genesisState.isNil:
-          await fetchGenesisState(
-            metadata, config.genesisState, config.genesisStateUrl)
-        else:
-          genesisState
-
-    if genesisState.isNil and checkpointState.isNil:
-      fatal "No database and no genesis snapshot found. Please supply a genesis.ssz " &
-            "with the network configuration"
-      return Opt.none(BeaconNode)
-
-    if not genesisState.isNil and not checkpointState.isNil:
-      if getStateField(genesisState[], genesis_validators_root) !=
-          getStateField(checkpointState[], genesis_validators_root):
-        fatal "Checkpoint state does not match genesis - check the --network parameter",
-          rootFromGenesis = getStateField(
-            genesisState[], genesis_validators_root),
-          rootFromCheckpoint = getStateField(
-            checkpointState[], genesis_validators_root)
-        return Opt.none(BeaconNode)
-
-    try:
-      # Always store genesis state if we have it - this allows reindexing and
-      # answering genesis queries
-      if not genesisState.isNil:
-        ChainDAGRef.preInit(db, genesisState[])
-        networkGenesisValidatorsRoot =
-          Opt.some(getStateField(genesisState[], genesis_validators_root))
-
-      if not checkpointState.isNil:
-        if genesisState.isNil or
-            getStateField(checkpointState[], slot) != GENESIS_SLOT:
-          ChainDAGRef.preInit(db, checkpointState[])
-
-      doAssert ChainDAGRef.isInitialized(db).isOk(), "preInit should have initialized db"
-    except CatchableError as exc:
-      error "Failed to initialize database", err = exc.msg
-      return Opt.none(BeaconNode)
-  elif not checkpointState.isNil:
-    fatal "A database already exists, cannot start from given checkpoint",
-      dataDir = config.dataDir
-    return Opt.none(BeaconNode)
+  let db = ?await setupDatabase(config, metadata)
 
   # Doesn't use std/random directly, but dependencies might
   randomize(rng[].rand(high(int)))
@@ -947,7 +924,7 @@ proc init*(
   # break existing setups
   let
     validatorMonitor = newClone(ValidatorMonitor.init(
-      cfg,
+      metadata.cfg,
       config.validatorMonitorAuto,
       config.validatorMonitorTotals.get(
         not config.validatorMonitorDetails)))
@@ -956,15 +933,24 @@ proc init*(
     validatorMonitor[].addMonitor(key, Opt.none(ValidatorIndex))
 
   let
+    eventBus = EventBus.init()
     dag = loadChainDag(
-      config, cfg, db, eventBus,
-      validatorMonitor, networkGenesisValidatorsRoot)
+      config, metadata.cfg, db, eventBus,
+      validatorMonitor, metadata.bakedGenesisValidatorsRoot())
     genesisTime = getStateField(dag.headState, genesis_time)
     beaconClock = BeaconClock.init(metadata.cfg.timeParams, genesisTime).valueOr:
       fatal "Invalid genesis time in state", genesisTime
       return Opt.none(BeaconNode)
 
     getBeaconTime = beaconClock.getBeaconTimeFn()
+
+  if config.reindexBN:
+    dag.rebuildIndex(
+      proc(): bool =
+        ProcessState.stopping.isSome()
+    )
+  if ProcessState.stopIt(notice("Shutting down", reason = it)):
+    return Opt.none(BeaconNode)
 
   let clist =
     block:
@@ -992,7 +978,10 @@ proc init*(
     dag.checkWeakSubjectivityCheckpoint(
       config.weakSubjectivityCheckpoint.get, beaconClock)
 
-  let elManager = ELManager.new(engineApiUrls, metadata.eth1Network)
+  if config.engineApiUrls.len == 0:
+    notice "Running without execution client - validator features disabled (see https://nimbus.guide/eth1.html)"
+
+  let elManager = ELManager.new(config.engineApiUrls, metadata.eth1Network)
 
   let restServer = if config.restEnabled:
     RestServerRef.init(config.restAddress, config.restPort,
@@ -1011,7 +1000,7 @@ proc init*(
       rng,
       config,
       netKeys,
-      cfg,
+      metadata.cfg,
       dag.forkDigests,
       getBeaconTime,
       getStateField(dag.headState, genesis_validators_root),
@@ -1036,10 +1025,10 @@ proc init*(
       getValidator(forkyState().data.validators.asSeq(), pubkey)
 
   func getCapellaForkVersion(): Opt[presets.Version] =
-    Opt.some(cfg.CAPELLA_FORK_VERSION)
+    Opt.some(metadata.cfg.CAPELLA_FORK_VERSION)
 
   func getDenebForkEpoch(): Opt[Epoch] =
-    Opt.some(cfg.DENEB_FORK_EPOCH)
+    Opt.some(metadata.cfg.DENEB_FORK_EPOCH)
 
   proc getForkForEpoch(epoch: Epoch): Opt[Fork] =
     Opt.some(dag.forkAtEpoch(epoch))
@@ -1062,7 +1051,7 @@ proc init*(
         validatorPool,
         keystoreCache,
         rng,
-        cfg.timeParams,
+        metadata.cfg.timeParams,
         keymanagerInitResult.token,
         config.validatorsDir,
         config.secretsDir,
@@ -1092,8 +1081,7 @@ proc init*(
 
   let node = BeaconNode(
     nickname: nickname,
-    graffitiBytes: if config.graffiti.isSome: config.graffiti.get
-                   else: defaultGraffitiBytes(),
+    graffitiBytes: config.graffiti.get(defaultGraffitiBytes()),
     network: network,
     netKeys: netKeys,
     db: db,
@@ -1112,7 +1100,8 @@ proc init*(
     dynamicFeeRecipientsStore: newClone(DynamicFeeRecipientsStore.init()))
 
   node.initLightClient(
-    rng, cfg, dag.forkDigests, getBeaconTime, dag.genesis_validators_root)
+    rng, metadata.cfg, dag.forkDigests, getBeaconTime, dag.genesis_validators_root)
+
   await node.initFullNode(rng, dag, clist, taskpool, getBeaconTime)
 
   node.updateLightClientFromDag()
@@ -3009,7 +2998,8 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
     let
       metadata = loadEth2Network(config)
       db = BeaconChainDB.new(config.databaseDir, metadata.cfg, inMemory = false)
-      genesisState = waitFor fetchGenesisState(metadata)
+      genesisState = (waitFor fetchGenesisState(metadata, config.eraDir)).valueOr:
+        quit 1
     waitFor db.doRunTrustedNodeSync(
       metadata,
       config.databaseDir,

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -60,18 +60,12 @@ proc main() {.noinline, raises: [CatchableError].} =
   template cfg(): auto = metadata.cfg
 
   let
-    genesisBytes = try: waitFor metadata.fetchGenesisBytes()
+    genesisState = try: waitFor metadata.fetchGenesisState()
                    except CatchableError as err:
                      error "Failed to obtain genesis state",
                             source = metadata.genesis.sourceDesc,
                             err = err.msg
                      quit 1
-    genesisState =
-      try:
-        newClone(readSszForkedHashedBeaconState(cfg, genesisBytes))
-      except CatchableError as err:
-        raiseAssert "Invalid baked-in state: " & err.msg
-
     genesisTime = getStateField(genesisState[], genesis_time)
     beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
       error "Invalid genesis time in state", genesisTime

--- a/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_debug_calls.nim
@@ -8,9 +8,10 @@
 {.push raises: [].}
 
 import
+  std/strformat,
   chronos, presto/client,
-  ".."/[helpers, forks],
-  "."/[rest_types, eth2_rest_serialization]
+  ../[helpers, forks],
+  ./[rest_types, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization
 
@@ -35,23 +36,18 @@ proc getStateV2*(client: RestClientRef, state_id: StateIdent,
       await client.getStateV2Plain(state_id, restAcceptType = restAccept)
     else:
       await client.getStateV2Plain(state_id)
-  return
-    case resp.status
-    of 200:
-      if resp.contentType.isNone() or
-         isWildCard(resp.contentType.get().mediaType):
-        raise newException(RestError, "Missing or incorrect Content-Type")
-      else:
-        let mediaType = resp.contentType.get().mediaType
+
+  case resp.status
+  of 200:
+    if resp.contentType.isNone():
+      raise newException(RestError, "Missing Content-Type")
+
+    let
+      mediaType = resp.contentType.get().mediaType
+      state =
         if mediaType == ApplicationJsonMediaType:
-          let state =
-            block:
-              let res = newClone(decodeBytes(GetStateV2Response, resp.data,
-                                    resp.contentType))
-              if res[].isErr():
-                raise newException(RestError, $res[].error())
-              newClone(res[].get())
-          state
+          decodeBytes(GetStateV2Response, resp.data, resp.contentType).valueOr:
+            raise newException(RestError, $error)
         elif mediaType == OctetStreamMediaType:
           try:
             newClone(readSszForkedHashedBeaconState(cfg, resp.data))
@@ -59,16 +55,30 @@ proc getStateV2*(client: RestClientRef, state_id: StateIdent,
             raise newException(RestError, exc.msg)
         else:
           raise newException(RestError, "Unsupported content-type")
-    of 404:
-      nil
-    of 400, 500:
-      let error = decodeBytes(RestErrorMessage, resp.data,
-                              resp.contentType).valueOr:
-        let msg = "Incorrect response error format (" & $resp.status &
-                  ") [" & $error & "]"
-        raise (ref RestResponseError)(msg: msg, status: resp.status)
-      let msg = "Error response (" & $resp.status & ") [" & error.message & "]"
-      raise (ref RestResponseError)(
-        msg: msg, status: error.code, message: error.message)
-    else:
-      raiseRestResponseError(resp)
+
+    case state_id.kind
+    of StateQueryKind.Slot:
+      if getStateField(state[], slot) != state_id.slot:
+        raise newException(RestError, "Wrong slot in received state")
+    of StateQueryKind.Root:
+      if state[].getStateRoot() != state_id.root:
+        raise newException(RestError, "Wrong root in received state")
+    of StateQueryKind.Named:
+      case state_id.value
+      of StateIdentType.Genesis:
+        if getStateField(state[], slot) != GENESIS_SLOT:
+          raise newException(RestError, "Wrong slot in received state")
+      else:
+        discard # can't trivially check these
+
+    state
+  of 404:
+    nil
+  of 400, 500:
+    let error = decodeBytes(RestErrorMessage, resp.data, resp.contentType).valueOr:
+      let msg = &"Incorrect response error format ({resp.status}) [{error}]"
+      raise (ref RestResponseError)(msg: msg, status: resp.status)
+    let msg = &"Error response ({resp.status}) [{error.message}]"
+    raise (ref RestResponseError)(msg: msg, status: error.code, message: error.message)
+  else:
+    raiseRestResponseError(resp)

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -14,7 +14,8 @@ import
   ./consensus_object_pools/[block_clearance, blockchain_dag],
   ./spec/eth2_apis/rest_beacon_client,
   ./spec/[beaconstate, eth2_merkleization, forks, light_client_sync,
-          network, presets, state_transition]
+          network, presets, state_transition],
+  ./process_state
 
 from presto import RestDecodingError
 from "."/beacon_clock import
@@ -47,12 +48,230 @@ func shortLog*(v: TrustedNodeSyncTarget): auto =
 
 chronicles.formatIt(TrustedNodeSyncTarget): shortLog(it)
 
+proc fromTrustedBlockRoot*(T: type TrustedNodeSyncTarget, v: Eth2Digest): T =
+  T(kind: TrustedNodeSyncKind.TrustedBlockRoot, trustedBlockRoot: v)
+
+proc fromStateId*(T: type TrustedNodeSyncTarget, v: string): T =
+  T(kind: TrustedNodeSyncKind.StateId, stateId: v)
+
 proc createNewRestClient(url: string): Result[RestClientRef, cstring] =
   let
     flags = {RestClientFlag.CommaSeparatedArray,
              RestClientFlag.ResolveAlways}
     socketFlags = {SocketFlags.TcpNoDelay}
   RestClientRef.new(url, flags = flags, socketFlags = socketFlags)
+
+proc fetchCheckpointState(
+    cfg: RuntimeConfig,
+    client: RestClientRef,
+    syncTarget: TrustedNodeSyncTarget,
+    genesisState: ref ForkedHashedBeaconState,
+): Future[ref ForkedHashedBeaconState] {.async: (raises: [CancelledError]).} =
+  var stateRoot: Opt[Eth2Digest]
+  let stateId =
+    case syncTarget.kind
+    of TrustedNodeSyncKind.TrustedBlockRoot:
+      # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/altair/light-client/light-client.md#light-client-sync-process
+      const lcDataFork = LightClientDataFork.high
+      var bestViableCheckpoint: Opt[tuple[slot: Slot, state_root: Eth2Digest]]
+      func trackBestViableCheckpoint(store: lcDataFork.LightClientStore) =
+        if store.finalized_header.beacon.slot.is_epoch:
+          bestViableCheckpoint.ok(
+            (
+              slot: store.finalized_header.beacon.slot,
+              state_root: store.finalized_header.beacon.state_root,
+            )
+          )
+
+      doAssert genesisState != nil, "Already checked for `TrustedBlockRoot`"
+      let
+        genesisTime = getStateField(genesisState[], genesis_time)
+        beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
+          error "Invalid genesis time in state", genesisTime
+          quit 1
+
+        genesis_validators_root = getStateField(genesisState[], genesis_validators_root)
+        forkDigests = newClone ForkDigests.init(cfg, genesis_validators_root)
+
+        trustedBlockRoot = syncTarget.trustedBlockRoot
+
+      notice "Downloading state verification light client data", trustedBlockRoot
+
+      var bootstrap =
+        try:
+          info "Downloading LC bootstrap", trustedBlockRoot
+          awaitWithTimeout(
+            client.getLightClientBootstrap(trustedBlockRoot, cfg, forkDigests),
+            smallRequestsTimeout,
+          ):
+            error "Attempt to download LC bootstrap timed out"
+            return nil
+        except CatchableError as exc:
+          error "Unable to download LC bootstrap", error = exc.msg
+          return nil
+      if bootstrap.kind == LightClientDataFork.None:
+        error "LC bootstrap unavailable on server"
+        return nil
+      bootstrap.migrateToDataFork(lcDataFork)
+
+      var store = initialize_light_client_store(
+        trustedBlockRoot, bootstrap.forky(lcDataFork), cfg
+      ).valueOr:
+        error "`initialize_light_client_store` failed", err = error
+        quit 1
+      store.trackBestViableCheckpoint()
+
+      while true:
+        let
+          finalized = store.finalized_header.beacon.slot.sync_committee_period
+          optimistic = store.optimistic_header.beacon.slot.sync_committee_period
+          current = beaconClock.currentSlot.sync_committee_period
+          isNextSyncCommitteeKnown = store.is_next_sync_committee_known
+          periods: Slice[SyncCommitteePeriod] =
+            if finalized == optimistic and not isNextSyncCommitteeKnown:
+              if finalized >= current:
+                finalized .. finalized
+              else:
+                finalized ..< current
+            elif finalized + 1 < current:
+              finalized + 1 ..< current
+            else:
+              break
+          startPeriod = periods.a
+          count = min(periods.len, MAX_REQUEST_LIGHT_CLIENT_UPDATES).uint64
+
+        var updates =
+          try:
+            info "Downloading LC updates", startPeriod, count
+            awaitWithTimeout(
+              client.getLightClientUpdatesByRange(startPeriod, count, cfg, forkDigests),
+              smallRequestsTimeout,
+            ):
+              error "Attempt to download LC updates timed out"
+              return nil
+          except CatchableError as exc:
+            error "Unable to download LC updates", error = exc.msg
+            return nil
+        updates.checkLightClientUpdates(startPeriod, count).isOkOr:
+          error "Malformed LC updates response", error
+          quit 1
+        if updates.len == 0:
+          warn "Server does not appear to be fully synced"
+          break
+
+        for i in 0 ..< updates.len:
+          doAssert updates[i].kind > LightClientDataFork.None
+          updates[i].migrateToDataFork(lcDataFork)
+          store.process_light_client_update(
+            updates[i].forky(lcDataFork),
+            beaconClock.currentSlot,
+            cfg,
+            genesis_validators_root,
+          ).isOkOr:
+            error "`process_light_client_update` failed", error
+            quit 1
+          store.trackBestViableCheckpoint()
+
+      var finalityUpdate =
+        try:
+          info "Downloading LC finality update"
+          awaitWithTimeout(
+            client.getLightClientFinalityUpdate(cfg, forkDigests), smallRequestsTimeout
+          ):
+            error "Attempt to download LC finality update timed out"
+            return nil
+        except CatchableError as exc:
+          error "Unable to download LC finality update", err = exc.msg
+          return nil
+      if bootstrap.kind == LightClientDataFork.None:
+        error "LC finality update unavailable on server"
+        return nil
+
+      finalityUpdate.migrateToDataFork(lcDataFork)
+
+      store.process_light_client_update(
+        finalityUpdate.forky(lcDataFork),
+        beaconClock.currentSlot,
+        cfg,
+        genesis_validators_root,
+      ).isOkOr:
+        error "`process_light_client_update` failed", error
+        quit 1
+      store.trackBestViableCheckpoint()
+
+      if bestViableCheckpoint.isErr:
+        error "CP not on epoch boundary. Retry later",
+          latestCheckpointSlot = store.finalized_header.beacon.slot
+        return nil
+      if not store.finalized_header.beacon.slot.is_epoch:
+        warn "CP not on epoch boundary. Using older one",
+          latestCheckpointSlot = store.finalized_header.beacon.slot,
+          bestViableCheckpointSlot = bestViableCheckpoint.get.slot
+
+      stateRoot.ok bestViableCheckpoint.get.state_root
+      Base10.toString(distinctBase(bestViableCheckpoint.get.slot))
+    of TrustedNodeSyncKind.StateId:
+      syncTarget.stateId
+
+  logScope:
+    stateId
+
+  notice "Downloading checkpoint state"
+
+  let state =
+    try:
+      let id = block:
+        let tmp = StateIdent.decodeString(stateId).valueOr:
+          error "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
+          return nil
+        if tmp.kind == StateQueryKind.Slot and not tmp.slot.is_epoch():
+          notice "Rounding given slot to epoch"
+          StateIdent.init(tmp.slot.epoch().start_slot)
+        else:
+          tmp
+      awaitWithTimeout(client.getStateV2(id, cfg), largeRequestsTimeout):
+        error "Attempt to download checkpoint state timed out; https://nimbus.guide/trusted-node-sync.html#sync-from-checkpoint-files provides an alternative approach"
+        return nil
+    except CatchableError as exc:
+      error "Unable to download checkpoint state", error = exc.msg
+      return nil
+
+  if state == nil:
+    error "No state found a given checkpoint"
+    return nil
+
+  if stateRoot.isSome:
+    if state[].getStateRoot() != stateRoot.get:
+      error "Checkpoint state has incorrect root!",
+        expectedStateRoot = stateRoot.get, actualStateRoot = state[].getStateRoot()
+      return nil
+
+    notice "Checkpoint state validated against light client data",
+      stateRoot = stateRoot.get
+
+  if not getStateField(state[], slot).is_epoch():
+    error "State slot must fall on an epoch boundary",
+      slot = getStateField(state[], slot),
+      offset =
+        getStateField(state[], slot) - getStateField(state[], slot).epoch.start_slot
+    return nil
+
+  state
+
+proc fetchCheckpointState*(
+  cfg: RuntimeConfig,
+  restUrl: string,
+  syncTarget: TrustedNodeSyncTarget,
+  genesisState: ref ForkedHashedBeaconState,
+): Future[ref ForkedHashedBeaconState] {.async: (raises: [CancelledError]).} =
+  var
+    client = createNewRestClient(restUrl).valueOr:
+      error "Cannot connect to server", url = restUrl, reason = error
+      quit 1
+  defer:
+    await client.closeWait()
+
+  await fetchCheckpointState(cfg, client, syncTarget, genesisState)
 
 proc doTrustedNodeSync*(
     db: BeaconChainDB,
@@ -74,8 +293,10 @@ proc doTrustedNodeSync*(
 
   var
     client = createNewRestClient(restUrl).valueOr:
-      error "Cannot connect to server", reason = error
+      error "Cannot connect to server", url = restUrl, reason = error
       quit 1
+  defer:
+    await client.closeWait()
 
   # If possible, we'll store the genesis state in the database - this is not
   # strictly necessary but renders the resulting database compatible with
@@ -160,193 +381,10 @@ proc doTrustedNodeSync*(
       Opt.none(BlockId)
 
   if head.isNone:
-    var stateRoot: Opt[Eth2Digest]
-    let stateId =
-      case syncTarget.kind
-      of TrustedNodeSyncKind.TrustedBlockRoot:
-        # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/altair/light-client/light-client.md#light-client-sync-process
-        const lcDataFork = LightClientDataFork.high
-        var bestViableCheckpoint: Opt[tuple[slot: Slot, state_root: Eth2Digest]]
-        func trackBestViableCheckpoint(store: lcDataFork.LightClientStore) =
-          if store.finalized_header.beacon.slot.is_epoch:
-            bestViableCheckpoint.ok((
-              slot: store.finalized_header.beacon.slot,
-              state_root: store.finalized_header.beacon.state_root))
-
-        doAssert genesisState != nil, "Already checked for `TrustedBlockRoot`"
-        let
-          genesisTime = getStateField(genesisState[], genesis_time)
-          beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
-            error "Invalid genesis time in state", genesisTime
-            quit 1
-
-          genesis_validators_root =
-            getStateField(genesisState[], genesis_validators_root)
-          forkDigests = newClone ForkDigests.init(cfg, genesis_validators_root)
-
-          trustedBlockRoot = syncTarget.trustedBlockRoot
-
-        var bootstrap =
-          try:
-            notice "Downloading LC bootstrap", trustedBlockRoot
-            awaitWithTimeout(
-              client.getLightClientBootstrap(
-                trustedBlockRoot, cfg, forkDigests),
-              smallRequestsTimeout
-            ):
-              error "Attempt to download LC bootstrap timed out"
-              quit 1
-          except CatchableError as exc:
-            error "Unable to download LC bootstrap", error = exc.msg
-            quit 1
-        if bootstrap.kind == LightClientDataFork.None:
-          error "LC bootstrap unavailable on server"
-          quit 1
-        bootstrap.migrateToDataFork(lcDataFork)
-
-        var storeRes = initialize_light_client_store(
-          trustedBlockRoot, bootstrap.forky(lcDataFork), cfg)
-        if storeRes.isErr:
-          error "`initialize_light_client_store` failed", err = storeRes.error
-          quit 1
-        template store: auto = storeRes.get
-        store.trackBestViableCheckpoint()
-
-        while true:
-          let
-            finalized =
-              store.finalized_header.beacon.slot.sync_committee_period
-            optimistic =
-              store.optimistic_header.beacon.slot.sync_committee_period
-            current =
-              beaconClock.currentSlot.sync_committee_period
-            isNextSyncCommitteeKnown =
-              store.is_next_sync_committee_known
-
-          let
-            periods: Slice[SyncCommitteePeriod] =
-              if finalized == optimistic and not isNextSyncCommitteeKnown:
-                if finalized >= current:
-                  finalized .. finalized
-                else:
-                  finalized ..< current
-              elif finalized + 1 < current:
-                finalized + 1 ..< current
-              else:
-                break
-            startPeriod = periods.a
-            count = min(periods.len, MAX_REQUEST_LIGHT_CLIENT_UPDATES).uint64
-
-          var updates =
-            try:
-              notice "Downloading LC updates", startPeriod, count
-              awaitWithTimeout(
-                client.getLightClientUpdatesByRange(
-                  startPeriod, count, cfg, forkDigests),
-                smallRequestsTimeout
-              ):
-                error "Attempt to download LC updates timed out"
-                quit 1
-            except CatchableError as exc:
-              error "Unable to download LC updates", error = exc.msg
-              quit 1
-          let e = updates.checkLightClientUpdates(startPeriod, count)
-          if e.isErr:
-            error "Malformed LC updates response", resError = e.error
-            quit 1
-          if updates.len == 0:
-            warn "Server does not appear to be fully synced"
-            break
-          for i in 0 ..< updates.len:
-            doAssert updates[i].kind > LightClientDataFork.None
-            updates[i].migrateToDataFork(lcDataFork)
-            let res = process_light_client_update(
-              store, updates[i].forky(lcDataFork),
-              beaconClock.currentSlot, cfg, genesis_validators_root)
-            if not res.isOk:
-              error "`process_light_client_update` failed", resError = res.error
-              quit 1
-            store.trackBestViableCheckpoint()
-
-        var finalityUpdate =
-          try:
-            notice "Downloading LC finality update"
-            awaitWithTimeout(
-              client.getLightClientFinalityUpdate(cfg, forkDigests),
-              smallRequestsTimeout
-            ):
-              error "Attempt to download LC finality update timed out"
-              quit 1
-          except CatchableError as exc:
-            error "Unable to download LC finality update", error = exc.msg
-            quit 1
-        if bootstrap.kind == LightClientDataFork.None:
-          error "LC finality update unavailable on server"
-          quit 1
-        finalityUpdate.migrateToDataFork(lcDataFork)
-
-        let res = process_light_client_update(
-          store, finalityUpdate.forky(lcDataFork),
-          beaconClock.currentSlot, cfg, genesis_validators_root)
-        if not res.isOk:
-          error "`process_light_client_update` failed", resError = res.error
-          quit 1
-        store.trackBestViableCheckpoint()
-
-        if bestViableCheckpoint.isErr:
-          error "CP not on epoch boundary. Retry later",
-            latestCheckpointSlot = store.finalized_header.beacon.slot
-          quit 1
-        if not store.finalized_header.beacon.slot.is_epoch:
-          warn "CP not on epoch boundary. Using older one",
-            latestCheckpointSlot = store.finalized_header.beacon.slot,
-            bestViableCheckpointSlot = bestViableCheckpoint.get.slot
-
-        stateRoot.ok bestViableCheckpoint.get.state_root
-        Base10.toString(distinctBase(bestViableCheckpoint.get.slot))
-      of TrustedNodeSyncKind.StateId:
-        syncTarget.stateId
-    logScope: stateId
-
-    notice "Downloading checkpoint state"
-
-    let
-      state = try:
-        let id = block:
-          let tmp = StateIdent.decodeString(stateId).valueOr:
-            error "Cannot decode checkpoint state id, must be a slot, hash, 'finalized' or 'head'"
-            quit 1
-          if tmp.kind == StateQueryKind.Slot and not tmp.slot.is_epoch():
-            notice "Rounding given slot to epoch"
-            StateIdent.init(tmp.slot.epoch().start_slot)
-          else:
-            tmp
-        awaitWithTimeout(client.getStateV2(id, cfg), largeRequestsTimeout):
-          error "Attempt to download checkpoint state timed out; https://nimbus.guide/trusted-node-sync.html#sync-from-checkpoint-files provides an alternative approach"
-          quit 1
-      except CatchableError as exc:
-        error "Unable to download checkpoint state",
-          error = exc.msg
-        quit 1
+    let state = await fetchCheckpointState(cfg, client, syncTarget, genesisState)
 
     if state == nil:
       error "No state found a given checkpoint"
-      quit 1
-
-    if stateRoot.isSome:
-      if state[].getStateRoot() != stateRoot.get:
-        error "Checkpoint state has incorrect root!",
-          expectedStateRoot = stateRoot.get,
-          actualStateRoot = state[].getStateRoot()
-        quit 1
-      info "Checkpoint state validated against LC data",
-        stateRoot = stateRoot.get
-
-    if not getStateField(state[], slot).is_epoch():
-      error "State slot must fall on an epoch boundary",
-        slot = getStateField(state[], slot),
-        offset = getStateField(state[], slot) -
-          getStateField(state[], slot).epoch.start_slot
       quit 1
 
     if genesisState != nil:
@@ -506,7 +544,10 @@ proc doTrustedNodeSync*(
     notice "Reindexing historical state lookup tables (you can interrupt this process at any time)"
 
     # Build a DAG
-    dag.rebuildIndex()
+    dag.rebuildIndex(
+      proc(): bool =
+        ProcessState.stopIt(notice("Shutting down", reason = it))
+    )
 
   notice "Done, your beacon node is ready to serve you! Don't forget to check that you're on the canonical chain by comparing the checkpoint root with other online sources. See https://nimbus.guide/trusted-node-sync.html for more information.",
     checkpoint = dag.head
@@ -519,9 +560,7 @@ when isMainModule:
   let
     cfg = getRuntimeConfig(some os.paramStr(1))
     databaseDir = os.paramStr(2)
-    syncTarget = TrustedNodeSyncTarget(
-      kind: TrustedNodeSyncKind.StateId,
-      stateId: os.paramStr(5))
+    syncTarget = TrustedNodeSyncTarget.fromStateId(os.paramStr(5))
     backfill = os.paramCount() > 5 and os.paramStr(6) == "true"
     db = BeaconChainDB.new(databaseDir, cfg, inMemory = false)
   waitFor db.doTrustedNodeSync(

--- a/docs/the_nimbus_book/src/era-store.md
+++ b/docs/the_nimbus_book/src/era-store.md
@@ -1,9 +1,5 @@
 # Era store
 
-!!! warning
-    This feature is currently in BETA!
-    Nodes using era files may need to be resynced as the data format is not yet considered stable.
-
 Era files are a long-term archival format for Ethereum data.
 They are used to provide an easy interchange medium that clients interested in deep ethereum history can use to recreate past states.
 
@@ -31,7 +27,19 @@ mkdir -p era
 wget --no-parent  -A '*.era' -q --show-progress -nd -r -c https://provider/era
 ```
 
-With the era files present, perform a [trusted node sync](./trusted-node-sync.md) to complete the import, possibly with `--reindex` in order to create an [archive node](./history.md).
+The beacon node will automatically serve data from the Era files.
+
+### Recreate historical state access indices
+
+To create an archive node that can access historical state, start the node with `--reindex --history:archive`:
+
+```sh
+build/nimbus_beacon_node \
+  --network=mainnet \
+  --data-dir=build/data/shared_mainnet_0 \
+  --reindex \
+  --history:archive
+```
 
 ## Generating era files
 

--- a/docs/the_nimbus_book/src/history.md
+++ b/docs/the_nimbus_book/src/history.md
@@ -35,7 +35,7 @@ To reclaim space, perform a [trusted node sync](./trusted-node-sync.md) using a 
 
 When switching to `archive` mode, the node will start keeping history from the most recent prune point, but will not recreate deep history.
 
-In order to recreate deep history in a pruned node, download the [era archive of deep history](./era-store.md) and [reindex the database](./trusted-node-sync.md#recreate-historical-state-access-indices) — this operation may take several hours.
+In order to recreate deep history in a pruned node, download the [era archive of deep history](./era-store.md) and [reindex the database](./era-store.md#recreate-historical-state-access-indices) — this operation may take several hours.
 
 ## Command line
 

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -140,6 +140,7 @@ The following options are available:
      --local-block-value-boost  Increase execution layer block values for builder bid comparison by a percentage
                                [=10].
      --history                 Retention strategy for historical data (archive/prune) [=HistoryMode.Prune].
+     --reindex                 Reindex historical states for archive access.
 
 ...
 ```

--- a/docs/the_nimbus_book/src/quick-start.md
+++ b/docs/the_nimbus_book/src/quick-start.md
@@ -49,7 +49,7 @@ See the [execution client guide](./eth1.md) for instructions on how to pick and 
 
 ### 4. Sync from a trusted node
 
-While this step is not mandatory, since Nimbus will automatically start syncing process on the first start, we recommend doing it as it will allow you to get started in **minutes** instead of hours or even days.
+While this step is not mandatory, it can cut down the initial sync time from days to **minutes**.
 
 Follow our [trusted node sync guide](./trusted-node-sync.md).
 

--- a/docs/the_nimbus_book/src/trusted-node-sync.md
+++ b/docs/the_nimbus_book/src/trusted-node-sync.md
@@ -1,8 +1,8 @@
 # Sync from a trusted node
 
-When you [start the beacon node](./quick-start.md) for the first time, it connects to the beacon chain network and starts syncing automatically — a process that can take **several hours or even days**.
+When you [start the beacon node](./quick-start.md) for the first time, it connects to the beacon chain network and starts syncing automatically — a process that can take **several days**.
 
-Trusted node sync allows you to get started more quickly by fetching a recent checkpoint from a trusted node — you can get started in **minutes** instead of hours or days.
+Trusted node sync allows you to get started more quickly by fetching a recent checkpoint from a trusted node — you can get started in **minutes** instead.
 
 To use trusted node sync, you must have access to a node that you trust and that exposes the [Beacon API](./rest-api.md) (for example, a locally running backup node).
 Should this node, or your connection to it, be compromised, your node will not be able to detect whether or not it is being served false information.
@@ -46,8 +46,8 @@ To start trusted node sync, run:
 If the command was executed successfully, following log lines will be visible:
 
 ```
-Writing checkpoint state
-Writing checkpoint block
+Database initialized from genesis
+Checkpoint written to database
 ```
 And eventually:
 ```
@@ -153,5 +153,5 @@ To recreate a historical index from before the checkpoint, it is necessary to fi
 build/nimbus_beacon_node trustedNodeSync \
   --network=mainnet \
   --data-dir=build/data/shared_mainnet_0 \
-  --reindex=true
+  --reindex
 ```

--- a/ncli/era.nim
+++ b/ncli/era.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/ncli/era.nim
+++ b/ncli/era.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/strformat,
+  std/[strformat, strutils],
   results,
   stew/[endians2, io2],
   snappy,
@@ -57,10 +57,22 @@ func eraRoot*(
 
 func eraFileName*(
     cfg: RuntimeConfig, era: Era, eraRoot: Eth2Digest): string =
-  try:
-    &"{cfg.name()}-{era.uint64:05}-{shortLog(eraRoot)}.era"
-  except ValueError as exc:
-    raiseAssert exc.msg
+  &"{cfg.name()}-{era.uint64:05}-{shortLog(eraRoot)}.era"
+
+func fromEraFile*(
+  _: type Era, cfg:RuntimeConfig, name: string
+): Opt[Era] =
+  ## Parse an Era number from an era file name.
+  ## Era files follow the naming convention: {network}-{era:05d}-{root}.era
+  ## Returns none if the file name doesn't match the expected format.
+  let parts = name.split("-")
+  if parts.len == 3 and parts[0] == cfg.name() and name.endsWith(".era") and parts[1].len == 5:
+    try:
+      Opt.some Era(parseInt(parts[1]))
+    except ValueError:
+      Opt.none Era
+  else:
+    Opt.none Era
 
 proc toCompressedBytes(item: auto): seq[byte] =
   snappy.encodeFramed(SSZ.encode(item))

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -896,7 +896,7 @@ suite "Backfill":
 
       dag.backfill.slot == GENESIS_SLOT
 
-    dag.rebuildIndex()
+    dag.rebuildIndex(proc(): bool = false)
 
     check:
       dag.getFinalizedEpochRef() != nil


### PR DESCRIPTION
While it's possible to bootstrap nodes from `era` files via trusted node sync, the process is quite opaque and unnecessarily requires a checkpoint server.

Instead of getting the checkpoint from a server, we can load it directly from the most recent era file - this is similar to creating a checkpointed database from a state file.

The process also allows the convenient creation of archive nodes - by adding the `--reindex` flag to the main launch command, an archive node can be created with a single command as long as era files are present.

Finally, on hoodi we download the genesis state from a server (it's not embedded in the binary due to its size). If we have genesis in an era file, we can grab it from there instead removing an annoying download step for launching a hoodi node - simply grab era files from https://hoodi.era.nimbus.team/ and put them in the [era folder](https://nimbus.guide/era-store.html).

* don't attempt creating the database directory in read-only mode
* add `--reindex` flag for reindexing before main process starts
* lookup blocks in era database even if backfill process hasn't finished, enabling their use during reindexing
* move `RuntimeConfig` consistency check earlier
* more robust error handling when light client verification of checkpoint state fails
* verify that states downloaded from REST server actually correspond to what was requested