### PR TITLE
Automate bumping submodules to latest tagged commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2025 Status Research & Development GmbH
+# Copyright (c) 2025-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,35 +9,6 @@ version: 2
 updates:
   - package-ecosystem: gitsubmodule
     directory: /
-    ignore:
-      # Libraries that track the latest tag have to be managed manually,
-      # as Dependabot otherwise suggests the latest unstable commit
-      # https://github.com/dependabot/dependabot-core/pull/13052
-      - dependency-name: vendor/nim-bearssl
-      - dependency-name: vendor/nim-chronicles
-      - dependency-name: vendor/nim-chronos
-      - dependency-name: vendor/nim-eth
-      - dependency-name: vendor/nim-faststreams
-      - dependency-name: vendor/nim-json-rpc
-      - dependency-name: vendor/nim-json-serialization
-      - dependency-name: vendor/nim-libbacktrace
-      - dependency-name: vendor/nim-libp2p
-      - dependency-name: vendor/nim-metrics
-      - dependency-name: vendor/nim-normalize
-      - dependency-name: vendor/nim-presto
-      - dependency-name: vendor/nim-results
-      - dependency-name: vendor/nim-serialization
-      - dependency-name: vendor/nim-stew
-      - dependency-name: vendor/nim-stint
-      - dependency-name: vendor/nim-taskpools
-      - dependency-name: vendor/nim-testutils
-      - dependency-name: vendor/nim-toml-serialization
-      - dependency-name: vendor/nim-unicodedb
-      - dependency-name: vendor/nim-unittest2
-      - dependency-name: vendor/nim-web3
-      - dependency-name: vendor/nim-websock
-      - dependency-name: vendor/nimcrypto
-      - dependency-name: vendor/NimYAML
     schedule:
       interval: daily
     target-branch: unstable


### PR DESCRIPTION
Dependabot feature was merged to track latest _tagged_ commit instead of latest _head_ commit, so we can use this for libraries where we wish to track the latest release.

- https://github.com/dependabot/dependabot-core/pull/13052

Merged 17 Feb 2026, so we need to wait for a release that is after that.

- https://github.com/dependabot/dependabot-core/releases

v0.361.1 was published before the merge, so needs a later release.

- https://github.com/github/dependabot-action/releases

This pulls in dependabot-core Docker images, so also have to wait for propagation in this repo. After this has a release that contains the latest dependabot-core, this should be good to go. It will then only activate once it hits `stable` (default branch), not yet on `unstable`.