### PR TITLE
EIP8025: Start of implementation

### DIFF
--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -19,6 +19,9 @@ import
 from ../spec/eth2_apis/dynamic_fee_recipients import
   DynamicFeeRecipientsStore, getDynamicFeeRecipient
 from ../validators/action_tracker import ActionTracker, getNextProposalSlot
+from ../spec/proof_engine import ProofEngine
+
+export ProofEngine
 
 logScope: topics = "cman"
 
@@ -39,6 +42,8 @@ type
     # Execution layer integration
     # ----------------------------------------------------------------
     elManager*: ELManager
+
+    proofEngine*: ProofEngine
 
     # Allow determination of whether there's an upcoming proposal
     # ----------------------------------------------------------------
@@ -68,6 +73,7 @@ func new*(T: type ConsensusManager,
           attestationPool: ref AttestationPool,
           quarantine: ref Quarantine,
           elManager: ELManager,
+          proofEngine: ProofEngine,
           actionTracker: ActionTracker,
           dynamicFeeRecipientsStore: ref DynamicFeeRecipientsStore,
           validatorsDir: string,
@@ -79,6 +85,7 @@ func new*(T: type ConsensusManager,
     attestationPool: attestationPool,
     quarantine: quarantine,
     elManager: elManager,
+    proofEngine: proofEngine,
     actionTracker: actionTracker,
     dynamicFeeRecipientsStore: dynamicFeeRecipientsStore,
     validatorsDir: validatorsDir,

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -39,6 +39,8 @@ from ../beacon_chain_db import getBlobSidecar, putBlobSidecar,
   getDataColumnSidecar, putDataColumnSidecar
 from ../spec/state_transition_block import validate_blobs
 
+from ../spec/proof_engine import ProofEngine, NewPayloadRequestHeader, verify_new_payload_request_header
+
 export sszdump, signatures_batch
 
 logScope: topics = "gossip_blocks"
@@ -361,7 +363,7 @@ proc newExecutionPayload*(
     elManager, blck, noEnvelope, sleepAsync(FORKCHOICEUPDATED_TIMEOUT), true)
 
 proc getExecutionValidity(
-    elManager: ELManager,
+    elManager: ELManager, proofEngine: ProofEngine,
     blck: bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
           deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
           fulu.SignedBeaconBlock | gloas.SignedBeaconBlock,
@@ -382,6 +384,12 @@ proc getExecutionValidity(
   let status = (await elManager.newExecutionPayload(
       blck.message, someEnvelope, deadline, retry)).valueOr:
     return Opt.none(OptimisticStatus)
+
+  debugEIP8025Comment("For now just log this result")
+  if proofEngine.verify_new_payload_request_header(NewPayloadRequestHeader()):
+    info "execution payload valid: valid optional proofs"
+  else:
+    info "execution payload invalid: invalid optional proofs"
 
   let optimisticStatus = status.to(OptimisticStatus)
 
@@ -681,6 +689,7 @@ proc storeBlock(
           func shouldRetry(): bool =
             not dag.is_optimistic(dag.head.bid)
           await self.consensusManager.elManager.getExecutionValidity(
+            self.consensusManager.proofEngine,
             signedBlock, noEnvelope, deadline, shouldRetry())
         else:
           Opt.some(OptimisticStatus.valid) # vacuously

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -15,6 +15,7 @@ import
   ssz_serialization/types,
   ../el/el_manager,
   ../spec/[helpers, forks],
+  ../spec/datatypes/eip8025,
   ../consensus_object_pools/[
     attestation_pool, blob_quarantine, block_clearance, block_quarantine,
     blockchain_dag, envelope_quarantine, execution_payload_pool,
@@ -949,3 +950,17 @@ proc processPayloadAttestationMessage*(
 
   trace "Payload attestation validated"
   return ok()
+
+proc processExecutionProof*(
+    self: var Eth2Processor, src: MsgSource,
+    execution_proof: SignedExecutionProof
+): ValidationRes =
+  let wallTime = self.getCurrentBeaconTime()
+
+  let v = validateExecutionProof(self.dag, execution_proof, wallTime)
+  if v.isOk():
+    debug "Execution proof validated"
+    ok()
+  else:
+    debug "Dropping execution proof", reason = $v.error
+    err(v.error())

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -16,6 +16,7 @@ import
   ../spec/[
     beaconstate, state_transition_block, forks,
     helpers, network, signatures, peerdas_helpers],
+  ../spec/datatypes/eip8025,
   ../consensus_object_pools/[
     attestation_pool, blockchain_dag, blob_quarantine, block_clearance,
     block_quarantine, envelope_quarantine, execution_payload_pool,
@@ -2168,5 +2169,37 @@ proc validatePayloadAttestationMessage*(
         "PayloadAttestationMessage: timeout checking signature")
     of BatchResult.Valid:
       discard
+
+  ok()
+
+# https://github.com/ethereum/consensus-specs/blob/f73487b93bfcf6a047766187578e513a69ee8c7f/specs/_features/eip8025/p2p-interface.md#execution_proof
+proc validateExecutionProof*(
+    dag: ChainDAGRef, executionProof: SignedExecutionProof, wallTime: BeaconTime
+): Result[void, ValidationError] =
+  debugEIP8025Comment("To implement")
+  # [IGNORE] The proof's corresponding new payload request (identified by
+  # proof.public_input.new_payload_request_root) has been seen (via gossip or
+  # non-gossip sources) (a client MAY queue proofs for processing once the new
+  # payload request is retrieved).
+  # [IGNORE] No valid proof has already been received for the tuple
+  # (proof.public_input.new_payload_request_root, proof.proof_type) -- i.e. no
+  # valid proof for proof.proof_type from any prover has been received.
+  # [IGNORE] The proof is the first proof received for the tuple
+  # (proof.public_input.new_payload_request_root, proof.proof_type,
+  # signed_execution_proof.validator_index) -- i.e. the first valid or invalid
+  # proof for proof.proof_type from signed_execution_proof.validator_index.
+  # [REJECT] The validator with index signed_execution_proof.validator_index is
+  # an active validator -- i.e. is_active_validator(state.validators[
+  # signed_execution_proof.validator_index], get_current_epoch(state)) returns
+  # True.
+  # [REJECT] signed_execution_proof.signature is valid with respect to the
+  # validator's public key.
+  # [REJECT] proof.proof_data is non-empty.
+  # [REJECT] proof.proof_data is not larger than MAX_PROOF_SIZE.
+  # [REJECT] All of the conditions within process_execution_proof pass
+  # validation.
+  # [IGNORE] No valid proof has already been received for the tuple
+  # (proof.public_input.new_payload_request_root, proof.proof_type) -- i.e. no
+  # valid proof for proof.proof_type from any prover has been received.
 
   ok()

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -28,6 +28,7 @@ import
   eth/net/nat, eth/p2p/discoveryv5/[node, random2],
   ".."/[version, conf, beacon_clock, conf_light_client],
   ../spec/[eth2_ssz_serialization, network, helpers, forks],
+  ../spec/datatypes/eip8025,
   ../validators/keystore_management,
   "."/[eth2_discovery, eth2_protocol_dsl, eth2_agents,
        libp2p_json_serialization, peer_pool, peer_scores]
@@ -76,7 +77,7 @@ type
     protocols: seq[ProtocolInfo]
       ## Protocols managed by the DSL and mounted on the switch
     protocolStates*: seq[RootRef]
-    metadata*: fulu.MetaData
+    metadata*: eip8025.MetaData
     connectTimeout*: chronos.Duration
     seenThreshold*: chronos.Duration
     connQueue: AsyncQueue[PeerAddr]
@@ -861,7 +862,7 @@ template gossipMaxSize(T: untyped): uint32 =
          T is phase0.SignedAggregateAndProof or T is phase0.SignedBeaconBlock or
          T is electra.SignedAggregateAndProof or T is electra.Attestation or
          T is electra.AttesterSlashing or T is altair.SignedBeaconBlock or
-         T is SomeForkyLightClientObject:
+         T is SomeForkyLightClientObject or T is SignedExecutionProof:
       MAX_PAYLOAD_SIZE
     else:
       {.fatal: "unknown type " & name(T).}
@@ -1850,7 +1851,7 @@ proc new(T: type Eth2Node,
     let
       connectTimeout = chronos.seconds(10)
       seenThreshold = chronos.seconds(10)
-  type MetaData = fulu.MetaData # Weird bug without this..
+  type MetaData = eip8025.MetaData # Weird bug without this..
 
   # Versions up to v22.3.0 would write an empty `MetaData` to
   #`data-dir/node-metadata.json` which would then be reloaded on startup - don't
@@ -1876,7 +1877,8 @@ proc new(T: type Eth2Node,
       config, ip, tcpPort, udpPort, privKey,
       {
         enrForkIdField: SSZ.encode(enrForkId),
-        enrAttestationSubnetsField: SSZ.encode(metadata.attnets)
+        enrAttestationSubnetsField: SSZ.encode(metadata.attnets),
+        enrExecutionProofAwarenessField: SSZ.encode(1'u8)
       },
     rng),
     discoveryEnabled: discovery,
@@ -2147,6 +2149,7 @@ proc p2pProtocolBackendImpl*(p: P2PProtocol): Backend =
 import ./peer_protocol
 export peer_protocol
 
+debugEIP8025Comment("Replace with V4 and V3ToV4 but we need a fork for it")
 func updateMetadataV2ToV3(metadataRes: NetRes[altair.MetaData]):
                           NetRes[fulu.MetaData] =
   if metadataRes.isOk:
@@ -2908,3 +2911,9 @@ proc broadcastExecutionPayloadEnvelope*(
     topic = getExecutionPayloadTopic(
       node.forkDigestAtEpoch(contextEpoch))
   node.broadcast(topic, envelope)
+
+proc broadcastExecutionProof*(
+    node: Eth2Node, proof: eip8025.SignedExecutionProof):
+    Future[SendResult] {.async: (raises: [CancelledError], raw: true).} =
+  let topic = getExecutionProofTopic(node.forkDigestAtEpoch(node.getWallEpoch))
+  node.broadcast(topic, proof)

--- a/beacon_chain/networking/peer_protocol.nim
+++ b/beacon_chain/networking/peer_protocol.nim
@@ -10,6 +10,7 @@
 import
   chronicles, stew/base10, metrics,
   ../spec/network,
+  ../spec/datatypes/eip8025,
   ".."/[beacon_clock],
   ../networking/eth2_network,
   ../consensus_object_pools/blockchain_dag,
@@ -271,6 +272,14 @@ p2pProtocol PeerSync(version = 1,
 
   proc getMetadata_v3(peer: Peer): fulu.MetaData
     {.libp2pProtocol("metadata", 3).} =
+    let fulu_metadata = fulu.MetaData(
+      seq_number: peer.network.metadata.seq_number,
+      attnets: peer.network.metadata.attnets,
+      syncnets: peer.network.metadata.syncnets)
+    fulu_metadata
+
+  proc getMetadata_v4(peer: Peer): eip8025.MetaData
+    {.libp2pProtocol("metadata", 4).} =
     peer.network.metadata
 
   proc goodbye(peer: Peer, reason: uint64) {.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -22,7 +22,7 @@ import
   ./consensus_object_pools/vanity_logs/vanity_logs,
   ./networking/[topic_params, network_metadata_downloads],
   ./rpc/[rest_api, state_ttl_cache],
-  ./spec/datatypes/[altair, bellatrix, phase0],
+  ./spec/datatypes/[altair, bellatrix, phase0, eip8025],
   ./spec/[
     engine_authentication, weak_subjectivity, peerdas_helpers],
   ./sync/[sync_protocol, light_client_protocol, sync_overseer, validator_custody],
@@ -599,7 +599,7 @@ proc initFullNode(
       dag.cfg, sortedColumns, dag.db.getQuarantineDB(), 10,
       onColumnSidecarAdded))
     consensusManager = ConsensusManager.new(
-      dag, attestationPool, quarantine, node.elManager,
+      dag, attestationPool, quarantine, node.elManager, ProofEngine(),
       ActionTracker.init(node.network.nodeId, config.subscribeAllSubnets),
       node.dynamicFeeRecipientsStore, config.validatorsDir,
       config.defaultFeeRecipient, config.suggestedGasLimit)
@@ -1369,6 +1369,12 @@ proc addElectraMessageHandlers(
   node.doAddDenebMessageHandlers(
     forkDigest, slot, node.dag.cfg.BLOB_SIDECAR_SUBNET_COUNT_ELECTRA)
 
+proc addFuluMessageHandlers(
+    node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
+  debugEIP8025Comment("CapellaMessageHandlers is used for Fulu, hence adding this with just EIP8025 subcription for now")
+  node.addCapellaMessageHandlers(forkDigest, slot)
+  node.network.subscribe(getExecutionProofTopic(forkDigest), basicParams())
+
 proc addGloasMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
   node.addCapellaMessageHandlers(forkDigest, slot)
@@ -1422,6 +1428,8 @@ proc removeFuluMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   for i in custody:
     let topic = getDataColumnSidecarTopic(forkDigest, i)
     node.network.unsubscribe(topic)
+
+  node.network.unsubscribe(getExecutionProofTopic(forkDigest))
 
 proc removeGloasMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removeFuluMessageHandlers(forkDigest)
@@ -1675,7 +1683,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     addCapellaMessageHandlers,
     addDenebMessageHandlers,
     addElectraMessageHandlers,
-    addCapellaMessageHandlers, # no blobs; updateDataColumnSidecarHandlers for rest
+    addFuluMessageHandlers, # no blobs; updateDataColumnSidecarHandlers for rest
     addGloasMessageHandlers
   ]
 
@@ -2550,6 +2558,18 @@ proc installMessageValidators(node: BeaconNode) =
                   toValidationResult(
                     node.processor[].processBlobSidecar(
                       MsgSource.gossip, blobSidecar, subnet_id)))
+
+        # execution_proof
+        # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/p2p-interface.md#execution_proof
+        when consensusFork >= ConsensusFork.Fulu:
+          node.network.addAsyncValidator(
+            getExecutionProofTopic(digest), proc (
+              msg: SignedExecutionProof,
+              src: PeerId
+            ): Future[ValidationResult] {.async: (raises: [CancelledError]).} =
+              return toValidationResult(
+                node.processor[].processExecutionProof(
+                  MsgSource.gossip, msg)))
 
   node.installLightClientMessageValidators()
 

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -987,3 +987,4 @@ func ofLen*[T, N](ListType: type List[T, N], n: int): ListType =
 
 template debugFuluComment*(s: string) = discard
 template debugGloasComment*(s: string) = discard
+template debugEIP8025Comment*(s: string) = discard

--- a/beacon_chain/spec/datatypes/eip8025.nim
+++ b/beacon_chain/spec/datatypes/eip8025.nim
@@ -1,0 +1,78 @@
+# beacon_chain
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+## Types and constants for EIP-8025: Execution Payloads with Multiple Execution Proofs
+
+import ssz_serialization, ../crypto, ../digest
+
+from eth/common/hashes import VersionedHash
+
+from ./constants import DomainType
+from ./base import AttnetBits, ValidatorIndex
+from ./altair import SyncnetBits
+from ./deneb import ExecutionPayloadHeader, ExecutionPayload
+from ./electra import ExecutionRequests
+
+export crypto, ssz_serialization
+
+const
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#constants
+  MAX_PROOF_SIZE = 307_200
+  DOMAIN_EXECUTION_PROOF* = DomainType([byte 0x0D, 0x00, 0x00, 0x00])
+
+type
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#types
+  ProofType* = uint8
+
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#containers
+  PublicInput* = object
+    new_payload_request_root*: Eth2Digest
+
+  ExecutionProof* = object
+    proof_data*: ByteList[MAX_PROOF_SIZE]
+    proof_type*: ProofType
+    public_input*: PublicInput
+
+  SignedExecutionProof* = object
+    message*: ExecutionProof
+    validator_index*: uint64
+      # ValidatorIndex is uint32 and not used in serialization. TODO create new distinct type here
+    signature*: ValidatorSig
+
+  # debugEIP8025Comment("not an SSZ type, this if for el manager, move it somewhere else?")
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#new-newpayloadrequestheader
+  NewPayloadRequestHeader* = object
+    execution_payload_header*: ExecutionPayloadHeader
+      # should this be ExecutionPayloadV3? No, these should get transformed later for Engine API
+    versioned_hashes*: seq[VersionedHash]
+    parent_beacon_block_root*: Eth2Digest
+    execution_requests*: ExecutionRequests
+      # should this be just seq[seq[byte]]. Not SSZ types..No, these should get transformed later for Engine API
+
+  # debugEIP8025Comment("Not a new type, we just didn't introduce it before at el manager")
+  NewPayloadRequest* = object
+    execution_payload: ExecutionPayload
+      # should this be ExecutionPayloadV3? No, these should get transformed later for Engine API
+    versioned_hashes: seq[VersionedHash]
+    parent_beacon_block_root: Eth2Digest
+    execution_requests: ExecutionRequests
+      # should this be just seq[seq[byte]]. Not SSZ types.. No, these should get transformed later for Engine API
+
+  # EIP8025 p2p-interface part
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/p2p-interface.md#metadata
+  MetaData* = object
+    seq_number*: uint64
+    attnets*: AttnetBits
+    syncnets*: SyncnetBits
+    custody_group_count*: uint64
+    execution_proof_aware*: bool
+
+  # callback type for execution proofs verification
+  VerifyPayload* =
+    proc(execution_payload: NewPayloadRequestHeader): bool {.gcsafe, raises: [].}

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -28,6 +28,7 @@ const
   topicExecutionPayloadBidSuffix = "execution_payload_bid/ssz_snappy"
   topicExecutionPayloadSuffix = "execution_payload/ssz_snappy"
   topicPayloadAttestationMessageSuffix = "payload_attestation_message/ssz_snappy"
+  topicExecutionProofSuffix = "execution_proof/ssz_snappy"
 
 const
   # The spec now includes this as a bare uint64 as `RESP_TIMEOUT`
@@ -40,6 +41,8 @@ const
   MAX_REQUEST_DATA_COLUMN_SIDECARS*: uint64 =
     MAX_REQUEST_BLOCKS_DENEB * NUMBER_OF_COLUMNS
 
+  MAX_EXECUTION_PROOFS_PER_PAYLOAD*: uint64 = 4
+
   defaultEth2TcpPort* = 9000
   defaultEth2TcpPortDesc* = $defaultEth2TcpPort
 
@@ -51,6 +54,7 @@ const
   enrSyncSubnetsField* = "syncnets"
   enrCustodySubnetCountField* = "cgc"
   enrNextForkDigestField* = "nfd"
+  enrExecutionProofAwarenessField* = "eproof"
   enrForkIdField* = "eth2"
 
 template eth2Prefix(forkDigest: ForkDigest): string =
@@ -152,6 +156,10 @@ func getLightClientFinalityUpdateTopic*(forkDigest: ForkDigest): string =
 func getLightClientOptimisticUpdateTopic*(forkDigest: ForkDigest): string =
   ## For broadcasting or obtaining the latest `LightClientOptimisticUpdate`.
   eth2Prefix(forkDigest) & "light_client_optimistic_update/ssz_snappy"
+
+# https://github.com/ethereum/consensus-specs/blob/323f4ae262ce83035ba4c99fe2437e40ecf9f09c/specs/_features/eip8025/p2p-interface.md#execution_proof
+func getExecutionProofTopic*(forkDigest: ForkDigest): string =
+  eth2Prefix(forkDigest) & topicExecutionProofSuffix
 
 func getForkDigest(
     cfg: RuntimeConfig, genesis_validators_root: Eth2Digest,

--- a/beacon_chain/spec/proof_engine.nim
+++ b/beacon_chain/spec/proof_engine.nim
@@ -1,0 +1,62 @@
+# beacon_chain
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+## ProofEngine for EIP-8025
+
+import ssz_serialization
+
+from ./datatypes/eip8025 import
+  ProofType, ExecutionProof, NewPayloadRequestHeader, NewPayloadRequest
+
+export ProofType, ExecutionProof, NewPayloadRequestHeader, NewPayloadRequest
+
+type
+  ProofGenId* = uint8
+
+  ProofAttributes* = object
+    proof_types: List[ProofType, 8]
+
+  ProofEngine* = object
+    stored_proofs: Table[ProofGenId, ProofAttributes] # TODO...
+
+## Proof verification functions
+
+func verify_execution_proof*(
+    engine: ProofEngine, execution_proof: ExecutionProof
+): bool =
+  # Verify an execution proof.
+  # Return ``True`` if proof is valid.
+  # TODO:
+  # This will hold actual verification logic for different proof types
+  # Can use Engine API to external prover (verification)
+  true
+
+func verify_new_payload_request_header*(
+    engine: ProofEngine, new_payload_request_header: NewPayloadRequestHeader
+): bool =
+  # Verify the corresponding new payload request execution is valid.
+  # Return ``True`` if proof requirements are satisfied.
+  # TODO:
+  # This will hold actual verification logic for different proof types
+  # Can use Engine API to external prover (verification)
+  true
+
+## Proof generation functions
+
+func request_proofs*(
+    engine: ProofEngine,
+    new_payload_request: NewPayloadRequest,
+    proof_attributes: ProofAttributes,
+): ProofGenId =
+  # Request proofs to be generated for a given proof generation ID and attributes.
+  # Return ``True`` if the request is accepted.
+  # Generated proofs are delivered asynchronously via the beacon API endpoint
+  # ``POST /eth/v1/prover/execution_proofs``.
+  # actual proof creation would be via engine API to external prover (generation)...?
+  ProofGenId(0)

--- a/beacon_chain/spec/prover.nim
+++ b/beacon_chain/spec/prover.nim
@@ -1,0 +1,129 @@
+# beacon_chain
+# Copyright (c) 2026 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
+#   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+{.push raises: [], gcsafe.}
+
+import
+  ssz_serialization,
+  ./proof_engine,
+  ./crypto,
+  ./helpers # get_domain, compute_signing_root
+
+from std/sequtils import mapIt
+from std/tables import Table
+
+from ./datatypes/eip8025 import
+  ExecutionProof, SignedExecutionProof, NewPayloadRequest, DOMAIN_EXECUTION_PROOF
+from ./datatypes/electra import BeaconBlockBody
+from ./beaconstate import ForkyBeaconState
+from ./state_transition_block import kzg_commitment_to_versioned_hash
+from ./beacon_time import epoch
+
+## Prover for EIP-8025
+##
+## Prover (Prover/Relay) is the Beacon Node component responsible for managing proof
+## generation for EIP-8025 execution proofs. It interacts with a external ProofEngine to
+## request proof generation and handles signing of proofs for broadcasting on the
+## execution proof gossip topic.
+## This compontent is not to be confused with the external component that actually creates
+## the proofs.
+##
+
+type Prover = object
+  proof_engine: ProofEngine
+  # TODO: here or in ProofEngine? Depends a bit on how we design this.
+  # - track response in ProofEngine and just await this here.
+  # - or track response here with some callback.
+  pending_proofs: Table[ProofGenId, ProofAttributes]
+
+# https://github.com/ethereum/consensus-specs/blob/f73487b93bfcf6a047766187578e513a69ee8c7f/specs/_features/eip8025/prover.md#new-get_execution_proof_signature
+# Not using state here but fork + genesis_validators_root + slot, similar as is done in signatures.nim code.
+func get_execution_proof_signature(
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
+    proof: ExecutionProof,
+    privkey: ValidatorPrivKey,
+    slot: Slot,
+): ValidatorSig =
+  let domain =
+    get_domain(fork, DOMAIN_EXECUTION_PROOF, epoch(slot), genesis_validators_root)
+  let signing_root = compute_signing_root(proof, domain)
+
+  blsSign(privkey, signing_root.data).toValidatorSig()
+
+# https://github.com/ethereum/consensus-specs/blob/9e00036e7a4596c5858187e4473ec4bbbb5ee3cc/specs/_features/eip8025/prover.md#constructing-signedexecutionproof
+func createSignedExecutionProof(
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
+    proof: ExecutionProof,
+    privkey: ValidatorPrivKey,
+    slot: Slot,
+): SignedExecutionProof =
+  let signature =
+    get_execution_proof_signature(fork, genesis_validators_root, proof, privkey, slot)
+  # let pubkey = privkey.toPubKey()
+  # TODO: get actual validator index here from state
+  # This used to be the pubkey but it got changed to index as this was easier
+  # in the verification code to check if the validator is active...
+  # But here it is making things more ugly as we need state access
+
+  let validator_index = 0'u64
+
+  SignedExecutionProof(
+    message: proof, validator_index: validator_index, signature: signature
+  )
+
+proc RequestExecutionProof(
+    prover: var Prover,
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
+    state: ForkyBeaconState,
+    beaconBlockBody: fulu.BeaconBlockBody,
+    proof_attributes: ProofAttributes,
+    privkey: ValidatorPrivKey,
+    slot: Slot,
+): ProofGenId =
+  # Extract NewPayloadRequest from BeaconBlockBody
+  let new_payload_request = NewPayloadRequest(
+    execution_payload: beaconBlockBody.execution_payload,
+    versioned_hashes:
+      mapIt(beaconBlockBody.blob_kzg_commitments, kzg_commitment_to_versioned_hash(it)),
+    parent_beacon_block_root: state.latest_block_header.parent_root,
+    execution_requests: beaconBlockBody.execution_requests,
+  )
+
+  # Create ProofAttributes with desired proof types and request proofs
+  let proof_gen_id =
+    prover.proof_engine.request_proofs(new_payload_request, proof_attributes)
+
+  # Track pending proof generation so responses can be matched later
+  prover.pending_proofs[proof_gen_id] = proof_attributes
+
+  proof_gen_id
+
+proc handleExecutionProof*(
+    prover: var Prover,
+    fork: Fork,
+    genesis_validators_root: Eth2Digest,
+    proof_gen_id: ProofGenId,
+    proof: ExecutionProof,
+    privkey: ValidatorPrivKey,
+    slot: Slot,
+    broadcast: proc(signed: SignedExecutionProof) {.gcsafe, raises: [].},
+) =
+  # Validate the proof matches a pending proof_gen_id
+  if proof_gen_id notin prover.pending_proofs:
+    return
+
+  prover.pending_proofs.del(proof_gen_id)
+
+  # Set message to the ExecutionProof and sign it
+  let signed =
+    createSignedExecutionProof(fork, genesis_validators_root, proof, privkey, slot)
+
+  # Broadcast the SignedExecutionProof on the execution_proof gossip topic
+  broadcast(signed)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -28,6 +28,8 @@ import
   chronicles, metrics,
   ../extras,
   ./[beaconstate, eth2_merkleization, forks, helpers, validator, signatures],
+  ./datatypes/eip8025,
+  ./proof_engine,
   kzg4844/kzg_abi, kzg4844/kzg
 
 from std/algorithm import fill, sorted
@@ -890,6 +892,18 @@ func get_participant_reward*(total_active_balance: Gwei): Gwei =
 func get_proposer_reward*(participant_reward: Gwei): Gwei =
   participant_reward * PROPOSER_WEIGHT div (WEIGHT_DENOMINATOR - PROPOSER_WEIGHT)
 
+# https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
+func kzg_commitment_to_versioned_hash*(
+    kzg_commitment: KzgCommitment): VersionedHash {.noinit.} =
+  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/deneb/beacon-chain.md#blob
+  const VERSIONED_HASH_VERSION_KZG = 0x01'u8
+
+  var res {.noinit.}: VersionedHash
+  static: assert res.data.len == 32
+  res.data[0] = VERSIONED_HASH_VERSION_KZG
+  res.data[1 .. 31] = eth2digest(kzg_commitment.bytes).data.toOpenArray(1, 31)
+  res
+
 proc process_sync_aggregate*(
     state: var (altair.BeaconState | bellatrix.BeaconState |
                 capella.BeaconState | deneb.BeaconState | electra.BeaconState |
@@ -1105,10 +1119,54 @@ type SomeFuluBeaconBlockBody =
   fulu.TrustedBeaconBlockBody
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/beacon-chain.md#modified-process_execution_payload
-proc process_execution_payload*(
+# proc process_execution_payload*(
+#     cfg: RuntimeConfig, state: var fulu.BeaconState,
+#     body: SomeFuluBeaconBlockBody | fulu_mev.SigVerifiedBlindedBeaconBlockBody,
+#     notify_new_payload: deneb.ExecutePayload): Result[void, cstring] =
+#   template payload: auto = body.payload()
+
+#   # Verify consistency of the parent hash with respect to the previous
+#   # execution payload header
+#   if not (payload.parent_hash ==
+#       state.latest_execution_payload_header.block_hash):
+#     return err("process_execution_payload: payload and state parent hash mismatch")
+
+#   # Verify prev_randao
+#   if not (payload.prev_randao == get_randao_mix(state, get_current_epoch(state))):
+#     return err("process_execution_payload: payload and state randomness mismatch")
+
+#   # Verify timestamp
+#   if not (payload.timestamp == cfg.timeParams
+#       .compute_timestamp_at_slot(state, state.slot)):
+#     return err("process_execution_payload: invalid timestamp")
+
+#   # Verify commitments are under limit
+#   let blob_params =
+#     cfg.get_blob_parameters(get_current_epoch(state))
+#   if not (lenu64(body.blob_kzg_commitments) <= blob_params.MAX_BLOBS_PER_BLOCK):
+#     return err("process_execution_payload: too many KZG commitments")
+
+#   when payload is ForkyExecutionPayloadHeader:
+#     # Assume valid, when blinded
+#     state.latest_execution_payload_header = payload
+#   else:
+#     # Verify the execution payload is valid
+#     if not notify_new_payload(payload):
+#       return err("process_execution_payload: execution payload invalid")
+
+#     # Cache execution payload header
+#     state.latest_execution_payload_header = payload.toExecutionPayloadHeader()
+
+#   ok()
+
+# https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#modified-process_execution_payload\
+debugEIP8025Comment("For now just replace fulu process_execution_payload, no fork yet")
+proc process_execution_payload(
     cfg: RuntimeConfig, state: var fulu.BeaconState,
     body: SomeFuluBeaconBlockBody | fulu_mev.SigVerifiedBlindedBeaconBlockBody,
-    notify_new_payload: deneb.ExecutePayload): Result[void, cstring] =
+    notify_new_payload: deneb.ExecutePayload,
+    verify_new_payload_request_header: eip8025.VerifyPayload
+    ) : Result[void, cstring] =
   template payload: auto = body.payload()
 
   # Verify consistency of the parent hash with respect to the previous
@@ -1140,8 +1198,21 @@ proc process_execution_payload*(
     if not notify_new_payload(payload):
       return err("process_execution_payload: execution payload invalid")
 
+    let execution_payload_header = payload.toExecutionPayloadHeader()
+    # [New in EIP8025]
+    # Note: actual check happens in `storeBlock` in block processor,
+    # here we just do a mock check, just like for verify_and_notify_new_payload
+    let new_payload_request_header = NewPayloadRequestHeader(
+      execution_payload_header: execution_payload_header,
+      versioned_hashes: mapIt(body.blob_kzg_commitments, kzg_commitment_to_versioned_hash(it)),
+      parent_beacon_block_root: state.latest_block_header.parent_root,
+      execution_requests: body.execution_requests,
+    )
+    if not verify_new_payload_request_header(new_payload_request_header):
+      return err("process_execution_payload: invalid optional proof")
+
     # Cache execution payload header
-    state.latest_execution_payload_header = payload.toExecutionPayloadHeader()
+    state.latest_execution_payload_header = execution_payload_header
 
   ok()
 
@@ -1503,17 +1574,17 @@ func process_withdrawals*(state: var gloas.BeaconState):
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
-func kzg_commitment_to_versioned_hash*(
-    kzg_commitment: KzgCommitment): VersionedHash {.noinit.} =
-  # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/deneb/beacon-chain.md#blob
-  const VERSIONED_HASH_VERSION_KZG = 0x01'u8
+# # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/beacon-chain.md#kzg_commitment_to_versioned_hash
+# func kzg_commitment_to_versioned_hash*(
+#     kzg_commitment: KzgCommitment): VersionedHash {.noinit.} =
+#   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/deneb/beacon-chain.md#blob
+#   const VERSIONED_HASH_VERSION_KZG = 0x01'u8
 
-  var res {.noinit.}: VersionedHash
-  static: assert res.data.len == 32
-  res.data[0] = VERSIONED_HASH_VERSION_KZG
-  res.data[1 .. 31] = eth2digest(kzg_commitment.bytes).data.toOpenArray(1, 31)
-  res
+#   var res {.noinit.}: VersionedHash
+#   static: assert res.data.len == 32
+#   res.data[0] = VERSIONED_HASH_VERSION_KZG
+#   res.data[1 .. 31] = eth2digest(kzg_commitment.bytes).data.toOpenArray(1, 31)
+#   res
 
 proc validate_blobs*(
     expected_kzg_commitments: seq[KzgCommitment], blobs: seq[KzgBlob],
@@ -1714,25 +1785,57 @@ proc process_block*(
 
 type SomeFuluBlock =
   fulu.BeaconBlock | fulu.SigVerifiedBeaconBlock | fulu.TrustedBeaconBlock
+
+# proc process_block*(
+#     cfg: RuntimeConfig,
+#     state: var fulu.BeaconState,
+#     blck: SomeFuluBlock | fulu_mev.SigVerifiedBlindedBeaconBlock,
+#     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
+#   ## When there's a new block, we need to verify that the block is sane and
+#   ## update the state accordingly - the state is left in an unknown state when
+#   ## block application fails (!)
+
+#   ? process_block_header(state, blck, flags, cache)
+
+#   # Consensus specs v1.4.0 unconditionally assume is_execution_enabled is
+#   # true, but intentionally keep such a check.
+#   if is_execution_enabled(state, blck.body):
+#     ? process_withdrawals(state, blck.body.payload)
+
+#     ? process_execution_payload(
+#         cfg, state, blck.body,
+#         func(_: deneb.ExecutionPayload): bool = true)
+#   ? process_randao(state, blck.body, flags, cache)
+#   ? process_eth1_data(state, blck.body)
+
+#   let
+#     total_active_balance = get_total_active_balance(state, cache)
+#     base_reward_per_increment =
+#       get_base_reward_per_increment(total_active_balance)
+#   var operations_rewards = ? process_operations(
+#     cfg, state, blck.body, base_reward_per_increment, flags, cache)
+#   operations_rewards.sync_aggregate = ? process_sync_aggregate(
+#     state, blck.body.sync_aggregate, total_active_balance, flags, cache)
+
+#   ok(operations_rewards)
+
+# https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/beacon-chain.md#modified-process_block
+debugEIP8025Comment("For now just replace fulu process_block, no fork yet")
 proc process_block*(
     cfg: RuntimeConfig,
     state: var fulu.BeaconState,
     blck: SomeFuluBlock | fulu_mev.SigVerifiedBlindedBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
-  ## When there's a new block, we need to verify that the block is sane and
-  ## update the state accordingly - the state is left in an unknown state when
-  ## block application fails (!)
 
   ? process_block_header(state, blck, flags, cache)
 
-  # Consensus specs v1.4.0 unconditionally assume is_execution_enabled is
-  # true, but intentionally keep such a check.
   if is_execution_enabled(state, blck.body):
     ? process_withdrawals(state, blck.body.payload)
-
     ? process_execution_payload(
         cfg, state, blck.body,
-        func(_: deneb.ExecutionPayload): bool = true)
+        func(_: deneb.ExecutionPayload): bool = true,
+        func(_: eip8025.NewPayloadRequestHeader): bool = true)
+
   ? process_randao(state, blck.body, flags, cache)
   ? process_eth1_data(state, blck.body)
 
@@ -1776,3 +1879,29 @@ proc process_block*(
     state, blck.body.sync_aggregate, total_active_balance, flags, cache)
 
   ok(operations_rewards)
+
+# https://github.com/ethereum/consensus-specs/blob/f73487b93bfcf6a047766187578e513a69ee8c7f/specs/_features/eip8025/beacon-chain.md#new-process_execution_proof
+proc process_execution_proof*(
+    state: var fulu.BeaconState,
+    signed_proof: SignedExecutionProof,
+    proof_engine: ProofEngine,
+): Result[void, cstring] =
+  debugEIP8025Comment("Not sure where to let this proc live")
+  let proof_message = signed_proof.message
+
+  # Verify prover is an active validator
+  let validator = state.validators.item(signed_proof.validator_index)
+  if not is_active_validator(validator, get_current_epoch(state)):
+    return err("process_execution_proof: prover is not an active validator")
+
+  let
+    domain = get_domain(state, DOMAIN_EXECUTION_PROOF, epoch(state.slot))
+    signing_root = compute_signing_root(proof_message, domain)
+  if not blsVerify(validator.pubkey, signing_root.data, signed_proof.signature):
+    return err("process_execution_proof: invalid proof signature")
+
+  # Verify the execution proof
+  if proof_engine.verify_execution_proof(proof_message):
+    ok()
+  else:
+    err("process_execution_proof: invalid execution proof")

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -10,6 +10,7 @@
 import
   chronicles, chronos, snappy, snappy/codec,
   ../spec/[helpers, forks, network],
+  ../spec/datatypes/eip8025,
   ".."/[beacon_clock],
   ../networking/eth2_network,
   ../consensus_object_pools/blockchain_dag,
@@ -126,6 +127,28 @@ proc readChunkPayload*(
   withConsensusFork(contextFork):
     when consensusFork >= ConsensusFork.Fulu:
       let res = await readChunkPayload(conn, peer, fulu.DataColumnSidecar)
+      if res.isOk:
+        return ok newClone(res.get)
+      else:
+        return err(res.error)
+    else:
+      return neterr InvalidContextBytes
+
+proc readChunkPayload*(
+    conn: Connection, peer: Peer, MsgType: type (ref eip8025.SignedExecutionProof)):
+    Future[NetRes[MsgType]] {.async: (raises: [CancelledError]).} =
+  var contextBytes: ForkDigest
+  try:
+    await conn.readExactly(addr contextBytes, sizeof contextBytes)
+  except CatchableError:
+    return neterr UnexpectedEOF
+  let contextFork =
+    peer.network.forkDigests[].consensusForkForDigest(contextBytes).valueOr:
+      return neterr InvalidContextBytes
+
+  withConsensusFork(contextFork):
+    when consensusFork >= ConsensusFork.Fulu:
+      let res = await readChunkPayload(conn, peer, eip8025.SignedExecutionProof)
       if res.isOk:
         return ok newClone(res.get)
       else:
@@ -636,6 +659,22 @@ p2pProtocol BeaconSync(version = 1,
 
     debug "Data column range request done",
       peer, startSlot, count = reqCount, columns = reqColumns, found
+
+  # https://github.com/ethereum/consensus-specs/blob/2938e1ad74cea54f1a24508a85704d5bd87837ad/specs/_features/eip8025/p2p-interface.md#executionproofsbyroot
+  proc executionProofsByRoot(
+      peer: Peer,
+      blockRoot: Eth2Digest,
+      response: MultipleChunksResponse[
+        ref eip8025.SignedExecutionProof, Limit(MAX_EXECUTION_PROOFS_PER_PAYLOAD)])
+      {.async, libp2pProtocol("execution_proofs_by_root", 1).} =
+    # [REJECT] The block_root is a 32-byte value.
+
+    # All available execution proofs for the requested block_root.
+    # The response MUST NOT contain more than MAX_EXECUTION_PROOFS_PER_PAYLOAD proofs.
+
+    # TODO: implement storage + returning of execution proofs
+
+    discard
 
 func init*(T: type BeaconSync.NetworkState, dag: ChainDAGRef): T =
   T(


### PR DESCRIPTION
WIP

Start of implementation of EIP8025: https://github.com/ethereum/consensus-specs/tree/master/specs/_features/eip8025

See also more details in PR: https://github.com/ethereum/consensus-specs/pull/4828

TODOs:
- [x] ~Add fork logic instead of Fulu piggyback: this was added in https://github.com/ethereum/consensus-specs/pull/4911/changes~ It has been made clear that eip8025 is to be made fork independent.
- [ ] Storage of Execution proofs (In `Prover` of `ProofEngine`)  + return at `executionProofsByRoot`
- [ ] Validation for execution proofs
    - [ ] Make use of `process_execution_proof` (dummy proof verification)
- [ ] On observe new beacon block -> Extract NewPayloadRequest - > request proofs -> sign proofs + broadcast
- [ ] Add `/eth/v1/prover/execution_proofs` (https://github.com/ethereum/beacon-APIs/pull/569)
- [ ] proof engine:
    - [ ] dummy version but that uses engine api + beacon api
        - [ ] making use of https://github.com/status-im/nim-web3/pull/241
    - [ ] could also go with request_proofs dummy within nimbus binary for now
- [ ] Prover/Relay: properly implement logic here + pending proofs (or in ProofEngine)
- [ ] conditional (cli flag) to enable/disable
