### PR TITLE
Move block confirmation logic out of proto array

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -59,7 +59,10 @@ func init*(
     T: type ForkChoiceBackend, confirmation_byzantine_threshold: uint64,
     finalized: BalanceCheckpoint, currentSlot: Slot): T =
   T(confirmation_byzantine_threshold: confirmation_byzantine_threshold,
-    proto_array: ProtoArray.init(finalized.checkpoint, currentSlot))
+    proto_array: ProtoArray.init(finalized.checkpoint, currentSlot),
+    confirmed: BlockId(
+      slot: finalized.checkpoint.epoch.start_slot,
+      root: finalized.checkpoint.root))
 
 proc init*(
     T: type ForkChoice, confirmation_byzantine_threshold: uint64,
@@ -128,6 +131,12 @@ proc update_checkpoints(
     self.finalized = checkpoints.finalized
 
   ok()
+
+proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
+  if confirmed.slot < self.confirmed.slot:
+    warn "Confirmed block was unconfirmed",
+      old_confirmed = shortLog(self.confirmed), new_confirmed = confirmed
+  self.confirmed = confirmed
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/fork-choice.md#on_tick_per_slot
 proc on_tick(
@@ -362,13 +371,16 @@ proc get_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     wallTime: BeaconTime): FcResult[Eth2Digest] =
   ? self.update_time(dag, wallTime)
-  self.backend.find_head(
+  result = self.backend.find_head(
     self.checkpoints.time.slotOrZero(dag.timeParams),
     self.checkpoints)
+  self.backend.update_confirmed BlockId(
+    slot: self.checkpoints.justified.checkpoint.epoch.start_slot,
+    root: self.checkpoints.justified.checkpoint.root)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
 func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
-  self.backend.proto_array.get_latest_confirmed()
+  self.backend.confirmed.root
 
 func prune(
     self: var ForkChoiceBackend,

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -93,7 +93,6 @@ type
 
   ProtoArray* = object
     currentSlot*: Slot
-    confirmed*: BlockId
     checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]
@@ -137,6 +136,7 @@ type
   ForkChoiceBackend* = object
     confirmation_byzantine_threshold*: uint64
     proto_array*: ProtoArray
+    confirmed*: BlockId
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -71,16 +71,6 @@ func len*(nodes: ProtoNodes): int =
 func add(nodes: var ProtoNodes, node: ProtoNode) =
   nodes.buf.add node
 
-func update_latest_confirmed(
-    self: var ProtoArray, headNode: ProtoNode): FcResult[void] =
-  # Use most recent justified block as a stopgap
-  self.confirmed = BlockId(
-    slot: self.checkpoints.justified.epoch.start_slot,
-    root: self.checkpoints.justified.root)
-  ok()
-
-func get_latest_confirmed*(self: ProtoArray): Eth2Digest =
-  self.confirmed.root
 
 # Forward declarations
 # ----------------------------------------------------------------------
@@ -108,7 +98,6 @@ func init*(T: type ProtoArray, finalized: Checkpoint, currentSlot: Slot): T =
       finalized: finalized))
 
   T(currentSlot: currentSlot,
-    confirmed: node.bid,
     checkpoints: node.checkpoints,
     nodes: ProtoNodes(buf: @[node], offset: 0),
     indices: {node.bid.root: 0}.toTable())
@@ -116,7 +105,7 @@ func init*(T: type ProtoArray, finalized: Checkpoint, currentSlot: Slot): T =
 iterator realizePendingCheckpoints*(
     self: var ProtoArray): FinalityCheckpoints =
   # Pull-up chain tips from previous epoch
-  for idx, unrealized in self.currentEpochTips.pairs():
+  for idx, unrealized in self.currentEpochTips:
     let physicalIdx = idx - self.nodes.offset
     if unrealized != self.nodes.buf[physicalIdx].checkpoints:
       trace "Pulling up chain tip",
@@ -223,8 +212,9 @@ func applyScoreChanges*(
 
     # If the node has a parent, try to update its best-child and best-descendent
     if node.parent.isSome():
-      let parentLogicalIdx = node.parent.unsafeGet()
-      let parentPhysicalIdx = parentLogicalIdx - self.nodes.offset
+      let
+        parentLogicalIdx = node.parent.unsafeGet()
+        parentPhysicalIdx = parentLogicalIdx - self.nodes.offset
       if parentPhysicalIdx < 0:
         # Orphan, for example
         #          0
@@ -356,7 +346,6 @@ func findHead*(self: var ProtoArray, head: var Eth2Digest): FcResult[void] =
       headCheckpoints: justifiedNode.checkpoints)
 
   head = bestNode.bid.root
-  ? self.update_latest_confirmed(bestNode)
   ok()
 
 func prune*(
@@ -607,7 +596,7 @@ type ProtoArrayItem* = object
   parent*: Eth2Digest
   checkpoints*: FinalityCheckpoints
   unrealized*: Opt[FinalityCheckpoints]
-  weight*: int64
+  weight*: uint64
   invalid*: bool
   bestChild*: Eth2Digest
   bestDescendant*: Eth2Digest
@@ -639,7 +628,7 @@ iterator items*(self: ProtoArray): ProtoArrayItem =
       parent: self.nodes.root(node.parent),
       checkpoints: node.checkpoints,
       unrealized: unrealized,
-      weight: node.weight,
+      weight: cast[uint64](node.weight),
       invalid: node.invalid,
       bestChild: self.nodes.root(node.bestChild),
       bestDescendant: self.nodes.root(node.bestDescendant))

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -97,8 +97,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
     )
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Debug/getDebugForkChoice
-  router.api2(MethodGet,
-              "/eth/v1/debug/fork_choice") do () -> RestApiResponse:
+  router.api2(MethodGet, "/eth/v1/debug/fork_choice") do () -> RestApiResponse:
     template forkChoice: auto = node.attestationPool[].forkChoice
 
     var response = GetForkChoiceResponse(
@@ -126,7 +125,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
         parent_root: item.parent,
         justified_epoch: item.checkpoints.justified.epoch,
         finalized_epoch: item.checkpoints.finalized.epoch,
-        weight: cast[uint64](item.weight),
+        weight: item.weight,
         validity:
           if item.invalid:
             RestNodeValidity.invalid


### PR DESCRIPTION
FCR should be implementable without touching the main fork choice. Move the confirmed block from proto array to ForkChoiceBackend.