### PR TITLE
Track current epoch observed justified and previous / current slot head

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -381,7 +381,7 @@ proc get_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     wallTime: BeaconTime): FcResult[Eth2Digest] =
   ? self.update_time(dag, wallTime)
-  result = self.backend.find_head(
+  self.backend.find_head(
     self.checkpoints.time.slotOrZero(dag.timeParams),
     self.checkpoints)
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -62,7 +62,10 @@ func init*(
     proto_array: ProtoArray.init(finalized.checkpoint, currentSlot),
     confirmed: BlockId(
       slot: finalized.checkpoint.epoch.start_slot,
-      root: finalized.checkpoint.root))
+      root: finalized.checkpoint.root),
+    current_epoch_observed_justified: finalized,
+    previous_slot_head: finalized.checkpoint.root,
+    current_slot_head: finalized.checkpoint.root)
 
 proc init*(
     T: type ForkChoice, confirmation_byzantine_threshold: uint64,
@@ -157,10 +160,17 @@ proc on_tick(
     # Reset store.proposer_boost_root
     self.checkpoints.proposer_boost_root = ZERO_HASH
 
+    # Update prev slot head
+    self.backend.previous_slot_head = dag.head.bid.root
+
     if current_slot.is_epoch:
       # Pull-up unrealized justified / finalized checkpoints from previous epoch
       for realized in self.backend.proto_array.realizePendingCheckpoints():
         ? self.checkpoints.update_checkpoints(dag, realized, current_slot)
+
+      # Update observed justified checkpoint before any attestations from the
+      # last slot of the previous epoch become processable
+      self.backend.current_epoch_observed_justified = self.checkpoints.justified
   ok()
 
 func process_attestation(
@@ -374,14 +384,15 @@ proc get_head*(
   result = self.backend.find_head(
     self.checkpoints.time.slotOrZero(dag.timeParams),
     self.checkpoints)
-  self.backend.update_confirmed BlockId(
-    slot: self.checkpoints.justified.checkpoint.epoch.start_slot,
-    root: self.checkpoints.justified.checkpoint.root)
 
 proc will_select_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
+  self.backend.current_slot_head = dag.head.root
+  self.backend.update_confirmed BlockId(
+    slot: self.checkpoints.justified.checkpoint.epoch.start_slot,
+    root: self.checkpoints.justified.checkpoint.root)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -161,7 +161,7 @@ proc on_tick(
     self.checkpoints.proposer_boost_root = ZERO_HASH
 
     # Update prev slot head
-    self.backend.previous_slot_head = dag.head.bid.root
+    self.backend.previous_slot_head = self.backend.current_slot_head
 
     if current_slot.is_epoch:
       # Pull-up unrealized justified / finalized checkpoints from previous epoch

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -137,6 +137,8 @@ type
     confirmation_byzantine_threshold*: uint64
     proto_array*: ProtoArray
     confirmed*: BlockId
+    current_epoch_observed_justified*: BalanceCheckpoint
+    previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
 

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -103,7 +103,12 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
     var response = GetForkChoiceResponse(
       justified_checkpoint: forkChoice.checkpoints.justified.checkpoint,
       finalized_checkpoint: forkChoice.checkpoints.finalized,
-      extra_data: RestExtraData())
+      extra_data: RestExtraData(
+        confirmed_root: forkChoice.get_safe_beacon_block_root,
+        current_epoch_observed_justified_checkpoint:
+          forkChoice.backend.current_epoch_observed_justified.checkpoint,
+        previous_slot_head: forkChoice.backend.previous_slot_head,
+        current_slot_head: forkChoice.backend.current_slot_head))
 
     for item in forkChoice.backend.proto_array:
       let

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -592,7 +592,7 @@ type
   RestExtraData* = object
     confirmed_root*: Eth2Digest
     current_epoch_observed_justified_checkpoint*: Checkpoint
-    previous_slot_head, current_slot_head*: Eth2Digest
+    previous_slot_head*, current_slot_head*: Eth2Digest
 
   GetForkChoiceResponse* = object
     justified_checkpoint*: Checkpoint

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -590,7 +590,9 @@ type
     extra_data*: Opt[RestNodeExtraData]
 
   RestExtraData* = object
-    discard
+    confirmed_root*: Eth2Digest
+    current_epoch_observed_justified_checkpoint*: Checkpoint
+    previous_slot_head, current_slot_head*: Eth2Digest
 
   GetForkChoiceResponse* = object
     justified_checkpoint*: Checkpoint


### PR DESCRIPTION
Fast Confirmation Rule needs to track a consistent checkpoint per epoch and the heads that were selected during current / previous slots.

These hooks give comparable data to `update_fast_confirmation_variables` in the spec but are slightly optimized to not trigger extra load.
- https://github.com/ethereum/consensus-specs/pull/4747