### PR TITLE
Update proto array to track slot instead of epoch

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -36,13 +36,13 @@ export proto_array.len
 type Index = fork_choice_types.Index
 
 func compute_deltas(
-       deltas: var openArray[Delta],
-       indices: Table[Eth2Digest, Index],
-       indices_offset: Index,
-       votes: var openArray[VoteTracker],
-       old_balances: openArray[Gwei],
-       new_balances: openArray[Gwei]
-     ): FcResult[void]
+    deltas: var openArray[Delta],
+    indices: Table[Eth2Digest, Index],
+    indices_offset: Index,
+    votes: var openArray[VoteTracker],
+    old_balances: openArray[Gwei],
+    new_balances: openArray[Gwei]): FcResult[void]
+
 # Fork choice routines
 # ----------------------------------------------------------------------
 
@@ -162,13 +162,14 @@ func process_attestation(
   self.votes.extend(validator_index.int + 1)
 
   template vote: untyped = self.votes[validator_index]
-  if target_epoch > vote.next_epoch or vote.next_root.isZero:
-    vote.next_root = block_root
-    vote.next_epoch = target_epoch
+  if vote.next_epoch != FAR_FUTURE_EPOCH:
+    if target_epoch > vote.next_epoch or vote.next_root.isZero:
+      vote.next_root = block_root
+      vote.next_epoch = target_epoch
 
-    trace "Integrating vote in fork choice",
-      validator_index = validator_index,
-      new_vote = shortLog(vote)
+      trace "Integrating vote in fork choice",
+        validator_index = validator_index,
+        new_vote = shortLog(vote)
 
 proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
   # Spec:
@@ -327,7 +328,7 @@ proc process_block*(self: var ForkChoice,
 
 func find_head(
        self: var ForkChoiceBackend,
-       current_epoch: Epoch,
+       current_slot: Slot,
        checkpoints: FinalityCheckpoints,
        justified_total_active_balance: Gwei,
        justified_state_balances: seq[Gwei],
@@ -347,7 +348,7 @@ func find_head(
 
   # Apply score changes
   ? self.proto_array.applyScoreChanges(
-    deltas, current_epoch, checkpoints,
+    deltas, current_slot, checkpoints,
     justified_total_active_balance, proposer_boost_root)
 
   self.balances = justified_state_balances
@@ -368,7 +369,7 @@ proc get_head*(self: var ForkChoice,
   ? self.update_time(dag, wallTime)
 
   self.backend.find_head(
-    self.checkpoints.time.slotOrZero(dag.timeParams).epoch,
+    self.checkpoints.time.slotOrZero(dag.timeParams),
     FinalityCheckpoints(
       justified: self.checkpoints.justified.checkpoint,
       finalized: self.checkpoints.finalized),
@@ -406,13 +407,12 @@ func mark_root_invalid*(self: var ForkChoice, root: Eth2Digest) =
     discard
 
 func compute_deltas(
-       deltas: var openArray[Delta],
-       indices: Table[Eth2Digest, Index],
-       indices_offset: Index,
-       votes: var openArray[VoteTracker],
-       old_balances: openArray[Gwei],
-       new_balances: openArray[Gwei]
-     ): FcResult[void] =
+    deltas: var openArray[Delta],
+    indices: Table[Eth2Digest, Index],
+    indices_offset: Index,
+    votes: var openArray[VoteTracker],
+    old_balances: openArray[Gwei],
+    new_balances: openArray[Gwei]): FcResult[void] =
   ## Update `deltas`
   ##   between old and new balances
   ##   between votes

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -88,7 +88,7 @@ type
     ## Subtracted from logical index to get the physical index
 
   ProtoArray* = object
-    currentEpoch*: Epoch
+    currentSlot*: Slot
     checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -127,7 +127,7 @@ func calculateProposerBoost(justifiedTotalActiveBalance: Gwei): Gwei =
 
 func applyScoreChanges*(self: var ProtoArray,
                         deltas: var openArray[Delta],
-                        currentEpoch: Epoch,
+                        currentSlot: Slot,
                         checkpoints: FinalityCheckpoints,
                         justifiedTotalActiveBalance: Gwei,
                         proposerBoostRoot: Eth2Digest): FcResult[void] =
@@ -152,7 +152,7 @@ func applyScoreChanges*(self: var ProtoArray,
       deltasLen: deltas.len,
       indicesLen: self.indices.len)
 
-  self.currentEpoch = currentEpoch
+  self.currentSlot = currentSlot
 
   doAssert checkpoints.finalized.epoch >= self.checkpoints.finalized.epoch
   doAssert checkpoints.finalized.epoch > self.checkpoints.finalized.epoch or
@@ -535,45 +535,44 @@ func nodeIsViableForHead(
     # The voting source should be either at the same height as the store's
     # justified checkpoint or not more than two epochs ago
     correctJustified =
-      node.checkpoints.justified.epoch + 2 >= self.currentEpoch
+      node.checkpoints.justified.epoch + 2 >= self.currentSlot.epoch
 
-  return
-    if not correctJustified:
-      false
-    elif self.checkpoints.finalized.epoch == GENESIS_EPOCH:
-      true
-    elif node.sharedFinalizedEpoch == self.checkpoints.finalized.epoch:
-      # Already checked to share history with `self.checkpoints.finalized`.
-      # `self.checkpoints.finalized` cannot reorg, see `applyScoreChanges`
-      true
-    else:
-      # Check that this node is not going to be pruned
-      let
-        finalizedEpoch = self.checkpoints.finalized.epoch
-        finalizedSlot = finalizedEpoch.start_slot
-      var ancestor = some node
-      while ancestor.isSome and ancestor.unsafeGet.bid.slot > finalizedSlot and
-          ancestor.unsafeGet.sharedFinalizedEpoch != finalizedEpoch:
-        if ancestor.unsafeGet.parent.isSome:
-          ancestor = self.nodes[ancestor.unsafeGet.parent.unsafeGet]
-        else:
-          ancestor.reset()
-      if ancestor.isNone:
-        false
-      elif ancestor.unsafeGet.sharedFinalizedEpoch != finalizedEpoch and
-          ancestor.unsafeGet.bid.root != self.checkpoints.finalized.root:
-        false
+  if not correctJustified:
+    false
+  elif self.checkpoints.finalized.epoch == GENESIS_EPOCH:
+    true
+  elif node.sharedFinalizedEpoch == self.checkpoints.finalized.epoch:
+    # Already checked to share history with `self.checkpoints.finalized`.
+    # `self.checkpoints.finalized` cannot reorg, see `applyScoreChanges`
+    true
+  else:
+    # Check that this node is not going to be pruned
+    let
+      finalizedEpoch = self.checkpoints.finalized.epoch
+      finalizedSlot = finalizedEpoch.start_slot
+    var ancestor = some node
+    while ancestor.isSome and ancestor.unsafeGet.bid.slot > finalizedSlot and
+        ancestor.unsafeGet.sharedFinalizedEpoch != finalizedEpoch:
+      if ancestor.unsafeGet.parent.isSome:
+        ancestor = self.nodes[ancestor.unsafeGet.parent.unsafeGet]
       else:
-        # An ancestor was already checked to share canonical history,
-        # or we reached the `finalizedSlot` and the root matches expectations
-        let ancestorSlot = ancestor.unsafeGet.bid.slot
-        var idx = nodeIdx
-        template mutableNode: untyped = self.nodes.buf[idx - self.nodes.offset]
-        while mutableNode.bid.slot > ancestorSlot:
-          mutableNode.sharedFinalizedEpoch = finalizedEpoch
-          idx = mutableNode.parent.unsafeGet
+        ancestor.reset()
+    if ancestor.isNone:
+      false
+    elif ancestor.unsafeGet.sharedFinalizedEpoch != finalizedEpoch and
+        ancestor.unsafeGet.bid.root != self.checkpoints.finalized.root:
+      false
+    else:
+      # An ancestor was already checked to share canonical history,
+      # or we reached the `finalizedSlot` and the root matches expectations
+      let ancestorSlot = ancestor.unsafeGet.bid.slot
+      var idx = nodeIdx
+      template mutableNode: untyped = self.nodes.buf[idx - self.nodes.offset]
+      while mutableNode.bid.slot > ancestorSlot:
         mutableNode.sharedFinalizedEpoch = finalizedEpoch
-        true
+        idx = mutableNode.parent.unsafeGet
+      mutableNode.sharedFinalizedEpoch = finalizedEpoch
+      true
 
 func propagateInvalidity*(
     self: var ProtoArray, startPhysicalIdx: Index) =


### PR DESCRIPTION
For Fast Confirmation Rule, certain computations in fork choice need access to the slot within the epoch. Update proto array backend to track the slot instead of just the epoch.