### PR TITLE
fix 32-bit compilation errors in fork choice

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -92,7 +92,7 @@ template toSszType*(v: ForkChoiceBalance): auto = uint64(v)
 const
   NumInfoBits = 1
   ForkChoiceInfoOffset* = bitsof(distinctBase(Gwei)) - NumInfoBits
-  ForkChoiceInfoMask = ((1 shl NumInfoBits) - 1) shl ForkChoiceInfoOffset
+  ForkChoiceInfoMask = ((1'u64 shl NumInfoBits) - 1) shl ForkChoiceInfoOffset
   EffectiveBalanceMask = not ForkChoiceInfoMask
   SlashedBit = distinctBase(1.Gwei) shl ForkChoiceInfoOffset
 static: doAssert(


### PR DESCRIPTION
On 32-bit ARM:
```
Building: build/nimbus_beacon_node
/home/user/nimbus-eth2/beacon_chain/fork_choice/fork_choice.nim(425, 32) template/generic instantiation of `unslashed_balance` from here
/home/user/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(111, 12) template/generic instantiation of `effective_balance` from here
/home/user/nimbus-eth2/beacon_chain/consensus_object_pools/blockchain_dag.nim(105, 26) Error: type mismatch
Expression: 
  [type node](old_balances[val_index]) and
    -1
  [1] 
[type node](old_balances[val_index]): uint64
  [2] -1: int literal(-1)

Expected one of (first mismatch at [position]):
[1] func `and`(a, b: StInt): StInt
[1] func `and`(a, b: StUint): StUint
[1] func `and`[N: static int; T](x, y: array[N, T]): array[N, T]
[1] proc `and`(a, b: typedesc): typedesc
[1] proc `and`(address1, address2: TransportAddress): TransportAddress
[1] proc `and`(x, y: bool): bool
[1] proc `and`(x, y: int): int
[1] proc `and`(x, y: int16): int16
[1] proc `and`(x, y: int32): int32
[1] proc `and`(x, y: int64): int64
[1] proc `and`(x, y: int8): int8
[1] proc `and`(x, y: uint): uint
[1] proc `and`(x, y: uint16): uint16
[1] proc `and`(x, y: uint32): uint32
[1] proc `and`(x, y: uint8): uint8
[1] proc `and`[T, Y](fut1: Future[T]; fut2: Future[Y]): Future[void]
[1] proc `and`[bits: static[int]](a`gensym40: StUint[bits]; b`gensym40: int{lit}): StUint[
    bits]
[1] proc `and`[bits: static[int]](a`gensym41: int{lit}; b`gensym41: StUint[bits]): StUint[
    bits]
[1] proc `and`[bits: static[int]](a`gensym42: StInt[bits]; b`gensym42: int{lit}): StInt[
    bits]
[1] proc `and`[bits: static[int]](a`gensym43: int{lit}; b`gensym43: StInt[bits]): StInt[
    bits]
[1] template `and`[T0, E, T1](self: Result[T0, E]; other: Result[T1, E]): Result[T1,
    E]
[2] proc `and`(x, y: uint64): uint64

make: *** [Makefile:453: nimbus_beacon_node] Error 1
make: *** [Makefile:815: dist-arm] Error 2
```