### PR TITLE
Add on_slot_start_after_past_attestations_applied hook

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -371,10 +371,11 @@ proc get_head*(
     wallTime: BeaconTime): FcResult[Eth2Digest] =
   ? self.update_time(dag, wallTime)
 
+  let checkpoints = FinalityCheckpoints(
+    justified: self.checkpoints.justified.checkpoint,
+    finalized: self.checkpoints.finalized)
   result = self.backend.find_head(
-    FinalityCheckpoints(
-      justified: self.checkpoints.justified.checkpoint,
-      finalized: self.checkpoints.finalized),
+    checkpoints,
     self.checkpoints.justified.total_active_balance,
     self.checkpoints.justified.balances,
     self.checkpoints.proposer_boost_root)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -155,11 +155,10 @@ proc on_tick(
   ok()
 
 func process_attestation(
-       self: var ForkChoiceBackend,
-       validator_index: ValidatorIndex,
-       block_root: Eth2Digest,
-       target_epoch: Epoch
-     ) =
+    self: var ForkChoiceBackend,
+    validator_index: ValidatorIndex,
+    block_root: Eth2Digest,
+    target_epoch: Epoch) =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 
@@ -214,6 +213,12 @@ proc update_time*(
 
     if preSlot != postSlot:
       self.process_attestation_queue(postSlot)
+
+      ? self.backend.proto_array.on_slot_start_after_past_attestations_applied(
+        currentSlot = postSlot,
+        FinalityCheckpoints(
+          justified: self.checkpoints.justified.checkpoint,
+          finalized: self.checkpoints.finalized))
 
   ok()
 
@@ -331,13 +336,11 @@ proc process_block*(
   ok()
 
 func find_head(
-       self: var ForkChoiceBackend,
-       current_slot: Slot,
-       checkpoints: FinalityCheckpoints,
-       justified_total_active_balance: Gwei,
-       justified_state_balances: seq[Gwei],
-       proposer_boost_root: Eth2Digest
-     ): FcResult[Eth2Digest] =
+    self: var ForkChoiceBackend,
+    checkpoints: FinalityCheckpoints,
+    justified_total_active_balance: Gwei,
+    justified_state_balances: seq[Gwei],
+    proposer_boost_root: Eth2Digest): FcResult[Eth2Digest] =
   ## Returns the new blockchain head
 
   # Compute deltas with previous call
@@ -352,17 +355,13 @@ func find_head(
 
   # Apply score changes
   ? self.proto_array.applyScoreChanges(
-    deltas, current_slot, checkpoints,
-    justified_total_active_balance, proposer_boost_root)
+    deltas, checkpoints, justified_total_active_balance, proposer_boost_root)
 
   self.balances = justified_state_balances
 
   # Find the best block
   var new_head{.noinit.}: Eth2Digest
   ? self.proto_array.findHead(new_head)
-
-  trace "Fork choice requested",
-    checkpoints, fork_choice_head = shortLog(new_head)
 
   return ok(new_head)
 
@@ -372,14 +371,16 @@ proc get_head*(
     wallTime: BeaconTime): FcResult[Eth2Digest] =
   ? self.update_time(dag, wallTime)
 
-  self.backend.find_head(
-    self.checkpoints.time.slotOrZero(dag.timeParams),
+  result = self.backend.find_head(
     FinalityCheckpoints(
       justified: self.checkpoints.justified.checkpoint,
       finalized: self.checkpoints.finalized),
     self.checkpoints.justified.total_active_balance,
     self.checkpoints.justified.balances,
     self.checkpoints.proposer_boost_root)
+  if result.isOk:
+    trace "Fork choice requested",
+      checkpoints, fork_choice_head = shortLog(result.unsafeGet)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
 func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
@@ -450,7 +451,8 @@ func compute_deltas(
 
     if vote.current_root != vote.next_root or old_balance != new_balance:
       # Ignore the current or next vote if it is not known in `indices`.
-      # We assume that it is outside of our tree (i.e., pre-finalization) and therefore not interesting.
+      # We assume that it is outside of our tree (i.e., pre-finalization)
+      # and therefore not interesting.
       if vote.current_root in indices:
         let index = indices.unsafeGet(vote.current_root) - indices_offset
         if index >= deltas.len:
@@ -494,12 +496,13 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test zero votes"
 
     const validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -508,16 +511,15 @@ when isMainModule:
       new_balances.add 0.Gwei
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     doAssert deltas == newSeq[Delta](validator_count), "deltas should be zeros"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tAll_voted_the_same() =
     echo "    fork_choice compute_deltas - test all same votes"
@@ -525,38 +527,38 @@ when isMainModule:
     const
       Balance = Gwei(42)
       validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
         next_root: fakeHash(0), # Get a non-zero hash
-        next_epoch: Epoch(0)
-      )
+        next_epoch: Epoch(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     for i, delta in deltas:
       if i == 0:
-        doAssert delta == Delta(Balance * validator_count), "The 0th root should have a delta"
+        doAssert delta == Delta(Balance * validator_count),
+          "The 0th root should have a delta"
       else:
         doAssert delta == 0, "The non-0 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tDifferent_votes() =
     echo "    fork_choice compute_deltas - test all different votes"
@@ -564,26 +566,25 @@ when isMainModule:
     const
       Balance = Gwei(42)
       validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
         next_root: fakeHash(i), # Each vote for a different root
-        next_epoch: Epoch(0)
-      )
+        next_epoch: Epoch(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
@@ -591,8 +592,8 @@ when isMainModule:
       doAssert delta == Delta(Balance), "Each root should have a delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tMoving_votes() =
     echo "    fork_choice compute_deltas - test moving votes"
@@ -601,12 +602,13 @@ when isMainModule:
       Balance = Gwei(42)
       validator_count = 16
       TotalDeltas = Delta(Balance * validator_count)
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -614,14 +616,12 @@ when isMainModule:
         # Move vote from root 0 to root 1
         current_root: fakeHash(0),
         next_root: fakeHash(1),
-        next_epoch: Epoch(0)
-      )
+        next_epoch: Epoch(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
@@ -631,53 +631,54 @@ when isMainModule:
       elif i == 1:
         doAssert delta == TotalDeltas, "1st root should have a positive delta"
       else:
-        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+        doAssert delta == 0,
+          "The non-0 and non-1 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tMove_out_of_tree() =
     echo "    fork_choice compute_deltas - test votes for unknown subtree"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add a block
     indices[fakeHash(1)] = 0
 
     # 2 validators
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance, Balance]
-    let new_balances = @[Balance, Balance]
+    let
+      old_balances = @[Balance, Balance]
+      new_balances = @[Balance, Balance]
 
     # One validator moves their vote from the block to the zero hash
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: default(Eth2Digest),
-      next_epoch: Epoch(0)
-    )
+      next_epoch: Epoch(0))
 
     # One validator moves their vote from the block to something outside of the tree
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: fakeHash(1337),
-      next_epoch: Epoch(0)
-    )
+      next_epoch: Epoch(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2, "The 0th block should have lost both balances."
+    doAssert deltas[0] == -Delta(Balance)*2,
+      "The 0th block should have lost both balances."
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tChanging_balances() =
     echo "    fork_choice compute_deltas - test changing balances"
@@ -688,12 +689,13 @@ when isMainModule:
       validator_count = 16
       TotalOldDeltas = Delta(OldBalance * validator_count)
       TotalNewDeltas = Delta(NewBalance * validator_count)
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -701,36 +703,38 @@ when isMainModule:
         # Move vote from root 0 to root 1
         current_root: fakeHash(0),
         next_root: fakeHash(1),
-        next_epoch: Epoch(0)
-      )
+        next_epoch: Epoch(0))
       old_balances.add OldBalance
       new_balances.add NewBalance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     for i, delta in deltas:
       if i == 0:
