### PR TITLE
Track fork choice votes by slot instead of epoch

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -651,14 +651,14 @@ when isMainModule:
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: default(Eth2Digest),
-      slot: Epoch(0))
+      slot: Slot(0))
 
     # One validator moves their vote from the block to
     # something outside of the tree
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: fakeHash(1337),
-      slot: Epoch(0))
+      slot: Slot(0))
 
     let err = deltas.compute_deltas(
       indices, indices_offset = 0, votes, old_balances, new_balances)

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -155,19 +155,16 @@ proc on_tick(
   ok()
 
 func process_attestation(
-       self: var ForkChoiceBackend,
-       validator_index: ValidatorIndex,
-       block_root: Eth2Digest,
-       target_epoch: Epoch
-     ) =
+    self: var ForkChoiceBackend,
+    validator_index: ValidatorIndex, block_root: Eth2Digest, slot: Slot) =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 
   template vote: untyped = self.votes[validator_index]
-  if vote.next_epoch != FAR_FUTURE_EPOCH:
-    if target_epoch > vote.next_epoch or vote.next_root.isZero:
+  if vote.slot != FAR_FUTURE_SLOT:
+    if slot.epoch > vote.slot.epoch or vote.next_root.isZero:
       vote.next_root = block_root
-      vote.next_epoch = target_epoch
+      vote.slot = slot
 
       trace "Integrating vote in fork choice",
         validator_index = validator_index,
@@ -182,7 +179,7 @@ proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
     if it.slot < slot:
       for validator_index in it.attesting_indices:
         self.backend.process_attestation(
-          validator_index, it.block_root, it.slot.epoch())
+          validator_index, it.block_root, it.slot)
       false
     else:
       true
@@ -219,13 +216,12 @@ proc update_time*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/phase0/fork-choice.md#on_attestation
 proc on_attestation*(
-       self: var ForkChoice,
-       dag: ChainDAGRef,
-       attestation_slot: Slot,
-       beacon_block_root: Eth2Digest,
-       attesting_indices: openArray[ValidatorIndex],
-       wallTime: BeaconTime
-     ): FcResult[void] =
+    self: var ForkChoice,
+    dag: ChainDAGRef,
+    attestation_slot: Slot,
+    beacon_block_root: Eth2Digest,
+    attesting_indices: openArray[ValidatorIndex],
+    wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag,
     max(wallTime, attestation_slot.start_beacon_time(dag.timeParams)))
 
@@ -233,32 +229,29 @@ proc on_attestation*(
     for validator_index in attesting_indices:
       # attestation_slot and target epoch must match, per attestation rules
       self.backend.process_attestation(
-        validator_index, beacon_block_root, attestation_slot.epoch)
+        validator_index, beacon_block_root, attestation_slot)
   else:
     # Spec:
     # Attestations can only affect the fork choice of subsequent slots.
     # Delay consideration in the fork choice until their slot is in the past.
-    self.queuedAttestations.add(QueuedAttestation(
-      slot: attestation_slot,
+    self.queuedAttestations.add QueuedAttestation(
       attesting_indices: @attesting_indices,
-      block_root: beacon_block_root))
+      block_root: beacon_block_root,
+      slot: attestation_slot)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/fork-choice.md#on_attester_slashing
 func process_equivocation*(
-       self: var ForkChoice,
-       validator_index: ValidatorIndex
-     ) =
+    self: var ForkChoice, validator_index: ValidatorIndex) =
   self.backend.votes.extend(validator_index.int + 1)
 
   # Disallow future votes
   template vote: untyped = self.backend.votes[validator_index]
-  if vote.next_epoch != FAR_FUTURE_EPOCH or not vote.next_root.isZero:
-    vote.next_epoch = FAR_FUTURE_EPOCH
+  if vote.slot != FAR_FUTURE_SLOT or not vote.next_root.isZero:
+    vote.slot = FAR_FUTURE_SLOT
     vote.next_root.reset()
 
