### PR TITLE
Inform fork choice about the current slot head

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -949,6 +949,16 @@ proc getBeaconHead*(
     safeExecutionBlockHash: safeExecutionBlockHash,
     finalizedExecutionBlockHash: finalizedExecutionBlockHash)
 
+proc willSelectNewHead*(
+    pool: var AttestationPool,
+    headBlock: BlockRef, wallTime: BeaconTime): Opt[void] =
+  ## Informs fork choice that a new head will be selected.
+  ## This may affect `get_safe_beacon_block_root` so must be called before that.
+  pool.forkChoice.will_select_head(pool.dag, headBlock, wallTime).isOkOr:
+    error "Couldn't store head to fork choice", err = error
+    return err()
+  ok()
+
 proc selectOptimisticHead*(
     pool: var AttestationPool, wallTime: BeaconTime): Opt[BeaconHead] =
   ## Trigger fork choice and returns the new head block.
@@ -964,12 +974,14 @@ proc selectOptimisticHead*(
     pool.quarantine[].addMissing(newHeadRoot).isOkOr:
       # The newly selected head is unviable for some reason - the only way out
       # here is that fork choice gets information about some other head
-      warn "Fork choice selected unviable head - cannot sync", newHeadRoot, err = error
+      warn "Fork choice selected unviable head - cannot sync",
+        newHeadRoot, err = error
       return Opt.none(BeaconHead)
 
     warn "Fork choice selected unknown head, trying to sync", newHeadRoot
     return Opt.none(BeaconHead)
 
+  ? pool.willSelectNewHead(headBlock, wallTime)
   ok pool.getBeaconHead(headBlock)
 
 proc prune*(pool: var AttestationPool) =

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -192,17 +192,17 @@ func getKnownValidatorsForBlsChangeTracking(
       break
   res
 
-proc updateHead*(self: var ConsensusManager, newHead: BlockRef) =
+proc updateHead(self: var ConsensusManager, newHead: BlockRef) =
   ## Trigger fork choice and update the DAG with the new head block
   ## This does not automatically prune the DAG after finalization
   ## `pruneFinalized` must be called for pruning.
 
   # Store the new head in the chain DAG - this may cause epochs to be
-  # justified and finalized
+  # justified and finalized.
+  # `willSelectNewHead` (part of `selectOptimisticHead`) required before this
   self.dag.updateHead(
     newHead, self.quarantine[],
     self.getKnownValidatorsForBlsChangeTracking(newHead))
-
   self.checkExpectedBlock()
 
 proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
@@ -212,8 +212,8 @@ proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =
 
   # Grab the new head according to our latest attestation data
   let
-    newHead = self.attestationPool[].selectOptimisticHead(
-        wallSlot.start_beacon_time(self.dag.timeParams)).valueOr:
+    wallTime = wallSlot.start_beacon_time(self.dag.timeParams)
+    newHead = self.attestationPool[].selectOptimisticHead(wallTime).valueOr:
       warn "Head selection failed, using previous head",
         head = shortLog(self.dag.head), wallSlot
       return
@@ -549,11 +549,7 @@ proc updateExecutionHead*(
 
     # Store the new head in the chain DAG - this may cause epochs to be
     # justified and finalized
-    self.dag.updateHead(
-      head.blck,
-      self.quarantine[],
-      self[].getKnownValidatorsForBlsChangeTracking(head.blck),
-    )
+    self[].updateHead(head.blck)
 
     attempts += 1
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -366,6 +366,12 @@ proc get_head*(
     self.checkpoints.time.slotOrZero(dag.timeParams),
     self.checkpoints)
 
+proc will_select_head*(
+    self: var ForkChoice, dag: ChainDAGRef,
+    blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
+  ? self.update_time(dag, wallTime)
+  ok()
+
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
 func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
   self.backend.proto_array.get_latest_confirmed()

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -39,7 +39,7 @@ from ../beacon_chain/spec/beaconstate import
   get_beacon_committee, get_beacon_proposer_index, get_committee_count_per_slot,
   get_committee_indices, get_ptc
 from ../beacon_chain/spec/state_transition_block import process_block
-from ../tests/testbcutil import addHeadBlock
+from ../tests/testbcutil import addHeadBlock, willSelectNewHead
 from ../tests/testblockutil import makeAttestationData, MockPrivKeys, `[]`
 
 type Timers = enum
@@ -422,7 +422,7 @@ cli do(
       )
 
     let added = dag.addHeadBlock(verifier, newBlock, onAdded)
-
+    discard attPool.willSelectNewHead(added[])
     dag.updateHead(added[], quarantine[], [])
     if dag.needStateCachesAndForkChoicePruning():
       dag.pruneStateCachesDAG()

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -281,8 +281,11 @@ proc stepOnBlock(
 
     # 5. Update DAG with new head
     var quarantine = Quarantine.init(dag.cfg)
-    let newHead = fkChoice[].get_head(dag, time).get()
-    dag.updateHead(dag.getBlockRef(newHead).get(), quarantine, [])
+    let
+      newHeadRoot = fkChoice[].get_head(dag, time).get()
+      newHead = dag.getBlockRef(newHeadRoot).get()
+    discard fkChoice[].will_select_head(dag, newHead, time)
+    dag.updateHead(newHead, quarantine, [])
     if dag.needStateCachesAndForkChoicePruning():
       dag.pruneStateCachesDAG()
       let pruneRes = fkChoice[].prune()

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -29,7 +29,7 @@ from ../beacon_chain/spec/beaconstate import
   latest_block_root
 from ../beacon_chain/spec/validator import
   get_beacon_committee, get_committee_count_per_slot, get_committee_indices
-from ./testbcutil import addHeadBlock
+from ./testbcutil import addHeadBlock, willSelectNewHead
 
 func combine(tgt: var electra.Attestation, src: electra.Attestation) =
   ## Combine the signature and participation bitfield, with the assumption that
@@ -739,6 +739,7 @@ suite "Attestation pool electra processing" & preset():
         let head = pool[].selectOptimisticHead(
           blockRef[].slot.start_beacon_time(cfg.timeParams)).get().blck
         doAssert: head == blockRef[]
+        discard pool[].willSelectNewHead(head)
         dag.updateHead(head, quarantine[], [])
         pruneAtFinalization(dag, pool[])
 

--- a/tests/testbcutil.nim
+++ b/tests/testbcutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024-2025 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,12 +9,15 @@
 
 import results
 
+from ../beacon_chain/consensus_object_pools/attestation_pool import
+  AttestationPool, willSelectNewHead
 from ../beacon_chain/consensus_object_pools/block_clearance import
   addHeadBlockWithParent
 from ../beacon_chain/consensus_object_pools/block_dag import
   BlockRef, OptimisticStatus
 from ../beacon_chain/consensus_object_pools/block_pools_types import
   ChainDAGRef, OnBlockAdded, VerifierError
+from ../beacon_chain/spec/beacon_time import start_beacon_time
 from ../beacon_chain/spec/forks import ForkySignedBeaconBlock
 from ../beacon_chain/spec/signatures_batch import BatchVerifier
 
@@ -35,3 +38,9 @@ template addHeadBlock*(
   let onBlockAdded: OnBlockAdded[typeof(signedBlock).kind] = onBlockAddedParam
 
   addHeadBlockImpl(dag, verifier, signedBlock, onBlockAdded)
+
+proc willSelectNewHead*(
+    pool: var AttestationPool, headBlock: BlockRef): Opt[void] =
+  let wallTime =
+    pool.dag.head.bid.slot.start_beacon_time(pool.dag.cfg.timeParams)
+  pool.willSelectNewHead(headBlock, wallTime)


### PR DESCRIPTION
Fast Confirmation Rule needs access to the latest head to advance the confirmed block. This needs to be run _before_ forkchoiceUpdated, so that the latest safeBlockHash is communicated to the EL.

In the spec, FCR is run on slot start. In Nimbus, we run fork choice after receiving the block (later in the slot). That's where the first hook is installed (`selectOptimisticHead`, after fork choice, before asking `getBeaconHead` to fill in safe / finalized information.

There are no other paths that update the DAG head and don't have a preceding `selectOptimisticHead`, so this should be sufficient.

https://github.com/ethereum/consensus-specs/pull/4747#issuecomment-3897294661