### PR TITLE
rm unused code in launch_local_testnet

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -49,7 +49,7 @@ CURL_BINARY="$(command -v curl)" || { echo "Curl not installed. Aborting."; exit
 JQ_BINARY="$(command -v jq)" || { echo "jq not installed. Aborting."; exit 1; }
 
 OPTS="ht:n:d:g"
-LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,lighthouse-vc-nodes:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:"
+LONGOPTS="help,preset:,nodes:,data-dir:,remote-validators-count:,threshold:,signer-nodes:,signer-type:,with-ganache,stop-at-epoch:,disable-htop,use-vc:,disable-vc,enable-payload-builder,log-level:,base-port:,base-rest-port:,base-metrics-port:,base-vc-metrics-port:,base-vc-keymanager-port:,base-remote-signer-port:,base-remote-signer-metrics-port:,base-el-net-port:,base-el-rpc-port:,base-el-ws-port:,base-el-auth-rpc-port:,el-port-offset:,reuse-existing-data-dir,reuse-binaries,timeout:,kill-old-processes,eth2-docker-image:,run-geth,dl-geth,dl-nimbus-eth1,dl-nimbus-eth2,run-spamoor,light-clients:,run-nimbus-eth1,verbose,fulu-fork-epoch:,gloas-fork-epoch:"
 
 # default values
 BINARIES=""
@@ -60,7 +60,6 @@ USE_HTOP="1"
 USE_PAYLOAD_BUILDER="false"
 : ${PAYLOAD_BUILDER_HOST:=127.0.0.1}
 : ${PAYLOAD_BUILDER_PORT:=4888}
-LIGHTHOUSE_VC_NODES="0"
 LOG_LEVEL="DEBUG; TRACE:networking"
 BASE_PORT="9000"
 BASE_REMOTE_SIGNER_PORT="6000"
@@ -144,7 +143,6 @@ CI run: $(basename "$0") --disable-htop -- --verify-finalization
                               (by default validators are split 50/50 between beacon nodes
                               and validator clients, with all beacon nodes being paired up
                               with a corresponding validator client)
-  --lighthouse-vc-nodes       number of Lighthouse VC nodes (assigned before Nimbus VC nodes, default: ${LIGHTHOUSE_VC_NODES})
   --log-level                 set the log level (default: "${LOG_LEVEL}")
   --reuse-existing-data-dir   instead of deleting and recreating the data dir, keep it and reuse everything we can from it
   --reuse-binaries            don't (re)build the binaries we need and don't delete them at the end (speeds up testing)
@@ -314,10 +312,6 @@ while true; do
       USE_VC="0"
       LC_NODES="0"
       ;;
-    --lighthouse-vc-nodes)
-      LIGHTHOUSE_VC_NODES="$2"
-      shift 2
-      ;;
     --light-clients)
       LC_NODES="$2"
       shift 2
@@ -380,11 +374,6 @@ fi
 
 rm -rf "${DATA_DIR}/pids/*"
 mkdir -p "${DATA_DIR}/pids" "${DATA_DIR}/logs"
-
-if [[ "${LIGHTHOUSE_VC_NODES}" != "0" && "${CONST_PRESET}" != "mainnet" ]]; then
-  echo "The prebuilt Lighthouse binary we're using only supports mainnet. Aborting."
-  exit 1
-fi
 
 scripts/makedir.sh "${DATA_DIR}"
 echo x > "${DATA_DIR}/keymanager-token"
@@ -617,37 +606,6 @@ download_nimbus_eth2() {
   fi
 }
 