-    trace "Integrating equivocation in fork choice",
-      validator_index
+    trace "Integrating equivocation in fork choice", validator_index
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/fork-choice.md#on_block
 func process_block*(
@@ -292,7 +285,7 @@ proc process_block*(
         self.backend.process_attestation(
           validator_index,
           attestation.data.beacon_block_root,
-          attestation.data.target.epoch)
+          attestation.data.slot)
 
   trace "Integrating block in fork choice",
     block_root = shortLog(blckRef)
@@ -331,13 +324,12 @@ proc process_block*(
   ok()
 
 func find_head(
-       self: var ForkChoiceBackend,
-       current_slot: Slot,
-       checkpoints: FinalityCheckpoints,
-       justified_total_active_balance: Gwei,
-       justified_state_balances: seq[Gwei],
-       proposer_boost_root: Eth2Digest
-     ): FcResult[Eth2Digest] =
+    self: var ForkChoiceBackend,
+    current_slot: Slot,
+    checkpoints: FinalityCheckpoints,
+    justified_total_active_balance: Gwei,
+    justified_state_balances: seq[Gwei],
+    proposer_boost_root: Eth2Digest): FcResult[Eth2Digest] =
   ## Returns the new blockchain head
 
   # Compute deltas with previous call
@@ -461,7 +453,7 @@ func compute_deltas(
           # Note that delta can be negative
           # TODO: is int64 big enough?
 
-      if vote.next_epoch != FAR_FUTURE_EPOCH or not vote.next_root.isZero:
+      if vote.slot != FAR_FUTURE_SLOT and not vote.next_root.isZero:
         if vote.next_root in indices:
           let index = indices.unsafeGet(vote.next_root) - indices_offset
           if index >= deltas.len:
@@ -494,12 +486,13 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test zero votes"
 
     const validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -508,16 +501,15 @@ when isMainModule:
       new_balances.add 0.Gwei
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     doAssert deltas == newSeq[Delta](validator_count), "deltas should be zeros"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tAll_voted_the_same() =
     echo "    fork_choice compute_deltas - test all same votes"
@@ -525,38 +517,39 @@ when isMainModule:
     const
       Balance = Gwei(42)
       validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
         next_root: fakeHash(0), # Get a non-zero hash
-        next_epoch: Epoch(0)
-      )
+        slot: Slot(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     for i, delta in deltas:
       if i == 0:
-        doAssert delta == Delta(Balance * validator_count), "The 0th root should have a delta"
+        doAssert delta == Delta(Balance * validator_count),
+          "The 0th root should have a delta"
       else:
-        doAssert delta == 0, "The non-0 indexes should have a zero delta"
+        doAssert delta == 0,
+          "The non-0 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tDifferent_votes() =
     echo "    fork_choice compute_deltas - test all different votes"
@@ -564,26 +557,25 @@ when isMainModule:
     const
       Balance = Gwei(42)
       validator_count = 16
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
         current_root: default(Eth2Digest),
         next_root: fakeHash(i), # Each vote for a different root
-        next_epoch: Epoch(0)
-      )
+        slot: Slot(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
@@ -591,8 +583,8 @@ when isMainModule:
       doAssert delta == Delta(Balance), "Each root should have a delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tMoving_votes() =
     echo "    fork_choice compute_deltas - test moving votes"
@@ -601,12 +593,13 @@ when isMainModule:
       Balance = Gwei(42)
       validator_count = 16
       TotalDeltas = Delta(Balance * validator_count)
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -614,14 +607,12 @@ when isMainModule:
         # Move vote from root 0 to root 1
         current_root: fakeHash(0),
         next_root: fakeHash(1),
-        next_epoch: Epoch(0)
-      )
+        slot: Slot(0))
       old_balances.add Balance
       new_balances.add Balance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
@@ -631,53 +622,55 @@ when isMainModule:
       elif i == 1:
         doAssert delta == TotalDeltas, "1st root should have a positive delta"
       else:
-        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+        doAssert delta == 0,
+          "The non-0 and non-1 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tMove_out_of_tree() =
     echo "    fork_choice compute_deltas - test votes for unknown subtree"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add a block
     indices[fakeHash(1)] = 0
 
     # 2 validators
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance, Balance]
-    let new_balances = @[Balance, Balance]
+    let
+      old_balances = @[Balance, Balance]
+      new_balances = @[Balance, Balance]
 
     # One validator moves their vote from the block to the zero hash
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: default(Eth2Digest),
-      next_epoch: Epoch(0)
-    )
+      slot: Epoch(0))
 
-    # One validator moves their vote from the block to something outside of the tree
+    # One validator moves their vote from the block to
+    # something outside of the tree
     votes.add VoteTracker(
       current_root: fakeHash(1),
       next_root: fakeHash(1337),
-      next_epoch: Epoch(0)
-    )
+      slot: Epoch(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2, "The 0th block should have lost both balances."
+    doAssert deltas[0] == -Delta(Balance)*2,
+      "The 0th block should have lost both balances."
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tChanging_balances() =
     echo "    fork_choice compute_deltas - test changing balances"
@@ -688,12 +681,13 @@ when isMainModule:
       validator_count = 16
       TotalOldDeltas = Delta(OldBalance * validator_count)
       TotalNewDeltas = Delta(NewBalance * validator_count)
-    var deltas = newSeqUninit[Delta](validator_count)
+    var
+      deltas = newSeqUninit[Delta](validator_count)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
-    var old_balances: seq[Gwei]
-    var new_balances: seq[Gwei]
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
+      old_balances: seq[Gwei]
+      new_balances: seq[Gwei]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -701,36 +695,38 @@ when isMainModule:
         # Move vote from root 0 to root 1
         current_root: fakeHash(0),
         next_root: fakeHash(1),
-        next_epoch: Epoch(0)
-      )
+        slot: Slot(0))
       old_balances.add OldBalance
       new_balances.add NewBalance
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     for i, delta in deltas:
       if i == 0:
