### PR TITLE
Add Nim caching to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ concurrency: # Cancel stale PR builds (but not push builds)
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,9 +164,23 @@ jobs:
           echo "ncpu=${ncpu}" >> $GITHUB_ENV
           echo "make_cmd=${make_cmd}" >> $GITHUB_ENV
 
+      - name: Get latest nimbus-build-system commit hash
+        id: versions
+        shell: bash
+        run: |
+          nbsHash=$(git rev-parse HEAD:vendor/nimbus-build-system)
+          echo "nimbus_build_system=$nbsHash" >> $GITHUB_OUTPUT
+
+      - name: Restore prebuilt Nim from cache
+        id: nim-cache
+        uses: actions/cache@v4
+        with:
+          path: NimBinCache
+          key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'
+
       - name: Build Nim and Nimbus dependencies
         run: |
-          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 update
+          ${make_cmd} -j ${ncpu} NIM_COMMIT=${{ matrix.branch }} ARCH_OVERRIDE=${PLATFORM} QUICK_AND_DIRTY_COMPILER=1 CI_CACHE=NimBinCache update
           ./env.sh nim --version
 
       - name: Build binaries (with trace logging enabled)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
           echo "nimbus_build_system=$nbsHash" >> $GITHUB_OUTPUT
 
       - name: Restore prebuilt Nim from cache
+        if: matrix.branch == null
         id: nim-cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
       - stable
       - testing
       - unstable
-      - cache-nim-2
   pull_request:
     paths-ignore: ['media/**', 'docs/**', '**/*.md']
     branches-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - stable
       - testing
       - unstable
+      - cache-nim-2
   pull_request:
     paths-ignore: ['media/**', 'docs/**', '**/*.md']
     branches-ignore:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ concurrency: # Cancel stale PR builds (but not push builds)
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
This adds Nim caching to the CI, like it was done in the `nimbus-eth1` repo.

I've run the CIs several times with these changes and compared the times of the "Build Nim and Nimbus dependencies" step to various random commits before this PR.
The usual time savings are on average between 1.5 and 3.5 minutes. Not very impressive on its own, but multiply it by the number of different OSes we run and the number of times the CIs are triggered every day - it quickly snowballs.