### PR TITLE
ensure advance slot preparation time triggers proportionally to slot time

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -427,7 +427,7 @@ proc checkWeakSubjectivityCheckpoint(
 
 from ./spec/state_transition_block import kzg_commitment_to_versioned_hash
 
-proc isSlotWithinWeakSubjectivityPeriod(dag: ChainDAGRef, slot: Slot): bool =
+func isSlotWithinWeakSubjectivityPeriod(dag: ChainDAGRef, slot: Slot): bool =
   let
     checkpoint = Checkpoint(
       epoch: dag.headState.slot.epoch(),
@@ -1021,7 +1021,7 @@ proc init*(
   info "Loading slashing protection database (v2)",
     path = config.validatorsDir()
 
-  proc getValidatorAndIdx(pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
+  func getValidatorAndIdx(pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
     getValidator(dag.headState.validators.asSeq, pubkey)
 
   func getCapellaForkVersion(): Opt[presets.Version] =
@@ -1030,10 +1030,10 @@ proc init*(
   func getDenebForkEpoch(): Opt[Epoch] =
     Opt.some(metadata.cfg.DENEB_FORK_EPOCH)
 
-  proc getForkForEpoch(epoch: Epoch): Opt[Fork] =
+  func getForkForEpoch(epoch: Epoch): Opt[Fork] =
     Opt.some(dag.forkAtEpoch(epoch))
 
-  proc getGenesisRoot(): Eth2Digest =
+  func getGenesisRoot(): Eth2Digest =
     dag.headState.genesis_validators_root
 
   let
@@ -1872,21 +1872,20 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
       node.pruneBlobs(slot)
       node.pruneDataColumns(slot)
 
-  when declared(GC_fullCollect):
-    # The slots in the beacon node work as frames in a game: we want to make
-    # sure that we're ready for the next one and don't get stuck in lengthy
-    # garbage collection tasks when time is of essence in the middle of a slot -
-    # while this does not guarantee that we'll never collect during a slot, it
-    # makes sure that all the scratch space we used during slot tasks (logging,
-    # temporary buffers etc) gets recycled for the next slot that is likely to
-    # need similar amounts of memory.
-    try:
-      GC_fullCollect()
-    except Defect as exc:
-      raise exc # Reraise to maintain call stack
-    except Exception:
-      # TODO upstream
-      raiseAssert "Unexpected exception during GC collection"
+  # The slots in the beacon node work as frames in a game: we want to make
+  # sure that we're ready for the next one and don't get stuck in lengthy
+  # garbage collection tasks when time is of essence in the middle of a slot -
+  # while this does not guarantee that we'll never collect during a slot, it
+  # makes sure that all the scratch space we used during slot tasks (logging,
+  # temporary buffers etc) gets recycled for the next slot that is likely to
+  # need similar amounts of memory.
+  try:
+    GC_fullCollect()
+  except Defect as exc:
+    raise exc # Reraise to maintain call stack
+  except Exception:
+    # TODO upstream
+    raiseAssert "Unexpected exception during GC collection"
   let gcCollectionTick = Moment.now()
 
   # Checkpoint the database to clear the WAL file and make sure changes in
@@ -1991,9 +1990,12 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # When we're not behind schedule, we'll speculatively update the clearance
   # state in anticipation of receiving the next block - we do it after
   # logging slot end since the nextActionWaitTime can be short
-  let advanceCutoff = node.beaconClock.fromNow(
-    slot.start_beacon_time(node.dag.timeParams) +
-    node.dag.timeParams.SLOT_DURATION - chronos.seconds(1))
+  let
+    advanceOffset = node.dag.timeParams.aggregateSlotOffset + nanos((
+      node.dag.timeParams.SLOT_DURATION.nanoseconds -
+      node.dag.timeParams.aggregateSlotOffset.nanoseconds) * 3 div 4)
+    advanceCutoff = node.beaconClock.fromNow(
+      slot.start_beacon_time(node.dag.timeParams) + advanceOffset)
 
   let proposalFcu =
     if advanceCutoff.inFuture:


### PR DESCRIPTION
Various minimal preset Jenkins finalization CIs have been failing fairly often specifically on macOS since
- https://github.com/status-im/nimbus-eth2/pull/7931

due to a half-second delay while waiting for the proposal fcU which wasn't sent ahead of the slot start, and only then calling `getPayload`. This is due to the interaction between
https://github.com/status-im/nimbus-eth2/blob/a3b2ad534f07e8fc222fb02479df36d2d4462dcd/beacon_chain/nimbus_beacon_node.nim#L1829-L1843
and
https://github.com/status-im/nimbus-eth2/blob/a3b2ad534f07e8fc222fb02479df36d2d4462dcd/beacon_chain/nimbus_beacon_node.nim#L1991-L2018

On slot end, it does two time skips:
- to 5/6 through the slot (2/3 + (1-2/3)/2), i.e. with mainnet presets, 10s and with minimal presets, 5s; and
- then, to slot end-1s, i.e. with mainnet presets, 11s and with minimal presets, 5s

The trouble is that the second time skip doesn't allow activation of the advance/proposal fcU if it's not seen as in the future, and 6s is exactly when those two slot times overlap. The more root cause here is having two different kinds of timing parameterization, one an absolute offset and one a proportion through the slot. The latter scales up/down better, so better to keep that consistent.

This PR adjusts the latter to still occur at 11s at mainnet but use a proportional style to achieve that effect, so it occurs at 11s, as now, in mainnet, but at 5.5s in minimal.