-        doAssert delta == -TotalOldDeltas, "0th root should have a negative delta"
+        doAssert delta == -TotalOldDeltas,
+          "0th root should have a negative delta"
       elif i == 1:
-        doAssert delta == TotalNewDeltas, "1st root should have a positive delta"
+        doAssert delta == TotalNewDeltas,
+          "1st root should have a positive delta"
       else:
-        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+        doAssert delta == 0,
+          "The non-0 and non-1 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tValidator_appears() =
     echo "    fork_choice compute_deltas - test validator appears"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add 2 blocks
     indices[fakeHash(1)] = 0
@@ -738,38 +742,39 @@ when isMainModule:
 
     # 1 validator at the start, 2 at the end
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance]
-    let new_balances = @[Balance, Balance]
+    let
+      old_balances = @[Balance]
+      new_balances = @[Balance, Balance]
 
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
         current_root: fakeHash(1),
         next_root: fakeHash(2),
-        next_epoch: Epoch(0)
-      )
-
+        next_epoch: Epoch(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance), "Block 1 should have lost only 1 balance"
-    doAssert deltas[1] == Delta(Balance)*2, "Block 2 should have gained 2 balances"
+    doAssert deltas[0] == -Delta(Balance),
+      "Block 1 should have lost only 1 balance"
+    doAssert deltas[1] == Delta(Balance)*2,
+      "Block 2 should have gained 2 balances"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tValidator_disappears() =
     echo "    fork_choice compute_deltas - test validator disappears"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add 2 blocks
     indices[fakeHash(1)] = 0