-# Download the Lighthouse binary.
-LH_VERSION="2.1.3"
-LH_ARCH="${ARCH}"
-if [[ "${LH_ARCH}" == "arm64" ]]; then
-  LH_ARCH="aarch64"
-fi
-
-case "${OS}" in
-  linux)
-    LH_TARBALL="lighthouse-v${LH_VERSION}-${LH_ARCH}-unknown-linux-gnu-portable.tar.gz"
-    ;;
-  macos)
-    LH_TARBALL="lighthouse-v${LH_VERSION}-${LH_ARCH}-apple-darwin-portable.tar.gz"
-    ;;
-  windows)
-    LH_TARBALL="lighthouse-v${LH_VERSION}-${LH_ARCH}-windows-portable.tar.gz"
-    ;;
-esac
-LH_URL="https://github.com/sigp/lighthouse/releases/download/v${LH_VERSION}/${LH_TARBALL}"
-LH_BINARY="lighthouse-${LH_VERSION}${EXE_EXTENSION}"
-
-if [[ "${USE_VC}" == "1" && "${LIGHTHOUSE_VC_NODES}" != "0" && ! -e "build/${LH_BINARY}" ]]; then
-  echo "Downloading Lighthouse binary"
-  pushd "build" >/dev/null
-  "${CURL_BINARY}" -sSLO "${LH_URL}"
-  tar -xzf "${LH_TARBALL}" # contains just one file named "lighthouse"
-  rm lighthouse-* # deletes both the tarball and old binary versions
-  mv "lighthouse$EXE_EXTENSION" "${LH_BINARY}"
-  popd >/dev/null
-fi
-
 BINARIES="ncli_testnet"
 
 if [[ "$LC_NODES" -ge "1" ]]; then
@@ -789,7 +747,6 @@ CONTAINER_DEPOSITS_FILE="${CONTAINER_DATA_DIR}/deposits.json"
 CONTAINER_BOOTSTRAP_NETWORK_KEYFILE="bootstrap_network_key.json"
 DIRECTPEER_NETWORK_KEYFILE="directpeer_network_key.json"
 
-
 BOOTSTRAP_NODE=1
 DIRECTPEER_NODE=2
 
@@ -804,7 +761,7 @@ if [[ "$REUSE_EXISTING_DATA_DIR" == "0" ]]; then
     --out-validators-dir="${VALIDATORS_DIR}" \
     --out-secrets-dir="${SECRETS_DIR}" \
     --out-deposits-file="${DEPOSITS_FILE}" \
-    --threshold=${REMOTE_SIGNER_THRESHOLD} \
+    --threshold="${REMOTE_SIGNER_THRESHOLD}" \
     --remote-validators-count="${REMOTE_VALIDATORS_COUNT}" \
     ${REMOTE_URLS}
 fi
@@ -940,12 +897,6 @@ GLOAS_FORK_EPOCH: ${GLOAS_FORK_EPOCH}
 EOF
 
 echo $DEPOSIT_CONTRACT_BLOCK > "${DATA_DIR}/deposit_contract_block.txt"
