### PR TITLE
nix: upgrade nixpkgs input to include geth 1.16.8

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,17 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712439257,
-        "narHash": "sha256-aSpiNepFOMk9932HOax0XwNxbA38GOUVOiXfUVPOrck=",
+        "lastModified": 1768818593,
+        "narHash": "sha256-sMGoIJFAdXvGh4lZppBxJd4FYHQbNWtuZY4sn70OcrY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ff0dbd94265ac470dda06a657d5fe49de93b4599",
+        "rev": "2a777ace4b722f2714cc06d596f2476ee628c04a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
         "repo": "nixpkgs",
+        "rev": "2a777ace4b722f2714cc06d596f2476ee628c04a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "nimbus-eth2";
 
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/master;
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
 
   outputs = { self, nixpkgs }:
     let
@@ -27,6 +27,9 @@
         validator_client = build ["nimbus_validator_client"];
         ncli             = build ["ncli"];
         ncli_db          = build ["ncli_db"];
+
+        # Useful for tests
+        inherit (pkgsFor.${system}) go-ethereum;
 
         default = beacon_node;
       });


### PR DESCRIPTION
This way we can use the `flake.nix` to provide Geth for tests.
```
 > nix build '.#go-ethereum' --print-out-paths
/nix/store/p2n9akf8xfh9x1vnq43590vlc0hky1xw-go-ethereum-1.16.8
```