### PR TITLE
temporarily stop using fulu in minimal local testnets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ local-testnet-minimal:
 		--signer-nodes 1 \
 		--remote-validators-count 512 \
 		--signer-type $(SIGNER_TYPE) \
-		--fulu-fork-epoch 1 \
+		--fulu-fork-epoch 1000 \
 		--stop-at-epoch 6 \
 		--disable-htop \
 		--base-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \

--- a/scripts/geth_binaries.sh
+++ b/scripts/geth_binaries.sh
@@ -19,7 +19,7 @@ source "${SCRIPTS_DIR}/bash_utils.sh"
 
 download_geth_stable() {
   if [[ ! -e "${STABLE_GETH_BINARY}" ]]; then
-    GETH_VERSION="1.16.8-abeb78c6"  # https://geth.ethereum.org/downloads
+    GETH_VERSION="1.17.0-0cf3d3ba"  # https://geth.ethereum.org/downloads
     GETH_URL="https://gethstore.blob.core.windows.net/builds/"
 
     case "${OS}-${ARCH}" in

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -88,7 +88,6 @@ ETH2_DOCKER_IMAGE=""
 REMOTE_SIGNER_THRESHOLD=1
 REMOTE_VALIDATORS_COUNT=0
 LC_NODES=1
-ACCOUNT_PASSWORD="nimbus"
 RUN_GETH="0"
 DL_GETH="0"
 RUN_SPAMOOR="0"
@@ -720,11 +719,6 @@ cleanup() {
   # Avoid the trap enterring an infinite loop
   trap - SIGINT SIGTERM EXIT
 
-  PKILL_ECHO_FLAG='-e'
-  if [[ "${OS}" == "macos" ]]; then
-    PKILL_ECHO_FLAG='-l'
-  fi
-
   PIDS_TO_KILL=$(find "${DATA_DIR}/pids" -type f -exec cat {} \+ 2>/dev/null)
 
   echo Terminating processes...
@@ -791,7 +785,6 @@ NUM_JOBS=${NUM_NODES}
 
 DEPOSITS_FILE="${DATA_DIR}/deposits.json"
 CONTAINER_DEPOSITS_FILE="${CONTAINER_DATA_DIR}/deposits.json"
-CONTAINER_DEPOSIT_TREE_SNAPSHOT_FILE="${CONTAINER_DATA_DIR}/deposit_tree_snapshot.ssz"
 
 CONTAINER_BOOTSTRAP_NETWORK_KEYFILE="bootstrap_network_key.json"
 DIRECTPEER_NETWORK_KEYFILE="directpeer_network_key.json"
@@ -1147,7 +1140,7 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
     --light-client-data-serve=on \
     --light-client-data-import-mode=full \
     --light-client-data-max-periods=999999 \
-    ${STOP_AT_EPOCH_FLAG} \
+    "${STOP_AT_EPOCH_FLAG}" \
     ${KEYMANAGER_FLAG} \
     --keymanager-token-file="${DATA_DIR}/keymanager-token" \
     --rest-port="$(( BASE_REST_PORT + NUM_NODE - 1 ))" \


### PR DESCRIPTION
Followup to
- https://github.com/status-im/nimbus-eth2/pull/7986

That PR shaved 0.5s off block production in `minimal` preset local testnets on CI, out of the 2s window for block + sidecar (blob, column) production by reinstating the proposer fcU lookahead. But it still wasn't enough to completely solve the problem of flaky local testnet CI.

Blobs (Electra) didn't trigger this, but columns (Fulu) do, because there are dozens of columns to verify for each block, versus around a dozen blobs.

From the longer logs below, examples of some fairly involved column validations:
```
{"lvl":"DBG","ts":"2026-02-17 12:04:19.968+00:00","msg":"Data column received","topics":"gossip_eth2","delay":"968ms568us","dcs":{"index":31,"kzg_commitments":5,"kzg_proofs":5,"bloLow sync committee participationck_header":{"slot":29,"proposer_index":958,"parent_root":"4d4e337f","state_root":"a2e4b13c"}},"wallSlot":29}
{"lvl":"DBG","ts":"2026-02-17 12:04:19.987+00:00","msg":"Data column validated, putting data column in quarantine","topics":"gossip_eth2","dcs":{"index":31,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":29,"proposer_index":958,"parent_root":"4d4e337f","state_root":"a2e4b13c"}},"wallSlot":29}
```
is 20ms, as is
```
{"lvl":"DBG","ts":"2026-02-17 12:04:20.252+00:00","msg":"Data column received","topics":"gossip_eth2","delay":"1s252ms541us","dcs":{"index":41,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":29,"proposer_index":958,"parent_root":"4d4e337f","state_root":"a2e4b13c"}},"wallSlot":29}
{"lvl":"DBG","ts":"2026-02-17 12:04:20.270+00:00","msg":"Data column validated, putting data column in quarantine","topics":"gossip_eth2","dcs":{"index":41,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":29,"proposer_index":958,"parent_root":"4d4e337f","state_root":"a2e4b13c"}},"wallSlot":29}
```

Others take even longer.  [find_validation_durations.py](https://github.com/user-attachments/files/25383989/find_validation_durations.py) finds the validation times by checking the deltas between "received" and "validated" logs per slot and column index, and
```
$ ... | datamash count 1 mean 1 q1 1 median 1 q3 1 perc:90 1 perc:95 1 perc:99 1
73	19.630136986301	9	13	20	50.4	59.2	95.24
```
i.e. the median isn't that bad, 13ms, but longer than it should be. Average, 20ms, is skewed up from median by the long tail.
- p25 is 9ms
- p50 is 13ms
- p75 is 20ms
- p90 is 50ms
- p95 is 60ms
- p99 is 95ms

This is all in
https://github.com/status-im/nimbus-eth2/blob/a18b9461822122f4a1cecfa50a26b95090178b35/beacon_chain/gossip_processing/eth2_processor.nim#L426-L439
i.e. there are no yield points or async delays involved. 

Excerpted logs of how this leads to the `Low sync committee participation`: 
[datacolumn_validation_delays.txt](https://github.com/user-attachments/files/25384089/datacolumn_validation_delays.txt)

- https://github.com/status-im/nimbus-eth2/pull/7949

should significantly ameliorate this and allow re-enabling Fulu in minimal preset local testnets, including in CI. Until then, Spamoor in fulu is too likely to result in flaky CI to keep enabled in `minimal` preset.