-
-if [[ "${LIGHTHOUSE_VC_NODES}" != "0" ]]; then
-  # I don't know what this is, but Lighthouse wants it, so we recreate it from
-  # Lighthouse's own local testnet.
-  echo $DEPOSIT_CONTRACT_BLOCK > "${DATA_DIR}/deploy_block.txt"
-fi
 
 dump_logs() {
   LOG_LINES=50
@@ -1153,42 +1104,21 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
   echo $PID > "$DATA_DIR/pids/nimbus_beacon_node.${NUM_NODE}"
 
   if [[ "${USE_VC}" == "1" ]]; then
-    if [[ "${LIGHTHOUSE_VC_NODES}" -ge "${NUM_NODE}" ]]; then
-      # Lighthouse needs a different keystore filename for its auto-discovery process.
-      for D in "${VALIDATOR_DATA_DIR}/validators"/0x*; do
-        if [[ -e "${D}/keystore.json" ]]; then
-          mv "${D}/keystore.json" "${D}/voting-keystore.json"
-        fi
-      done
-
-      ./build/"${LH_BINARY}" vc \
-        --debug-level "debug" \
-        --logfile-max-number 0 \
-        --log-format "JSON" \
-        --validators-dir "${VALIDATOR_DATA_DIR}" \
-        --secrets-dir "${VALIDATOR_DATA_DIR}/secrets" \
-        --beacon-nodes "http://127.0.0.1:$((BASE_REST_PORT + NUM_NODE))" \
-        --testnet-dir "${DATA_DIR}" \
-        --init-slashing-protection \
-        &> "${DATA_DIR}/logs/lighthouse_vc.${NUM_NODE}.txt" &
-      echo $! > "$DATA_DIR/pids/lighthouse_vc.${NUM_NODE}"
-    else
-      ./build/nimbus_validator_client \
-        --log-level="${LOG_LEVEL}" \
-        "${STOP_AT_EPOCH_FLAG}" \
-        --data-dir="${VALIDATOR_DATA_DIR}" \
-        --metrics \
-        --metrics-port=$(( BASE_VC_METRICS_PORT + NUM_NODE - 1 )) \
-        --payload-builder=${USE_PAYLOAD_BUILDER} \
-        ${KEYMANAGER_FLAG} \
-        --keymanager-port=$(( BASE_VC_KEYMANAGER_PORT + NUM_NODE - 1 )) \
-        --keymanager-token-file="${DATA_DIR}/keymanager-token" \
-        --beacon-node="http://127.0.0.1:$(( BASE_REST_PORT + NUM_NODE - 1 ))" \
-        &> "${DATA_DIR}/logs/nimbus_validator_client.${NUM_NODE}.jsonl" &
-      PID=$!
-      PIDS_TO_WAIT="${PIDS_TO_WAIT},$PID"
-      echo $PID > "$DATA_DIR/pids/nimbus_validator_client.${NUM_NODE}"
-    fi
+    ./build/nimbus_validator_client \
+      --log-level="${LOG_LEVEL}" \
+      "${STOP_AT_EPOCH_FLAG}" \
+      --data-dir="${VALIDATOR_DATA_DIR}" \
+      --metrics \
+      --metrics-port=$(( BASE_VC_METRICS_PORT + NUM_NODE - 1 )) \
+      --payload-builder=${USE_PAYLOAD_BUILDER} \
+      ${KEYMANAGER_FLAG} \
+      --keymanager-port=$(( BASE_VC_KEYMANAGER_PORT + NUM_NODE - 1 )) \
+      --keymanager-token-file="${DATA_DIR}/keymanager-token" \
+      --beacon-node="http://127.0.0.1:$(( BASE_REST_PORT + NUM_NODE - 1 ))" \
+      &> "${DATA_DIR}/logs/nimbus_validator_client.${NUM_NODE}.jsonl" &
+    PID=$!
+    PIDS_TO_WAIT="${PIDS_TO_WAIT},$PID"
+    echo $PID > "$DATA_DIR/pids/nimbus_validator_client.${NUM_NODE}"
   fi
 
   # Wait for the master node to write out its address file

--- a/scripts/mainnet-non-overriden-config.yaml
+++ b/scripts/mainnet-non-overriden-config.yaml
@@ -1,7 +1,7 @@
 # This file should contain the origin run-time config for the mainnet
 # network [1] without all properties overriden in the local network
 # simulation. We use to generate a full run-time config as required
-# by third-party binaries, such as Lighthouse and Web3Signer.
+# by third-party binaries, such as Web3Signer.
 #
 # [1]: https://raw.githubusercontent.com/ethereum/consensus-specs/dev/configs/mainnet.yaml
 

--- a/scripts/minimal-non-overriden-config.yaml
+++ b/scripts/minimal-non-overriden-config.yaml
@@ -1,7 +1,7 @@
 # This file should contain the origin run-time config for the minimal
 # network [1] without all properties overriden in the local network
 # simulation. We use to generate a full run-time config as required
-# by third-party binaries, such as Lighthouse and Web3Signer.
+# by third-party binaries, such as Web3Signer.
 #
 # [1]: https://raw.githubusercontent.com/ethereum/consensus-specs/dev/configs/minimal.yaml
 


### PR DESCRIPTION
https://github.com/sigp/lighthouse/releases/tag/v2.1.3 was released on 2022-02-11, 4 years ago now. Bellatrix wouldn't go live on mainnet [until 2022-09-06](https://blog.ethereum.org/2022/08/24/mainnet-merge-announcement) and Shapella [not until a year after the release](https://blog.ethereum.org/2023/03/28/shapella-mainnet-announcement).

So no one can have run this for several years, and now the [Kurtosis ethereum-package](https://github.com/ethpandaops/ethereum-package) provides a better way to do this that doesn't involve tracking multiple other Ethereum clients.