### PR TITLE
clean up attestation index iteration

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -594,11 +594,12 @@ func init(
       state.data, epoch, cache)
     for committee_index in get_committee_indices(committees_per_slot):
       for slot in epoch.slots():
-        let committee = get_beacon_committee(
-            state.data, slot, committee_index, cache)
-        var
-          validator_bits = ElectraCommitteeValidatorsBits.init(committee.len)
-        for index_in_committee, validator_index in committee:
+        let committee_len =
+          get_beacon_committee_len(state.data, slot, committee_index, cache)
+        var validator_bits = ElectraCommitteeValidatorsBits.init(committee_len.int)
+        for index_in_committee, validator_index in get_beacon_committee(
+          state.data, slot, committee_index, cache
+        ):
           if participation_bitmap[validator_index] != 0:
             # If any flag got set, there was an attestation from this validator.
             validator_bits[index_in_committee] = true
@@ -697,7 +698,7 @@ proc getAttestationsForBlock*(
         # attestation to - there might have been a fork between when we first
         # saw the attestation and the time that we added it
         if not check_attestation(
-              state.data, attestation, {skipBlsValidation}, cache, false).isOk():
+              state.data, attestation, {skipBlsValidation}, cache).isOk():
           continue
 
         let score = attCache.score(

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -79,59 +79,80 @@ func get_beacon_committee_len*(
   )
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
-func compatible_with_shuffling*(
-    bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits,
+iterator get_attesting_indices*(
     shufflingRef: ShufflingRef,
     slot: Slot,
-    committee_index: CommitteeIndex): bool =
-  bits.lenu64 == get_beacon_committee_len(shufflingRef, slot, committee_index)
-
-iterator get_attesting_indices*(shufflingRef: ShufflingRef,
-                                slot: Slot,
-                                committee_index: CommitteeIndex,
-                                bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits):
-                                  ValidatorIndex =
-  if not bits.compatible_with_shuffling(shufflingRef, slot, committee_index):
-    trace "get_attesting_indices: inconsistent aggregation and committee length"
-  else:
+    index: CommitteeIndex,
+    aggregation_bits: CommitteeValidatorsBits,
+): ValidatorIndex =
+  if slot.epoch == shufflingRef.epoch and
+      aggregation_bits.lenu64 == get_beacon_committee_len(shufflingRef, slot, index):
     for index_in_committee, validator_index in get_beacon_committee(
-        shufflingRef, slot, committee_index):
-      if bits[index_in_committee]:
+      shufflingRef, slot, index
+    ):
+      if aggregation_bits[index_in_committee]:
         yield validator_index
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/electra/beacon-chain.md#modified-get_attesting_indices
 iterator get_attesting_indices*(
-    shufflingRef: ShufflingRef, slot: Slot,
+    shufflingRef: ShufflingRef,
+    slot: Slot,
     committee_bits: AttestationCommitteeBits,
-    aggregation_bits: ElectraCommitteeValidatorsBits, on_chain: static bool):
-    ValidatorIndex =
-  when on_chain:
+    aggregation_bits: ElectraCommitteeValidatorsBits,
+): ValidatorIndex =
+  if slot.epoch == shufflingRef.epoch:
     var committee_offset = 0
-    for committee_index in committee_bits.oneIndices:
-      if not (committee_index.uint64 <
-          get_committee_count_per_slot(shufflingRef)):
-        continue    # invalid attestation, but found in check_attestation()
-      let committee = get_beacon_committee(
-        shufflingRef, slot, committee_index.CommitteeIndex)
-
-      if aggregation_bits.len < committee_offset + len(committee):
+    for index in get_committee_indices(committee_bits):
+      let committee_len = get_beacon_committee_len(shufflingRef, slot, index).int
+      if aggregation_bits.len < committee_offset + committee_len:
         # Would overflow, invalid attestation caught in check_attestation()
-        continue
+        break
 
-      for i, attester_index in committee:
+      for i, attester_index in get_beacon_committee(shufflingRef, slot, index):
         if aggregation_bits[committee_offset + i]:
           yield attester_index
 
-      committee_offset += len(committee)
-  else:
-    let committee_index = get_committee_index_one(committee_bits)
-    for validator_index in get_attesting_indices(
-        shufflingRef, slot, committee_index, aggregation_bits, on_chain):
-      yield validator_index
+      committee_offset += committee_len
+
+func get_attesting_indices*(
+    shufflingRef: ShufflingRef,
+    slot: Slot,
+    committee_bits: AttestationCommitteeBits,
+    aggregation_bits: ElectraCommitteeValidatorsBits,
+): seq[ValidatorIndex] =
+  for vidx in shufflingRef.get_attesting_indices(slot, committee_bits, aggregation_bits):
+    result.add vidx
 
 iterator get_attesting_indices*(
-    dag: ChainDAGRef, attestation: phase0.TrustedAttestation,
-    on_chain: static bool = true): ValidatorIndex =
+    shufflingRef: ShufflingRef,
+    attestation: phase0.Attestation | phase0.TrustedAttestation,
+): ValidatorIndex =
+  block iter:
+    let index = shufflingRef.get_committee_index(attestation.data.index).valueOr:
+      break iter
+    for vidx in shufflingRef.get_attesting_indices(
+      attestation.data.slot, index, attestation.aggregation_bits
+    ):
+      yield vidx
+
+iterator get_attesting_indices*(
+    shufflingRef: ShufflingRef,
+    attestation: electra.Attestation | electra.TrustedAttestation,
+): ValidatorIndex =
+  for vidx in shufflingRef.get_attesting_indices(
+    attestation.data.slot, attestation.committee_bits, attestation.aggregation_bits
+  ):
+    yield vidx
+
+iterator get_attesting_indices*(
+    dag: ChainDAGRef,
+    attestation:
+      phase0.Attestation | phase0.TrustedAttestation | electra.Attestation |
+      electra.TrustedAttestation,
+): ValidatorIndex =
+  ## Iterate over the attesting indices based on the target of the attestation -
+  ## looks up the shuffling based on the attestation target which in the case
+  ## of attestations in a block may differ from the shuffling of the block slot
   block gaiBlock: # `return` is not allowed in an inline iterator
     let
       slot =