-        doAssert delta == -TotalOldDeltas, "0th root should have a negative delta"
+        doAssert delta == -TotalOldDeltas,
+          "0th root should have a negative delta"
       elif i == 1:
-        doAssert delta == TotalNewDeltas, "1st root should have a positive delta"
+        doAssert delta == TotalNewDeltas,
+          "1st root should have a positive delta"
       else:
-        doAssert delta == 0, "The non-0 and non-1 indexes should have a zero delta"
+        doAssert delta == 0,
+          "The non-0 and non-1 indexes should have a zero delta"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tValidator_appears() =
     echo "    fork_choice compute_deltas - test validator appears"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add 2 blocks
     indices[fakeHash(1)] = 0
@@ -738,38 +734,39 @@ when isMainModule:
 
     # 1 validator at the start, 2 at the end
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance]
-    let new_balances = @[Balance, Balance]
+    let
+      old_balances = @[Balance]
+      new_balances = @[Balance, Balance]
 
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
         current_root: fakeHash(1),
         next_root: fakeHash(2),
-        next_epoch: Epoch(0)
-      )
-
+        slot: Slot(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance), "Block 1 should have lost only 1 balance"
-    doAssert deltas[1] == Delta(Balance)*2, "Block 2 should have gained 2 balances"
+    doAssert deltas[0] == -Delta(Balance),
+      "Block 1 should have lost only 1 balance"
+    doAssert deltas[1] == Delta(Balance)*2,
+      "Block 2 should have gained 2 balances"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   proc tValidator_disappears() =
     echo "    fork_choice compute_deltas - test validator disappears"
 
     const Balance = Gwei(42)
 
-    var indices: Table[Eth2Digest, Index]
-    var votes: seq[VoteTracker]
+    var
+      indices: Table[Eth2Digest, Index]
+      votes: seq[VoteTracker]
 
     # Add 2 blocks
     indices[fakeHash(1)] = 0
@@ -777,30 +774,30 @@ when isMainModule:
 
     # 2 validator at the start, 1 at the end
     var deltas = newSeqUninit[Delta](2)
-    let old_balances = @[Balance, Balance]
-    let new_balances = @[Balance]
+    let
+      old_balances = @[Balance, Balance]
+      new_balances = @[Balance]
 
     # Both moves vote from Block 1 to 2
     for _ in 0 ..< 2:
       votes.add VoteTracker(
         current_root: fakeHash(1),
         next_root: fakeHash(2),
-        next_epoch: Epoch(0)
-      )
-
+        slot: Slot(0))
 
     let err = deltas.compute_deltas(
-      indices, indices_offset = 0, votes, old_balances, new_balances
-    )
+      indices, indices_offset = 0, votes, old_balances, new_balances)
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2, "Block 1 should have lost 2 balances"
-    doAssert deltas[1] == Delta(Balance), "Block 2 should have gained 1 balance"
+    doAssert deltas[0] == -Delta(Balance)*2,
+      "Block 1 should have lost 2 balances"
+    doAssert deltas[1] == Delta(Balance),
+      "Block 2 should have gained 1 balance"
 
     for vote in votes:
-      doAssert vote.current_root == vote.next_root, "The vote should have been updated"
-
+      doAssert vote.current_root == vote.next_root,
+        "The vote should have been updated"
 
   # ----------------------------------------------------------------------
 

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -126,7 +126,7 @@ type
   VoteTracker* = object
     current_root*: Eth2Digest
     next_root*: Eth2Digest
-    next_epoch*: Epoch
+    slot*: Slot
 
   ForkChoiceBackend* = object
     proto_array*: ProtoArray
@@ -134,10 +134,9 @@ type
     balances*: seq[Gwei]
 
   QueuedAttestation* = object
-    slot*: Slot
     attesting_indices*: seq[ValidatorIndex]
     block_root*: Eth2Digest
-    target_epoch*: Epoch
+    slot*: Slot
 
   ForkChoice* = object
     backend*: ForkChoiceBackend
@@ -146,9 +145,9 @@ type
 
 func shortLog*(vote: VoteTracker): auto =
   (
+    slot: vote.slot,
     current_root: shortLog(vote.current_root),
     next_root: shortLog(vote.next_root),
-    next_epoch: vote.next_epoch
   )
 
 chronicles.formatIt VoteTracker: it.shortLog

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -162,6 +162,7 @@ func applyScoreChanges*(
       deltasLen: deltas.len,
       indicesLen: self.indices.len)
 
+  doAssert currentSlot >= self.currentSlot
   self.currentSlot = currentSlot
 
   doAssert checkpoints.finalized.epoch >= self.checkpoints.finalized.epoch


### PR DESCRIPTION
FCR needs access to the latest vote of each validator, to estimate the share of votes coming from empty/non-canonical slots, vs canonical ones. We can simply track the latest slot, then we don't need access to a historical shuffling, as the slot implies that they were part of a committee that was allowed to contribute during that slot.