@@ -777,30 +782,30 @@ when isMainModule:
 
     # 2 validator at the start, 1 at the end
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance, Balance]
-    let new_balances = @[Balance]
+    let
+      old_balances = @[Balance, Balance]
+      new_balances = @[Balance]
 
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
         current_root: fakeHash(1),
         next_root: fakeHash(2),
-        next_epoch: Epoch(0)
-      )
-
+        next_epoch: Epoch(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2, "Block 1 should have lost 2 balances"
-    doAssert deltas[1] == Delta(Balance), "Block 2 should have gained 1 balance"
+    doAssert deltas[0] == -Delta(Balance)*2,
+      "Block 1 should have lost 2 balances"
+    doAssert deltas[1] == Delta(Balance),
+      "Block 2 should have gained 1 balance"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   # ----------------------------------------------------------------------
 

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -91,6 +91,7 @@ type
     currentSlot*: Slot
     confirmed*: BlockId
     checkpoints*: FinalityCheckpoints
+    justifiedTotalActiveBalance*: Gwei
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]
     currentEpochTips*: Table[Index, FinalityCheckpoints]

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -71,6 +71,15 @@ func len*(nodes: ProtoNodes): int =
 func add(nodes: var ProtoNodes, node: ProtoNode) =
   nodes.buf.add node
 
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/phase0/fork-choice.md#compute_proposer_score
+func compute_proposer_score(justifiedTotalActiveBalance: Gwei): Gwei =
+  let committee_weight = justifiedTotalActiveBalance div SLOTS_PER_EPOCH
+  (committee_weight * PROPOSER_SCORE_BOOST) div 100
+
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/phase0/fork-choice.md#get_proposer_score
+func get_proposer_score(self: ProtoArray): Gwei =
+  compute_proposer_score(self.justifiedTotalActiveBalance)
+
 func update_latest_confirmed(
     self: var ProtoArray, headNode: ProtoNode): FcResult[void] =
   # Use most recent justified block as a stopgap
