### PR TITLE
Delete obsolete fork choice test checks

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -73,8 +73,7 @@ proc init*(
         checkpoint: checkpoint,
         total_active_balance: epochRef.total_active_balance,
         balances: epochRef.effective_balances),
-      finalized: checkpoint,
-      best_justified: checkpoint))
+      finalized: checkpoint))
 
 func extend[T](s: var seq[T], minLen: int) =
   ## Extend a sequence so that it can contains at least `minLen` elements.

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -116,7 +116,6 @@ type
     time*: BeaconTime
     justified*: BalanceCheckpoint
     finalized*: Checkpoint
-    best_justified*: Checkpoint
     proposer_boost_root*: Eth2Digest
 
 # Fork choice high-level types

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -311,17 +311,9 @@ proc stepChecks(
       let checkpointEpoch = fkChoice.checkpoints.justified.checkpoint.epoch
       doAssert checkpointEpoch == Epoch(val["epoch"].getInt())
       doAssert checkpointRoot == Eth2Digest.fromHex(val["root"].getStr())
-    elif check == "justified_checkpoint_root": # undocumented check
-      let checkpointRoot = fkChoice.checkpoints.justified.checkpoint.root
-      doAssert checkpointRoot == Eth2Digest.fromHex(val.getStr())
     elif check == "finalized_checkpoint":
       let checkpointRoot = fkChoice.checkpoints.finalized.root
       let checkpointEpoch = fkChoice.checkpoints.finalized.epoch
-      doAssert checkpointEpoch == Epoch(val["epoch"].getInt())
-      doAssert checkpointRoot == Eth2Digest.fromHex(val["root"].getStr())
-    elif check == "best_justified_checkpoint":
-      let checkpointRoot = fkChoice.checkpoints.best_justified.root
-      let checkpointEpoch = fkChoice.checkpoints.best_justified.epoch
       doAssert checkpointEpoch == Epoch(val["epoch"].getInt())
       doAssert checkpointRoot == Eth2Digest.fromHex(val["root"].getStr())
     elif check == "proposer_boost_root":


### PR DESCRIPTION
Since https://github.com/ethereum/consensus-specs/pull/3290 the checks `justified_checkpoint_root` and `best_justified_checkpoint` are not used in consensus-spec tests anymore and can be dropped.