### PR TITLE
use newPayloadV5 for Glamsterdam

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -613,10 +613,10 @@ AllTests-mainnet
 ```
 ## Engine API conversions
 ```diff
-+ ExecutionPayloadV4 to deneb.ExecutionPayload conversion                                    OK
 + Roundtrip engine RPC V1 and bellatrix ExecutionPayload representations                     OK
 + Roundtrip engine RPC V2 and capella ExecutionPayload representations                       OK
 + Roundtrip engine RPC V3 and deneb ExecutionPayload representations                         OK
++ Roundtrip engine RPC V4 and deneb ExecutionPayload representations                         OK
 ```
 ## Envelope Quarantine
 ```diff

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -633,6 +633,18 @@ proc sendNewPayloadToSingleEL(
     payload, versioned_hashes, parent_beacon_block_root,
     executionRequests)
 
+proc sendNewPayloadToSingleEL(
+    connection: ELConnection,
+    payload: engine_api.ExecutionPayloadV4,
+    versioned_hashes: seq[engine_api.VersionedHash],
+    parent_beacon_block_root: Hash32,
+    executionRequests: seq[seq[byte]]
+): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
+  let rpcClient = await connection.connectedRpcClient()
+  await rpcClient.engine_newPayloadV5(
+    payload, versioned_hashes, parent_beacon_block_root,
+    executionRequests)
+
 proc sendGetBlobsV2toSingleEl(
     connection: ELConnection,
     versioned_hashes: seq[engine_api.VersionedHash]
@@ -926,7 +938,10 @@ proc sendNewPayload*(
 
   let
     startTime = Moment.now()
-    payload = executionPayload.asEngineExecutionPayload()
+    payload =
+      when consensusFork >= ConsensusFork.Gloas:
+        executionPayload.asEngineExecutionPayloadV4()
+      else: executionPayload.asEngineExecutionPayload()
 
   when consensusFork >= ConsensusFork.Deneb:
     let

--- a/beacon_chain/el/engine_api_conversions.nim
+++ b/beacon_chain/el/engine_api_conversions.nim
@@ -284,6 +284,33 @@ func asEngineExecutionPayload*(executionPayload: deneb.ExecutionPayload):
     blobGasUsed: Quantity(executionPayload.blob_gas_used),
     excessBlobGas: Quantity(executionPayload.excess_blob_gas))
 
+func asEngineExecutionPayloadV4*(executionPayload: deneb.ExecutionPayload):
+    ExecutionPayloadV4 =
+  template getTypedTransaction(tt: bellatrix.Transaction): TypedTransaction =
+    TypedTransaction(tt.distinctBase)
+
+  engine_api.ExecutionPayloadV4(
+    parentHash: executionPayload.parent_hash.asBlockHash,
+    feeRecipient: executionPayload.fee_recipient,
+    stateRoot: executionPayload.state_root.asBlockHash,
+    receiptsRoot: executionPayload.receipts_root.asBlockHash,
+    logsBloom:
+      FixedBytes[BYTES_PER_LOGS_BLOOM](executionPayload.logs_bloom.data),
+    prevRandao: executionPayload.prev_randao.data.to(Bytes32),
+    blockNumber: Quantity(executionPayload.block_number),
+    gasLimit: Quantity(executionPayload.gas_limit),
+    gasUsed: Quantity(executionPayload.gas_used),
+    timestamp: Quantity(executionPayload.timestamp),
+    extraData: DynamicBytes[0, MAX_EXTRA_DATA_BYTES](executionPayload.extra_data),
+    baseFeePerGas: executionPayload.base_fee_per_gas,
+    blockHash: executionPayload.block_hash.asBlockHash,
+    transactions: mapIt(executionPayload.transactions, it.getTypedTransaction),
+    withdrawals: mapIt(executionPayload.withdrawals, it.asEngineWithdrawal),
+    blobGasUsed: Quantity(executionPayload.blob_gas_used),
+    excessBlobGas: Quantity(executionPayload.excess_blob_gas),
+    blockAccessList: @[],  # TODO: stub
+    slotNumber: Quantity(0)) # TODO: stub
+
 proc asEngineVersionedHashes*(
     blob_kzg_commitments: KzgCommitments
 ): seq[VersionedHash] =

--- a/tests/test_engine_api_conversions.nim
+++ b/tests/test_engine_api_conversions.nim
@@ -1611,7 +1611,7 @@ suite "Engine API conversions":
         blockBody.execution_payload == asConsensusType(
           asEngineExecutionPayload(blockBody.execution_payload))
 
-  test "ExecutionPayloadV4 to deneb.ExecutionPayload conversion":
+  test "Roundtrip engine RPC V4 and deneb ExecutionPayload representations":
     # Each Eth2Digest field is chosen randomly. Each uint64 field is random,
     # with boosted probabilities for 0, 1, and high(uint64). There can be 0,
     # 1, 2, or 3 transactions uniformly. Each transaction is 0, 8, 13, or 16
@@ -2177,23 +2177,6 @@ suite "Engine API conversions":
       )]
 
     for execution_payload in executionPayloads:
-      let v4_payload = ExecutionPayloadV4(
-          parentHash: execution_payload.parent_hash.asBlockHash,
-          feeRecipient: execution_payload.fee_recipient,
-          stateRoot: execution_payload.state_root.asBlockHash,
-          receiptsRoot: execution_payload.receipts_root.asBlockHash,
-          logsBloom: FixedBytes[BYTES_PER_LOGS_BLOOM](execution_payload.logs_bloom.data),
-          prevRandao: Bytes32(execution_payload.prev_randao.data),
-          blockNumber: Quantity(execution_payload.block_number),
-          gasLimit: Quantity(execution_payload.gas_limit),
-          gasUsed: Quantity(execution_payload.gas_used),
-          timestamp: Quantity(execution_payload.timestamp),
-          extraData: DynamicBytes[0, MAX_EXTRA_DATA_BYTES](execution_payload.extra_data),
-          baseFeePerGas: execution_payload.base_fee_per_gas,
-          blockHash: execution_payload.block_hash.asBlockHash,
-          transactions: mapIt(execution_payload.transactions, TypedTransaction(it.distinctBase)),
-          withdrawals: mapIt(execution_payload.withdrawals, it.asEngineWithdrawal),
-          blobGasUsed: Quantity(execution_payload.blob_gas_used),
-          excessBlobGas: Quantity(execution_payload.excess_blob_gas))
       check:
-        execution_payload == asConsensusType(v4_payload)
+        execution_payload == asConsensusType(
+          asEngineExecutionPayloadV4(execution_payload))


### PR DESCRIPTION
Fixes: `newPayloadV4` should not be called for amsterdam payloads, use `newPayloadV5`