@@ -144,15 +153,10 @@ func on_slot_start_after_past_attestations_applied*(
   ## of a slot after attestations from past slots have been applied. Otherwise,
   ## the synchrony assumption that the algorithm relies upon may not hold.
   doAssert currentSlot >= self.currentSlot
+  self.currentSlot = currentSlot
   self.advance_checkpoints(checkpoints)
 
-  self.currentSlot = currentSlot
   ok()
-
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/phase0/fork-choice.md#get_weight
-func calculateProposerBoost(justifiedTotalActiveBalance: Gwei): Gwei =
-  let committee_weight = justifiedTotalActiveBalance div SLOTS_PER_EPOCH
-  (committee_weight * PROPOSER_SCORE_BOOST) div 100
 
 func applyScoreChanges*(
     self: var ProtoArray,
@@ -182,6 +186,7 @@ func applyScoreChanges*(
       indicesLen: self.indices.len)
 
   self.advance_checkpoints(checkpoints)
+  self.justifiedTotalActiveBalance = justifiedTotalActiveBalance
 
   ## Alias
   # This cannot raise the IndexError exception, how to tell compiler?
@@ -214,7 +219,7 @@ func applyScoreChanges*(
     #
     # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/phase0/fork-choice.md#get_weight
     if (not proposerBoostRoot.isZero) and proposerBoostRoot == node.bid.root:
-      proposerBoostScore = calculateProposerBoost(justifiedTotalActiveBalance)
+      proposerBoostScore = self.get_proposer_score()
       if  nodeDelta >= 0 and
           high(Delta) - nodeDelta < proposerBoostScore.int64:
         return err ForkChoiceError(
@@ -313,12 +318,12 @@ func onBlock*(
       childRoot: bid.root,
       parentRoot: parent)
 
-  let nodeLogicalIdx = self.nodes.offset + self.nodes.buf.len
-
-  let node = ProtoNode(
-    bid: bid,
-    parent: Opt.some(parentIdx),
-    checkpoints: checkpoints)
+  let
+    nodeLogicalIdx = self.nodes.offset + self.nodes.buf.len
+    node = ProtoNode(
+      bid: bid,
+      parent: Opt.some(parentIdx),
+      checkpoints: checkpoints)
 
   self.indices[node.bid.root] = nodeLogicalIdx
   self.nodes.add node
@@ -339,8 +344,8 @@ func findHead*(self: var ProtoArray, head: var Eth2Digest): FcResult[void] =
   ## `applyScoreChanges` as `onBlock` does not update the whole tree.
   template justifiedRoot: Eth2Digest = self.checkpoints.justified.root
   var justifiedIdx: Index
-  self.indices.withValue(justifiedRoot, value):
-    justifiedIdx = value[]
+  self.indices.withValue(justifiedRoot, index):
+    justifiedIdx = index[]
   do:
     return err ForkChoiceError(
       kind: fcJustifiedNodeUnknown,

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -129,6 +129,26 @@ iterator realizePendingCheckpoints*(
   # Reset tip tracking for new epoch
   self.currentEpochTips.clear()
 
+func advance_checkpoints(
+    self: var ProtoArray, checkpoints: FinalityCheckpoints) =
+  doAssert checkpoints.finalized.epoch >= self.checkpoints.finalized.epoch
+  doAssert checkpoints.finalized.epoch > self.checkpoints.finalized.epoch or
+    checkpoints.finalized.root == self.checkpoints.finalized.root or
+    self.checkpoints.finalized.epoch == GENESIS_EPOCH
+  self.checkpoints = checkpoints
+
+func on_slot_start_after_past_attestations_applied*(
+    self: var ProtoArray,
+    currentSlot: Slot, checkpoints: FinalityCheckpoints): FcResult[void] =
+  ## Implementations MUST call `update_fast_confirmation_variables` at the start
+  ## of a slot after attestations from past slots have been applied. Otherwise,
+  ## the synchrony assumption that the algorithm relies upon may not hold.
+  doAssert currentSlot >= self.currentSlot
+  self.advance_checkpoints(checkpoints)
+
+  self.currentSlot = currentSlot
+  ok()
+
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/phase0/fork-choice.md#get_weight
 func calculateProposerBoost(justifiedTotalActiveBalance: Gwei): Gwei =
   let committee_weight = justifiedTotalActiveBalance div SLOTS_PER_EPOCH
@@ -137,7 +157,6 @@ func calculateProposerBoost(justifiedTotalActiveBalance: Gwei): Gwei =
 func applyScoreChanges*(
     self: var ProtoArray,
     deltas: var openArray[Delta],
-    currentSlot: Slot,
     checkpoints: FinalityCheckpoints,
     justifiedTotalActiveBalance: Gwei,
     proposerBoostRoot: Eth2Digest): FcResult[void] =
@@ -162,13 +181,7 @@ func applyScoreChanges*(
       deltasLen: deltas.len,
       indicesLen: self.indices.len)
 
-  self.currentSlot = currentSlot
-
-  doAssert checkpoints.finalized.epoch >= self.checkpoints.finalized.epoch
-  doAssert checkpoints.finalized.epoch > self.checkpoints.finalized.epoch or
-    checkpoints.finalized.root == self.checkpoints.finalized.root or
-    self.checkpoints.finalized.epoch == GENESIS_EPOCH
-  self.checkpoints = checkpoints
+  self.advance_checkpoints(checkpoints)
 
   ## Alias
   # This cannot raise the IndexError exception, how to tell compiler?


### PR DESCRIPTION
Fast Confirmation Rule needs to re-check that the confirmed block is still confirmed at the start of a new epoch, after unrealized justifications / finalizations are realized, and after processing any deferred attestations from the queue. Add this hook, while retaining current safe block behaviour.