### PR TITLE
nix: enforce submodule fetching without Git LFS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,21 @@
 {
   description = "nimbus-eth2";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
+    self = {
+      # WARNING: Does not work with 'github:' schema URLs.
+      # https://github.com/NixOS/nix/issues/14982
+      submodules = true;
+      # Avoid fetching big files from vendor/hoodi submodule.
+      lfs = false;
+    };
+  };
 
   outputs = { self, nixpkgs }:
+    assert (builtins.compareVersions builtins.nixVersion "2.27") <= 0
+      -> throw "Nix 2.27 or newer needed for proper submodules support!";
+
     let
       stableSystems = [
         "x86_64-linux" "aarch64-linux" "armv7a-linux"

--- a/nix/README.md
+++ b/nix/README.md
@@ -11,20 +11,20 @@ nix develop
 
 To build a beacon node you can use:
 ```sh
-nix build '.?submodules=1#beacon_node'
+nix build .
 ```
-The `?submodules=1` part should eventually not be necessary.
-For more details see:
-https://github.com/NixOS/nix/issues/4423
-
 It can be also done without even cloning the repo:
+```sh
+nix build 'git+https://github.com/status-im/nimbus-eth2'
+```
+When using `github:` schema the `?submodules=1#` argument is required:
 ```sh
 nix build 'github:status-im/nimbus-eth2?submodules=1#'
 ```
-The trailing `#` is required due to [URI parsing bug in Nix](https://github.com/NixOS/nix/issues/6633).
+This is [a known issue with `github:` schema](https://github.com/NixOS/nix/issues/14982) as well [as a URI parsing bug in Nix](https://github.com/NixOS/nix/issues/6633).
 
 ## Running
 
 ```sh
-nix run 'github:status-im/nimbus-eth2?submodules=1#'
+nix run 'git+https://github.com/status-im/nimbus-eth2'
 ```


### PR DESCRIPTION
We use `inputs.self.submodules=true` to ensure the Nix build has fetched all submodules from vendor folder for the build to work.

One issue worth noting with this setting is that it does not work with `github:` schema that can be used with nix run or nix build:
- https://github.com/NixOS/nix/issues/14982

We need to be sure that LFS is disabled because fetching big files contained within the `vendor/hoodi` submodule are a source of problems for Ethereum Foundation and client teams when LFS usage limit is hit.