### PR TITLE
ForkedHashedBeaconState helpers

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -19,7 +19,7 @@ func shouldSyncOptimistically*(node: BeaconNode, wallSlot: Slot): bool =
     when lcDataFork > LightClientDataFork.None:
       shouldSyncOptimistically(
         optimisticSlot = forkyHeader.beacon.slot,
-        dagSlot = getStateField(node.dag.headState, slot),
+        dagSlot = node.dag.headState.slot,
         wallSlot = wallSlot)
     else:
       false

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -169,9 +169,8 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
     doAssert status.isOk(), "Error in preloading the fork choice: " & $status.error
 
   info "Fork choice initialized",
-    justified = shortLog(getStateField(
-      dag.headState, current_justified_checkpoint)),
-    finalized = shortLog(getStateField(dag.headState, finalized_checkpoint))
+    justified = shortLog(dag.headState.current_justified_checkpoint),
+    finalized = shortLog(dag.headState.finalized_checkpoint)
   T(
     dag: dag,
     quarantine: quarantine,

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -106,7 +106,7 @@ proc addResolvedHeadBlock(
   # Regardless of the chain we're on, the deposits come in the same order so
   # as soon as we import a block, we'll also update the shared public key
   # cache
-  dag.updateValidatorKeys(getStateField(state, validators).asSeq())
+  dag.updateValidatorKeys(state.validators.asSeq())
 
   # Getting epochRef with the state will potentially create a new EpochRef
   let
@@ -374,7 +374,7 @@ proc addBackfillBlock*(
 
         if not verify_block_signature(
             dag.forkAtEpoch(blck.slot.epoch),
-            getStateField(dag.headState, genesis_validators_root),
+            dag.headState.genesis_validators_root,
             blck.slot,
             signedBlock.root,
             proposerKey,

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -300,8 +300,8 @@ proc getBlock*(
     T: type ForkyTrustedSignedBeaconBlock): Opt[T] =
   dag.db.getBlock(bid.root, T) or
     getBlock(
-      dag.era, getStateField(dag.headState, historical_roots).asSeq,
-      dag.headState.historical_summaries().asSeq,
+      dag.era, dag.headState.historical_roots.asSeq,
+      dag.headState.historical_summaries.asSeq,
       bid.slot, Opt[Eth2Digest].ok(bid.root), T)
 
 proc getBlockSSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
@@ -311,8 +311,8 @@ proc getBlockSSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
   dag.db.getBlockSSZ(bid.root, bytes, fork) or
     (bid.slot <= dag.finalizedHead.slot and
       getBlockSSZ(
-        dag.era, getStateField(dag.headState, historical_roots).asSeq,
-        dag.headState.historical_summaries().asSeq,
+        dag.era, dag.headState.historical_roots.asSeq,
+        dag.headState.historical_summaries.asSeq,
         bid.slot, bytes).isOk() and bytes.len > 0)
 
 proc getBlockSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
@@ -324,8 +324,8 @@ proc getBlockSZ*(dag: ChainDAGRef, bid: BlockId, bytes: var seq[byte]): bool =
   dag.db.getBlockSZ(bid.root, bytes, fork) or
     (bid.slot <= dag.finalizedHead.slot and
       getBlockSZ(
-        dag.era, getStateField(dag.headState, historical_roots).asSeq,
-        dag.headState.historical_summaries().asSeq,
+        dag.era, dag.headState.historical_roots.asSeq,
+        dag.headState.historical_summaries.asSeq,
         bid.slot, bytes).isOk and bytes.len > 0)
 
 proc getForkedBlock*(
@@ -337,8 +337,8 @@ proc getForkedBlock*(
     type T = type(forkyBlck)
     forkyBlck = getBlock(dag, bid, T).valueOr:
         getBlock(
-            dag.era, getStateField(dag.headState, historical_roots).asSeq,
-            dag.headState.historical_summaries().asSeq,
+            dag.era, dag.headState.historical_roots.asSeq,
+            dag.headState.historical_summaries.asSeq,
             bid.slot, Opt[Eth2Digest].ok(bid.root), T).valueOr:
           result.err()
           return
@@ -621,15 +621,12 @@ func init*(
       key: dag.epochKey(state.latest_block_id, epoch).expect(
         "Valid epoch ancestor when processing state"),
 
-      eth1_data:
-        getStateField(state, eth1_data),
-      eth1_deposit_index:
-        getStateField(state, eth1_deposit_index),
+      eth1_data: state.eth1_data,
+      eth1_deposit_index: state.eth1_deposit_index,
 
-      checkpoints:
-        FinalityCheckpoints(
-          justified: getStateField(state, current_justified_checkpoint),
-          finalized: getStateField(state, finalized_checkpoint)),
+      checkpoints:FinalityCheckpoints(
+        justified: state.current_justified_checkpoint,
+        finalized: state.finalized_checkpoint),
 
       # beacon_proposers: Separately filled below
       proposer_dependent_root: proposer_dependent_root,
@@ -656,7 +653,7 @@ func init*(
   epochRef.effective_balances_bytes =
     snappyEncode(SSZ.encode(
       List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT](
-        get_effective_balances(getStateField(state, validators).asSeq, epoch))))
+        get_effective_balances(state.validators.asSeq, epoch))))
 
   epochRef
 
@@ -922,11 +919,11 @@ export
 
 proc putState(dag: ChainDAGRef, state: ForkedHashedBeaconState, bid: BlockId) =
   # Store a state and its root
-  let slot = getStateField(state, slot)
+  let slot = state.slot
   logScope:
     blck = shortLog(bid)
     stateSlot = shortLog(slot)
-    stateRoot = shortLog(getStateRoot(state))
+    stateRoot = shortLog(state.root)
 
   if not dag.isStateCheckpoint(BlockSlotId.init(bid, slot)):
     return
@@ -934,7 +931,7 @@ proc putState(dag: ChainDAGRef, state: ForkedHashedBeaconState, bid: BlockId) =
   # Don't consider legacy tables here, they are slow to read so we'll want to
   # rewrite things in the new table anyway.
   if dag.db.containsState(
-      dag.cfg.consensusForkAtEpoch(slot.epoch), getStateRoot(state),
+      dag.cfg.consensusForkAtEpoch(slot.epoch), state.root,
       legacy = false):
     return
 
@@ -953,17 +950,16 @@ proc advanceSlots*(
     updateFlags: UpdateFlags) =
   # Given a state, advance it zero or more slots by applying empty slot
   # processing - the state must be positioned at or before `slot`
-  doAssert getStateField(state, slot) <= slot
+  doAssert state.slot <= slot
 
   let stateBid = state.latest_block_id
-  while getStateField(state, slot) < slot:
-    let
-      preEpoch = getStateField(state, slot).epoch
+  while state.slot < slot:
+    let preEpoch = state.slot.epoch
 
-    loadStateCache(dag, cache, stateBid, getStateField(state, slot).epoch)
+    loadStateCache(dag, cache, stateBid, state.slot.epoch)
 
     process_slots(
-      dag.cfg, state, getStateField(state, slot) + 1, cache, info,
+      dag.cfg, state, state.slot + 1, cache, info,
       updateFlags).expect("process_slots shouldn't fail when state slot is correct")
     if save:
       dag.putState(state, stateBid)
@@ -988,7 +984,7 @@ proc applyBlock(
     dag: ChainDAGRef, state: var ForkedHashedBeaconState, bid: BlockId,
     cache: var StateCache, info: var ForkedEpochInfo,
     updateFlags: UpdateFlags): Result[void, cstring] =
-  loadStateCache(dag, cache, bid, getStateField(state, slot).epoch)
+  loadStateCache(dag, cache, bid, state.slot.epoch)
 
   withConsensusFork(dag.cfg.consensusForkAtEpoch(bid.slot.epoch)):
     let data = getBlock(dag, bid, consensusFork.TrustedSignedBeaconBlock).valueOr:
@@ -1015,7 +1011,7 @@ proc applyExecutionPayloadEnvelope(
   ok()
 
 proc genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
-  getStateField(dag.headState, genesis_validators_root)
+  dag.headState.genesis_validators_root
 
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
@@ -1170,12 +1166,10 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
     if dag.headState.latest_block_root == tail.root:
       # In case we started from a checkpoint with an empty slot
-      finalizedSlot = getStateField(dag.headState, slot)
+      finalizedSlot = dag.headState.slot
 
     finalizedSlot =
-      max(
-        finalizedSlot,
-        getStateField(dag.headState, finalized_checkpoint).epoch.start_slot)
+      max(finalizedSlot, dag.headState.finalized_checkpoint.epoch.start_slot)
 
   let
     configFork = case dag.headState.kind
@@ -1187,7 +1181,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of ConsensusFork.Electra:   electraFork(cfg)
       of ConsensusFork.Fulu:      fuluFork(cfg)
       of ConsensusFork.Gloas:     gloasFork(cfg)
-    stateFork = getStateField(dag.headState, fork)
+    stateFork = dag.headState.fork
 
   # Here, we check only the `current_version` field because the spec
   # mandates that testnets starting directly from a particular fork
@@ -1286,7 +1280,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     dag.frontfillBlocks = newSeqOfCap[Eth2Digest](backfillSlot.int)
 
     let
-      historical_roots = getStateField(dag.headState, historical_roots).asSeq()
+      historical_roots = dag.headState.historical_roots.asSeq()
       historical_summaries = dag.headState.historical_summaries.asSeq()
 
     var
@@ -1332,7 +1326,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   # Fill validator key cache in case we're loading an old database that doesn't
   # have a cache
-  dag.updateValidatorKeys(getStateField(dag.headState, validators).asSeq())
+  dag.updateValidatorKeys(dag.headState.validators.asSeq())
 
   # Initialize pruning such that when starting with a database that hasn't been
   # pruned, we work our way from the tail to the horizon in incremental steps
@@ -1860,7 +1854,7 @@ proc updateState*(
     assignTick = Moment.now()
     ancestor {.used.} = withState(state):
       BlockSlotId.init(forkyState.latest_block_id, forkyState.data.slot)
-    ancestorRoot {.used.} = getStateRoot(state)
+    ancestorRoot {.used.} = state.root
 
   var info: ForkedEpochInfo
   # Time to replay all the blocks between then and now
@@ -1897,7 +1891,7 @@ proc updateState*(
   dag.advanceSlots(state, bsi.slot, save, cache, info, updateFlags)
 
   # ...and make sure to load the state cache, if it exists
-  loadStateCache(dag, cache, bsi.bid, getStateField(state, slot).epoch)
+  loadStateCache(dag, cache, bsi.bid, state.slot.epoch)
 
   let
     assignDur = assignTick - startTick
@@ -1911,36 +1905,36 @@ proc updateState*(
     # time might need tuning
     info "State replayed",
       blocks = ancestors.len,
-      slots = getStateField(state, slot) - ancestor.slot,
+      slots = state.slot - ancestor.slot,
       current = shortLog(current),
       ancestor = shortLog(ancestor),
       target = shortLog(bsi),
       ancestorStateRoot = shortLog(ancestorRoot),
-      targetStateRoot = shortLog(getStateRoot(state)),
+      targetStateRoot = shortLog(state.root),
       found,
       assignDur,
       replayDur
   elif ancestors.len > 0:
     debug "State replayed",
       blocks = ancestors.len,
-      slots = getStateField(state, slot) - ancestor.slot,
+      slots = state.slot - ancestor.slot,
       current = shortLog(current),
       ancestor = shortLog(ancestor),
       target = shortLog(bsi),
       ancestorStateRoot = shortLog(ancestorRoot),
-      targetStateRoot = shortLog(getStateRoot(state)),
+      targetStateRoot = shortLog(state.root),
       found,
       assignDur,
       replayDur
   else: # Normal case!
     trace "State advanced",
       blocks = ancestors.len,
-      slots = getStateField(state, slot) - ancestor.slot,
+      slots = state.slot - ancestor.slot,
       current = shortLog(current),
       ancestor = shortLog(ancestor),
       target = shortLog(bsi),
       ancestorStateRoot = shortLog(ancestorRoot),
-      targetStateRoot = shortLog(getStateRoot(state)),
+      targetStateRoot = shortLog(state.root),
       found,
       assignDur,
       replayDur
@@ -2406,7 +2400,7 @@ func trackVanityState(
     dag: ChainDAGRef, knownValidators: openArray[ValidatorIndex]): auto =
   (
     lastHeadKind: dag.headState.kind,
-    lastHeadEpoch: getStateField(dag.headState, slot).epoch,
+    lastHeadEpoch: dag.headState.slot.epoch,
     lastKnownValidatorsChangeStatuses:
       dag.headState.getBlsToExecutionChangeStatuses(knownValidators),
     lastKnownCompoundingChangeStatuses:
@@ -2429,7 +2423,7 @@ proc processVanityLogs(dag: ChainDAGRef, vanityState: auto) =
   else:
     if dag.vanityLogs.onBlobParametersUpdate != nil and
         dag.headState.kind >= ConsensusFork.Fulu:
-      let headEpoch = getStateField(dag.headState, slot).epoch
+      let headEpoch = dag.headState.slot.epoch
       if headEpoch > vanityState.lastHeadEpoch:
         for entry in dag.cfg.BLOB_SCHEDULE:
           if headEpoch >= entry.EPOCH:
@@ -2483,7 +2477,7 @@ proc updateHead*(
     return
 
   let
-    lastHeadStateRoot = getStateRoot(dag.headState)
+    lastHeadStateRoot = dag.headState.root
     vanityState = dag.trackVanityState(knownValidators)
 
   # Start off by making sure we have the right state - updateState will try
@@ -2512,7 +2506,7 @@ proc updateHead*(
 
   let
     finalized_checkpoint =
-      getStateField(dag.headState, finalized_checkpoint)
+      dag.headState.finalized_checkpoint
     finalizedSlot =
       # finalized checkpoint may move back in the head state compared to what
       # we've seen in other forks - it does not move back in fork choice
@@ -2530,10 +2524,9 @@ proc updateHead*(
   if not(isAncestor):
     notice "Updated head block with chain reorg",
       headParent = shortLog(newHead.parent),
-      stateRoot = shortLog(getStateRoot(dag.headState)),
-      justified = shortLog(getStateField(
-        dag.headState, current_justified_checkpoint)),
-      finalized = shortLog(getStateField(dag.headState, finalized_checkpoint)),
+      stateRoot = shortLog(dag.headState.root),
+      justified = shortLog(dag.headState.current_justified_checkpoint),
+      finalized = shortLog(dag.headState.finalized_checkpoint),
       optStatus = newHead.optimisticStatus
 
     if not(isNil(dag.onReorgHappened)):
@@ -2542,7 +2535,7 @@ proc updateHead*(
         data = ReorgInfoObject.init(dag.head.slot, uint64(ancestorDepth),
                                     lastHead.root, newHead.root,
                                     lastHeadStateRoot,
-                                    getStateRoot(dag.headState))
+                                    dag.headState.root)
       dag.onReorgHappened(data)
 
     # A reasonable criterion for "reorganizations of the chain"
@@ -2552,10 +2545,9 @@ proc updateHead*(
     beacon_reorgs_total.inc()
   else:
     debug "Updated head block",
-      stateRoot = shortLog(getStateRoot(dag.headState)),
-      justified = shortLog(getStateField(
-        dag.headState, current_justified_checkpoint)),
-      finalized = shortLog(getStateField(dag.headState, finalized_checkpoint)),
+      stateRoot = shortLog(dag.headState.root),
+      justified = shortLog(dag.headState.current_justified_checkpoint),
+      finalized = shortLog(dag.headState.finalized_checkpoint),
       optStatus = newHead.optimisticStatus
 
     if not(isNil(dag.onHeadChanged)):
@@ -2566,7 +2558,7 @@ proc updateHead*(
         epochTransition = (finalizedHead != dag.finalizedHead)
         # TODO (cheatfate): Proper implementation required
         data = HeadChangeInfoObject.init(dag.head.slot, dag.head.root,
-                                         getStateRoot(dag.headState),
+                                         dag.headState.root,
                                          epochTransition, prevDepRoot,
                                          depRoot)
       dag.onHeadChanged(data)
@@ -2580,10 +2572,9 @@ proc updateHead*(
 
   if finalizedHead != dag.finalizedHead:
     debug "Reached new finalization checkpoint",
-      stateRoot = shortLog(getStateRoot(dag.headState)),
-      justified = shortLog(getStateField(
-        dag.headState, current_justified_checkpoint)),
-      finalized = shortLog(getStateField(dag.headState, finalized_checkpoint))
+      stateRoot = shortLog(dag.headState.root),
+      justified = shortLog(dag.headState.current_justified_checkpoint),
+      finalized = shortLog(dag.headState.finalized_checkpoint)
     let oldFinalizedHead = dag.finalizedHead
 
     block:
@@ -2617,9 +2608,9 @@ proc updateHead*(
     # Send notification about new finalization point via callback.
     if not(isNil(dag.onFinHappened)):
       let stateRoot =
-        if dag.finalizedHead.slot == dag.head.slot: getStateRoot(dag.headState)
+        if dag.finalizedHead.slot == dag.head.slot: dag.headState.root
         elif dag.finalizedHead.slot + SLOTS_PER_HISTORICAL_ROOT > dag.head.slot:
-          getStateField(dag.headState, state_roots).data[
+          dag.headState.state_roots.data[
             int(dag.finalizedHead.slot mod SLOTS_PER_HISTORICAL_ROOT)]
         else:
           Eth2Digest() # The thing that finalized was >8192 blocks old?
@@ -2688,10 +2679,10 @@ proc preInit*(
   ## When used with a non-genesis state, the resulting database will not be
   ## compatible with pre-22.11 versions.
   logScope:
-    stateRoot = $getStateRoot(state)
-    stateSlot = getStateField(state, slot)
+    stateRoot = $state.root
+    stateSlot = state.slot
 
-  doAssert getStateField(state, slot).is_epoch,
+  doAssert state.slot.is_epoch,
     "Can only initialize database from epoch states"
 
   withState(state):
@@ -2769,7 +2760,7 @@ proc getProposalState*(
   else:
     loadStateCache(dag, cache, head.bid, slot.epoch)
 
-  if getStateField(state[], slot) < slot:
+  if state[].slot < slot:
     process_slots(
       dag.cfg, state[], slot, cache, info,
       {skipLastStateRootCalculation}).expect("advancing 1 slot should not fail")
@@ -2840,7 +2831,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
   # resuming the operation at any time
   let
     roots = dag.db.loadStateRoots()
-    historicalRoots = getStateField(dag.headState, historical_roots).asSeq()
+    historicalRoots = dag.headState.historical_roots.asSeq()
     historicalSummaries = dag.headState.historical_summaries.asSeq()
 
   var
@@ -2905,7 +2896,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
         # starting point - ignore failures for now
         if dag.era.getState(
             historicalRoots, historicalSummaries, slot, state[]).isOk():
-          state_root = getStateRoot(state[])
+          state_root = state[].root
 
           withState(state[]): dag.db.putState(forkyState)
           tailBid = Opt.some state[].latest_block_id()
@@ -2935,7 +2926,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
     info "Recreating state snapshot",
       slot, startStateRoot = canonical[i - 1],  startSlot
 
-    if getStateRoot(state[]) != canonical[i - 1]:
+    if state[].root != canonical[i - 1]:
       if not dag.db.getState(
           dag.cfg.consensusForkAtEpoch(startSlot.epoch), canonical[i - 1],
           state[], noRollback):
@@ -2949,7 +2940,7 @@ proc rebuildIndex*(dag: ChainDAGRef) =
         return
 
       # The slot check is needed to avoid re-applying a block
-      if bids.isProposed and getStateField(state[], latest_block_header).slot < bids.bid.slot:
+      if bids.isProposed and state[].latest_block_header.slot < bids.bid.slot:
         let res = dag.applyBlock(state[], bids.bid, cache, info,
                                  dag.updateFlags)
         if res.isErr:

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -154,7 +154,7 @@ func shouldSyncOptimistically*(self: ConsensusManager, wallSlot: Slot): bool =
 
   shouldSyncOptimistically(
     optimisticSlot = self.optimisticHead.bid.slot,
-    dagSlot = getStateField(self.dag.headState, slot),
+    dagSlot = self.dag.headState.slot,
     wallSlot = wallSlot)
 
 func optimisticHead*(self: ConsensusManager): BlockId =

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -249,7 +249,7 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
           # Batch-verification more than doubles total verification speed
           sigs.add block_signature_set(
               cfg.forkAtEpoch(slot.epoch),
-              getStateField(state[], genesis_validators_root), slot,
+              state[].genesis_validators_root, slot,
               blck[].root, cooked.get(), sig.get())
 
         else: # slot == GENESIS_SLOT:
@@ -259,7 +259,7 @@ proc verify*(f: EraFile, cfg: RuntimeConfig): Result[Eth2Digest, string] =
     if sigs.len > 0 and not batchVerify(verifier, sigs):
       return err("Invalid block signature")
 
-  ok(getStateRoot(state[]))
+  ok(state[].root)
 
 proc getEraFile(
     db: EraDB, historical_roots: openArray[Eth2Digest],

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -600,7 +600,7 @@ proc validateBlobSidecar*(
   # block -- i.e. `get_checkpoint_block(store, block_header.parent_root,
   # store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root`.
   let
-    finalized_checkpoint = getStateField(dag.headState, finalized_checkpoint)
+    finalized_checkpoint = dag.headState.finalized_checkpoint
     ancestor = get_ancestor(parent, finalized_checkpoint.epoch.start_slot)
 
   if ancestor.isNil:
@@ -729,7 +729,7 @@ proc validateDataColumnSidecar*(
   # block -- i.e. `get_checkpoint_block(store, block_header.parent_root,
   # store.finalized_checkpoint.epoch) == store.finalized_checkpoint.root`.
   let
-    finalized_checkpoint = getStateField(dag.headState, finalized_checkpoint)
+    finalized_checkpoint = dag.headState.finalized_checkpoint
     ancestor = get_ancestor(parent, finalized_checkpoint.epoch.start_slot)
 
   if ancestor.isNil:
@@ -992,7 +992,7 @@ proc validateBeaconBlock*(
   # compute_start_slot_at_epoch(store.finalized_checkpoint.epoch)) ==
   # store.finalized_checkpoint.root
   let
-    finalized_checkpoint = getStateField(dag.headState, finalized_checkpoint)
+    finalized_checkpoint = dag.headState.finalized_checkpoint
     ancestor = get_ancestor(parent, finalized_checkpoint.epoch.start_slot)
 
   if ancestor.isNil:
@@ -1829,10 +1829,10 @@ proc validateVoluntaryExit*(
   # [IGNORE] The voluntary exit is the first valid voluntary exit received for
   # the validator with index signed_voluntary_exit.message.validator_index.
   if signed_voluntary_exit.message.validator_index >=
-      getStateField(pool.dag.headState, validators).lenu64:
+      pool.dag.headState.validators.lenu64:
     return errIgnore("VoluntaryExit: validator index too high")
 
-  # Given that getStateField(pool.dag.headState, validators) is a seq,
+  # Given that pool.dag.headState.validators is a seq,
   # signed_voluntary_exit.message.validator_index.int is already valid, but
   # check explicitly if one changes that data structure.
   if pool.isSeen(signed_voluntary_exit):
@@ -2264,7 +2264,7 @@ proc validateExecutionPayloadBid*(
 
       if not verify_execution_payload_bid_signature(
           dag.forkAtEpoch(bid.slot.epoch),
-          getStateField(dag.headState, genesis_validators_root),
+          dag.headState.genesis_validators_root,
           bid.slot.epoch,
           bid,
           builderPubkey,

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -183,7 +183,7 @@ proc ETHBeaconStateCopyGenesisValidatorsRoot(
   ## Returns:
   ## * Pointer to a copy of the given beacon state's genesis validators root.
   let genesisValRoot = Eth2Digest.new()
-  genesisValRoot[] = getStateField(state[], genesis_validators_root)
+  genesisValRoot[] = state[].genesis_validators_root
   genesisValRoot.toUnmanagedPtr()
 
 proc ETHRootDestroy(root: ptr Eth2Digest) {.exported.} =
@@ -216,8 +216,7 @@ proc ETHForkDigestsCreateFromState(
   ## See:
   ## * https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#compute_fork_digest
   let forkDigests = ForkDigests.new()
-  forkDigests[] = ForkDigests.init(
-    cfg[], getStateField(state[], genesis_validators_root))
+  forkDigests[] = ForkDigests.init(cfg[], state[].genesis_validators_root)
   forkDigests.toUnmanagedPtr()
 
 proc ETHForkDigestsDestroy(forkDigests: ptr ForkDigests) {.exported.} =
@@ -245,7 +244,7 @@ proc ETHBeaconClockCreateFromState(
   ## * Pointer to an initialized beacon clock based on the beacon state or
   ##   NULL if the state contained an invalid time.
   let
-    genesisTime = getStateField(state[], genesis_time)
+    genesisTime = state[].genesis_time
     beaconClock = BeaconClock.new()
   beaconClock[] = BeaconClock.init(cfg[].timeParams, genesisTime).valueOr:
     return nil

--- a/beacon_chain/networking/network_metadata_downloads.nim
+++ b/beacon_chain/networking/network_metadata_downloads.nim
@@ -58,10 +58,9 @@ proc fetchGenesisBytes*(
     if result.isSnappyFramedStream:
       result = decodeFramed(result)
     let state = newClone(readSszForkedHashedBeaconState(metadata.cfg, result))
-    withState(state[]):
-      if forkyState.root != metadata.genesis.digest:
-        raise (ref DigestMismatchError)(
-          msg: "The downloaded genesis state cannot be verified (checksum mismatch)")
+    if state[].root != metadata.genesis.digest:
+      raise (ref DigestMismatchError)(
+        msg: "The downloaded genesis state cannot be verified (checksum mismatch)")
   of UserSuppliedFile:
     result = readAllBytes(metadata.genesis.path).tryGet()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -243,8 +243,7 @@ proc loadChainDag(
       onLightClientOptimisticUpdate: onLightClientOptimisticUpdateCb))
 
   if networkGenesisValidatorsRoot.isSome:
-    let databaseGenesisValidatorsRoot =
-      getStateField(dag.headState, genesis_validators_root)
+    let databaseGenesisValidatorsRoot = dag.headState.genesis_validators_root
     if networkGenesisValidatorsRoot.get != databaseGenesisValidatorsRoot:
       fatal "The specified --data-dir contains data for a different network",
             networkGenesisValidatorsRoot = networkGenesisValidatorsRoot.get,
@@ -270,7 +269,7 @@ proc checkWeakSubjectivityCheckpoint(
   if isCheckpointStale:
     error "Weak subjectivity checkpoint is stale",
           currentSlot, checkpoint = wsCheckpoint,
-          headStateSlot = getStateField(dag.headState, slot)
+          headStateSlot = dag.headState.slot
     quit 1
 
 from ./spec/state_transition_block import kzg_commitment_to_versioned_hash
@@ -278,8 +277,8 @@ from ./spec/state_transition_block import kzg_commitment_to_versioned_hash
 proc isSlotWithinWeakSubjectivityPeriod(dag: ChainDAGRef, slot: Slot): bool =
   let
     checkpoint = Checkpoint(
-      epoch: epoch(getStateField(dag.headState, slot)),
-      root: getStateField(dag.headState, latest_block_header).state_root)
+      epoch: dag.headState.slot.epoch(),
+      root: dag.headState.latest_block_header.state_root)
   is_within_weak_subjectivity_period(dag.cfg, slot,
                                      dag.headState, checkpoint)
 
@@ -767,15 +766,15 @@ proc init*(
       await fetchGenesisState(
         metadata, config.genesisState, config.genesisStateUrl)
     let
-      genesisTime = getStateField(genesisState[], genesis_time)
+      genesisTime = genesisState[].genesis_time
       beaconClock = BeaconClock.init(
           metadata.cfg.timeParams, genesisTime).valueOr:
         fatal "Invalid genesis time in genesis state", genesisTime
         return Opt.none(BeaconNode)
       currentSlot = beaconClock.currentSlot
       checkpoint = Checkpoint(
-        epoch: epoch(getStateField(genesisState[], slot)),
-        root: getStateField(genesisState[], latest_block_header).state_root)
+        epoch: genesisState[].slot.epoch(),
+        root: genesisState[].latest_block_header.state_root)
 
     notice "Genesis state information",
            genesis_fork = genesisState.kind,
@@ -880,9 +879,9 @@ proc init*(
       fatal "Failed to read checkpoint state file", err = err.msg
       return Opt.none(BeaconNode)
 
-    if not getStateField(tmp[], slot).is_epoch:
+    if not tmp[].slot.is_epoch:
       fatal "--finalized-checkpoint-state must point to a state for an epoch slot",
-        slot = getStateField(tmp[], slot)
+        slot = tmp[].slot
       return Opt.none(BeaconNode)
     tmp
   else:
@@ -898,7 +897,7 @@ proc init*(
   if not ChainDAGRef.isInitialized(db).isOk():
     genesisState =
       if not checkpointState.isNil and
-          getStateField(checkpointState[], slot) == 0:
+          checkpointState[].slot == 0:
         checkpointState
       else:
         if genesisState.isNil:
@@ -913,13 +912,11 @@ proc init*(
       return Opt.none(BeaconNode)
 
     if not genesisState.isNil and not checkpointState.isNil:
-      if getStateField(genesisState[], genesis_validators_root) !=
-          getStateField(checkpointState[], genesis_validators_root):
+      if genesisState[].genesis_validators_root !=
+          checkpointState[].genesis_validators_root:
         fatal "Checkpoint state does not match genesis - check the --network parameter",
-          rootFromGenesis = getStateField(
-            genesisState[], genesis_validators_root),
-          rootFromCheckpoint = getStateField(
-            checkpointState[], genesis_validators_root)
+          rootFromGenesis = genesisState[].genesis_validators_root,
+          rootFromCheckpoint = checkpointState[].genesis_validators_root
         return Opt.none(BeaconNode)
 
     try:
@@ -928,11 +925,10 @@ proc init*(
       if not genesisState.isNil:
         ChainDAGRef.preInit(db, genesisState[])
         networkGenesisValidatorsRoot =
-          Opt.some(getStateField(genesisState[], genesis_validators_root))
+          Opt.some(genesisState[].genesis_validators_root)
 
       if not checkpointState.isNil:
-        if genesisState.isNil or
-            getStateField(checkpointState[], slot) != GENESIS_SLOT:
+        if genesisState.isNil or checkpointState[].slot != GENESIS_SLOT:
           ChainDAGRef.preInit(db, checkpointState[])
 
       doAssert ChainDAGRef.isInitialized(db).isOk(), "preInit should have initialized db"
@@ -964,7 +960,7 @@ proc init*(
     dag = loadChainDag(
       config, cfg, db, eventBus,
       validatorMonitor, networkGenesisValidatorsRoot)
-    genesisTime = getStateField(dag.headState, genesis_time)
+    genesisTime = dag.headState.genesis_time
     beaconClock = BeaconClock.init(metadata.cfg.timeParams, genesisTime).valueOr:
       fatal "Invalid genesis time in state", genesisTime
       return Opt.none(BeaconNode)
@@ -1019,7 +1015,7 @@ proc init*(
       cfg,
       dag.forkDigests,
       getBeaconTime,
-      getStateField(dag.headState, genesis_validators_root),
+      dag.headState.genesis_validators_root,
     ).valueOr:
       error "Failed to initialize node", err = error
       return Opt.none(BeaconNode)
@@ -1037,8 +1033,7 @@ proc init*(
     path = config.validatorsDir()
 
   proc getValidatorAndIdx(pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
-    withState(dag.headState):
-      getValidator(forkyState().data.validators.asSeq(), pubkey)
+    getValidator(dag.headState.validators.asSeq, pubkey)
 
   func getCapellaForkVersion(): Opt[presets.Version] =
     Opt.some(cfg.CAPELLA_FORK_VERSION)
@@ -1050,13 +1045,13 @@ proc init*(
     Opt.some(dag.forkAtEpoch(epoch))
 
   proc getGenesisRoot(): Eth2Digest =
-    getStateField(dag.headState, genesis_validators_root)
+    dag.headState.genesis_validators_root
 
   let
     keystoreCache = KeystoreCacheRef.init()
     slashingProtectionDB =
       SlashingProtectionDB.init(
-          getStateField(dag.headState, genesis_validators_root),
+          dag.headState.genesis_validators_root,
           config.validatorsDir(), SlashingDbName)
     validatorPool = newClone(ValidatorPool.init(
       slashingProtectionDB, config.doppelgangerDetection))
@@ -1160,9 +1155,7 @@ proc updateAttestationSubnetHandlers(node: BeaconNode, slot: Slot) =
     stabilitySubnets =
       node.consensusManager[].actionTracker.stabilitySubnets(slot)
     subnets = aggregateSubnets + stabilitySubnets
-    validatorsCount =
-      withState(node.dag.headState):
-        forkyState.data.validators.lenu64
+    validatorsCount = node.dag.headState.validators.lenu64
 
   node.network.updateStabilitySubnetMetadata(stabilitySubnets)
 
@@ -1239,9 +1232,7 @@ proc updateBlocksGossipStatus*(
 
 proc addPhase0MessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
-  let validatorsCount =
-    withState(node.dag.headState):
-      forkyState.data.validators.lenu64
+  let validatorsCount = node.dag.headState.validators.lenu64
   node.network.subscribe(
     getAttesterSlashingsTopic(forkDigest),
     getAttesterSlashingTopicParams(node.dag.timeParams))
@@ -1354,9 +1345,7 @@ proc addAltairMessageHandlers(
   # replaced as usual by trackSyncCommitteeTopics, which runs at slot end.
   let
     syncnets = node.getSyncCommitteeSubnets(slot.epoch)
-    validatorsCount =
-      withState(node.dag.headState):
-        forkyState.data.validators.lenu64
+    validatorsCount = node.dag.headState.validators.lenu64
 
   for subcommitteeIdx in SyncSubcommitteeIndex:
     if syncnets[subcommitteeIdx]:
@@ -1485,9 +1474,7 @@ proc updateSyncCommitteeTopics(node: BeaconNode, slot: Slot) =
       syncnets - node.network.metadata.syncnets
     oldSyncnets =
       node.network.metadata.syncnets - syncnets
-    validatorsCount =
-      withState(node.dag.headState):
-        forkyState.data.validators.lenu64
+    validatorsCount = node.dag.headState.validators.lenu64
 
   for subcommitteeIdx in SyncSubcommitteeIndex:
     doAssert not (newSyncnets[subcommitteeIdx] and
@@ -2190,8 +2177,7 @@ proc onSlotStart(node: BeaconNode, wallTime: BeaconTime,
       sync = node.syncStatus(wallSlot)
       peers = len(node.network.peerPool)
       head = shortLog(node.dag.head)
-      finalized = shortLog(getStateField(
-        node.dag.headState, finalized_checkpoint))
+      finalized = shortLog(node.dag.headState.finalized_checkpoint)
       delay = shortLog(delay)
     let nextConsensusForkDescription = node.formatNextConsensusFork()
     if nextConsensusForkDescription.isNone:
@@ -2644,10 +2630,8 @@ proc run*(node: BeaconNode, stopper: StopFuture) {.raises: [CatchableError].} =
       node.beaconClock.now() -
       finalizedHead.slot.start_beacon_time(node.dag.timeParams),
     head = shortLog(head),
-    justified = shortLog(getStateField(
-      node.dag.headState, current_justified_checkpoint)),
-    finalized = shortLog(getStateField(
-      node.dag.headState, finalized_checkpoint)),
+    justified = shortLog(node.dag.headState.current_justified_checkpoint),
+    finalized = shortLog(node.dag.headState.finalized_checkpoint),
     finalizedHead = shortLog(finalizedHead),
     SLOTS_PER_EPOCH,
     SPEC_VERSION,
@@ -2740,8 +2724,7 @@ when not defined(windows):
 
     proc dataResolver(expr: string): string {.raises: [].} =
       template justified: untyped = node.dag.head.atEpochStart(
-        getStateField(
-          node.dag.headState, current_justified_checkpoint).epoch)
+        node.dag.headState.current_justified_checkpoint.epoch)
       # TODO:
       # We should introduce a general API for resolving dot expressions
       # such as `db.latest_block.slot` or `metrics.connected_peers`.

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -72,14 +72,13 @@ proc main() {.noinline, raises: [CatchableError].} =
       except CatchableError as err:
         raiseAssert "Invalid baked-in state: " & err.msg
 
-    genesisTime = getStateField(genesisState[], genesis_time)
+    genesisTime = genesisState[].genesis_time
     beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
       error "Invalid genesis time in state", genesisTime
       quit 1
     getBeaconTime = beaconClock.getBeaconTimeFn()
 
-    genesis_validators_root =
-      getStateField(genesisState[], genesis_validators_root)
+    genesis_validators_root = genesisState[].genesis_validators_root
     forkDigests = newClone ForkDigests.init(cfg, genesis_validators_root)
 
     genesisBlockRoot = get_initial_beacon_block(genesisState[]).root

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -195,9 +195,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api2(MethodGet, "/eth/v1/beacon/genesis") do () -> RestApiResponse:
     RestApiResponse.jsonResponse(
       (
-        genesis_time: getStateField(node.dag.headState, genesis_time),
-        genesis_validators_root:
-          getStateField(node.dag.headState, genesis_validators_root),
+        genesis_time: node.dag.headState.genesis_time,
+        genesis_validators_root: node.dag.headState.genesis_validators_root,
         genesis_fork_version: node.dag.cfg.GENESIS_FORK_VERSION
       )
     )
@@ -247,11 +246,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonResponseFinalized(
         (
           previous_version:
-            getStateField(state, fork).previous_version,
+            state.fork.previous_version,
           current_version:
-            getStateField(state, fork).current_version,
+            state.fork.current_version,
           epoch:
-            getStateField(state, fork).epoch
+            state.fork.epoch
         ),
         node.getStateOptimistic(state),
         node.dag.isFinalized(bslot.bid)
@@ -280,11 +279,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       return RestApiResponse.jsonResponseFinalized(
         (
           previous_justified:
-            getStateField(state, previous_justified_checkpoint),
+            state.previous_justified_checkpoint,
           current_justified:
-            getStateField(state, current_justified_checkpoint),
+            state.current_justified_checkpoint,
           finalized:
-            getStateField(state, finalized_checkpoint)
+            state.finalized_checkpoint
         ),
         node.getStateOptimistic(state),
         node.dag.isFinalized(bslot.bid)
@@ -301,7 +300,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       keyset: HashSet[ValidatorPubKey]
       indexset: HashSet[ValidatorIndex]
 
-    let validatorsCount = lenu64(getStateField(state, validators))
+    let validatorsCount = lenu64(state.validators)
 
     for item in validatorIds:
       case item.kind
@@ -344,7 +343,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
        ): RestApiResponse =
     node.withStateForBlockSlotId(bslot):
       let
-        stateEpoch = getStateField(state, slot).epoch()
+        stateEpoch = state.slot.epoch()
         indices = node.getIndices(validatorIds, state).valueOr:
           return RestApiResponse.jsonError(error)
         response =
@@ -357,9 +356,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               if len(validatorIds) == 0:
                 # There are no indices, so we're going to filter all the
                 # validators.
-                for index, validator in getStateField(state, validators):
+                for index, validator in state.validators:
                   let
-                    balance = getStateField(state, balances).item(index)
+                    balance = state.balances.item(index)
                     status = validator.getStatus(stateEpoch).valueOr:
                       return RestApiResponse.jsonError(
                         Http400, ValidatorStatusNotFoundError, $error)
@@ -369,8 +368,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             else:
               for index in indices:
                 let
-                  validator = getStateField(state, validators).item(index)
-                  balance = getStateField(state, balances).item(index)
+                  validator = state.validators.item(index)
+                  balance = state.balances.item(index)
                   status = validator.getStatus(stateEpoch).valueOr:
                     return RestApiResponse.jsonError(
                       Http400, ValidatorStatusNotFoundError, $error)
@@ -404,14 +403,14 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               if len(validatorIds) == 0:
                 # There are no indices, so we're going to filter all the
                 # validators.
-                for index, validator in getStateField(state, validators):
+                for index, validator in state.validators:
                   res.add(RestValidatorIdentity.init(ValidatorIndex(index),
                                                      validator.pubkeyData.pubkey(),
                                                      validator.activation_epoch))
             else:
               for index in indices:
                 let
-                  validator = getStateField(state, validators).item(index)
+                  validator = state.validators.item(index)
                 res.add(RestValidatorIdentity.init(index,
                                                    validator.pubkeyData.pubkey(),
                                                    validator.activation_epoch))
@@ -442,12 +441,12 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               if len(validatorIds) == 0:
                 # There are no indices, so we're going to return balances of all
                 # known validators.
-                for index, balance in getStateField(state, balances):
+                for index, balance in state.balances:
                   res.add(RestValidatorBalance.init(ValidatorIndex(index),
                                                     balance))
             else:
               for index in indices:
-                let balance = getStateField(state, balances).item(index)
+                let balance = state.balances.item(index)
                 res.add(RestValidatorBalance.init(index, balance))
             res
 
@@ -550,8 +549,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     node.withStateForBlockSlotId(bslot):
       let
-        current_epoch = getStateField(state, slot).epoch()
-        validatorsCount = lenu64(getStateField(state, validators))
+        current_epoch = state.slot.epoch()
+        validatorsCount = lenu64(state.validators)
 
       let vindex =
         block:
@@ -577,8 +576,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             index
 
       let
-        validator = getStateField(state, validators).item(vindex)
-        balance = getStateField(state, balances).item(vindex)
+        validator = state.validators.item(vindex)
+        balance = state.balances.item(vindex)
         status =
           block:
             let sres = validator.getStatus(current_epoch)
@@ -774,7 +773,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       var res: seq[RestBeaconStatesCommittees]
       let qepoch =
         if vepoch.isNone:
-          epoch(getStateField(state, slot))
+          epoch(state.slot)
         else:
           vepoch.get()
 

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -157,9 +157,8 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api2(MethodGet, "/nimbus/v1/chain/head") do() -> RestApiResponse:
     let
       head = node.dag.head
-      finalized = getStateField(node.dag.headState, finalized_checkpoint)
-      justified =
-        getStateField(node.dag.headState, current_justified_checkpoint)
+      finalized = node.dag.headState.finalized_checkpoint
+      justified = node.dag.headState.current_justified_checkpoint
     RestApiResponse.jsonResponse(
       (
         head_slot: head.slot,

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -66,17 +66,17 @@ func getBlockSlotId*(node: BeaconNode,
     ok(bsi)
 
   of StateQueryKind.Root:
-    if stateIdent.root == getStateRoot(node.dag.headState):
+    if stateIdent.root == node.dag.headState.root:
       ok(node.dag.head.bid.atSlot())
     else:
       # The `state_roots` field holds 8k historical state roots but not the
       # one of the current state - this trick allows us to lookup states without
       # keeping an on-disk index.
-      let headSlot = getStateField(node.dag.headState, slot)
+      let headSlot = node.dag.headState.slot
       for i in 0'u64..<SLOTS_PER_HISTORICAL_ROOT:
         if i >= headSlot:
           break
-        if getStateField(node.dag.headState, state_roots).item(
+        if node.dag.headState.state_roots.item(
             (headSlot - i - 1) mod SLOTS_PER_HISTORICAL_ROOT) ==
             stateIdent.root:
           return node.dag.getBlockIdAtSlot(headSlot - i - 1).orErr(
@@ -98,7 +98,7 @@ func getBlockSlotId*(node: BeaconNode,
       # Take checkpoint-synced nodes into account
       let justifiedEpoch =
         max(
-          getStateField(node.dag.headState, current_justified_checkpoint).epoch,
+          node.dag.headState.current_justified_checkpoint.epoch,
           node.dag.finalizedHead.slot.epoch)
       ok(node.dag.head.atEpochStart(justifiedEpoch).toBlockSlotId().expect("not nil"))
 
@@ -179,7 +179,7 @@ template withStateForBlockSlotId*(nodeParam: BeaconNode,
     if isState(node.dag.headState):
       template state: untyped {.inject, used.} = node.dag.headState
       template stateRoot: untyped {.inject, used.} =
-        getStateRoot(node.dag.headState)
+        node.dag.headState.root
       body
     else:
       let cachedState = if node.stateTtlCache != nil:
@@ -199,7 +199,7 @@ template withStateForBlockSlotId*(nodeParam: BeaconNode,
           node.stateTtlCache.add(stateToAdvance)
 
         template state: untyped {.inject, used.} = stateToAdvance[]
-        template stateRoot: untyped {.inject, used.} = getStateRoot(stateToAdvance[])
+        template stateRoot: untyped {.inject, used.} = stateToAdvance[].root
 
         body
 
@@ -229,7 +229,7 @@ func keysToIndices*(cacheTable: var Table[ValidatorPubKey, ValidatorIndex],
                     keys: openArray[ValidatorPubKey]
                    ): seq[Opt[ValidatorIndex]] =
   var indices = newSeq[Opt[ValidatorIndex]](len(keys))
-  let totalValidatorsInState = getStateField(forkedState, validators).lenu64
+  let totalValidatorsInState = forkedState.validators.lenu64
   var keyset =
     block:
       var res: Table[ValidatorPubKey, int]
@@ -242,7 +242,7 @@ func keysToIndices*(cacheTable: var Table[ValidatorPubKey, ValidatorIndex],
           res[pubkey] = inputIndex
       res
   if len(keyset) > 0:
-    for validatorIndex, validator in getStateField(forkedState, validators):
+    for validatorIndex, validator in forkedState.validators:
       keyset.withValue(validator.pubkey, listIndex):
         # Store pair (pubkey, index) into cache table.
         cacheTable[validator.pubkey] = ValidatorIndex(validatorIndex)

--- a/beacon_chain/rpc/rest_utils.nim
+++ b/beacon_chain/rpc/rest_utils.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2024 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -14,7 +14,7 @@ import std/macros,
        ../validators/beacon_validators,
        ../consensus_object_pools/blockchain_dag,
        ../beacon_node,
-       "."/[rest_constants, state_ttl_cache]
+       ./[rest_constants, state_ttl_cache]
 
 export
   results, eth2_rest_serialization, blockchain_dag, rest_types,

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -694,8 +694,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
       if uint64(request.committee_index) >= uint64(MAX_COMMITTEES_PER_SLOT):
         return RestApiResponse.jsonError(Http400,
                                          InvalidCommitteeIndexValueError)
-      if uint64(request.validator_index) >=
-                  lenu64(getStateField(node.dag.headState, validators)):
+      if uint64(request.validator_index) >= node.dag.headState.validators.lenu64:
         return RestApiResponse.jsonError(Http400,
                                          InvalidValidatorIndexValueError)
       if wallSlot > request.slot + 1:
@@ -717,8 +716,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         request.committee_index)
 
       if not is_active_validator(
-          getStateField(
-            node.dag.headState, validators).item(request.validator_index),
+          node.dag.headState.validators.item(request.validator_index),
           request.slot.epoch):
         return RestApiResponse.jsonError(Http400, ValidatorNotActive)
 
@@ -727,8 +725,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         request.is_aggregator)
 
       let validator_pubkey =
-        getStateField(node.dag.headState, validators).item(
-          request.validator_index).pubkey
+        node.dag.headState.validators.item(request.validator_index).pubkey
 
       node.validatorMonitor[].addAutoMonitor(
         validator_pubkey, request.validator_index)
@@ -756,8 +753,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           if item.until_epoch < node.dag.cfg.ALTAIR_FORK_EPOCH:
             return RestApiResponse.jsonError(Http400,
                                              EpochFromTheIncorrectForkError)
-          if uint64(item.validator_index) >=
-            lenu64(getStateField(node.dag.headState, validators)):
+          if uint64(item.validator_index) >= node.dag.headState.validators.lenu64:
             return RestApiResponse.jsonError(Http400,
                                              InvalidValidatorIndexValueError)
           res.add(item)
@@ -765,8 +761,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     for item in subscriptions:
       let validator_pubkey =
-        getStateField(node.dag.headState, validators).item(
-          item.validator_index).pubkey
+        node.dag.headState.validators.item(item.validator_index).pubkey
 
       node.consensusManager[].actionTracker.registerSyncDuty(
         validator_pubkey, item.until_epoch)

--- a/beacon_chain/rpc/state_ttl_cache.nim
+++ b/beacon_chain/rpc/state_ttl_cache.nim
@@ -1,9 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2021 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
 
 import
   chronos,

--- a/beacon_chain/rpc/state_ttl_cache.nim
+++ b/beacon_chain/rpc/state_ttl_cache.nim
@@ -81,7 +81,7 @@ proc getClosestState*(
     if cache.entries[i] == nil:
       continue
 
-    let stateSlot = getStateField(cache.entries[i][].state[], slot)
+    let stateSlot = cache.entries[i][].state[].slot
     if stateSlot > bsi.slot:
       # We can use only states that can be advanced forward in time.
       continue

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1093,13 +1093,50 @@ template getStateField*(x: ForkedHashedBeaconState, y: untyped): untyped =
   (block:
     withState(x): unsafeAddr forkyState.data.y)[]
 
-func getStateRoot*(x: ForkedHashedBeaconState): Eth2Digest =
-  withState(x): forkyState.root
+func root*(state: ForkedHashedBeaconState): lent Eth2Digest =
+  (block: withState(state): addr forkyState.root)[]
 
-{.push warning[ProveField]:off.}  # https://github.com/nim-lang/Nim/issues/22060
-func setStateRoot*(x: var ForkedHashedBeaconState, root: Eth2Digest) =
-  withState(x): forkyState.root = root
-{.pop.}
+func genesis_time*(state: ForkedHashedBeaconState): uint64 =
+  withState(state): forkyState.data.genesis_time
+
+func genesis_validators_root*(state: ForkedHashedBeaconState): lent Eth2Digest =
+  (block: withState(state): addr forkyState.data.genesis_validators_root)[]
+
+func slot*(state: ForkedHashedBeaconState): Slot =
+  withState(state): forkyState.data.slot
+
+func fork*(state: ForkedHashedBeaconState): Fork =
+  withState(state): forkyState.data.fork
+
+func latest_block_header*(state: ForkedHashedBeaconState): lent BeaconBlockHeader =
+  (block: withState(state): addr forkyState.data.latest_block_header)[]
+
+func state_roots*(state: ForkedHashedBeaconState): lent HashArray[Limit SLOTS_PER_HISTORICAL_ROOT, Eth2Digest] =
+  (block: withState(state): addr forkyState.data.state_roots)[]
+
+func historical_roots*(state: ForkedHashedBeaconState): lent HashList[Eth2Digest, Limit HISTORICAL_ROOTS_LIMIT] =
+  (block: withState(state): addr forkyState.data.historical_roots)[]
+
+func eth1_data*(state: ForkedHashedBeaconState): lent Eth1Data =
+  (block: withState(state): addr forkyState.data.eth1_data)[]
+
+func eth1_deposit_index*(state: ForkedHashedBeaconState): uint64 =
+  withState(state): forkyState.data.eth1_deposit_index
+
+func validators*(state: ForkedHashedBeaconState): lent HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT] =
+  (block: withState(state): addr forkyState.data.validators)[]
+
+func balances*(state: ForkedHashedBeaconState): lent HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT] =
+  (block: withState(state): addr forkyState.data.balances)[]
+
+func previous_justified_checkpoint*(state: ForkedHashedBeaconState): lent Checkpoint =
+  (block: withState(state): addr forkyState.data.previous_justified_checkpoint)[]
+
+func current_justified_checkpoint*(state: ForkedHashedBeaconState): lent Checkpoint =
+  (block: withState(state): addr forkyState.data.current_justified_checkpoint)[]
+
+func finalized_checkpoint*(state: ForkedHashedBeaconState): lent Checkpoint =
+  (block: withState(state): addr forkyState.data.finalized_checkpoint)[]
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/specs/fulu/beacon-chain.md#new-get_blob_parameters
 func get_blob_parameters*(cfg: RuntimeConfig, epoch: Epoch): BlobParameters =

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -203,7 +203,7 @@ func noRollback*(state: var fulu.HashedBeaconState) =
 func maybeUpgradeState*(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState, cache: var StateCache
 ) =
-  let curFork = cfg.consensusForkAtEpoch(getStateField(state, slot).epoch)
+  let curFork = cfg.consensusForkAtEpoch(state.slot.epoch)
 
   if state.kind < curFork:
     # Typically, only one upgrade is done here but when generating a genesis
@@ -225,12 +225,12 @@ proc process_slots*(
     cfg: RuntimeConfig, state: var ForkedHashedBeaconState, slot: Slot,
     cache: var StateCache, info: var ForkedEpochInfo, flags: UpdateFlags):
     Result[void, cstring] =
-  if not (getStateField(state, slot) < slot):
-    if slotProcessed notin flags or getStateField(state, slot) != slot:
+  if not (state.slot < slot):
+    if slotProcessed notin flags or state.slot != slot:
       return err("process_slots: cannot rewind state to past slot")
 
   # Update the state so its slot matches that of the block
-  while getStateField(state, slot) < slot:
+  while state.slot < slot:
     withState(state):
       withEpochInfo(forkyState.data, info):
         ? advance_slot(

--- a/beacon_chain/spec/weak_subjectivity.nim
+++ b/beacon_chain/spec/weak_subjectivity.nim
@@ -54,14 +54,13 @@ func is_within_weak_subjectivity_period*(cfg: RuntimeConfig, current_slot: Slot,
                                          ws_state: ForkedHashedBeaconState,
                                          ws_checkpoint: Checkpoint): bool =
   ## Clients may choose to validate the input state against the input Weak Subjectivity Checkpoint
-  doAssert getStateField(ws_state, latest_block_header).state_root ==
-    ws_checkpoint.root
-  doAssert epoch(getStateField(ws_state, slot)) == ws_checkpoint.epoch
+  doAssert ws_state.latest_block_header.state_root == ws_checkpoint.root
+  doAssert epoch(ws_state.slot) == ws_checkpoint.epoch
 
   let
     ws_period = withState(ws_state):
       cfg.compute_weak_subjectivity_period(forkyState.data)
-    ws_state_epoch = epoch(getStateField(ws_state, slot))
+    ws_state_epoch = epoch(ws_state.slot)
     current_epoch = epoch(current_slot)
 
   current_epoch <= ws_state_epoch + ws_period

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -153,10 +153,8 @@ proc isWithinWeakSubjectivityPeriod(
     dag = overseer.consensusManager.dag
     currentSlot = overseer.getWallSlot()
     checkpoint = Checkpoint(
-      epoch:
-        getStateField(dag.headState, slot).epoch(),
-      root:
-        getStateField(dag.headState, latest_block_header).state_root)
+      epoch: dag.headState.slot.epoch(),
+      root: dag.headState.latest_block_header.state_root)
 
   is_within_weak_subjectivity_period(
     dag.cfg, currentSlot, dag.headState, checkpoint)
@@ -332,10 +330,8 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
               return ok()
 
             let
-              fork =
-                getStateField(dag.clearanceState, fork)
-              genesis_validators_root =
-                getStateField(dag.clearanceState, genesis_validators_root)
+              fork = dag.clearanceState.fork
+              genesis_validators_root = dag.clearanceState.genesis_validators_root
 
             verifyBlockSignatures(batchVerifier[], fork, genesis_validators_root,
                                   dag.db.immutableValidators, blocksOnly).isOkOr:
@@ -362,8 +358,7 @@ proc rebuildState(overseer: SyncOverseerRef): Future[void] {.
           debug "Number of blocks injected",
                 blocks_count = len(blocks),
                 head = shortLog(dag.head),
-                finalized = shortLog(getStateField(
-                  dag.headState, finalized_checkpoint)),
+                finalized = shortLog(dag.headState.finalized_checkpoint),
                 store_update_time = updateTick - startTick
 
           overseer.updatePerformance(startTick, len(blocks))

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -96,11 +96,10 @@ proc doTrustedNodeSync*(
           genesisStateRoot
         quit 1
 
-      if (genesisState != nil) and
-          (getStateRoot(tmp[]) != getStateRoot(genesisState[])):
+      if (genesisState != nil) and (tmp[].root != genesisState[].root):
         error "Unexpected genesis state in database, is this the same network?",
-          databaseRoot = getStateRoot(tmp[]),
-          genesisRoot = getStateRoot(genesisState[])
+          databaseRoot = tmp[].root,
+          genesisRoot = genesisState[].root
         quit 1
       tmp
     else:
@@ -175,13 +174,12 @@ proc doTrustedNodeSync*(
 
         doAssert genesisState != nil, "Already checked for `TrustedBlockRoot`"
         let
-          genesisTime = getStateField(genesisState[], genesis_time)
+          genesisTime = genesisState[].genesis_time
           beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
             error "Invalid genesis time in state", genesisTime
             quit 1
 
-          genesis_validators_root =
-            getStateField(genesisState[], genesis_validators_root)
+          genesis_validators_root = genesisState[].genesis_validators_root
           forkDigests = newClone ForkDigests.init(cfg, genesis_validators_root)
 
           trustedBlockRoot = syncTarget.trustedBlockRoot
@@ -334,38 +332,35 @@ proc doTrustedNodeSync*(
       quit 1
 
     if stateRoot.isSome:
-      if state[].getStateRoot() != stateRoot.get:
+      if state[].root != stateRoot.get:
         error "Checkpoint state has incorrect root!",
           expectedStateRoot = stateRoot.get,
-          actualStateRoot = state[].getStateRoot()
+          actualStateRoot = state[].root
         quit 1
       info "Checkpoint state validated against LC data",
         stateRoot = stateRoot.get
 
-    if not getStateField(state[], slot).is_epoch():
+    if not state[].slot.is_epoch():
       error "State slot must fall on an epoch boundary",
-        slot = getStateField(state[], slot),
-        offset = getStateField(state[], slot) -
-          getStateField(state[], slot).epoch.start_slot
+        slot = state[].slot,
+        offset = state[].slot - state[].slot.epoch.start_slot
       quit 1
 
     if genesisState != nil:
-      if getStateField(state[], genesis_time) !=
-          getStateField(genesisState[], genesis_time):
+      if state[].genesis_time != genesisState[].genesis_time:
         error "Checkpoint state does not match genesis",
-          timeInCheckpoint = getStateField(state[], genesis_time),
-          timeInGenesis = getStateField(genesisState[], genesis_time)
+          timeInCheckpoint = state[].genesis_time,
+          timeInGenesis = genesisState[].genesis_time
         quit 1
-      if getStateField(state[], genesis_validators_root) !=
-          getStateField(genesisState[], genesis_validators_root):
+      if state[].genesis_validators_root != genesisState[].genesis_validators_root:
         error "Checkpoint state does not match genesis",
-          rootInCheckpoint = getStateField(state[], genesis_validators_root),
-          rootInGenesis = getStateField(genesisState[], genesis_validators_root)
+          rootInCheckpoint = state[].genesis_validators_root,
+          rootInGenesis = genesisState[].genesis_validators_root
         quit 1
 
       ChainDAGRef.preInit(db, genesisState[])
 
-      if getStateField(genesisState[], slot) != getStateField(state[], slot):
+      if genesisState[].slot != state[].slot:
         ChainDAGRef.preInit(db, state[])
     else:
       ChainDAGRef.preInit(db, state[])

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1052,14 +1052,14 @@ proc updateValidatorMetrics*(node: BeaconNode) =
       if v.index.isNone():
         0.Gwei
       elif v.index.get().uint64 >=
-          getStateField(node.dag.headState, balances).lenu64:
+          node.dag.headState.balances.lenu64:
         debug "Cannot get validator balance, index out of bounds",
           pubkey = shortLog(v.pubkey), index = v.index.get(),
-          balances = getStateField(node.dag.headState, balances).len,
-          stateRoot = getStateRoot(node.dag.headState)
+          balances = node.dag.headState.balances.len,
+          stateRoot = node.dag.headState.root
         0.Gwei
       else:
-        getStateField(node.dag.headState, balances).item(v.index.get())
+        node.dag.headState.balances.item(v.index.get())
 
     if i < 64:
       attached_validator_balance.set(

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -185,10 +185,10 @@ proc doSlots(conf: NcliConf) =
     cache = StateCache()
     info = ForkedEpochInfo()
   for i in 0'u64..<conf.slot:
-    let isEpoch = (getStateField(stateY[], slot) + 1).is_epoch
+    let isEpoch = (stateY[].slot + 1).is_epoch
     withTimer(timers[if isEpoch: tApplyEpochSlot else: tApplySlot]):
       process_slots(
-        cfg, stateY[], getStateField(stateY[], slot) + 1,
+        cfg, stateY[], stateY[].slot + 1,
         cache, info, {}).expect("should be able to advance slot")
 
   withTimer(timers[tSaveState]):

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -314,11 +314,11 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
   template processBlocks(blocks: auto) =
     for b in blocks.mitems():
       if shouldShutDown: quit QuitSuccess
-      while getStateField(stateData[], slot) < b.message.slot:
-        let isEpoch = (getStateField(stateData[], slot) + 1).is_epoch()
+      while stateData[].slot < b.message.slot:
+        let isEpoch = (stateData[].slot + 1).is_epoch()
         withTimer(timers[if isEpoch: tAdvanceEpoch else: tAdvanceSlot]):
           process_slots(
-            dag.cfg, stateData[], getStateField(stateData[], slot) + 1, cache,
+            dag.cfg, stateData[], stateData[].slot + 1, cache,
             info, {}).expect("Slot processing can't fail with correct inputs")
 
       var start = Moment.now()
@@ -758,7 +758,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
     (start, ends) = dag.getSlotRange(conf.perfSlot, conf.perfSlots)
     blockRefs = dag.getBlockRange(start, ends)
     perfs = newSeq[ValidatorPerformance](
-      getStateField(dag.headState, validators).len())
+      dag.headState.validators.len())
     cache = StateCache()
     info = ForkedEpochInfo()
     blck: phase0.TrustedSignedBeaconBlock
@@ -833,9 +833,9 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
     blck = db.getBlock(
       blockRefs[blockRefs.len - bi - 1].root,
       phase0.TrustedSignedBeaconBlock).get()
-    while getStateField(state[], slot) < blck.message.slot:
+    while state[].slot < blck.message.slot:
       let
-        nextSlot = getStateField(state[], slot) + 1
+        nextSlot = state[].slot + 1
         flags =
           if nextSlot == blck.message.slot: {skipLastStateRootCalculation}
           else: {}
@@ -843,7 +843,7 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
         dag.cfg, state[], nextSlot, cache, info, flags).expect(
           "Slot processing can't fail with correct inputs")
 
-      if getStateField(state[], slot).is_epoch():
+      if state[].slot.is_epoch():
         processEpoch()
 
     let res = state_transition_block(
@@ -853,12 +853,12 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
       quit 1
 
   # Capture rewards of empty slots as well
-  while getStateField(state[], slot) < ends:
+  while state[].slot < ends:
     process_slots(
-      dag.cfg, state[], getStateField(state[], slot) + 1, cache,
+      dag.cfg, state[], state[].slot + 1, cache,
       info, {}).expect("Slot processing can't fail with correct inputs")
 
-    if getStateField(state[], slot).is_epoch():
+    if state[].slot.is_epoch():
       processEpoch()
 
   echo "validator_index,attestation_hits,attestation_misses,head_attestation_hits,head_attestation_misses,target_attestation_hits,target_attestation_misses,delay_avg,first_slot_head_attester_when_first_slot_empty,first_slot_head_attester_when_first_slot_not_empty"
@@ -1078,7 +1078,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
       dag.updateFlags)
 
   let savedValidatorsCount = outDb.getDbValidatorsCount
-  var validatorsCount = getStateField(tmpState[], validators).len
+  var validatorsCount = tmpState[].validators.len
   outDb.insertValidators(tmpState[], savedValidatorsCount, validatorsCount)
 
   var previousEpochBalances: seq[uint64]
@@ -1095,7 +1095,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
     aggregatedFilesOutputDir, conf.resolution, endEpoch)
 
   proc processEpoch() =
-    let epoch = getStateField(tmpState[], slot).epoch
+    let epoch = tmpState[].slot.epoch
     info "Processing epoch ...", epoch = epoch
 
     var csvLines = newStringOfCap(1000000)
@@ -1141,7 +1141,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
     collectBalances(previousEpochBalances, tmpState[])
 
   proc processSlots(ends: Slot, endsFlags: UpdateFlags) =
-    var currentSlot = getStateField(tmpState[], slot)
+    var currentSlot = tmpState[].slot
     while currentSlot < ends:
       let nextSlot = currentSlot + 1
       let flags = if nextSlot == ends: endsFlags else: {}
@@ -1178,7 +1178,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
         fatal "State transition failed (!)"
         quit QuitFailure
 
-      let newValidatorsCount = getStateField(tmpState[], validators).len
+      let newValidatorsCount = tmpState[].validators.len
       if newValidatorsCount > validatorsCount:
         # Resize the structures in case a new validator has appeared after
         # the state_transition_block procedure call ...

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -112,7 +112,7 @@ cli do(
 
     dag.withUpdatedState(tmpState[], attestationHead.toBlockSlotId.expect("not nil")):
       let
-        fork = getStateField(updatedState, fork)
+        fork = updatedState.fork
         genesis_validators_root = dag.genesis_validators_root
         committees_per_slot =
           get_committee_count_per_slot(updatedState, slot.epoch, cache)
@@ -270,7 +270,7 @@ cli do(
     dag.withUpdatedState(tmpState[],
         dag.head.atSlot(slot).toBlockSlotId.expect("not nil")):
       let
-        fork = getStateField(updatedState, fork)
+        fork = updatedState.fork
         genesis_validators_root = dag.genesis_validators_root
 
       # We make the assumption that payload was present and blobs available

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -38,8 +38,8 @@ template withTimerRet*(stats: var RunningStat, body: untyped): untyped =
 
 func verifyConsensus*(state: ForkedHashedBeaconState, attesterRatio: float) =
   if attesterRatio < 0.63:
-    doAssert getStateField(state, current_justified_checkpoint).epoch == 0
-    doAssert getStateField(state, finalized_checkpoint).epoch == 0
+    doAssert state.current_justified_checkpoint.epoch == 0
+    doAssert state.finalized_checkpoint.epoch == 0
 
   # Quorum is 2/3 of validators, and at low numbers, quantization effects
   # can dominate, so allow for play above/below attesterRatio of 2/3.
@@ -48,11 +48,9 @@ func verifyConsensus*(state: ForkedHashedBeaconState, attesterRatio: float) =
 
   let current_epoch = get_current_epoch(state)
   if current_epoch >= 3:
-    doAssert getStateField(
-      state, current_justified_checkpoint).epoch + 1 >= current_epoch
+    doAssert state.current_justified_checkpoint.epoch + 1 >= current_epoch
   if current_epoch >= 4:
-    doAssert getStateField(
-      state, finalized_checkpoint).epoch + 2 >= current_epoch
+    doAssert state.finalized_checkpoint.epoch + 2 >= current_epoch
 
 func getSimulationConfig*(): RuntimeConfig {.compileTime.} =
   var cfg = defaultRuntimeConfig
@@ -162,7 +160,7 @@ proc printTimers*[Timers: enum](
 proc printTimers*[Timers: enum](
     state: ForkedHashedBeaconState, attesters: RunningStat, validate: bool,
     timers: array[Timers, RunningStat]) =
-  echo "Validators: ", getStateField(state, validators).len,
+  echo "Validators: ", state.validators.len,
     ", epoch length: ", SLOTS_PER_EPOCH
   echo "Validators per attestation (mean): ", attesters.mean
   printTimers(validate, timers)

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -138,7 +138,7 @@ cli do(validatorsDir: string, secretsDir: string,
             break
 
   var
-    genesisTime = getStateField(state[], genesis_time)
+    genesisTime = state[].genesis_time
     beaconClock = BeaconClock.init(cfg.timeParams, genesisTime).valueOr:
       error "Invalid genesis time in state",
         genesis_time = genesisTime,
@@ -151,7 +151,7 @@ cli do(validatorsDir: string, secretsDir: string,
                                     {KeystoreKind.Local}, nil):
     let
       pubkey = item.privateKey.toPubKey().toPubKey()
-      idx = findValidator(getStateField(state[], validators).toSeq, pubkey)
+      idx = findValidator(state[].validators.toSeq, pubkey)
     if idx.isSome():
       notice "Loaded validator", pubkey
       validators[idx.get()] = item.privateKey
@@ -167,7 +167,7 @@ cli do(validatorsDir: string, secretsDir: string,
     syncAggregate = SyncAggregate.init()
 
   let
-    genesis_validators_root = getStateField(state[], genesis_validators_root)
+    genesis_validators_root = state[].genesis_validators_root
 
   block:
     let
@@ -182,7 +182,7 @@ cli do(validatorsDir: string, secretsDir: string,
   while true:
     # Move to slot
     let
-      slot = getStateField(state[], slot) + 1
+      slot = state[].slot + 1
     process_slots(cfg, state[], slot, cache, info, {}).expect("works")
 
     if slot.start_beacon_time(cfg.timeParams) > beaconClock.now():
@@ -192,12 +192,12 @@ cli do(validatorsDir: string, secretsDir: string,
 
     var exited: seq[ValidatorIndex]
     for k, v in validators:
-      if getStateField(state[], validators).asSeq[k].exit_epoch != FAR_FUTURE_EPOCH:
+      if state[].validators.asSeq[k].exit_epoch != FAR_FUTURE_EPOCH:
         exited.add k
     for k in exited:
       warn "Validator exited", k
 
-      validatorKeys.del(getStateField(state[], validators).asSeq[k].pubkey)
+      validatorKeys.del(state[].validators.asSeq[k].pubkey)
       validators.del(k)
 
     if slot.epoch != (slot - 1).epoch:
@@ -207,13 +207,13 @@ cli do(validatorsDir: string, secretsDir: string,
         balance = block:
           var b: Gwei
           for k, _ in validators:
-            if is_active_validator(getStateField(state[], validators).asSeq[k], slot.epoch):
-              b += getStateField(state[], balances).asSeq[k]
+            if is_active_validator(state[].validators.asSeq[k], slot.epoch):
+              b += state[].balances.asSeq[k]
           b
         validators = block:
           var b: int
           for k, _ in validators:
-            if is_active_validator(getStateField(state[], validators).asSeq[k], slot.epoch):
+            if is_active_validator(state[].validators.asSeq[k], slot.epoch):
               b += 1
           b
         avgBalance = balance.int64 div validators.int64
@@ -222,7 +222,7 @@ cli do(validatorsDir: string, secretsDir: string,
         epoch = slot.epoch,
         active,
         epochsSinceFinality =
-          slot.epoch - getStateField(state[], finalized_checkpoint).epoch,
+          slot.epoch - state[].finalized_checkpoint.epoch,
         balance,
         validators,
         avgBalance
@@ -231,7 +231,7 @@ cli do(validatorsDir: string, secretsDir: string,
         withState(state[]): dump(".", forkyState)
 
     let
-      fork = getStateField(state[], fork)
+      fork = state[].fork
       proposer = get_beacon_proposer_index(state[], cache, slot).get()
 
     if proposer in validators:

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/test_fixture_sanity_blocks.nim
+++ b/tests/consensus_spec/test_fixture_sanity_blocks.nim
@@ -65,7 +65,7 @@ proc runTest(
         SSZ, consensusFork.BeaconState))
       when false:
         reportDiff(hashedPreState.phase0Data.data, postState)
-      doAssert getStateRoot(fhPreState[]) == postState[].hash_tree_root()
+      doAssert fhPreState[].root == postState[].hash_tree_root()
 
 template runForkBlockTests(consensusFork: static ConsensusFork) =
   const

--- a/tests/consensus_spec/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/test_fixture_sanity_slots.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/test_fixture_sanity_slots.nim
+++ b/tests/consensus_spec/test_fixture_sanity_slots.nim
@@ -36,10 +36,10 @@ proc runTest(
     check:
       process_slots(
         defaultRuntimeConfig,
-        fhPreState[], getStateField(fhPreState[], slot) + num_slots, cache,
+        fhPreState[], fhPreState[].slot + num_slots, cache,
         info, {}).isOk()
 
-      getStateRoot(fhPreState[]) == postState[].hash_tree_root()
+      fhPreState[].root == postState[].hash_tree_root()
 
     withState(fhPreState[]):
       when forkyState.data isnot typeof(postState[]):

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/test_fixture_transition.nim
+++ b/tests/consensus_spec/test_fixture_transition.nim
@@ -80,7 +80,7 @@ proc runTest(
       parseTest(testPath/"post.ssz_snappy", SSZ, PostBeaconState))
     when false:
       reportDiff(fhPreState.data, postState)
-    doAssert getStateRoot(fhPreState[]) == postState[].hash_tree_root()
+    doAssert fhPreState[].root == postState[].hash_tree_root()
 
 from ../../beacon_chain/spec/datatypes/phase0 import
   BeaconState, SignedBeaconBlock

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -101,7 +101,7 @@ suite "Attestation pool electra processing" & preset():
       process_slots(
         dag.cfg,
         state[],
-        getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+        state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
         cache,
         info,
         {}).isOk()
@@ -118,14 +118,13 @@ suite "Attestation pool electra processing" & preset():
     const epoch = 3.Epoch
     template fillToEpoch(
         state: ref ForkedHashedBeaconState, cache: var StateCache) =
-      while getStateField(state[], slot).epoch <= epoch:
+      while state[].slot.epoch <= epoch:
         check process_slots(
-          dag.cfg, state[], getStateField(state[], slot) + 1, cache, info,
-          {}).isOk
+          dag.cfg, state[], state[].slot + 1, cache, info, {}).isOk
         let
           parent_root = withState(state[]): forkyState.latest_block_root
           attestations = makeFullAttestations(
-            state[], parent_root, getStateField(state[], slot), cache)
+            state[], parent_root, state[].slot, cache)
           blck = addTestBlock(
             state[], cache, attestations = attestations, cfg = dag.cfg)
         check dag.addHeadBlock(
@@ -137,8 +136,7 @@ suite "Attestation pool electra processing" & preset():
     # History 2 contains all even blocks
     var cache2 = StateCache()
     check process_slots(
-      dag.cfg, state2[], getStateField(state2[], slot) + 1, cache2, info,
-      {}).isOk
+      dag.cfg, state2[], state2[].slot + 1, cache2, info, {}).isOk
     state2.fillToEpoch(cache2)
 
     # The shuffling for epoch 3 among both chains should now be different
@@ -152,13 +150,13 @@ suite "Attestation pool electra processing" & preset():
       cIndex = 0.CommitteeIndex
       att1 = block:
         let
-          slot = getStateField(state[], slot)
+          slot = state[].slot
           parent_root = withState(state[]): forkyState.latest_block_root
           committee = get_beacon_committee(state[], slot, cIndex, cache)
         makeElectraAttestation(state[], parent_root, committee[0], cache)
       att2 = block:
         let
-          slot = getStateField(state2[], slot)
+          slot = state2[].slot
           parent_root = withState(state2[]): forkyState.latest_block_root
           committee = get_beacon_committee(state2[], slot, cIndex, cache2)
         makeElectraAttestation(state2[], parent_root, committee[0], cache2)
@@ -212,7 +210,7 @@ suite "Attestation pool electra processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
       attestation = makeElectraAttestation(
         state[], state[].latest_block_root, bc0[0], cache)
 
@@ -221,7 +219,7 @@ suite "Attestation pool electra processing" & preset():
       attestation.loadSig, attestation.startTime)
 
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+      state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
       cache, info, {}).isOk()
 
     let attestations = pool[].getElectraAttestationsForBlock(state[], cache)
@@ -234,14 +232,14 @@ suite "Attestation pool electra processing" & preset():
         state[], cache, electraAttestations = attestations,
         nextSlot = false).electraData.root
       bc1 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
       att1 = makeElectraAttestation(state[], root1, bc1[0], cache)
 
     check:
       withState(state[]): forkyState.latest_block_root == root1
 
       cfg.process_slots(
-        state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+        state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
         cache, info, {}).isOk()
 
       withState(state[]): forkyState.latest_block_root == root1
@@ -299,10 +297,10 @@ suite "Attestation pool electra processing" & preset():
   test "Attestations with disjoint comittee bits and equal data into single on-chain aggregate" & preset():
     let
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
 
       bc1 = get_beacon_committee(
-        state[], getStateField(state[], slot), 1.CommitteeIndex, cache)
+        state[], state[].slot, 1.CommitteeIndex, cache)
 
       # atestation from committee 1
       attestation1 = makeElectraAttestation(
@@ -322,7 +320,7 @@ suite "Attestation pool electra processing" & preset():
       attestation2.loadSig, attestation2.startTime)
 
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+      state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
       cache, info, {}).isOk()
 
     let attestations = pool[].getElectraAttestationsForBlock(state[], cache)
@@ -352,10 +350,10 @@ suite "Attestation pool electra processing" & preset():
 
     let
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
 
       bc1 = get_beacon_committee(
-        state[], getStateField(state[], slot), 1.CommitteeIndex, cache)
+        state[], state[].slot, 1.CommitteeIndex, cache)
 
       # attestation from first committee
       attestation1 = makeElectraAttestation(
@@ -388,7 +386,7 @@ suite "Attestation pool electra processing" & preset():
       attestation3.loadSig, attestation3.startTime)
 
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+      state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
       cache, info, {}).isOk()
 
     let attestations = pool[].getElectraAttestationsForBlock(state[], cache)
@@ -410,7 +408,7 @@ suite "Attestation pool electra processing" & preset():
       var root: Eth2Digest
       root.data[0..<8] = toBytesBE(i.uint64)
       let bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
 
       for j in 0..<bc0.len():
         root.data[8..<16] = toBytesBE(j.uint64)
@@ -420,7 +418,7 @@ suite "Attestation pool electra processing" & preset():
         inc attestations
 
       check cfg.process_slots(
-        state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
+        state[], state[].slot + 1, cache, info, {}).isOk()
 
     doAssert attestations.uint64 > MAX_ATTESTATIONS_ELECTRA,
       "6*SLOTS_PER_EPOCH validators > 8 mainnet MAX_ATTESTATIONS_ELECTRA"
@@ -429,23 +427,23 @@ suite "Attestation pool electra processing" & preset():
       pool[].getElectraAttestationsForBlock(state[], cache).lenu64() ==
         MAX_ATTESTATIONS_ELECTRA
       pool[].getElectraAggregatedAttestation(
-        getStateField(state[], slot) - 1, 0.CommitteeIndex).isSome()
+        state[].slot - 1, 0.CommitteeIndex).isSome()
 
   test "Attestations may arrive in any order" & preset():
     var cache = StateCache()
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
       attestation0 = makeElectraAttestation(
         state[], state[].latest_block_root, bc0[0], cache)
 
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
+      state[], state[].slot + 1, cache, info, {}).isOk()
 
     let
       bc1 = get_beacon_committee(state[],
-        getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[].slot, 0.CommitteeIndex, cache)
       attestation1 = makeElectraAttestation(
         state[], state[].latest_block_root, bc1[0], cache)
 
@@ -467,7 +465,7 @@ suite "Attestation pool electra processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
       attestation0 =
         makeElectraAttestation(state[], state[].latest_block_root, bc0[0], cache)
       attestation1 =
@@ -495,7 +493,7 @@ suite "Attestation pool electra processing" & preset():
     var
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
       attestation0 = makeElectraAttestation(
         state[], state[].latest_block_root, bc0[0], cache)
       attestation1 = makeElectraAttestation(
@@ -524,7 +522,7 @@ suite "Attestation pool electra processing" & preset():
     var
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(state[],
-        getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[].slot, 0.CommitteeIndex, cache)
       attestation0 = makeElectraAttestation(
         state[], state[].latest_block_root, bc0[0], cache)
       attestation1 = makeElectraAttestation(
@@ -619,7 +617,7 @@ suite "Attestation pool electra processing" & preset():
           cfg.timeParams.SLOT_DURATION)
 
       bc1 = get_beacon_committee(
-        state[], getStateField(state[], slot) - 1, 1.CommitteeIndex,
+        state[], state[].slot - 1, 1.CommitteeIndex,
         cache)
       attestation0 = makeElectraAttestation(state[], b10.root, bc1[0], cache)
 
@@ -747,7 +745,7 @@ suite "Attestation pool electra processing" & preset():
         attestations.setLen(0)
         for committee_index in get_committee_indices(committees_per_slot):
           let committee = get_beacon_committee(
-            state[], getStateField(state[], slot), committee_index,
+            state[], state[].slot, committee_index,
             cache)
 
           # Create a bitfield filled with the given count per attestation,
@@ -762,7 +760,7 @@ suite "Attestation pool electra processing" & preset():
           attestations.add electra.Attestation(
             committee_bits: committee_bits,
             aggregation_bits: aggregation_bits,
-            data: makeAttestationData(state[], getStateField(state[], slot),
+            data: makeAttestationData(state[], state[].slot,
               0.CommitteeIndex, blockRef.get().root)
             # signature: ValidatorSig()
           )
@@ -793,7 +791,7 @@ suite "Attestation pool electra processing" & preset():
     let
       # Create an attestation for slot 1!
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
 
     var
       att0 = makeElectraAttestation(
@@ -855,7 +853,7 @@ suite "Attestation pool electra processing" & preset():
       pool[].covers(att2.data, att2.aggregation_bits, att2.committee_bits)
 
       cfg.process_slots(
-        state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+        state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
         cache, info, {}).isOk()
 
     for att in pool[].electraAttestations(Opt.none Slot, Opt.none CommitteeIndex):
@@ -936,7 +934,7 @@ suite "Attestation pool electra processing" & preset():
     for i in 0 ..< 4:
       let
         bc = get_beacon_committee(
-          state[], getStateField(state[], slot), i.CommitteeIndex, cache)
+          state[], state[].slot, i.CommitteeIndex, cache)
         att = makeElectraAttestation(
           state[], state[].latest_block_root, bc[0], cache)
       var att2 = makeElectraAttestation(
@@ -983,10 +981,10 @@ suite "Attestation pool electra processing" & preset():
   test "Simple add and get with electra nonzero committee" & preset():
     let
       bc0 = get_beacon_committee(
-        state[], getStateField(state[], slot), 0.CommitteeIndex, cache)
+        state[], state[].slot, 0.CommitteeIndex, cache)
 
       bc1 = get_beacon_committee(
-        state[], getStateField(state[], slot), 1.CommitteeIndex, cache)
+        state[], state[].slot, 1.CommitteeIndex, cache)
 
       attestation1 = makeElectraAttestation(
         state[], state[].latest_block_root, bc0[0], cache)
@@ -1004,7 +1002,7 @@ suite "Attestation pool electra processing" & preset():
 
     check:
       cfg.process_slots(
-        state[], getStateField(state[], slot) + MIN_ATTESTATION_INCLUSION_DELAY,
+        state[], state[].slot + MIN_ATTESTATION_INCLUSION_DELAY,
         cache, info, {}).isOk()
 
       pool[].getElectraAggregatedAttestation(1.Slot, hash_tree_root(attestation1.data),
@@ -1019,7 +1017,7 @@ suite "Attestation pool electra processing" & preset():
     for i in 0 ..< 4:
       let
         bc = get_beacon_committee(
-          state[], getStateField(state[], slot), i.CommitteeIndex, cache)
+          state[], state[].slot, i.CommitteeIndex, cache)
         att = makeElectraAttestation(
           state[], state[].latest_block_root, bc[0], cache)
       var att2 = makeElectraAttestation(

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -119,7 +119,7 @@ proc getTestStates(
 
   # Ensure transitions beyond just adding validators and increasing slots
   sort(testStates) do (x, y: ref ForkedHashedBeaconState) -> int:
-    cmp($getStateRoot(x[]), $getStateRoot(y[]))
+    cmp($x[].root, $y[].root)
 
   testStates
 

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -71,7 +71,7 @@ suite "Block processor" & preset():
       )
       state = newClone(dag.headState)
       getTimeFn = proc(): BeaconTime =
-        getStateField(state[], slot).start_beacon_time(cfg.timeParams)
+        state[].slot.start_beacon_time(cfg.timeParams)
       batchVerifier = BatchVerifier.new(rng, taskpool)
     var
       cache: StateCache
@@ -135,7 +135,7 @@ suite "Block processor" & preset():
     check:
       # ensure we loaded the correct head state
       dag2.head.root == b2.root
-      getStateRoot(dag2.headState) == b2.message.state_root
+      dag2.headState.root == b2.message.state_root
       dag2.getBlockRef(b1.root).isSome()
       dag2.getBlockRef(b2.root).isSome()
       dag2.heads.len == 1
@@ -190,7 +190,7 @@ suite "Block processor" & preset():
         cfg,
         state[],
         max(
-          getStateField(state[], slot) + 1,
+          state[].slot + 1,
           cfg.consensusForkEpoch(consensusFork).start_slot,
         ),
         cache,

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -93,7 +93,7 @@ suite "Block pool processing" & preset():
       b2Get = dag.getForkedBlock(b2.root)
       sr = dag.findShufflingRef(b1Add[].bid, b1Add[].slot.epoch)
       er = dag.findEpochRef(b1Add[].bid, b1Add[].slot.epoch)
-      validators = getStateField(dag.headState, validators).lenu64()
+      validators = dag.headState.validators.lenu64()
 
     check:
       b2Get.isSome()
@@ -124,7 +124,7 @@ suite "Block pool processing" & preset():
 
     # Skip one slot to get a gap
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
+      state[], state[].slot + 1, cache, info, {}).isOk()
 
     let
       b4 = addTestBlock(state[], cache).phase0Data
@@ -191,7 +191,7 @@ suite "Block pool processing" & preset():
       db.getStateRoot(stateCheckpoint.bid.root, stateCheckpoint.slot).isErr()
       # this is required for the test to work - it's not a "public"
       # post-condition of getEpochRef
-      getStateField(dag.epochRefState, slot) == nextEpochSlot
+      dag.epochRefState.slot == nextEpochSlot
 
     assign(state[], dag.epochRefState)
 
@@ -220,7 +220,7 @@ suite "Block pool processing" & preset():
 
     check:
       dag.head == b1Add[]
-      getStateField(dag.headState, slot) == b1Add[].slot
+      dag.headState.slot == b1Add[].slot
 
   test "updateState sanity" & preset():
     let
@@ -237,13 +237,13 @@ suite "Block pool processing" & preset():
     check:
       dag.updateState(tmpState[], bs1, false, cache, dag.updateFlags)
       tmpState[].latest_block_root == b1Add[].root
-      getStateField(tmpState[], slot) == bs1.slot
+      tmpState[].slot == bs1.slot
 
     # Skip slots
     check:
       dag.updateState(tmpState[], bs1_3, false, cache, dag.updateFlags) # skip slots
       tmpState[].latest_block_root == b1Add[].root
-      getStateField(tmpState[], slot) == bs1_3.slot
+      tmpState[].slot == bs1_3.slot
 
     # Move back slots, but not blocks
     check:
@@ -251,19 +251,19 @@ suite "Block pool processing" & preset():
         tmpState[], dag.parent(bs1_3.bid).expect("block").atSlot(), false,
         cache, dag.updateFlags)
       tmpState[].latest_block_root == b1Add[].parent.root
-      getStateField(tmpState[], slot) == b1Add[].parent.slot
+      tmpState[].slot == b1Add[].parent.slot
 
     # Move to different block and slot
     check:
       dag.updateState(tmpState[], bs2_3, false, cache, dag.updateFlags)
       tmpState[].latest_block_root == b2Add[].root
-      getStateField(tmpState[], slot) == bs2_3.slot
+      tmpState[].slot == bs2_3.slot
 
     # Move back slot and block
     check:
       dag.updateState(tmpState[], bs1, false, cache, dag.updateFlags)
       tmpState[].latest_block_root == b1Add[].root
-      getStateField(tmpState[], slot) == bs1.slot
+      tmpState[].slot == bs1.slot
 
     # Move back to genesis
     check:
@@ -271,7 +271,7 @@ suite "Block pool processing" & preset():
         tmpState[], dag.parent(bs1.bid).expect("block").atSlot(), false, cache,
         dag.updateFlags)
       tmpState[].latest_block_root == b1Add[].parent.root
-      getStateField(tmpState[], slot) == b1Add[].parent.slot
+      tmpState[].slot == b1Add[].parent.slot
 
 suite "Block pool altair processing" & preset():
   setup:
@@ -374,7 +374,7 @@ suite "chain DAG finalization tests" & preset():
       blck = makeTestBlock(dag.headState, cache).phase0Data
       tmpState = assignClone(dag.headState)
     check cfg.process_slots(
-      tmpState[], getStateField(tmpState[], slot) + (5 * SLOTS_PER_EPOCH),
+      tmpState[], tmpState[].slot + (5 * SLOTS_PER_EPOCH),
       cache, info, {}).isOk()
 
     let lateBlock = addTestBlock(tmpState[], cache).phase0Data
@@ -386,7 +386,7 @@ suite "chain DAG finalization tests" & preset():
 
     # skip slots so we can test gappy getBlockIdAtSlot
     check cfg.process_slots(
-      tmpState[], getStateField(tmpState[], slot) + 2.uint64,
+      tmpState[], tmpState[].slot + 2.uint64,
       cache, info, {}).isOk()
 
     for i in 0 ..< (SLOTS_PER_EPOCH * 6):
@@ -398,7 +398,7 @@ suite "chain DAG finalization tests" & preset():
       blck = addTestBlock(
         tmpState[], cache,
         attestations = makeFullAttestations(
-          tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {})).phase0Data
+          tmpState[], dag.head.root, tmpState[].slot, cache, {})).phase0Data
       let added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine, [])
@@ -425,7 +425,7 @@ suite "chain DAG finalization tests" & preset():
       isNil dag.finalizedHead.blck.parent
 
     check:
-      dag.db.immutableValidators.len() == getStateField(dag.headState, validators).len()
+      dag.db.immutableValidators.len() == dag.headState.validators.len()
 
     block:
       var cur = dag.head.bid
@@ -520,7 +520,7 @@ suite "chain DAG finalization tests" & preset():
       dag2.head.root == parentRoot
       dag2.finalizedHead.blck.root == dag.finalizedHead.blck.root
       dag2.finalizedHead.slot == dag.finalizedHead.slot
-      getStateRoot(dag2.headState) == getStateRoot(dag.headState)
+      dag2.headState.root == dag.headState.root
 
     # No canonical block data should be pruned by the removal of the fork
     for i in Slot(0)..dag2.head.slot:
@@ -550,7 +550,7 @@ suite "chain DAG finalization tests" & preset():
     cache = StateCache()
 
     doAssert cfg.process_slots(
-      prestate[], getStateField(prestate[], slot) + 1,
+      prestate[], prestate[].slot + 1,
       cache, info, {}).isOk()
 
     # create another block, orphaning the head
@@ -584,7 +584,7 @@ suite "chain DAG finalization tests" & preset():
     let blck = makeTestBlock(
       dag.headState, cache,
       attestations = makeFullAttestations(
-        dag.headState, dag.head.root, getStateField(dag.headState, slot),
+        dag.headState, dag.head.root, dag.headState.slot,
         cache, {})).phase0Data
 
     let added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
@@ -603,8 +603,8 @@ suite "chain DAG finalization tests" & preset():
           dag.updateState(tmpStateData[], cur.bid.atSlot(), false, cache,
                           dag.updateFlags)
           dag.getForkedBlock(cur.bid).get().phase0Data.message.state_root ==
-            getStateRoot(tmpStateData[])
-          getStateRoot(tmpStateData[]) == hash_tree_root(
+            tmpStateData[].root
+          tmpStateData[].root == hash_tree_root(
             tmpStateData[].phase0Data.data)
         cur = cur.parent
 
@@ -618,7 +618,7 @@ suite "chain DAG finalization tests" & preset():
       dag2.head.root == dag.head.root
       dag2.finalizedHead.blck.root == dag.finalizedHead.blck.root
       dag2.finalizedHead.slot == dag.finalizedHead.slot
-      getStateRoot(dag2.headState) == getStateRoot(dag.headState)
+      dag2.headState.root == dag.headState.root
 
   test "shutdown during finalization" & preset():
     var testPassed: bool
@@ -635,7 +635,7 @@ suite "chain DAG finalization tests" & preset():
         # Check test assumption: New finalized blocks were not written yet
         let
           stateFinalizedSlot =
-            dag.headState.getStateField(finalized_checkpoint).epoch.start_slot
+            dag.headState.finalized_checkpoint.epoch.start_slot
           dbFinalizedSlot =
             dag.db.finalizedBlocks.high.expect("Valid DB")
         doAssert stateFinalizedSlot > dbFinalizedSlot, "Finalized not written"
@@ -725,7 +725,7 @@ suite "Diverging hardforks":
     check:
       process_slots(
         phase0RuntimeConfig, tmpState[],
-        getStateField(tmpState[], slot) + (3 * SLOTS_PER_EPOCH).uint64,
+        tmpState[].slot + (3 * SLOTS_PER_EPOCH).uint64,
         cache, info, {}).isOk()
 
     # Because the first block is after the Altair transition, the only block in
@@ -748,7 +748,7 @@ suite "Diverging hardforks":
     check:
       process_slots(
         phase0RuntimeConfig, tmpState[],
-        getStateField(tmpState[], slot) + SLOTS_PER_EPOCH.uint64,
+        tmpState[].slot + SLOTS_PER_EPOCH.uint64,
         cache, info, {}).isOk()
 
     # There's a block in the shared-correct phase0 hardfork, before epoch 2
@@ -760,7 +760,7 @@ suite "Diverging hardforks":
       b1Add.isOk()
       process_slots(
         phase0RuntimeConfig, tmpState[],
-        getStateField(tmpState[], slot) + (3 * SLOTS_PER_EPOCH).uint64,
+        tmpState[].slot + (3 * SLOTS_PER_EPOCH).uint64,
         cache, info, {}).isOk()
 
     var
@@ -1048,7 +1048,7 @@ suite "Starting states":
       genBlock = get_initial_beacon_block(genState[])
       blocks = block:
         var blocks: seq[ForkedSignedBeaconBlock]
-        while getStateField(tailState[], slot).uint64 + 1 < SLOTS_PER_EPOCH:
+        while tailState[].slot.uint64 + 1 < SLOTS_PER_EPOCH:
           blocks.add addTestBlock(tailState[], cache)
         blocks
       tailBlock = blocks[^1]
@@ -1173,7 +1173,7 @@ suite "Latest valid hash" & preset():
   test "LVH searching":
     # Reach Bellatrix, where execution payloads exist
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + (3 * SLOTS_PER_EPOCH),
+      state[], state[].slot + (3 * SLOTS_PER_EPOCH),
       cache, info, {}).isOk()
 
     var
@@ -1243,7 +1243,7 @@ suite "Pruning":
       let blck = addTestBlock(
         tmpState[], cache,
         attestations = makeFullAttestations(
-          tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {})).phase0Data
+          tmpState[], dag.head.root, tmpState[].slot, cache, {})).phase0Data
       let added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
       check: added.isOk()
       blocks.add(added[])
@@ -1263,7 +1263,7 @@ suite "Pruning":
       let blck = addTestBlock(
         tmpState[], cache,
         attestations = makeFullAttestations(
-          tmpState[], dag.head.root, getStateField(tmpState[], slot), cache, {})).phase0Data
+          tmpState[], dag.head.root, tmpState[].slot, cache, {})).phase0Data
       let added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
       check: added.isOk()
       dag.updateHead(added[], quarantine, [])
@@ -1734,7 +1734,7 @@ template runShufflingTests(cfg: RuntimeConfig, numRandomTests: int) =
       var info: ForkedEpochInfo
       check cfg.process_slots(
         dag.headState,
-        getStateField(dag.headState, slot) + delaySlots,
+        dag.headState.slot + delaySlots,
         cache, info, flags = {}).isOk
 
     # Add 0.75 epochs

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -58,7 +58,7 @@ suite "Gossip validation " & preset():
           "working batcher")
     # Slot 0 is a finalized slot - won't be making attestations for it..
     check cfg.process_slots(
-      state[], getStateField(state[], slot) + 1, cache, info, {}).isOk()
+      state[], state[].slot + 1, cache, info, {}).isOk()
 
   test "Empty committee when no committee for slot":
     template committee(idx: uint64): untyped =
@@ -240,7 +240,7 @@ suite "Gossip validation - Altair":
           continue
       let
         subcommitteeIndex = SyncSubcommitteeIndex(i div indicesPerSubcommittee)
-        pubkey = getStateField(dag.headState, validators).item(index).pubkey
+        pubkey = dag.headState.validators.item(index).pubkey
         keystoreData = KeystoreData(
           kind: KeystoreKind.Local,
           pubkey: pubkey,
@@ -248,9 +248,9 @@ suite "Gossip validation - Altair":
         validator = AttachedValidator(
           kind: ValidatorKind.Local, data: keystoreData, index: Opt.some index)
         proofFut = validator.getSyncCommitteeSelectionProof(
-          getStateField(dag.headState, fork),
-          getStateField(dag.headState, genesis_validators_root),
-          getStateField(dag.headState, slot),
+          dag.headState.fork,
+          dag.headState.genesis_validators_root,
+          dag.headState.slot,
           subcommitteeIndex)
       check proofFut.completed  # Local signatures complete synchronously
       let proof = proofFut.value
@@ -278,7 +278,7 @@ suite "Gossip validation - Altair":
       subcommittee = toSeq(syncCommittee.syncSubcommittee(subcommitteeIdx))
       index = subcommittee[indexInSubcommittee]
       numPresent = subcommittee.count(index)
-      pubkey = getStateField(dag.headState, validators).item(index).pubkey
+      pubkey = dag.headState.validators.item(index).pubkey
       keystoreData = KeystoreData(
         kind: KeystoreKind.Local,
         pubkey: pubkey,
@@ -286,8 +286,8 @@ suite "Gossip validation - Altair":
       validator = AttachedValidator(
         kind: ValidatorKind.Local, data: keystoreData, index: Opt.some index)
       msgFut = validator.getSyncCommitteeMessage(
-        getStateField(dag.headState, fork),
-        getStateField(dag.headState, genesis_validators_root),
+        dag.headState.fork,
+        dag.headState.genesis_validators_root,
         msgSlot, dag.headState.latest_block_root)
     check msgFut.completed  # Local signatures complete synchronously
     let msg = msgFut.value
@@ -339,7 +339,7 @@ suite "Gossip validation - Altair":
       cache, info, flags = {}).isOk
     for i in 0 ..< SLOTS_PER_EPOCH - 1:
       dag.addBlock(cache, verifier, quarantine[])
-    let slot = getStateField(dag.headState, slot)
+    let slot = dag.headState.slot
 
     # The following slots determine what the sync committee signs:
     # 1. `state.latest_block_header.slot` --> ConsensusFork of signed block
@@ -386,9 +386,9 @@ suite "Gossip validation - Altair":
           message: ContributionAndProof(
             aggregator_index: distinctBase(validator.index.get),
             selection_proof: validator.getSyncCommitteeSelectionProof(
-              getStateField(dag.headState, fork),
-              getStateField(dag.headState, genesis_validators_root),
-              getStateField(dag.headState, slot),
+              dag.headState.fork,
+              dag.headState.genesis_validators_root,
+              dag.headState.slot,
               subcommitteeIdx).value.get))
         check syncCommitteePool[].produceContribution(
           slot, bid, subcommitteeIdx,
@@ -396,8 +396,8 @@ suite "Gossip validation - Altair":
         syncCommitteePool[].addContribution(
           contrib[], bid, contrib.message.contribution.signature.load.get)
         let res = waitFor noCancel validator.getContributionAndProofSignature(
-          getStateField(dag.headState, fork),
-          getStateField(dag.headState, genesis_validators_root),
+          dag.headState.fork,
+          dag.headState.genesis_validators_root,
           contrib[].message)
         doAssert(res.isOk())
         contrib[].signature = res.get()

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -46,7 +46,7 @@ suite "Light client" & preset():
     var cache: StateCache
     const maxAttestedSlotsPerPeriod = 3 * SLOTS_PER_EPOCH
     while true:
-      var slot = getStateField(dag.headState, slot)
+      var slot = dag.headState.slot
       doAssert targetSlot >= slot
       if targetSlot == slot: break
 
@@ -142,7 +142,7 @@ suite "Light client" & preset():
       periodEpoch = headPeriod.start_epoch
       headSlot = (periodEpoch + 2).start_slot + 5
     dag.advanceToSlot(headSlot, verifier, quarantine[])
-    let currentSlot = getStateField(dag.headState, slot)
+    let currentSlot = dag.headState.slot
 
     # Initialize light client store
     var bootstrap = dag.getLightClientBootstrap(trusted_block_root)

--- a/tests/test_network_metadata.nim
+++ b/tests/test_network_metadata.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_network_metadata.nim
+++ b/tests/test_network_metadata.nim
@@ -14,14 +14,14 @@ import
 
 {.used.}
 
-template checkRoot(name, root) =
+template checkRoot(name, eroot) =
   let
     metadata = getMetadataForNetwork(name)
     state = newClone(readSszForkedHashedBeaconState(
       metadata.cfg, metadata.genesis.bakedBytes))
 
   check:
-    $getStateRoot(state[]) == root
+    $state[].root == eroot
 
 suite "Network metadata":
   test "mainnet":

--- a/tests/test_payload_attestation_pool.nim
+++ b/tests/test_payload_attestation_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_payload_attestation_pool.nim
+++ b/tests/test_payload_attestation_pool.nim
@@ -78,14 +78,14 @@ suite "Payload attestation pool" & preset():
       process_slots(
         dag.cfg,
         state[],
-        getStateField(state[], slot) + 1,
+        state[].slot + 1,
         cache,
         info,
         {}).isOk()
 
   test "Can add and retrieve payload attestations" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -120,7 +120,7 @@ suite "Payload attestation pool" & preset():
 
   test "Multiple validators in PTC can attest" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -152,7 +152,7 @@ suite "Payload attestation pool" & preset():
 
   test "Duplicate validator in PTC - multiple signatures" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -201,7 +201,7 @@ suite "Payload attestation pool" & preset():
 
   test "Can get payload attestations for block production" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -227,7 +227,7 @@ suite "Payload attestation pool" & preset():
 
   test "Payload attestations get pruned" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -258,7 +258,7 @@ suite "Payload attestation pool" & preset():
 
   test "Different payload presence values" & preset():
     let
-      slot = getStateField(state[], slot)
+      slot = state[].slot
       beacon_block_root =
         withState(state[]): hash_tree_root(forkyState.data.latest_block_header)
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
@@ -292,7 +292,7 @@ suite "Payload attestation pool" & preset():
         check agg1.isSome()
 
   test "get_ptc with ShufflingRef matches StateCache version" & preset():
-    let slot = getStateField(state[], slot)
+    let slot = state[].slot
 
     withState(state[]):
       when consensusFork >= ConsensusFork.Gloas:

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_spec.nim
+++ b/tests/test_spec.nim
@@ -89,7 +89,7 @@ suite "Beacon state" & preset():
     check:
       state[].phase0Data.dependent_root(Epoch(0)) == genBlock.root
 
-    while getStateField(state[], slot).epoch < Epoch(1):
+    while state[].slot.epoch < Epoch(1):
       discard addTestBlock(state[], cache)
 
     check:
@@ -97,7 +97,7 @@ suite "Beacon state" & preset():
         state[].phase0Data.data.get_block_root_at_slot(Epoch(1).start_slot - 1)
       state[].phase0Data.dependent_root(Epoch(0)) == genBlock.root
 
-    while getStateField(state[], slot).epoch < Epoch(2):
+    while state[].slot.epoch < Epoch(2):
       discard addTestBlock(state[], cache)
 
     check:

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -51,10 +51,10 @@ suite "state diff tests" & preset():
 
     for i in 0 ..< testStates.len:
       for j in (i+1) ..< testStates.len:
-        doAssert getStateField(testStates[i][], slot) <
-          getStateField(testStates[j][], slot)
-        if  getStateField(testStates[i][], slot) + SLOTS_PER_EPOCH !=
-            getStateField(testStates[j][], slot):
+        doAssert testStates[i][].slot <
+          testStates[j][].slot
+        if  testStates[i][].slot + SLOTS_PER_EPOCH !=
+            testStates[j][].slot:
           continue
         let
           tmpStateApplyBase = assignClone(testStates[i].capellaData.data)
@@ -65,9 +65,9 @@ suite "state diff tests" & preset():
         applyDiff(
           tmpStateApplyBase[],
           mapIt(
-            getStateField(testStates[j][], validators).asSeq[
-              getStateField(testStates[i][], validators).len ..
-              getStateField(testStates[j][], validators).len - 1],
+            testStates[j][].validators.asSeq[
+              testStates[i][].validators.len ..
+              testStates[j][].validators.len - 1],
             it.getImmutableValidatorData),
           diff)
         check hash_tree_root(testStates[j][].capellaData.data) ==

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -293,7 +293,7 @@ proc addTestBlock*(
   if nextSlot:
     var info = ForkedEpochInfo()
     process_slots(
-      cfg, state, getStateField(state, slot) + 1, cache, info, flags).expect(
+      cfg, state, state.slot + 1, cache, info, flags).expect(
         "can advance 1")
 
   withState(state):
@@ -405,8 +405,8 @@ func makeAttestation(
     ValidatorSig()
   else:
     makeAttestationSig(
-      getStateField(state, fork),
-      getStateField(state, genesis_validators_root),
+      state.fork,
+      state.genesis_validators_root,
       data, committee, aggregation_bits)
 
   phase0.Attestation(
@@ -418,7 +418,7 @@ func makeAttestation(
 func find_beacon_committee(
     state: ForkedHashedBeaconState, validator_index: ValidatorIndex,
     cache: var StateCache): auto =
-  let epoch = epoch(getStateField(state, slot))
+  let epoch = epoch(state.slot)
   for epoch_committee_index in 0'u64 ..< get_committee_count_per_slot(
       state, epoch, cache) * SLOTS_PER_EPOCH:
     let
@@ -459,8 +459,8 @@ func makeFullAttestations*(
       attestation.aggregation_bits.setBit(i)
 
     attestation.signature = makeAttestationSig(
-        getStateField(state, fork),
-        getStateField(state, genesis_validators_root), data, committee,
+        state.fork,
+        state.genesis_validators_root, data, committee,
         attestation.aggregation_bits)
 
     result.add attestation
@@ -483,8 +483,8 @@ func makeElectraAttestation(
     ValidatorSig()
   else:
     makeAttestationSig(
-      getStateField(state, fork),
-      getStateField(state, genesis_validators_root),
+      state.fork,
+      state.genesis_validators_root,
       data, committee, aggregation_bits)
 
   var committee_bits: AttestationCommitteeBits
@@ -531,8 +531,8 @@ func makeFullElectraAttestations*(
       attestation.aggregation_bits.setBit(i)
 
     attestation.signature = makeAttestationSig(
-        getStateField(state, fork),
-        getStateField(state, genesis_validators_root), data, committee,
+        state.fork,
+        state.genesis_validators_root, data, committee,
         attestation.aggregation_bits)
 
     result.add attestation
@@ -555,11 +555,11 @@ proc makeSyncAggregate(
         else:
           return SyncAggregate.init()
     fork =
-      getStateField(state, fork)
+      state.fork
     genesis_validators_root =
-      getStateField(state, genesis_validators_root)
+      state.genesis_validators_root
     slot =
-      getStateField(state, slot)
+      state.slot
     latest_block_id =
       withState(state): forkyState.latest_block_id
     rng = HmacDrbgContext.new()
@@ -594,7 +594,7 @@ proc makeSyncAggregate(
         validatorIdx =
           block:
             var res = 0
-            for i, validator in getStateField(state, validators):
+            for i, validator in state.validators:
               if validator.pubkey == validatorKey:
                 res = i
                 break
@@ -673,17 +673,17 @@ iterator makeTestBlocks*(
       attestations =
         if attested and state.kind < ConsensusFork.Electra:
           makeFullAttestations(
-            state[], parent_root, getStateField(state[], slot), cache)
+            state[], parent_root, state[].slot, cache)
         else:
           @[]
       electraAttestations =
         if attested and state.kind >= ConsensusFork.Electra:
           makeFullElectraAttestations(
-            state[], parent_root, getStateField(state[], slot), cache)
+            state[], parent_root, state[].slot, cache)
         else:
           @[]
-      stateEth1 = getStateField(state[], eth1_data)
-      stateDepositIndex = getStateField(state[], eth1_deposit_index)
+      stateEth1 = state[].eth1_data
+      stateDepositIndex = state[].eth1_deposit_index
       deposits =
         if stateDepositIndex < stateEth1.deposit_count:
           let

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -154,14 +154,14 @@ proc getTestStates*(
 
   for i, epoch in stateEpochs:
     let slot = epoch.Epoch.start_slot
-    if getStateField(tmpState[], slot) < slot:
+    if tmpState[].slot < slot:
       process_slots(
         cfg, tmpState[], slot, cache, info, {}).expect("no failure")
 
     if i mod 3 == 0:
       withState(tmpState[]):
         valid_deposit(forkyState)
-    doAssert getStateField(tmpState[], slot) == slot
+    doAssert tmpState[].slot == slot
 
     if tmpState[].kind == consensusFork:
       result.add assignClone(tmpState[])
@@ -169,4 +169,4 @@ proc getTestStates*(
 when isMainModule:
   # Smoke test
   let state = initGenesisState(defaultRuntimeConfig, num_validators = SLOTS_PER_EPOCH)
-  doAssert getStateField(state[], validators).lenu64 == SLOTS_PER_EPOCH
+  doAssert state[].validators.lenu64 == SLOTS_PER_EPOCH

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)


### PR DESCRIPTION
Using `func` avoids a template expansion at every usage site and just looks nicer .. unlike earlier nim versions, good code  is generated for `lent`.

An additional benefit is that mutability semantics are preserved and the resulting value is immutable even when being accessed indirectly (unlike `addr`+`[]` which results in a `var`).

No matter what, when iterating over validators we continue to be affected by:

* https://github.com/nim-lang/Nim/issues/25470
* https://github.com/nim-lang/Nim/issues/25469