@@ -147,19 +168,8 @@ iterator get_attesting_indices*(
           debug "Pruned block in trusted attestation",
             attestation = shortLog(attestation)
           break gaiBlock
-      target =
-        blck.atCheckpoint(attestation.data.target).valueOr:
-          # This may happen when there's no block at the epoch boundary slot
-          # leading to the case where the attestation block root is the
-          # finalized head (exists as BlockRef) but its target vote has
-          # already been pruned
-          notice "Pruned target in trusted attestation",
-            blck = shortLog(blck),
-            attestation = shortLog(attestation)
-          doAssert strictVerification notin dag.updateFlags
-          break gaiBlock
       shufflingRef =
-        dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
+        dag.getShufflingRef(blck, slot.epoch, false).valueOr:
           warn "Attestation shuffling not found",
             blck = shortLog(blck),
             attestation = shortLog(attestation)
@@ -167,115 +177,8 @@ iterator get_attesting_indices*(
           doAssert strictVerification notin dag.updateFlags
           break gaiBlock
 
-      committeesPerSlot = get_committee_count_per_slot(shufflingRef)
-      committeeIndex =
-        CommitteeIndex.init(attestation.data.index, committeesPerSlot).valueOr:
-          warn "Unexpected committee index in trusted attestation",
-            blck = shortLog(blck),
-            attestation = shortLog(attestation)
-
-          doAssert strictVerification notin dag.updateFlags
-          break gaiBlock
-
-    for validator in get_attesting_indices(
-        shufflingRef, slot, committeeIndex, attestation.aggregation_bits):
-      yield validator
-
-iterator get_attesting_indices*(
-    dag: ChainDAGRef,
-    attestation: electra.Attestation | electra.TrustedAttestation,
-    on_chain: static bool): ValidatorIndex =
-  block gaiBlock: # `return` is not allowed in an inline iterator
-    let
-      slot =
-        check_attestation_slot_target(attestation.data).valueOr:
-          warn "Invalid attestation slot in attestation",
-            attestation = shortLog(attestation)
-          doAssert strictVerification notin dag.updateFlags
-          break gaiBlock
-      blck =
-        dag.getBlockRef(attestation.data.beacon_block_root).valueOr:
-          # Attestation block unknown - this is fairly common because we
-          # discard alternative histories on restart
-          debug "Pruned block in attestation",
-            attestation = shortLog(attestation)
-          break gaiBlock
-      target =
-        blck.atCheckpoint(attestation.data.target).valueOr:
-          # This may happen when there's no block at the epoch boundary slot
-          # leading to the case where the attestation block root is the
-          # finalized head (exists as BlockRef) but its target vote has
-          # already been pruned
-          notice "Pruned target in attestation",
-            blck = shortLog(blck),
-            attestation = shortLog(attestation)
-          doAssert strictVerification notin dag.updateFlags
-          break gaiBlock
-      shufflingRef =
-        dag.getShufflingRef(target.blck, target.slot.epoch, false).valueOr:
-          warn "Attestation shuffling not found",
-            blck = shortLog(blck),
-            attestation = shortLog(attestation)
-
-          doAssert strictVerification notin dag.updateFlags
-          break gaiBlock
-
-    for validator in get_attesting_indices(
-        shufflingRef, slot, attestation.committee_bits,
-        attestation.aggregation_bits, on_chain):
-      yield validator
-
-func get_attesting_indices_one*(shufflingRef: ShufflingRef,
-                                slot: Slot,
-                                committee_index: CommitteeIndex,
-                                bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits):
-                                  Opt[ValidatorIndex] =
-  # A variation on get_attesting_indices that returns the validator index only
-  # if only one validator index is set
-  var res = Opt.none(ValidatorIndex)
-  for validator_index in get_attesting_indices(
-      shufflingRef, slot, committee_index, bits):
-    if res.isSome(): return Opt.none(ValidatorIndex)
-    res = Opt.some(validator_index)
-  res
-
-func get_attesting_indices_one*(shufflingRef: ShufflingRef,
-                                slot: Slot,
-                                committee_bits: AttestationCommitteeBits,
-                                aggregation_bits: ElectraCommitteeValidatorsBits,
-                                on_chain: static bool):
-                                  Opt[ValidatorIndex] =
-  # A variation on get_attesting_indices that returns the validator index only
-  # if only one validator index is set
-  static: doAssert not on_chain, "only not on_chain supported"
-
-  var res = Opt.none(ValidatorIndex)
-  let committee_index = ? get_committee_index_one(committee_bits)
-  for validator_index in get_attesting_indices(
-      shufflingRef, slot, committee_index, aggregation_bits):
-    if res.isSome(): return Opt.none(ValidatorIndex)
-    res = Opt.some(validator_index)
-  res
-
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
-func get_attesting_indices*(shufflingRef: ShufflingRef,
-                            slot: Slot,
-                            committee_index: CommitteeIndex,
-                            bits: CommitteeValidatorsBits):
-                              seq[ValidatorIndex] =
-  for idx in get_attesting_indices(shufflingRef, slot, committee_index, bits):
-    result.add(idx)
-
-func get_attesting_indices*(shufflingRef: ShufflingRef,
-                            slot: Slot,
-                            committee_index: CommitteeIndex,
-                            bits: ElectraCommitteeValidatorsBits,
-                            on_chain: static bool = true):
-                              seq[ValidatorIndex] =
-  static: doAssert on_chain, "only on_chain supported"
-
-  for idx in get_attesting_indices(shufflingRef, slot, committee_index, bits):
-    result.add(idx)
+    for vidx in shufflingRef.get_attesting_indices(attestation):
+      yield vidx
 
 func makeAttestationData*(
     epochRef: EpochRef, bs: BlockSlot,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -300,11 +300,10 @@ proc process_block*(
 
   for attestation in blck.body.attestations:
     if attestation.data.beacon_block_root in self.backend:
-      for validator_index in dag.get_attesting_indices(attestation, true):
+      for vidx in dag.get_attesting_indices(attestation):
         self.backend.process_attestation(
-          validator_index,
-          attestation.data.beacon_block_root,
-          attestation.data.slot)
+          vidx, attestation.data.beacon_block_root, attestation.data.slot
+        )
 
   trace "Integrating block in fork choice",
     block_root = shortLog(blckRef)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -478,7 +478,7 @@ proc onBlockAdded*(
     validatorMonitor[].registerBeaconBlock(src, wallTime, blck.message)
 
     for attestation in blck.message.body.attestations:
-      for vidx in dag.get_attesting_indices(attestation, true):
+      for vidx in dag.get_attesting_indices(attestation):
         validatorMonitor[].registerAttestationInBlock(
           attestation.data, vidx, blck.message.slot
         )

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1390,7 +1390,7 @@ proc validateAggregate*(
     shufflingRef.get_committee_index(agg_idx.uint64).valueOr:
       return pool.checkedReject("Aggregate: committee index not within expected range")
 
-  if not aggregate.aggregation_bits.lenu64 != get_beacon_committee_len(
+  if not aggregate.aggregation_bits.lenu64 == get_beacon_committee_len(
     shufflingRef, slot, committee_index
   ):
     return pool.checkedReject(

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1390,7 +1390,7 @@ proc validateAggregate*(
     shufflingRef.get_committee_index(agg_idx.uint64).valueOr:
       return pool.checkedReject("Aggregate: committee index not within expected range")
 
-  if not aggregate.aggregation_bits.compatible_with_shuffling(
+  if not aggregate.aggregation_bits.lenu64 != get_beacon_committee_len(
     shufflingRef, slot, committee_index
   ):
     return pool.checkedReject(
@@ -1433,8 +1433,8 @@ proc validateAggregate*(
 
   let
     fork = pool.dag.forkAtEpoch(aggregate.data.slot.epoch)
-    attesting_indices = get_attesting_indices(
-      shufflingRef, slot, committee_index, aggregate.aggregation_bits
+    attesting_indices = shufflingRef.get_attesting_indices(
+      slot, aggregate.committee_bits, aggregate.aggregation_bits
     )
     sig = aggregate.signature.load().valueOr:
       return pool.checkedReject("Aggregate: unable to load signature")

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -674,89 +674,133 @@ proc is_valid_indexed_attestation*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
-iterator get_attesting_indices_iter*(state: ForkyBeaconState,
-                                     data: AttestationData,
-                                     bits: CommitteeValidatorsBits,
-                                     cache: var StateCache): ValidatorIndex =
-  ## Return the set of attesting indices corresponding to ``data`` and ``bits``
-  ## or nothing if `data` is invalid
-  ## This iterator must not be called in functions using a
-  ## ForkedHashedBeaconState due to https://github.com/nim-lang/Nim/issues/18188
-  let committee_index = CommitteeIndex.init(data.index)
-  if committee_index.isErr() or bits.lenu64 != get_beacon_committee_len(
-      state, data.slot, committee_index.get(), cache):
-    trace "get_attesting_indices: invalid attestation data"
-  else:
+iterator get_attesting_indices*(
+    state: ForkyBeaconState,
+    slot: Slot,
+    index: CommitteeIndex,
+    aggregation_bits: CommitteeValidatorsBits,
+    cache: var StateCache,
+): ValidatorIndex =
+  ## Return the set of attesting indices corresponding to ``data`` and
+  ## ``aggregation_bits`` or nothing if `data` is invalid
+  if aggregation_bits.lenu64 == get_beacon_committee_len(state, slot, index, cache):
     for index_in_committee, validator_index in get_beacon_committee(
-        state, data.slot, committee_index.get(), cache):
-      if bits[index_in_committee]:
+      state, slot, index, cache
+    ):
+      if aggregation_bits[index_in_committee]:
         yield validator_index
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#modified-get_attesting_indices
-iterator get_attesting_indices_iter*(
-    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState,
-    data: AttestationData,
+iterator get_attesting_indices*(
+    state: ForkyBeaconState,
+    slot: Slot,
+    committee_bits: AttestationCommitteeBits,
     aggregation_bits: ElectraCommitteeValidatorsBits,
-    committee_bits: auto,
     cache: var StateCache): ValidatorIndex =
   ## Return the set of attesting indices corresponding to ``aggregation_bits``
   ## and ``committee_bits``.
-  var pos = 0
-  for committee_index in get_committee_indices(committee_bits):
-    for _, validator_index in get_beacon_committee(
-        state, data.slot, committee_index, cache):
+  var committee_offset = 0
+  for index in get_committee_indices(committee_bits):
+    let committee_len = get_beacon_committee_len(state, slot, index, cache).int
+    if aggregation_bits.len < committee_offset + committee_len:
+      # Would overflow, invalid attestation caught in check_attestation()
+      break
 
-      if aggregation_bits[pos]:
-        yield validator_index
-      pos += 1
+    for i, attester_index in get_beacon_committee(state, slot, index, cache):
+      if aggregation_bits[committee_offset + i]:
+        yield attester_index
+
+    committee_offset += committee_len
+
+# Attestation validation
+# ------------------------------------------------------------------------------------------
+# https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/beacon-chain.md#attestations
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
+
+func check_attestation_index*(
+    index, committees_per_slot: uint64
+): Result[CommitteeIndex, cstring] =
+  CommitteeIndex.init(index, committees_per_slot)
+
+func check_attestation_index*(
+    data: AttestationData, committees_per_slot: uint64
+): Result[CommitteeIndex, cstring] =
+  check_attestation_index(data.index, committees_per_slot)
+
+# Attestation validation
+# ------------------------------------------------------------------------------------------
+# https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/beacon-chain.md#attestations
+# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
+
+func check_attestation_slot_target*(data: AttestationData): Result[Slot, cstring] =
+  if not (data.target.epoch == epoch(data.slot)):
+    return err("Target epoch doesn't match attestation slot")
+
+  ok(data.slot)
+
+func check_attestation_target_epoch(
+    data: AttestationData, current_epoch: Epoch
+): Result[Epoch, cstring] =
+  if not (
+    data.target.epoch == get_previous_epoch(current_epoch) or
+    data.target.epoch == current_epoch
+  ):
+    return err("Target epoch not current or previous epoch")
+
+  ok(data.target.epoch)
+
+func check_attestation_slot_target*(
+    data: AttestationData, current_epoch: Epoch
+): Result[Slot, cstring] =
+  check_attestation_target_epoch(data, current_epoch) and
+    check_attestation_slot_target(data)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
+iterator get_attesting_indices*(
+    state: ForkyBeaconState,
+    attestation: phase0.Attestation | phase0.TrustedAttestation,
+    cache: var StateCache,
+): ValidatorIndex =
+  block iter:
+    let
+      slot = check_attestation_slot_target(attestation.data, state.get_current_epoch()).valueOr:
+        break iter
+      committees_per_slot = get_committee_count_per_slot(state, slot.epoch, cache)
+      index = check_attestation_index(attestation.data, committees_per_slot).valueOr:
+        break iter
+    for vidx in state.get_attesting_indices(
+      slot, index, attestation.aggregation_bits, cache
+    ):
+      yield vidx
+
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#modified-get_attesting_indices
+iterator get_attesting_indices*(
+    state: ForkyBeaconState,
+    attestation: electra.Attestation | electra.TrustedAttestation,
+    cache: var StateCache,
+): ValidatorIndex =
+  block iter:
+    let slot = check_attestation_slot_target(attestation.data, get_current_epoch(state)).valueOr:
+      break iter
+
+    for vidx in state.get_attesting_indices(
+      slot, attestation.committee_bits, attestation.aggregation_bits, cache
+    ):
+      yield vidx
+
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#get_attesting_indices
+# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/beacon-chain.md#modified-get_attesting_indices
 func get_attesting_indices*(
-    state: ForkyBeaconState, data: AttestationData,
-    aggregation_bits: CommitteeValidatorsBits, cache: var StateCache):
-    seq[ValidatorIndex] =
-  ## Return the set of attesting indices corresponding to ``data`` and ``bits``
+    state: ForkyBeaconState,
+    attestation:
+      phase0.Attestation | phase0.TrustedAttestation | electra.Attestation |
+      electra.TrustedAttestation,
+    cache: var StateCache,
+): seq[ValidatorIndex] =
+  ## Return the set of attesting indices corresponding to ``attestation``
   ## or nothing if `data` is invalid
-
-  toSeq(get_attesting_indices_iter(state, data, aggregation_bits, cache))
-
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/beacon-chain.md#get_attesting_indices
-func get_attesting_indices*(
-    state: ForkyBeaconState, data: AttestationData,
-    aggregation_bits: ElectraCommitteeValidatorsBits, committee_bits: auto,
-    cache: var StateCache): seq[ValidatorIndex] =
-  ## Return the set of attesting indices corresponding to ``data`` and ``bits``
-  ## or nothing if `data` is invalid
-
-  toSeq(get_attesting_indices_iter(state, data, aggregation_bits, committee_bits, cache))
-
-func get_attesting_indices*(state: ForkedHashedBeaconState;
-                            data: AttestationData;
-                            bits: CommitteeValidatorsBits;
-                            cache: var StateCache): seq[ValidatorIndex] =
-  # TODO when https://github.com/nim-lang/Nim/issues/18188 fixed, use an
-  # iterator
-
-  var idxBuf: seq[ValidatorIndex]
-  withState(state):
-    for vidx in forkyState.data.get_attesting_indices(data, bits, cache):
-      idxBuf.add vidx
-  idxBuf
-
-func get_attesting_indices*(state: ForkedHashedBeaconState;
-                            data: AttestationData;
-                            aggregation_bits: ElectraCommitteeValidatorsBits;
-                            committee_bits: auto,
-                            cache: var StateCache): seq[ValidatorIndex] =
-  # TODO when https://github.com/nim-lang/Nim/issues/18188 fixed, use an
-  # iterator
-  var idxBuf: seq[ValidatorIndex]
-  withState(state):
-    when consensusFork >= ConsensusFork.Electra:
-      for vidx in forkyState.data.get_attesting_indices(
-          data, aggregation_bits, committee_bits, cache):
-        idxBuf.add vidx
-  idxBuf
+  for vidx in state.get_attesting_indices(attestation, cache):
+    result.add vidx
 
 proc is_valid_indexed_attestation(
     state: ForkyBeaconState,
@@ -776,9 +820,8 @@ proc is_valid_indexed_attestation(
   if not (skipBlsValidation in flags or attestation.signature is TrustedSig):
     var
       pubkeys = newSeqOfCap[ValidatorPubKey](sigs)
-    for index in get_attesting_indices_iter(
-        state, attestation.data, attestation.aggregation_bits, cache):
-      pubkeys.add(state.validators[index].pubkey)
+    for vidx in state.get_attesting_indices(attestation, cache):
+      pubkeys.add(state.validators[vidx].pubkey)
 
     if not verify_attestation_signature(
         state.fork, state.genesis_validators_root, attestation.data,
@@ -805,9 +848,8 @@ proc is_valid_indexed_attestation(
   if not (skipBlsValidation in flags or attestation.signature is TrustedSig):
     var
       pubkeys = newSeqOfCap[ValidatorPubKey](sigs)
-    for index in get_attesting_indices_iter(
-        state, attestation.data, attestation.aggregation_bits, attestation.committee_bits, cache):
-      pubkeys.add(state.validators[index].pubkey)
+    for vidx in state.get_attesting_indices(attestation, cache):
+      pubkeys.add(state.validators[vidx].pubkey)
 
     if not verify_attestation_signature(
         state.fork, state.genesis_validators_root, attestation.data,
@@ -815,25 +857,6 @@ proc is_valid_indexed_attestation(
       return err("indexed attestation: signature verification failure")
 
   ok()
-
-# Attestation validation
-# ------------------------------------------------------------------------------------------
-# https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/beacon-chain.md#attestations
-# https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/p2p-interface.md#beacon_attestation_subnet_id
-
-func check_attestation_slot_target*(data: AttestationData): Result[Slot, cstring] =
-  if not (data.target.epoch == epoch(data.slot)):
-    return err("Target epoch doesn't match attestation slot")
-
-  ok(data.slot)
-
-func check_attestation_target_epoch(
-    data: AttestationData, current_epoch: Epoch): Result[Epoch, cstring] =
-  if not (data.target.epoch == get_previous_epoch(current_epoch) or
-      data.target.epoch == current_epoch):
-    return err("Target epoch not current or previous epoch")
-
-  ok(data.target.epoch)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.6/specs/phase0/beacon-chain.md#attestations
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#modified-process_attestation
@@ -855,17 +878,6 @@ func check_attestation_inclusion(
       return err("Attestation too old")
 
   ok()
-
-func check_attestation_index*(
-    index, committees_per_slot: uint64):
-    Result[CommitteeIndex, cstring] =
-  CommitteeIndex.init(index, committees_per_slot)
-
-func check_attestation_index(
-    data: AttestationData, committees_per_slot: uint64):
-    Result[CommitteeIndex, cstring] =
-  check_attestation_index(data.index, committees_per_slot)
-
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.6/specs/gloas/beacon-chain.md#new-is_attestation_same_slot
 func is_attestation_same_slot(
@@ -1045,7 +1057,7 @@ func get_base_reward(
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/beacon-chain.md#attestations
 proc check_attestation*(
     state: ForkyBeaconState, attestation: SomeAttestation, flags: UpdateFlags,
-    cache: var StateCache, on_chain: static bool = true): Result[void, cstring] =
+    cache: var StateCache): Result[void, cstring] =
   ## Check that an attestation follows the rules of being included in the state
   ## at the current slot. When acting as a proposer, the same rules need to
   ## be followed!
@@ -1054,9 +1066,8 @@ proc check_attestation*(
     data = attestation.data
     epoch = ? check_attestation_target_epoch(data, state.get_current_epoch())
     slot = ? check_attestation_slot_target(data)
-    committee_index = ? check_attestation_index(
-      data,
-      get_committee_count_per_slot(state, epoch, cache))
+    committee_count_per_slot = get_committee_count_per_slot(state, epoch, cache)
+    committee_index = ? check_attestation_index(data, committee_count_per_slot)
 
   ? check_attestation_inclusion((typeof state).kind, slot, state.slot)
 
@@ -1082,7 +1093,7 @@ proc check_attestation*(
 proc check_attestation*(
     state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState,
     attestation: electra.Attestation | electra.TrustedAttestation,
-    flags: UpdateFlags, cache: var StateCache, on_chain: static bool):
+    flags: UpdateFlags, cache: var StateCache):
     Result[void, cstring] =
   ## Check that an attestation follows the rules of being included in the state
   ## at the current slot. When acting as a proposer, the same rules need to
@@ -1106,42 +1117,34 @@ proc check_attestation*(
     if not (data.index == 0):
       return err("Electra attestation data index not 0")
 
-  when on_chain:
-    var committee_offset = 0
-    for committee_index in attestation.committee_bits.oneIndices:
-      if not (committee_index.uint64 < get_committee_count_per_slot(
-          state, data.target.epoch, cache)):
-        return err("attestation wrong committee index len")
-      let committee = get_beacon_committee(
-        state, data.slot, committee_index.CommitteeIndex, cache)
+  var committee_offset = 0
+  for committee_index in attestation.committee_bits.oneIndices:
+    if not (committee_index.uint64 < get_committee_count_per_slot(
+        state, epoch, cache)):
+      return err("attestation wrong committee index len")
+    let committee_index = CommitteeIndex(committee_index)
+    let committee_len = get_beacon_committee_len(
+      state, slot, committee_index, cache)
 
-      if attestation.aggregation_bits.len < committee_offset + len(committee):
-        # This would overflow; see invalid_too_many_committee_bits test case
-        return err("Electra attestation has too many committee bits")
+    if attestation.aggregation_bits.len < committee_offset + committee_len.int:
+      # This would overflow; see invalid_too_many_committee_bits test case
+      return err("Electra attestation has too many committee bits")
 
-      # This construction modified slightly from spec version to early-exit and
-      # not create the actual set, but the result is it uses a flag variable to
-      # look similar.
-      var committee_attesters_nonzero = false
-      for i, attester_index in committee:
-        if attestation.aggregation_bits[committee_offset + i]:
-          committee_attesters_nonzero = true
-          break
-      if not committee_attesters_nonzero:
-        return err("Electra attestation committee not present in aggregated bits")
+    # This construction modified slightly from spec version to early-exit and
+    # not create the actual set, but the result is it uses a flag variable to
+    # look similar.
+    var committee_attesters_nonzero = false
+    for i, attester_index in get_beacon_committee(state, slot, committee_index, cache):
+      if attestation.aggregation_bits[committee_offset + i]:
+        committee_attesters_nonzero = true
+        break
+    if not committee_attesters_nonzero:
+      return err("Electra attestation committee not present in aggregated bits")
 
-      committee_offset += len(committee)
+    committee_offset += committee_len.int
 
-    if not (len(attestation.aggregation_bits) == committee_offset):
-      return err("attestation wrong aggregation bit length")
-  else:
-    let
-      committee_index = get_committee_index_one(attestation.committee_bits).valueOr:
-        return err("Network attestation without single committee index")
-
-    if not (lenu64(attestation.aggregation_bits) ==
-        get_beacon_committee_len(state, data.slot, committee_index, cache)):
-      return err("attestation wrong aggregation bit length")
+  if not (len(attestation.aggregation_bits) == committee_offset):
+    return err("attestation wrong aggregation bit length")
 
   if epoch == get_current_epoch(state):
     if not (data.source == state.current_justified_checkpoint):
@@ -1193,15 +1196,14 @@ func get_proposer_reward*(
     epoch_participation: var EpochParticipationFlags): Gwei =
   let participation_flag_indices = get_attestation_participation_flag_indices(
     state, attestation.data, state.slot - attestation.data.slot)
-  for index in get_attesting_indices_iter(
-      state, attestation.data, attestation.aggregation_bits, cache):
+  for vidx in state.get_attesting_indices(attestation, cache):
     let
-      base_reward = get_base_reward(state, index, base_reward_per_increment)
+      base_reward = get_base_reward(state, vidx, base_reward_per_increment)
     for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
       if flag_index in participation_flag_indices and
-         not has_flag(epoch_participation.item(index), flag_index):
-        asList(epoch_participation)[index] =
-          add_flag(epoch_participation.item(index), flag_index)
+         not has_flag(epoch_participation.item(vidx), flag_index):
+        asList(epoch_participation)[vidx] =
+          add_flag(epoch_participation.item(vidx), flag_index)
         # these are all valid; TODO statically verify or do it type-safely
         result += base_reward * weight.uint64
 
@@ -1219,15 +1221,14 @@ func get_proposer_reward*(
     epoch_participation: var EpochParticipationFlags): Gwei =
   let participation_flag_indices = get_attestation_participation_flag_indices(
     state, attestation.data, state.slot - attestation.data.slot)
-  for index in get_attesting_indices_iter(
-      state, attestation.data, attestation.aggregation_bits, attestation.committee_bits, cache):
+  for vidx in state.get_attesting_indices(attestation, cache):
     let
-      base_reward = get_base_reward(state, index, base_reward_per_increment)
+      base_reward = get_base_reward(state, vidx, base_reward_per_increment)
     for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
       if flag_index in participation_flag_indices and
-         not has_flag(epoch_participation.item(index), flag_index):
-        asList(epoch_participation)[index] =
-          add_flag(epoch_participation.item(index), flag_index)
+         not has_flag(epoch_participation.item(vidx), flag_index):
+        asList(epoch_participation)[vidx] =
+          add_flag(epoch_participation.item(vidx), flag_index)
         # these are all valid; TODO statically verify or do it type-safely
         result += base_reward * weight.uint64
 
@@ -1295,7 +1296,7 @@ proc process_attestation*(
     attestation: electra.Attestation | electra.TrustedAttestation,
     flags: UpdateFlags, base_reward_per_increment: Gwei,
     cache: var StateCache): Result[Gwei, cstring] =
-  ? check_attestation(state, attestation, flags, cache, true)
+  ? check_attestation(state, attestation, flags, cache)
 
   let proposer_index = get_beacon_proposer_index(state, cache).valueOr:
     return err("process_attestation: no beacon proposer index and probably no active validators")
@@ -1321,7 +1322,7 @@ proc process_attestation*(
     attestation: electra.Attestation | electra.TrustedAttestation,
     flags: UpdateFlags, base_reward_per_increment: Gwei,
     cache: var StateCache): Result[Gwei, cstring] =
-  ? check_attestation(state, attestation, flags, cache, true)
+  ? check_attestation(state, attestation, flags, cache)
 
   let proposer_index = get_beacon_proposer_index(state, cache).valueOr:
     return err("process_attestation: no beacon proposer index and probably no active validators")
@@ -1342,21 +1343,19 @@ proc process_attestation*(
 
   template updateParticipationFlags(epoch_participation: untyped): Gwei =
     var proposer_reward_numerator = 0.Gwei
-    for index in get_attesting_indices_iter(
-        state, attestation.data, attestation.aggregation_bits,
-        attestation.committee_bits, cache):
+    for vidx in state.get_attesting_indices(attestation, cache):
       # [New in Gloas:EIP7732]
       # For same-slot attestations, check if we're setting any new flags
       # If we are, this validator hasn't contributed to this slot's quorum yet
       var will_set_new_flag = false
       for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
         if flag_index in participation_flag_indices and
-           not has_flag(epoch_participation.item(index), flag_index):
-          asList(epoch_participation)[index] =
-            add_flag(epoch_participation.item(index), flag_index)
+           not has_flag(epoch_participation.item(vidx), flag_index):
+          asList(epoch_participation)[vidx] =
+            add_flag(epoch_participation.item(vidx), flag_index)
           proposer_reward_numerator +=
             get_base_reward(
-              state, index, base_reward_per_increment) * weight.uint64
+              state, vidx, base_reward_per_increment) * weight.uint64
           will_set_new_flag = true
 
       # [New in Gloas:EIP7732]
@@ -1365,7 +1364,7 @@ proc process_attestation*(
       if will_set_new_flag and
           is_attestation_same_slot(state, attestation.data) and
           payment.withdrawal.amount > 0.Gwei:
-        payment.weight += state.validators.item(index).effective_balance
+        payment.weight += state.validators.item(vidx).effective_balance
 
     let
       proposer_reward_denominator =
@@ -2140,17 +2139,19 @@ func translate_participation(
     let
       data = attestation.data
       inclusion_delay = attestation.inclusion_delay
-
+      slot = data.slot
+      index = CommitteeIndex.init(data.index).expect("valid index in state")
       # Translate attestation inclusion info to flag indices
       participation_flag_indices =
         get_attestation_participation_flag_indices(state, data, inclusion_delay)
 
     # Apply flags to all attesting validators
-    for index in get_attesting_indices_iter(
-        state, data, attestation.aggregation_bits, cache):
+    for vidx in state.get_attesting_indices(
+      slot, index, attestation.aggregation_bits, cache
+    ):
       for flag_index in participation_flag_indices:
-        state.previous_epoch_participation[index] =
-          add_flag(state.previous_epoch_participation.item(index), flag_index)
+        state.previous_epoch_participation[vidx] =
+          add_flag(state.previous_epoch_participation.item(vidx), flag_index)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-get_index_for_new_builder
 func get_index_for_new_builder(state: gloas.BeaconState): BuilderIndex =

--- a/beacon_chain/spec/datatypes/phase0.nim
+++ b/beacon_chain/spec/datatypes/phase0.nim
@@ -422,13 +422,13 @@ func init*(
     committee_len: int,
     data: AttestationData,
     signature: ValidatorSig): Result[T, cstring] =
-  var bits = CommitteeValidatorsBits.init(committee_len)
+  var aggregation_bits = CommitteeValidatorsBits.init(committee_len)
   for index_in_committee in indices_in_committee:
     if index_in_committee >= committee_len.uint64: return err("Invalid index for committee")
-    bits.setBit index_in_committee
+    aggregation_bits.setBit index_in_committee
 
   ok Attestation(
-    aggregation_bits: bits,
+    aggregation_bits: aggregation_bits,
     data: data,
     signature: signature
   )

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1968,20 +1968,6 @@ template init*(T: type ForkedMaybeBlindedBeaconBlock,
     consensusValue: cvalue,
     executionValue: evalue)
 
-func committee_index*(
-    v: phase0.Attestation, on_chain: static bool = false): uint64 =
-  v.data.index
-
-func committee_index*(v: electra.Attestation, on_chain: static bool): uint64 =
-  when on_chain:
-    {.error: "cannot get single committee_index for on_chain attestation".}
-  else:
-    uint64 v.committee_bits.get_committee_index_one().expect("network attestation")
-
-func committee_index*(
-    v: SingleAttestation, on_chain: static bool = false): uint64 =
-  v.committee_index
-
 template init*(T: type ForkedAttestation,
                attestation: phase0.Attestation,
                fork: ConsensusFork): T =

--- a/beacon_chain/spec/signatures_batch.nim
+++ b/beacon_chain/spec/signatures_batch.nim
@@ -405,16 +405,7 @@ proc collectSignatureSets*(
   for attestation in signed_block.message.body.attestations:
     let
       attesting_indices =
-        when consensusFork < ConsensusFork.Electra:
-          get_attesting_indices(
-            forkyState.data, attestation.data, attestation.aggregation_bits, cache
-          )
-        else:
-          get_attesting_indices(
-            forkyState.data, attestation.data, attestation.aggregation_bits,
-            attestation.committee_bits, cache,
-          )
-
+        forkyState.data.get_attesting_indices(attestation, cache)
       key = ?aggregateAttesters(attesting_indices, validatorKeys)
       sig = attestation.signature.load().valueOr:
         return err("Invalid attestation signature")

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -111,11 +111,11 @@ func process_attestation(
 
       if a.data.beacon_block_root == get_block_root_at_slot(state, a.data.slot):
         flags.incl RewardFlags.isPreviousEpochHeadAttester
+  let index = CommitteeIndex.init(a.data.index).expect("valid index in state")
 
   # Update the cache for all participants
-  for validator_index in get_attesting_indices_iter(
-      state, a.data, a.aggregation_bits, cache):
-    template v(): untyped = info.validators[validator_index]
+  for vidx in state.get_attesting_indices(a.data.slot, index, a.aggregation_bits, cache):
+    template v(): untyped = info.validators[vidx]
 
     v.flags = v.flags + flags
 

--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -18,8 +18,6 @@ import
   ../[beacon_clock, beacon_node],
   ./[sync_types, sync_manager, sync_queue]
 
-from ../consensus_object_pools/spec_cache import get_attesting_indices
-
 export sync_types
 
 logScope:

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -366,7 +366,7 @@ proc routeAttestation*(
         attestation = shortLog(attestation)
       return
     committee_index =
-      shufflingRef.get_committee_index(attestation.committee_index(false)).valueOr:
+      shufflingRef.get_committee_index(attestation.committee_index).valueOr:
         notice "Invalid committee index in attestation",
           attestation = shortLog(attestation)
         return err("Invalid committee index in attestation")

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -392,18 +392,9 @@ func collectFromAttestations(
         rewardsAndPenalties[forkyBlck.message.proposer_index]
           .proposer_outcome += proposerReward.int64
         let inclusionDelay = forkyState.data.slot - attestation.data.slot
-        when consensusFork >= ConsensusFork.Electra:
-          for index in get_attesting_indices(
-              forkyState.data, attestation.data, attestation.aggregation_bits,
-              attestation.committee_bits, cache):
-            rewardsAndPenalties[index].inclusion_delay =
-              Opt.some(inclusionDelay.uint64)
-        else:
-          for index in get_attesting_indices(
-              forkyState.data, attestation.data, attestation.aggregation_bits,
-              cache):
-            rewardsAndPenalties[index].inclusion_delay =
-              Opt.some(inclusionDelay.uint64)
+        for vidx in forkyState.data.get_attesting_indices(attestation, cache):
+          rewardsAndPenalties[vidx].inclusion_delay =
+            Opt.some(inclusionDelay.uint64)
 
 from ".."/beacon_chain/validator_bucket_sort import
   findValidatorIndex, sortValidatorBuckets

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2025 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -379,7 +379,7 @@ func collectFromAttestations(
       doAssert base_reward_per_increment > 0.Gwei
       for attestation in forkyBlck.message.body.attestations:
         doAssert check_attestation(
-          forkyState.data, attestation, {}, cache, true).isOk
+          forkyState.data, attestation, {}, cache).isOk
         let proposerReward =
           if attestation.data.target.epoch == get_current_epoch(forkyState.data):
             get_proposer_reward(

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -373,7 +373,7 @@ proc doRunTest(
       let status = stores.fkChoice[].on_attestation(
         stores.dag, step.electraAtt.data.slot,
         step.electraAtt.data.beacon_block_root,
-        toSeq(stores.dag.get_attesting_indices(step.electraAtt, true)), time)
+        toSeq(stores.dag.get_attesting_indices(step.electraAtt)), time)
       doAssert status.isOk == step.valid
     of opOnBlock:
       withBlck(step.blck):

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -176,26 +176,26 @@ suite "Attestation pool electra processing" & preset():
     withState(state[]):
       when consensusFork >= ConsensusFork.Electra:
         check:
-          check_attestation(forkyState.data, att1, {}, cache, true).isOk
-          check_attestation(forkyState.data, att2, {}, cache, true).isErr
+          check_attestation(forkyState.data, att1, {}, cache).isOk
+          check_attestation(forkyState.data, att2, {}, cache).isErr
     withState(state2[]):
       when consensusFork >= ConsensusFork.Electra:
         check:
-          check_attestation(forkyState.data, att1, {}, cache2, true).isErr
-          check_attestation(forkyState.data, att2, {}, cache2, true).isOk
+          check_attestation(forkyState.data, att1, {}, cache2).isErr
+          check_attestation(forkyState.data, att2, {}, cache2).isOk
 
     # If signature checks are skipped, state incompatibility is not detected
     const flags = {skipBlsValidation}
     withState(state[]):
       when consensusFork >= ConsensusFork.Electra:
         check:
-          check_attestation(forkyState.data, att1, flags, cache, true).isOk
-          check_attestation(forkyState.data, att2, flags, cache, true).isOk
+          check_attestation(forkyState.data, att1, flags, cache).isOk
+          check_attestation(forkyState.data, att2, flags, cache).isOk
     withState(state2[]):
       when consensusFork >= ConsensusFork.Electra:
         check:
-          check_attestation(forkyState.data, att1, flags, cache2, true).isOk
-          check_attestation(forkyState.data, att2, flags, cache2, true).isOk
+          check_attestation(forkyState.data, att1, flags, cache2).isOk
+          check_attestation(forkyState.data, att2, flags, cache2).isOk
 
     # An additional compatibility check catches that (used in block production)
     withState(state[]):
@@ -336,18 +336,14 @@ suite "Attestation pool electra processing" & preset():
   test "Aggregated attestations with disjoint comittee bits into a single on-chain aggregate" & preset():
     proc verifyAttestationSignature(attestation: electra.Attestation): bool =
       withState(state[]):
-        when consensusFork == ConsensusFork.Electra:
-          let
-            fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
-            attesting_indices = get_attesting_indices(
-              forkyState.data, attestation.data, attestation.aggregation_bits,
-              attestation.committee_bits, cache)
-          verify_attestation_signature(
-            fork, pool.dag.genesis_validators_root, attestation.data,
-            attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
-            attestation.signature)
-        else:
-          raiseAssert "must be electra"
+        let
+          fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
+          attesting_indices =
+            forkyState.data.get_attesting_indices(attestation, cache)
+        verify_attestation_signature(
+          fork, pool.dag.genesis_validators_root, attestation.data,
+          attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
+          attestation.signature)
 
     let
       bc0 = get_beacon_committee(
@@ -395,7 +391,7 @@ suite "Attestation pool electra processing" & preset():
     check:
       verifyAttestationSignature(attestations[0])
       check_attestation(
-        state[].electraData.data, attestations[0], {}, cache, true).isOk
+        state[].electraData.data, attestations[0], {}, cache).isOk
 
       # A single final chain aggregated attestation should be created
       # with same data, 2 committee bits and 3 aggregation bits
@@ -808,18 +804,14 @@ suite "Attestation pool electra processing" & preset():
 
     proc verifyAttestationSignature(attestation: electra.Attestation): bool =
       withState(state[]):
-        when consensusFork == ConsensusFork.Electra:
-          let
-            fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
-            attesting_indices = get_attesting_indices(
-              forkyState.data, attestation.data, attestation.aggregation_bits,
-              attestation.committee_bits, cache)
-          verify_attestation_signature(
-            fork, pool.dag.genesis_validators_root, attestation.data,
-            attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
-            attestation.signature)
-        else:
-          raiseAssert "must be electra"
+        let
+          fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
+          attesting_indices =
+            forkyState.data.get_attesting_indices(attestation, cache)
+        verify_attestation_signature(
+          fork, pool.dag.genesis_validators_root, attestation.data,
+          attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
+          attestation.signature)
 
     check:
       verifyAttestationSignature(att0)
@@ -877,7 +869,7 @@ suite "Attestation pool electra processing" & preset():
         attestations.len() == 1
         attestations[0].aggregation_bits.countOnes() == 3
         check_attestation(
-          state[].electraData.data, attestations[0], {}, cache, true).isOk
+          state[].electraData.data, attestations[0], {}, cache).isOk
         verifyAttestationSignature(attestations[0])
         # Can get either aggregate here, random!
         verifyAttestationSignature(pool[].getElectraAggregatedAttestation(
@@ -895,7 +887,7 @@ suite "Attestation pool electra processing" & preset():
         attestations.len() == 1
         attestations[0].aggregation_bits.countOnes() == 4
         check_attestation(
-          state[].electraData.data, attestations[0], {}, cache, true).isOk
+          state[].electraData.data, attestations[0], {}, cache).isOk
         verifyAttestationSignature(attestations[0])
         verifyAttestationSignature(pool[].getElectraAggregatedAttestation(
           1.Slot, hash_tree_root(attestations[0].data), 0.CommitteeIndex).get)
@@ -917,18 +909,14 @@ suite "Attestation pool electra processing" & preset():
       cache: var StateCache,
       attestation: electra.Attestation): bool =
     withState(state[]):
-      when consensusFork == ConsensusFork.Electra:
-        let
-          fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
-          attesting_indices = get_attesting_indices(
-            forkyState.data, attestation.data, attestation.aggregation_bits,
-            attestation.committee_bits, cache)
-        verify_attestation_signature(
-          fork, pool.dag.genesis_validators_root, attestation.data,
-          attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
-          attestation.signature)
-      else:
-        raiseAssert "must be electra"
+      let
+        fork = pool.dag.cfg.forkAtEpoch(forkyState.data.slot.epoch)
+        attesting_indices =
+          forkyState.data.get_attesting_indices(attestation, cache)
+      verify_attestation_signature(
+        fork, pool.dag.genesis_validators_root, attestation.data,
+        attesting_indices.mapIt(forkyState.data.validators.item(it).pubkey),
+        attestation.signature)
 
   test "Aggregating across committees" & preset():
     # Add attestation from different committee
@@ -974,9 +962,9 @@ suite "Attestation pool electra processing" & preset():
       attestations[1].aggregation_bits.countOnes() == 4
       attestations[1].committee_bits.countOnes() == 2
       check_attestation(
-        state[].electraData.data, attestations[0], {}, cache, true).isOk
+        state[].electraData.data, attestations[0], {}, cache).isOk
       check_attestation(
-        state[].electraData.data, attestations[1], {}, cache, true).isOk
+        state[].electraData.data, attestations[1], {}, cache).isOk
       pool[].verifyAttestationSignature(state, cache, attestations[0])
       pool[].verifyAttestationSignature(state, cache, attestations[1])
 
@@ -1059,8 +1047,8 @@ suite "Attestation pool electra processing" & preset():
       attestations[1].data.slot == 2.Slot
 
       check_attestation(
-        state[].electraData.data, attestations[0], {}, cache, true).isOk
+        state[].electraData.data, attestations[0], {}, cache).isOk
       check_attestation(
-        state[].electraData.data, attestations[1], {}, cache, true).isOk
+        state[].electraData.data, attestations[1], {}, cache).isOk
       pool[].verifyAttestationSignature(state, cache, attestations[0])
       pool[].verifyAttestationSignature(state, cache, attestations[1])


### PR DESCRIPTION
Following the removal of gossip support for phase0 attestations we can clean up how we iterate over attestations, removing the single-attestation phase0 forms.

Also, since the electra network attestation format is a special case of the on-chain format, we can reuse the latter in the iteration helpers for the former, getting rid of the on-chain flag.

Finally, we can also avoid some memory allocations by not constructing an in-memory copy of the committee and instead iterate over its indices in-place.