### PR TITLE
Track slashed validators in EpochRef

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -273,6 +273,8 @@ type
 
     shuffled_active_validator_indices*: seq[ValidatorIndex]
 
+  ForkChoiceBalance* = distinct Gwei
+
   EpochRef* = ref object
     key*: EpochKey
 
@@ -287,9 +289,7 @@ type
     shufflingRef*: ShufflingRef
 
     total_active_balance*: Gwei
-
-    # balances, as used in fork choice
-    effective_balances_bytes*: seq[byte]
+    fork_choice_balances_bytes*: seq[byte]
 
   BlockData* = object
     blck*: ForkedSignedBeaconBlock

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -9,7 +9,7 @@
 
 import
   std/[algorithm, sequtils, tables, sets],
-  stew/[arrayops, assign2, byteutils],
+  stew/[arrayops, assign2, bitops2, byteutils],
   chronos, metrics, results, snappy, chronicles,
   ../spec/[beaconstate, eth2_merkleization, eth2_ssz_serialization, helpers,
     state_transition, validator],
@@ -81,13 +81,37 @@ template withUpdatedState*(
     var cache {.inject.} = StateCache()
     if updateState(dag, stateParam, bsi, false, cache, dag.updateFlags):
       template bid(): BlockId {.inject, used.} = bsi.bid
-      template updatedState(): ForkedHashedBeaconState {.inject, used.} = stateParam
+      template updatedState(): ForkedHashedBeaconState {.inject, used.} =
+        stateParam
       okBody
     else:
       failureBody
 
-func get_effective_balances(
-    validators: openArray[Validator], epoch: Epoch): seq[Gwei] =
+template toSszType*(v: ForkChoiceBalance): auto = uint64(v)
+
+const
+  NumInfoBits = 1
+  ForkChoiceInfoOffset* = bitsof(distinctBase(Gwei)) - NumInfoBits
+  ForkChoiceInfoMask = ((1 shl NumInfoBits) - 1) shl ForkChoiceInfoOffset
+  EffectiveBalanceMask = not ForkChoiceInfoMask
+  SlashedBit = distinctBase(1.Gwei) shl ForkChoiceInfoOffset
+static: doAssert(
+  max(MAX_EFFECTIVE_BALANCE, MAX_EFFECTIVE_BALANCE_ELECTRA) < SlashedBit)
+
+template slashed*(balance: ForkChoiceBalance): bool =
+  (distinctBase(balance) and SlashedBit) == SlashedBit
+
+template effective_balance*(balance: ForkChoiceBalance): Gwei =
+  (distinctBase(balance) and EffectiveBalanceMask).Gwei
+
+template unslashed_balance*(balance: ForkChoiceBalance): Gwei =
+  if balance.slashed:
+    0.Gwei
+  else:
+    balance.effective_balance
+
+func get_fork_choice_balances*(
+    validators: openArray[Validator], epoch: Epoch): seq[ForkChoiceBalance] =
   ## Get the balances from a state as counted for fork choice
   result.newSeq(validators.len) # zero-init
 
@@ -95,7 +119,11 @@ func get_effective_balances(
     # All non-active validators have a 0 balance
     let validator = unsafeAddr validators[i]
     if validator[].is_active_validator(epoch) and not validator[].slashed:
-      result[i] = validator[].effective_balance
+      result[i] = ForkChoiceBalance(
+        if validator[].slashed:
+          distinctBase(validator[].effective_balance) or SlashedBit
+        else:
+          distinctBase(validator[].effective_balance))
 
 proc updateValidatorKeys*(dag: ChainDAGRef, validators: openArray[Validator]) =
   # Update validator key cache - must be called every time a valid block is
@@ -154,10 +182,11 @@ template is_merge_transition_complete*(
     else:
       false
 
-func effective_balances*(epochRef: EpochRef): seq[Gwei] =
+func fork_choice_balances*(epochRef: EpochRef): seq[ForkChoiceBalance] =
   try:
-    SSZ.decode(snappy.decode(epochRef.effective_balances_bytes, uint32.high),
-      List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT]).toSeq()
+    SSZ.decode(
+      snappy.decode(epochRef.fork_choice_balances_bytes, uint32.high),
+      seq[ForkChoiceBalance])
   except CatchableError as exc:
     raiseAssert exc.msg
 
@@ -632,7 +661,7 @@ func init*(
       eth1_data: state.eth1_data,
       eth1_deposit_index: state.eth1_deposit_index,
 
-      checkpoints:FinalityCheckpoints(
+      checkpoints: FinalityCheckpoints(
         justified: state.current_justified_checkpoint,
         finalized: state.finalized_checkpoint),
 
@@ -658,10 +687,8 @@ func init*(
     except CatchableError as err:
       raiseAssert err.msg
 
-  epochRef.effective_balances_bytes =
-    snappyEncode(SSZ.encode(
-      List[Gwei, Limit VALIDATOR_REGISTRY_LIMIT](
-        get_effective_balances(state.validators.asSeq, epoch))))
+  epochRef.fork_choice_balances_bytes = snappyEncode(
+    SSZ.encode(get_fork_choice_balances(state.validators.asSeq, epoch)))
 
   epochRef
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -540,7 +540,7 @@ when isMainModule:
 
     for i, delta in deltas:
       if i == 0:
-        doAssert delta == Delta(Balance * validator_count),
+        doAssert delta == Delta(Balance.unslashed_balance * validator_count),
           "The 0th root should have a delta"
       else:
         doAssert delta == 0,
@@ -579,7 +579,8 @@ when isMainModule:
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
     for i, delta in deltas:
-      doAssert delta == Delta(Balance), "Each root should have a delta"
+      doAssert delta == Delta(Balance.unslashed_balance),
+        "Each root should have a delta"
 
     for vote in votes:
       doAssert vote.current_root == vote.next_root,
@@ -591,7 +592,7 @@ when isMainModule:
     const
       Balance = ForkChoiceBalance(42)
       validator_count = 16
-      TotalDeltas = Delta(Balance * validator_count)
+      TotalDeltas = Delta(Balance.unslashed_balance * validator_count)
     var
       deltas = newSeqUninit[Delta](validator_count)
 
@@ -664,7 +665,7 @@ when isMainModule:
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2,
+    doAssert deltas[0] == -Delta(Balance.unslashed_balance) * 2,
       "The 0th block should have lost both balances."
 
     for vote in votes:
@@ -676,10 +677,10 @@ when isMainModule:
 
     const
       OldBalance = ForkChoiceBalance(42)
-      NewBalance = OldBalance * 2
+      NewBalance = ForkChoiceBalance(OldBalance.unslashed_balance * 2)
       validator_count = 16
-      TotalOldDeltas = Delta(OldBalance * validator_count)
-      TotalNewDeltas = Delta(NewBalance * validator_count)
+      TotalOldDeltas = Delta(OldBalance.unslashed_balance * validator_count)
+      TotalNewDeltas = Delta(NewBalance.unslashed_balance * validator_count)
     var
       deltas = newSeqUninit[Delta](validator_count)
 
@@ -749,9 +750,9 @@ when isMainModule:
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance),
+    doAssert deltas[0] == -Delta(Balance.unslashed_balance),
       "Block 1 should have lost only 1 balance"
-    doAssert deltas[1] == Delta(Balance)*2,
+    doAssert deltas[1] == Delta(Balance.unslashed_balance) * 2,
       "Block 2 should have gained 2 balances"
 
     for vote in votes:
@@ -789,9 +790,9 @@ when isMainModule:
 
     doAssert err.isOk, "compute_deltas finished with error: " & $err
 
-    doAssert deltas[0] == -Delta(Balance)*2,
+    doAssert deltas[0] == -Delta(Balance.unslashed_balance) * 2,
       "Block 1 should have lost 2 balances"
-    doAssert deltas[1] == Delta(Balance),
+    doAssert deltas[1] == Delta(Balance.unslashed_balance),
       "Block 2 should have gained 1 balance"
 
     for vote in votes:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -351,7 +351,9 @@ func find_head(
   ? self.proto_array.findHead(new_head)
 
   trace "Fork choice requested",
-    current_slot, checkpoints,
+    current_slot, checkpoints = FinalityCheckpoints(
+      justified: checkpoints.justified.checkpoint,
+      finalized: checkpoints.finalized),
     fork_choice_head = shortLog(new_head)
   ok(new_head)
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -40,8 +40,8 @@ func compute_deltas(
     indices: Table[Eth2Digest, Index],
     indices_offset: Index,
     votes: var openArray[VoteTracker],
-    old_balances: openArray[Gwei],
-    new_balances: openArray[Gwei]): FcResult[void]
+    old_balances: openArray[ForkChoiceBalance],
+    new_balances: openArray[ForkChoiceBalance]): FcResult[void]
 
 # Fork choice routines
 # ----------------------------------------------------------------------
@@ -53,7 +53,7 @@ template to_balance_checkpoint(
   BalanceCheckpoint(
     checkpoint: Checkpoint(root: blck.root, epoch: epochRef.epoch),
     total_active_balance: epochRef.total_active_balance,
-    balances: epochRef.effective_balances)
+    validators: ValidatorInfo(balances: epochRef.fork_choice_balances))
 
 func init*(
     T: type ForkChoiceBackend, confirmation_byzantine_threshold: uint64,
@@ -336,7 +336,7 @@ func find_head(
     indices_offset = self.proto_array.nodes.offset,
     votes = self.votes,
     old_balances = self.balances,
-    new_balances = checkpoints.justified.balances)
+    new_balances = checkpoints.justified.validators.balances)
   ? self.proto_array.applyScoreChanges(
     deltas, current_slot,
     FinalityCheckpoints(
@@ -344,7 +344,7 @@ func find_head(
       finalized: checkpoints.finalized),
     checkpoints.justified.total_active_balance,
     checkpoints.proposer_boost_root)
-  self.balances = checkpoints.justified.balances
+  self.balances = checkpoints.justified.validators.balances
 
   # Find the best block
   var new_head{.noinit.}: Eth2Digest
@@ -397,8 +397,8 @@ func compute_deltas(
     indices: Table[Eth2Digest, Index],
     indices_offset: Index,
     votes: var openArray[VoteTracker],
-    old_balances: openArray[Gwei],
-    new_balances: openArray[Gwei]): FcResult[void] =
+    old_balances: openArray[ForkChoiceBalance],
+    new_balances: openArray[ForkChoiceBalance]): FcResult[void] =
   ## Update `deltas`
   ##   between old and new balances
   ##   between votes
@@ -420,7 +420,7 @@ func compute_deltas(
     # its balance is zero
     let old_balance =
       if val_index < old_balances.len:
-        old_balances[val_index]
+        old_balances[val_index].unslashed_balance
       else:
         0.Gwei
 
@@ -433,7 +433,7 @@ func compute_deltas(
     # Note that attesters are not different as they are activated only under finality
     let new_balance =
       if val_index < new_balances.len:
-        new_balances[val_index]
+        new_balances[val_index].unslashed_balance
       else:
         0.Gwei
 
@@ -488,14 +488,14 @@ when isMainModule:
 
       indices: Table[Eth2Digest, Index]
       votes: seq[VoteTracker]
-      old_balances: seq[Gwei]
-      new_balances: seq[Gwei]
+      old_balances: seq[ForkChoiceBalance]
+      new_balances: seq[ForkChoiceBalance]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add default(VoteTracker)
-      old_balances.add 0.Gwei
-      new_balances.add 0.Gwei
+      old_balances.add 0.ForkChoiceBalance
+      new_balances.add 0.ForkChoiceBalance
 
     let err = deltas.compute_deltas(
       indices, indices_offset = 0, votes, old_balances, new_balances)
@@ -512,15 +512,15 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test all same votes"
 
     const
-      Balance = Gwei(42)
+      Balance = ForkChoiceBalance(42)
       validator_count = 16
     var
       deltas = newSeqUninit[Delta](validator_count)
 
       indices: Table[Eth2Digest, Index]
       votes: seq[VoteTracker]
-      old_balances: seq[Gwei]
-      new_balances: seq[Gwei]
+      old_balances: seq[ForkChoiceBalance]
+      new_balances: seq[ForkChoiceBalance]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -552,15 +552,15 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test all different votes"
 
     const
-      Balance = Gwei(42)
+      Balance = ForkChoiceBalance(42)
       validator_count = 16
     var
       deltas = newSeqUninit[Delta](validator_count)
 
       indices: Table[Eth2Digest, Index]
       votes: seq[VoteTracker]
-      old_balances: seq[Gwei]
-      new_balances: seq[Gwei]
+      old_balances: seq[ForkChoiceBalance]
+      new_balances: seq[ForkChoiceBalance]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -587,7 +587,7 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test moving votes"
 
     const
-      Balance = Gwei(42)
+      Balance = ForkChoiceBalance(42)
       validator_count = 16
       TotalDeltas = Delta(Balance * validator_count)
     var
@@ -595,8 +595,8 @@ when isMainModule:
 
       indices: Table[Eth2Digest, Index]
       votes: seq[VoteTracker]
-      old_balances: seq[Gwei]
-      new_balances: seq[Gwei]
+      old_balances: seq[ForkChoiceBalance]
+      new_balances: seq[ForkChoiceBalance]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -629,7 +629,7 @@ when isMainModule:
   proc tMove_out_of_tree() =
     echo "    fork_choice compute_deltas - test votes for unknown subtree"
 
-    const Balance = Gwei(42)
+    const Balance = ForkChoiceBalance(42)
 
     var
       indices: Table[Eth2Digest, Index]
@@ -673,7 +673,7 @@ when isMainModule:
     echo "    fork_choice compute_deltas - test changing balances"
 
     const
-      OldBalance = Gwei(42)
+      OldBalance = ForkChoiceBalance(42)
       NewBalance = OldBalance * 2
       validator_count = 16
       TotalOldDeltas = Delta(OldBalance * validator_count)
@@ -683,8 +683,8 @@ when isMainModule:
 
       indices: Table[Eth2Digest, Index]
       votes: seq[VoteTracker]
-      old_balances: seq[Gwei]
-      new_balances: seq[Gwei]
+      old_balances: seq[ForkChoiceBalance]
+      new_balances: seq[ForkChoiceBalance]
 
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
@@ -719,7 +719,7 @@ when isMainModule:
   proc tValidator_appears() =
     echo "    fork_choice compute_deltas - test validator appears"
 
-    const Balance = Gwei(42)
+    const Balance = ForkChoiceBalance(42)
 
     var
       indices: Table[Eth2Digest, Index]
@@ -759,7 +759,7 @@ when isMainModule:
   proc tValidator_disappears() =
     echo "    fork_choice compute_deltas - test validator disappears"
 
-    const Balance = Gwei(42)
+    const Balance = ForkChoiceBalance(42)
 
     var
       indices: Table[Eth2Digest, Index]

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -17,6 +17,8 @@ import
   ../spec/datatypes/base,
   ../spec/helpers
 
+from ../consensus_object_pools/block_pools_types import ForkChoiceBalance
+
 export results, base
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/fork-choice.md
@@ -109,10 +111,13 @@ type
     bestChild*: Opt[Index]
     bestDescendant*: Opt[Index]
 
+  ValidatorInfo* = object
+    balances*: seq[ForkChoiceBalance]
+
   BalanceCheckpoint* = object
     checkpoint*: Checkpoint
     total_active_balance*: Gwei
-    balances*: seq[Gwei]
+    validators*: ValidatorInfo
 
   Checkpoints* = object
     time*: BeaconTime
@@ -133,7 +138,7 @@ type
     confirmation_byzantine_threshold*: uint64
     proto_array*: ProtoArray
     votes*: seq[VoteTracker]
-    balances*: seq[Gwei]
+    balances*: seq[ForkChoiceBalance]
 
   QueuedAttestation* = object
     attesting_indices*: seq[ValidatorIndex]


### PR DESCRIPTION
Fast Confirmation Rule needs to know the historical slashing status of validators at the beginning of the epoch. We currently only track the effective balances of unslashed validators. Just use the top bit of the effective balance to track the slashing status as well.