### PR TITLE
Disable columns processing for Gloas block

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -819,8 +819,8 @@ proc addBlock*(
         if sidecarsOpt.isSome:
           self.dataColumnQuarantine[].put(blockRoot, sidecarsOpt.get)
       elif sidecarsOpt is Opt[gloas.DataColumnSidecars]:
-        # In Gloas, block is enqueued with NoSidecar so this should be
-        # non-reachable code.
+        # In Gloas, block is enqueued with NoSidecar so we need not to care
+        # about quarantine.
         discard
       elif sidecarsOpt is NoSidecars:
         discard

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -403,10 +403,8 @@ proc enqueueQuarantine(self: ref BlockProcessor, parent: BlockRef) =
     debug "Block from quarantine", parent, quarantined = shortLog(quarantined.root)
 
     withBlck(quarantined):
-      when consensusFork == ConsensusFork.Gloas:
-        debugGloasComment ""
-        # Representing only Phase0 -> Capella sidecars as `noSidecars` for now
-        let sidecarsOpt = Opt.none(gloas.DataColumnSidecars)
+      when consensusFork >= ConsensusFork.Gloas:
+        const sidecarsOpt = noSidecars
       elif consensusFork == ConsensusFork.Fulu:
         let sidecarsOpt =
           if len(forkyBlck.message.body.blob_kzg_commitments) == 0:
@@ -533,8 +531,9 @@ proc enqueueFromDb(self: ref BlockProcessor, root: Eth2Digest) =
     var sidecarsOk = true
 
     let sidecarsOpt =
-      when consensusFork >= ConsensusFork.Fulu:
-        debugGloasComment ""
+      when consensusFork >= ConsensusFork.Gloas:
+        noSidecars
+      elif consensusFork == ConsensusFork.Fulu:
         var data_column_sidecars: fulu.DataColumnSidecars
         for i in self.dataColumnQuarantine[].custodyColumns:
           let data_column = fulu.DataColumnSidecar.new()
@@ -820,8 +819,9 @@ proc addBlock*(
         if sidecarsOpt.isSome:
           self.dataColumnQuarantine[].put(blockRoot, sidecarsOpt.get)
       elif sidecarsOpt is Opt[gloas.DataColumnSidecars]:
-        if sidecarsOpt.isSome:
-          debugGloasComment ""
+        # In Gloas, block is enqueued with NoSidecar so this should be
+        # non-reachable code.
+        discard
       elif sidecarsOpt is NoSidecars:
         discard
       else:

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -286,10 +286,9 @@ proc processSignedBeaconBlock*(
   if not (isNil(self.dag.onBlockGossipAdded)):
     self.dag.onBlockGossipAdded(ForkedSignedBeaconBlock.init(signedBlock))
 
-  when consensusFork == ConsensusFork.Gloas:
-    debugGloasComment ""
-    # gloas needs proper data column handling
-    let sidecarsOpt = Opt.some(default(seq[ref gloas.DataColumnSidecar]))
+  when consensusFork >= ConsensusFork.Gloas:
+    # Disable processing sidecars at block time.
+    const sidecarsOpt = noSidecars
   elif consensusFork == ConsensusFork.Fulu:
     let sidecarsOpt =
       if len(signedBlock.message.body.blob_kzg_commitments) == 0:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -467,7 +467,8 @@ proc initFullNode(
         when consensusFork in ConsensusFork.Fulu .. ConsensusFork.Gloas:
           # TODO document why there are no columns here
           when consensusFork == ConsensusFork.Gloas:
-            let sidecarsOpt = Opt.none(gloas.DataColumnSidecars)
+            # Disable sidecars processing at block time.
+            const sidecarsOpt = noSidecars
           else:
             let sidecarsOpt = Opt.none(fulu.DataColumnSidecars)
         elif consensusFork in ConsensusFork.Deneb .. ConsensusFork.Electra:
@@ -489,9 +490,9 @@ proc initFullNode(
                              maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork == ConsensusFork.Gloas:
-          debugGloasComment "no blob_kzg_commitments field for gloas"
-          let sidecarsOpt = Opt.none(gloas.DataColumnSidecars)
+        when consensusFork >= ConsensusFork.Gloas:
+          # Disable sidecars processing at block time.
+          const sidecarsOpt = noSidecars
         elif consensusFork == ConsensusFork.Fulu:
           let sidecarsOpt =
             if len(forkyBlck.message.body.blob_kzg_commitments) == 0:


### PR DESCRIPTION
Part of #7748 

### Summary

`Opt.none(DataColumnSidecars)` is used for verification in some places. So using `NoSidecars` to disable sidecars in Gloas block processing.