### PR TITLE
el_manager: update multi-el support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ build/
 
 test_keymanager_api
 test_sim
+spamoor_*.tar.gz
 
 /*linkerArgs.txt
 

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -611,6 +611,46 @@ AllTests-mainnet
 + Old style config files                                                                     OK
 + URL parsing                                                                                OK
 ```
+## EL Manager - Async Operations
+```diff
++ ELManager can be started and stopped safely                                                OK
++ ELManager with custom chain network                                                        OK
+```
+## EL Manager - Helpers
+```diff
++ Rewrite URLs                                                                               OK
+```
+## EL Manager - Multiple Engines
+```diff
++ forkchoiceUpdated with multiple engines                                                    OK
++ getPayload with multiple engines                                                           OK
++ newPayload with multiple engines                                                           OK
++ two engines, one broken, retry                                                             OK
+```
+## EL Manager - Payload Request Caching
+```diff
++ concurrent forkchoiceUpdated calls                                                         OK
++ forkchoiceUpdated without payload attributes doesn't cache                                 OK
++ getPayload makes new forkchoiceUpdated when parameters change                              OK
++ getPayload reuses cached forkchoiceUpdated when parameters match                           OK
++ getPayload with different forkchoiceUpdated attributes                                     OK
++ multiple sequential forkchoiceUpdated calls with payload attributes                        OK
+```
+## EL Manager - forkchoiceUpdated
+```diff
++ forkchoiceUpdated basic call                                                               OK
++ forkchoiceUpdated multiple sequential calls                                                OK
++ forkchoiceUpdated with payload attributes                                                  OK
++ forkchoiceUpdated with response delay                                                      OK
+```
+## EL Manager - getPayload
+```diff
++ success without retry                                                                      OK
+```
+## EL Manager - newPayload
+```diff
++ success without retry                                                                      OK
+```
 ## Engine API conversions
 ```diff
 + Roundtrip engine RPC V1 and bellatrix ExecutionPayload representations                     OK
@@ -624,10 +664,6 @@ AllTests-mainnet
 + Add orphan                                                                                 OK
 + Clean up orphans                                                                           OK
 + Pop orphan                                                                                 OK
-```
-## Eth1 monitor
-```diff
-+ Rewrite URLs                                                                               OK
 ```
 ## Eth2 specific discovery tests
 ```diff

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -98,12 +98,14 @@ proc initLightClient*(
             let beaconHead = node.attestationPool[].getBeaconHead(nil)
             withConsensusFork(consensusFork):
               when lcDataForkAtConsensusFork(consensusFork) == lcDataFork:
+                let state = ForkchoiceStateV1.init(
+                  blockHash, beaconHead.safeExecutionBlockHash,
+                  beaconHead.finalizedExecutionBlockHash,
+                )
                 node.optimisticFcuFut = node.elManager.forkchoiceUpdated(
-                  headBlockHash = blockHash,
-                  safeBlockHash = beaconHead.safeExecutionBlockHash,
-                  finalizedBlockHash = beaconHead.finalizedExecutionBlockHash,
-                  payloadAttributes = Opt.none consensusFork.PayloadAttributes)
-                node.optimisticFcuFut.addCallback do (future: pointer):
+                  state, payloadAttributes = Opt.none consensusFork.PayloadAttributes
+                )
+                node.optimisticFcuFut.addCallback do(future: pointer):
                   node.optimisticFcuFut = nil
           else:
             # The execution block hash is only available from Capella onward

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -332,7 +332,7 @@ proc prepareNextSlot*(
   withState(dag.clearanceState):
     when consensusFork == ConsensusFork.Gloas:
       debugGloasComment "well, likely can't keep reusing V3 much longer"
-    elif consensusFork in ConsensusFork.Bellatrix .. ConsensusFork.Fulu:
+    elif consensusFork in ConsensusFork.Electra .. ConsensusFork.Fulu:
       debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer
       let
         timestamp = dag.timeParams
@@ -351,41 +351,26 @@ proc prepareNextSlot*(
       if headBlockHash.isZero:
         return
 
-      when consensusFork >= ConsensusFork.Deneb:
-        # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/prague.md
-        # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
-        let attributes = PayloadAttributesV3(
-          timestamp: Quantity timestamp,
-          prevRandao: Bytes32 prevRandao.to(Hash32),
-          suggestedFeeRecipient: feeRecipient,
-          withdrawals: toEngineWithdrawals get_expected_withdrawals(forkyState.data),
-          parentBeaconBlockRoot: beaconHead.blck.bid.root.to(Hash32),
+      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/cancun.md#payloadattributesv3
+      let
+        state = ForkchoiceStateV1.init(
+          headBlockHash, beaconHead.safeExecutionBlockHash,
+          beaconHead.finalizedExecutionBlockHash,
         )
-      elif consensusFork >= ConsensusFork.Capella:
-        let attributes = PayloadAttributesV2(
-          timestamp: Quantity timestamp,
-          prevRandao: Bytes32 prevRandao.to(Hash32),
-          suggestedFeeRecipient: feeRecipient,
-          withdrawals: toEngineWithdrawals get_expected_withdrawals(forkyState.data),
-        )
-      else:
-        let attributes = PayloadAttributesV1(
-          timestamp: Quantity timestamp,
-          prevRandao: Bytes32 prevRandao.to(Hash32),
-          suggestedFeeRecipient: feeRecipient,
+        attributes = PayloadAttributesV3.init(
+          timestamp,
+          prevRandao,
+          feeRecipient,
+          get_expected_withdrawals(forkyState.data),
+          beaconHead.blck.bid.root,
         )
 
-      let (status, _) = await self.elManager.forkchoiceUpdated(
-        headBlockHash,
-        beaconHead.safeExecutionBlockHash,
-        beaconHead.finalizedExecutionBlockHash,
-        Opt.some(attributes),
-        deadline,
-        false,
-      )
+        (status, _) = await self.elManager.forkchoiceUpdated(
+          state, Opt.some(attributes), deadline, false
+        )
       debug "Fork-choice updated for proposal", status, headBlockHash, attributes
-    elif consensusFork in ConsensusFork.Phase0 .. ConsensusFork.Altair:
-      discard
+    elif consensusFork in ConsensusFork.Phase0 .. ConsensusFork.Deneb:
+      debug "Not producing blocks in pre-Electra fork"
     else:
       {.error: "Unknown consensus fork " & $consensusFork.}
 
@@ -398,20 +383,19 @@ proc forkchoiceUpdated*(
 ): Future[PayloadExecutionStatus] {.async: (raises: [CancelledError]).} =
   ## Call non-proposer version of forkchoiceUpdated using the given slot to
   ## select the correct PayloadAttributes version
+
   withConsensusFork(self[].dag.cfg.consensusForkAtEpoch(slot.epoch)):
     when consensusFork >= ConsensusFork.Bellatrix:
       if headBlockHash.isZero:
         # Merge not yet activated
         PayloadExecutionStatus.valid
       else:
-        let (status, _) = await self.elManager.forkchoiceUpdated(
-          headBlockHash,
-          safeBlockHash,
-          finalizedBlockHash,
-          Opt.none consensusFork.PayloadAttributes,
-          deadline,
-          retry,
-        )
+        let
+          state =
+            ForkchoiceStateV1.init(headBlockHash, safeBlockHash, finalizedBlockHash)
+          (status, _) = await self.elManager.forkchoiceUpdated(
+            state, Opt.none consensusFork.PayloadAttributes, deadline, retry
+          )
         status
     else:
       PayloadExecutionStatus.valid

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -34,28 +34,19 @@ logScope:
   topics = "elman"
 
 const
-  SleepDurations =
-    [100.milliseconds, 200.milliseconds, 500.milliseconds, 1.seconds]
-
-type
-  WithoutTimeout = distinct int
-
-  DeadlineFuture* = Future[void].Raising([CancelledError])
-
-  SomeEnginePayloadWithValue =
-    BellatrixExecutionPayloadWithValue |
-    GetPayloadV2Response |
-    GetPayloadV3Response |
-    GetPayloadV4Response |
-    GetPayloadV5Response |
-    GetPayloadV6Response
-
-const
-  noTimeout = WithoutTimeout(0)
+  minBackoff = 10.millis
+  maxBackoff = 160.millis
 
   # Engine API timeouts
   engineApiConnectionTimeout = 5.seconds  # How long we wait before giving up connecting to the Engine API
   web3RequestsTimeout = 8.seconds # How long we wait for eth_* requests
+
+  multiTimeout = 1.seconds
+    ## When multiple beacon nodes are connected, this is the amount of time we
+    ## give them to respond, when looking for disagreements about valid and
+    ## invalid blocks - we have to balance getting a response at all with the
+    ## slowing down of all requests since the total request time will be based
+    ## on the slowest response.
 
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/paris.md#request-2
   # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/shanghai.md#request-2
@@ -68,11 +59,16 @@ const
     ## before declaring the connection as degraded/restored
 
 type
-  NextExpectedPayloadParams = object
-    headBlockHash: Eth2Digest
-    safeBlockHash: Eth2Digest
-    finalizedBlockHash: Eth2Digest
-    payloadAttributes: PayloadAttributesV3
+  DeadlineFuture* = Future[void].Raising([CancelledError])
+
+  PayloadParams = object
+    ## Parameters given to the latest payload-preparing forkChoiceParameters
+    ## call - if all parameters match, we can use the payload id given in
+    ## response, else we have to make a new call
+    state: ForkchoiceStateV1
+    attributes: PayloadAttributesV3
+
+  PayloadReq = tuple[params: PayloadParams, resp: Future[ForkchoiceUpdatedResponse]]
 
   ELManager* = ref object
     eth1Network: Opt[Eth1Network]
@@ -83,7 +79,6 @@ type
       ## All active EL connections
 
     checkChainIdLoopFut: Future[void]
-    nextExpectedPayloadParams: Opt[NextExpectedPayloadParams]
 
   ChainIdStatus {.pure.} = enum
     notExchangedYet
@@ -111,9 +106,12 @@ type
 
     state: ELConnectionState
     hysteresisCounter: int
-    lastPayloadId: Opt[Bytes8]
 
-  DataProviderTimeout* = object of CatchableError
+    lastPayloadReq: PayloadReq
+      ## Cache of the latest in-flight payload request with its parameters -
+      ## when requesting payloads from the execution client, we expect that the
+      ## block we receive in response will match the parameters we send as
+      ## agreed based on the payload id.
 
 declareCounter engine_api_responses,
   "Number of successful requests to the newPayload Engine API end-point",
@@ -131,19 +129,6 @@ declareCounter engine_api_timeouts,
 declareCounter engine_api_last_minute_forkchoice_updates_sent,
   "Number of last minute requests to the forkchoiceUpdated Engine API end-point just before block proposals",
   labels = ["url"]
-
-proc variedSleep(
-    counter: var int,
-    durations: openArray[Duration]
-): Future[void] {.async: (raises: [CancelledError], raw: true).} =
-  doAssert(len(durations) > 0, "Empty durations array!")
-  let index =
-    if (counter < 0) or (counter > high(durations)):
-      high(durations)
-    else:
-      counter
-  inc(counter)
-  sleepAsync(durations[index])
 
 proc close(connection: ELConnection): Future[void] {.async: (raises: []).} =
   if connection.web3.isSome:
@@ -210,43 +195,21 @@ proc setWorkingState(connection: ELConnection) =
     connection.decreaseCounterTowardsStateChange()
 
 proc engineApiRequest[T](
-    connection: ELConnection,
-    request: Future[T],
-    requestName: string,
-    startTime: Moment,
-    deadline: Future[void] | Duration | WithoutTimeout,
-    failureAllowed = false
+    connection: ELConnection, request: Future[T], requestName: string, startTime: Moment
 ): Future[T] {.async: (raises: [CatchableError]).} =
-  ## This procedure raises `CancelledError` and `DataProviderTimeout`
-  ## exceptions, and everything which `request` could raise.
   try:
-    let res =
-      when deadline is WithoutTimeout:
-        await request
-      else:
-        await request.wait(deadline)
+    let res = await request
     engine_api_request_duration_seconds.observe(
       float(milliseconds(Moment.now - startTime)) / 1000.0,
-        [connection.engineUrl.url, requestName])
-    engine_api_responses.inc(
-      1, [connection.engineUrl.url, requestName, "200"])
+      [connection.engineUrl.url, requestName],
+    )
+    engine_api_responses.inc(1, [connection.engineUrl.url, requestName, "200"])
     connection.setWorkingState()
     res
-  except AsyncTimeoutError:
-    engine_api_timeouts.inc(1, [connection.engineUrl.url, requestName])
-    if not(failureAllowed):
-      await connection.setDegradedState(requestName, 0, "Request timed out")
-    raise newException(DataProviderTimeout, "Request timed out")
   except CancelledError as exc:
-    when deadline is WithoutTimeout:
-      # When `deadline` is set to `noTimeout`, we usually get cancelled on
-      # timeout which was handled by caller.
-      engine_api_timeouts.inc(1, [connection.engineUrl.url, requestName])
-      if not(failureAllowed):
-        await connection.setDegradedState(requestName, 0, "Request timed out")
-    else:
-      if not(failureAllowed):
-        await connection.setDegradedState(requestName, 0, "Request interrupted")
+    # Cancellation is usually due to timeout
+    engine_api_timeouts.inc(1, [connection.engineUrl.url, requestName])
+    await connection.setDegradedState(requestName, 0, "Request timed out")
     raise exc
   except CatchableError as exc:
     let statusCode =
@@ -254,26 +217,9 @@ proc engineApiRequest[T](
         ((ref ErrorResponse) request.error).status
       else:
         0
-    engine_api_responses.inc(
-      1, [connection.engineUrl.url, requestName, $statusCode])
-    if not(failureAllowed):
-      await connection.setDegradedState(
-        requestName, statusCode, request.error.msg)
+    engine_api_responses.inc(1, [connection.engineUrl.url, requestName, $statusCode])
+    await connection.setDegradedState(requestName, statusCode, request.error.msg)
     raise exc
-
-func raiseIfNil(web3block: BlockObject): BlockObject {.raises: [ValueError].} =
-  if web3block == nil:
-    raise newException(ValueError, "EL returned 'null' result for block")
-  web3block
-
-func hasJwtSecret(m: ELManager): bool =
-  for c in m.elConnections:
-    if c.engineUrl.jwtSecret.isSome:
-      return true
-  false
-
-# TODO: Add cfg validation
-# MIN_GENESIS_ACTIVE_VALIDATOR_COUNT should be larger than SLOTS_PER_EPOCH
 
 func isConnected(connection: ELConnection): bool =
   connection.web3.isSome
@@ -330,128 +276,111 @@ proc connectedRpcClient(connection: ELConnection): Future[RpcClient] {.
 
   connection.web3.get.provider
 
-func areSameAs(expectedParams: Opt[NextExpectedPayloadParams],
-               latestHead, latestSafe, latestFinalized: Eth2Digest,
-               timestamp: uint64,
-               randomData: Eth2Digest,
-               feeRecipient: Eth1Address,
-               withdrawals: seq[WithdrawalV1]): bool =
-  expectedParams.isSome and
-    expectedParams.get.headBlockHash == latestHead and
-    expectedParams.get.safeBlockHash == latestSafe and
-    expectedParams.get.finalizedBlockHash == latestFinalized and
-    expectedParams.get.payloadAttributes.timestamp.uint64 == timestamp and
-    expectedParams.get.payloadAttributes.prevRandao.data == randomData.data and
-    expectedParams.get.payloadAttributes.suggestedFeeRecipient == feeRecipient and
-    expectedParams.get.payloadAttributes.withdrawals == withdrawals
+template retryUntilCancelled(body: untyped) =
+  ## Perform the same request in a loop until it is explicitly cancelled,
+  ## usually due to a timeout.
+  ##
+  ## When we make the request, the connection might have died for unrelated
+  ## reasons and we only get to know this when we try to use the connection -
+  ## instead of waiting for the next round of communication, retry the same
+  ## request if there is time.
 
-proc forkchoiceUpdated(rpcClient: RpcClient,
-                       state: ForkchoiceStateV1,
-                       payloadAttributes: Opt[PayloadAttributesV1] |
-                                          Opt[PayloadAttributesV2] |
-                                          Opt[PayloadAttributesV3]):
-                       Future[ForkchoiceUpdatedResponse] =
-  when payloadAttributes is Opt[PayloadAttributesV1]:
-    rpcClient.engine_forkchoiceUpdatedV1(state, payloadAttributes)
-  elif payloadAttributes is Opt[PayloadAttributesV2]:
-    rpcClient.engine_forkchoiceUpdatedV2(state, payloadAttributes)
-  elif payloadAttributes is Opt[PayloadAttributesV3]:
-    rpcClient.engine_forkchoiceUpdatedV3(state, payloadAttributes)
-  else:
-    static: doAssert false
+  # Don't retry on already-degraded connections to prevent a single broken
+  # connection from slowing down all requests indefinately
+  let retry = retry and connection.state != ELConnectionState.Degraded
+  var
+    lastError: ref CatchableError
+    backoff = minBackoff
+  while true:
+    try:
+      body
+    except CancelledError as exc:
+      if lastError != nil:
+        raise lastError
+      raise exc
+    except CatchableError as exc:
+      if not retry:
+        raise exc
 
-proc getPayloadFromSingleEL(
+      lastError = exc
+
+    await sleepAsync(backoff)
+
+    if backoff < maxBackoff: # Exponential backoff
+      backoff = backoff * 2
+
+proc getPayload(
     connection: ELConnection,
     GetPayloadResponseType: type,
-    isForkChoiceUpToDate: bool,
-    consensusHead: Eth2Digest,
-    headBlock, safeBlock, finalizedBlock: Eth2Digest,
-    timestamp: uint64,
-    prevRandao: Eth2Digest,
-    suggestedFeeRecipient: Eth1Address,
-    withdrawals: seq[WithdrawalV1]
+    params: PayloadParams,
+    retry: bool,
 ): Future[GetPayloadResponseType] {.async: (raises: [CatchableError]).} =
+  template payloadReq(): auto =
+    connection.lastPayloadReq
 
-  let
-    rpcClient = await connection.connectedRpcClient()
-    payloadId = if isForkChoiceUpToDate and connection.lastPayloadId.isSome:
-      connection.lastPayloadId.get
-    elif not headBlock.isZero:
-      engine_api_last_minute_forkchoice_updates_sent.inc(1, [connection.engineUrl.url])
+  var
+    payload: GetPayloadResponseType
+    payloadId: Bytes8
 
-      when GetPayloadResponseType is BellatrixExecutionPayloadWithValue:
-        let response = await rpcClient.forkchoiceUpdated(
-          ForkchoiceStateV1(
-            headBlockHash: headBlock.asBlockHash,
-            safeBlockHash: safeBlock.asBlockHash,
-            finalizedBlockHash: finalizedBlock.asBlockHash),
-          Opt.some PayloadAttributesV1(
-            timestamp: Quantity timestamp,
-            prevRandao: Bytes32 prevRandao.to(Hash32),
-            suggestedFeeRecipient: suggestedFeeRecipient))
-      elif GetPayloadResponseType is engine_api.GetPayloadV2Response:
-        let response = await rpcClient.forkchoiceUpdated(
-          ForkchoiceStateV1(
-            headBlockHash: headBlock.asBlockHash,
-            safeBlockHash: safeBlock.asBlockHash,
-            finalizedBlockHash: finalizedBlock.asBlockHash),
-          Opt.some PayloadAttributesV2(
-            timestamp: Quantity timestamp,
-            prevRandao: Bytes32 prevRandao.to(Hash32),
-            suggestedFeeRecipient: suggestedFeeRecipient,
-            withdrawals: withdrawals))
-      elif  GetPayloadResponseType is engine_api.GetPayloadV3Response or
-            GetPayloadResponseType is engine_api.GetPayloadV4Response or
-            GetPayloadResponseType is engine_api.GetPayloadV5Response or
-            GetPayloadResponseType is engine_api.GetPayloadV6Response:
-        # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/prague.md
-        # does not define any new forkchoiceUpdated, so reuse V3 from Dencun
-        # https://github.com/ethereum/execution-apis/blob/5d634063ccfd897a6974ea589c00e2c1d889abc9/src/engine/osaka.md
-        let response = await rpcClient.forkchoiceUpdated(
-          ForkchoiceStateV1(
-            headBlockHash: headBlock.asBlockHash,
-            safeBlockHash: safeBlock.asBlockHash,
-            finalizedBlockHash: finalizedBlock.asBlockHash),
-          Opt.some PayloadAttributesV3(
-            timestamp: Quantity timestamp,
-            prevRandao: Bytes32 prevRandao.to(Hash32),
-            suggestedFeeRecipient: suggestedFeeRecipient,
-            withdrawals: withdrawals,
-            parentBeaconBlockRoot: consensusHead.to(Hash32)))
-      else:
-        static: doAssert false
+  retryUntilCancelled:
+    let
+      rpcClient = await connection.connectedRpcClient()
+      # Use prepared payload if it was given or still pending, otherwise make a
+      # new request
+      useLastPayload =
+        payloadReq.resp != nil and payloadReq.params == params and
+        (not payloadReq.resp.completed or payloadReq.resp.value().payloadId.isSome())
 
-      if response.payloadStatus.status != PayloadExecutionStatus.valid or
-         response.payloadId.isNone:
-        raise newException(CatchableError, "Head block is not a valid payload; " & $response)
+      forkchoiceUpdated = await(
+        if useLastPayload:
+          payloadReq.resp
+        else:
+          notice "Payload not prepared, sending last-minute payload request",
+            url = connection.engineUrl.url
 
-      # Give the EL some time to assemble the block
-      await sleepAsync(chronos.milliseconds 500)
+          rpcClient.forkchoiceUpdated(params.state, Opt.some params.attributes)
+      )
 
-      response.payloadId.get
-    else:
-      raise newException(CatchableError, "No confirmed execution head yet")
+    payloadId = forkchoiceUpdated.payloadId.valueOr:
+      warn "Execution client did not return payload id",
+        url = connection.engineUrl.url, status = forkchoiceUpdated.payloadStatus.status
+      raise newException(
+        CatchableError,
+        "No payload id given: " & $forkchoiceUpdated.payloadStatus.status,
+      )
 
-  when GetPayloadResponseType is BellatrixExecutionPayloadWithValue:
-    let payload =
-      await engine_api.getPayload(rpcClient, ExecutionPayloadV1, payloadId)
-    return BellatrixExecutionPayloadWithValue(
-      executionPayload: payload, blockValue: Wei.zero)
-  else:
-    return await engine_api.getPayload(
-      rpcClient, GetPayloadResponseType, payloadId)
+    if not useLastPayload:
+      # Give the EL some time to build the block
+      await sleepAsync(500.milliseconds)
 
-func cmpGetPayloadResponses(lhs, rhs: SomeEnginePayloadWithValue): int =
-  cmp(distinctBase lhs.blockValue, distinctBase rhs.blockValue)
+    payload = await rpcClient.getPayload(GetPayloadResponseType, payloadId)
+    break # retryUntilCancelled
 
-template EngineApiResponseType(T: type bellatrix.ExecutionPayloadForSigning): type =
-  BellatrixExecutionPayloadWithValue
+  # Check that the execution payload matches the attributes we asked for, as
+  # aggreed per payload id - this is done outside of the retry loop to avoid
+  # re-requesting from a faulty client
+  if payload.executionPayload.extraData.len > MAX_EXTRA_DATA_BYTES:
+    warn "Execution client payload with extraData exceeding limit",
+      url = connection.engineUrl.url,
+      payloadId,
+      size = payload.executionPayload.extraData.len,
+      limit = MAX_EXTRA_DATA_BYTES
+    raise newException(CatchableError, "Execution payload extraData exceeds max size")
 
-template EngineApiResponseType(T: type capella.ExecutionPayloadForSigning): type =
-  engine_api.GetPayloadV2Response
+  if params.attributes.withdrawals != payload.executionPayload.withdrawals:
+    warn "Execution client returned unexpected payload withdrawals",
+      url = connection.engineUrl.url,
+      payloadId,
+      withdrawals_from_cl_len = params.attributes.withdrawals.len,
+      withdrawals_from_el_len = payload.executionPayload.withdrawals.maybeDeref.len,
+      withdrawals_from_cl =
+        mapIt(params.attributes.withdrawals, it.asConsensusWithdrawal),
+      withdrawals_from_el =
+        mapIt(payload.executionPayload.withdrawals, it.asConsensusWithdrawal)
+    raise
+      newException(CatchableError, "Execution client returned mismatching withdrawals")
 
-template EngineApiResponseType(T: type deneb.ExecutionPayloadForSigning): type =
-  engine_api.GetPayloadV3Response
+  payload
 
 template EngineApiResponseType(T: type electra.ExecutionPayloadForSigning): type =
   engine_api.GetPayloadV4Response
@@ -465,194 +394,149 @@ template EngineApiResponseType(T: type gloas.ExecutionPayloadForSigning): type =
 template toEngineWithdrawals*(withdrawals: seq[capella.Withdrawal]): seq[WithdrawalV1] =
   mapIt(withdrawals, toEngineWithdrawal(it))
 
-template kind(T: type ExecutionPayloadV1): ConsensusFork =
-  ConsensusFork.Bellatrix
+func init*(
+    T: type ForkchoiceStateV1, headBlock, safeBlock, finalizedBlock: Eth2Digest
+): T =
+  T(
+    headBlockHash: headBlock.asBlockHash,
+    safeBlockHash: safeBlock.asBlockHash,
+    finalizedBlockHash: finalizedBlock.asBlockHash,
+  )
 
-template kind(T: typedesc[ExecutionPayloadV1OrV2|ExecutionPayloadV2]): ConsensusFork =
-  ConsensusFork.Capella
-
-template kind(T: type ExecutionPayloadV3): ConsensusFork =
-  ConsensusFork.Deneb
+func init*(
+    T: type PayloadAttributesV3,
+    timestamp: uint64,
+    prevRandao: Eth2Digest,
+    suggestedFeeRecipient: Eth1Address,
+    withdrawals: seq[capella.Withdrawal],
+    consensusHead: Eth2Digest,
+): T =
+  T(
+    timestamp: Quantity timestamp,
+    prevRandao: Bytes32 prevRandao.to(Hash32),
+    suggestedFeeRecipient: suggestedFeeRecipient,
+    withdrawals: withdrawals.toEngineWithdrawals(),
+    parentBeaconBlockRoot: consensusHead.to(Hash32),
+  )
 
 proc getPayload*(
     m: ELManager,
     PayloadType: type ForkyExecutionPayloadForSigning,
-    consensusHead: Eth2Digest,
-    headBlock, safeBlock, finalizedBlock: Eth2Digest,
-    timestamp: uint64,
-    prevRandao: Eth2Digest,
-    suggestedFeeRecipient: Eth1Address,
-    withdrawals: seq[capella.Withdrawal]
+    state: ForkchoiceStateV1,
+    payloadAttributes: PayloadAttributesV3,
 ): Future[Opt[PayloadType]] {.async: (raises: [CancelledError]).} =
   if m.elConnections.len == 0:
     notice "No engine configured, using empty payload"
     return Opt.none(PayloadType)
 
-  let
-    engineApiWithdrawals = toEngineWithdrawals withdrawals
-    isFcUpToDate = m.nextExpectedPayloadParams.areSameAs(
-      headBlock, safeBlock, finalizedBlock, timestamp,
-      prevRandao, suggestedFeeRecipient, engineApiWithdrawals)
+  let params = PayloadParams(
+    state: state,
+    attributes: payloadAttributes,
+  )
 
   # `getPayloadFromSingleEL` may introduce additional latency
   const extraProcessingOverhead = 500.milliseconds
-  let
-    timeout = GETPAYLOAD_TIMEOUT + extraProcessingOverhead
-    deadline = sleepAsync(timeout)
+  let deadline = sleepAsync(GETPAYLOAD_TIMEOUT + extraProcessingOverhead)
+
+  let requests = m.elConnections.mapIt(
+    it.getPayload(EngineApiResponseType(PayloadType), params, true)
+  )
+  defer:
+    # In case any request didn't complete on time
+    await cancelAndWait(requests)
+
+  discard await race(allFutures(requests), deadline)
+
+  # Of the payloads that arrived on time, select the one with the highest
+  # block value
+  func betterThan(a, b: auto): bool =
+    a.blockValue > b.blockValue
 
   var bestPayloadIdx = Opt.none(int)
+  for idx, req in requests:
+    if req.completed():
+      if bestPayloadIdx.isNone() or
+          req.value().betterThan(requests[bestPayloadIdx.get].value()):
+        bestPayloadIdx = Opt.some(idx)
+    elif req.failed():
+      warn "Failed to get execution payload from EL",
+        url = m.elConnections[idx].engineUrl.url, reason = req.error.msg
+    else:
+      warn "Timeout while getting execution payload",
+        url = m.elConnections[idx].engineUrl.url
 
-  while true:
-    let requests =
-      m.elConnections.mapIt(
-        it.getPayloadFromSingleEL(EngineApiResponseType(PayloadType),
-          isFcUpToDate, consensusHead, headBlock, safeBlock, finalizedBlock,
-          timestamp, prevRandao, suggestedFeeRecipient, engineApiWithdrawals))
+  if bestPayloadIdx.isSome():
+    debugGloasComment "Temp workaround for Gloas using GetPayloadV5Response"
+    when PayloadType.kind == ConsensusFork.Gloas:
+      ok(requests[bestPayloadIdx.get()].value().asConsensusTypeGloas)
+    else:
+      ok(requests[bestPayloadIdx.get()].value().asConsensusType)
+  else:
+    Opt.none(PayloadType)
 
-    let timeoutExceeded =
-      try:
-        await allFutures(requests).wait(deadline)
-        false
-      except AsyncTimeoutError:
-        true
-      except CancelledError as exc:
-        let pending =
-          requests.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
-        await noCancel allFutures(pending)
-        raise exc
-
-    for idx, req in requests:
-      if not(req.finished()):
-        warn "Timeout while getting execution payload",
-             url = m.elConnections[idx].engineUrl.url
-      elif req.failed():
-        warn "Failed to get execution payload from EL",
-             url = m.elConnections[idx].engineUrl.url,
-             reason = req.error.msg
-      else:
-        const payloadFork = PayloadType.kind
-        when payloadFork >= ConsensusFork.Capella:
-          when payloadFork == ConsensusFork.Capella:
-            # TODO: The engine_api module may offer an alternative API where
-            # it is guaranteed to return the correct response type (i.e. the
-            # rule below will be enforced during deserialization).
-            if req.value().executionPayload.withdrawals.isNone:
-              warn "Execution client returned a block without a " &
-                   "'withdrawals' field for a post-Shanghai block",
-                    url = m.elConnections[idx].engineUrl.url
-              continue
-
-          if engineApiWithdrawals !=
-             req.value().executionPayload.withdrawals.maybeDeref:
-            # otherwise it formats as "@[(index: ..., validatorIndex: ...,
-            # address: ..., amount: ...), (index: ..., validatorIndex: ...,
-            # address: ..., amount: ...)]"
-            # TODO (cheatfate): should we have `continue` statement at the
-            # end of this branch. If no such payload could be choosen as
-            # best one.
-            warn "Execution client did not return correct withdrawals",
-              withdrawals_from_cl_len = engineApiWithdrawals.len,
-              withdrawals_from_el_len =
-                req.value().executionPayload.withdrawals.maybeDeref.len,
-              withdrawals_from_cl =
-                mapIt(engineApiWithdrawals, it.asConsensusWithdrawal),
-              withdrawals_from_el =
-                mapIt(
-                  req.value().executionPayload.withdrawals.maybeDeref,
-                  it.asConsensusWithdrawal),
-              url = m.elConnections[idx].engineUrl.url
-            # If we have more than one EL connection we consider this as
-            # a failure.
-            if len(requests) > 1:
-              continue
-
-        if req.value().executionPayload.extraData.len > MAX_EXTRA_DATA_BYTES:
-          warn "Execution client provided a block with invalid extraData " &
-               "(size exceeds limit)",
-               url = m.elConnections[idx].engineUrl.url,
-               size = req.value().executionPayload.extraData.len,
-               limit = MAX_EXTRA_DATA_BYTES
-          continue
-
-        if bestPayloadIdx.isNone:
-          bestPayloadIdx = Opt.some(idx)
-        else:
-          if cmpGetPayloadResponses(
-               req.value(), requests[bestPayloadIdx.get].value()) > 0:
-            bestPayloadIdx = Opt.some(idx)
-
-    let pending =
-      requests.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
-    await noCancel allFutures(pending)
-
-    if bestPayloadIdx.isSome():
-      debugGloasComment "Temp workaround for Gloas using GetPayloadV5Response"
-      when PayloadType.kind == ConsensusFork.Gloas:
-        return ok(requests[bestPayloadIdx.get()].value().asConsensusTypeGloas)
-      else:
-        return ok(requests[bestPayloadIdx.get()].value().asConsensusType)
-
-    if timeoutExceeded:
-      break
-
-  err()
-
-proc sendNewPayloadToSingleEL(
-    connection: ELConnection,
-    payload: engine_api.ExecutionPayloadV1
+proc newPayload(
+    connection: ELConnection, payload: engine_api.ExecutionPayloadV1, retry: bool
 ): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let rpcClient = await connection.connectedRpcClient()
-  await rpcClient.engine_newPayloadV1(payload)
+  retryUntilCancelled:
+    let rpcClient = await connection.connectedRpcClient()
+    return await rpcClient.engine_newPayloadV1(payload)
 
-proc sendNewPayloadToSingleEL(
-    connection: ELConnection,
-    payload: engine_api.ExecutionPayloadV2
+proc newPayload(
+    connection: ELConnection, payload: engine_api.ExecutionPayloadV2, retry: bool
 ): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let rpcClient = await connection.connectedRpcClient()
-  await rpcClient.engine_newPayloadV2(payload)
+  retryUntilCancelled:
+    let rpcClient = await connection.connectedRpcClient()
+    return await rpcClient.engine_newPayloadV2(payload)
 
-proc sendNewPayloadToSingleEL(
-    connection: ELConnection,
-    payload: engine_api.ExecutionPayloadV3,
-    versioned_hashes: seq[engine_api.VersionedHash],
-    parent_beacon_block_root: Hash32
-): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let rpcClient = await connection.connectedRpcClient()
-  await rpcClient.engine_newPayloadV3(
-    payload, versioned_hashes, parent_beacon_block_root)
-
-proc sendNewPayloadToSingleEL(
+proc newPayload(
     connection: ELConnection,
     payload: engine_api.ExecutionPayloadV3,
     versioned_hashes: seq[engine_api.VersionedHash],
     parent_beacon_block_root: Hash32,
-    executionRequests: seq[seq[byte]]
+    retry: bool,
 ): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let rpcClient = await connection.connectedRpcClient()
-  await rpcClient.engine_newPayloadV4(
-    payload, versioned_hashes, parent_beacon_block_root,
-    executionRequests)
+  retryUntilCancelled:
+    let rpcClient = await connection.connectedRpcClient()
+    return await rpcClient.engine_newPayloadV3(
+      payload, versioned_hashes, parent_beacon_block_root
+    )
 
-proc sendNewPayloadToSingleEL(
+proc newPayload(
+    connection: ELConnection,
+    payload: engine_api.ExecutionPayloadV3,
+    versioned_hashes: seq[engine_api.VersionedHash],
+    parent_beacon_block_root: Hash32,
+    executionRequests: seq[seq[byte]],
+    retry: bool,
+): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
+  retryUntilCancelled:
+    let rpcClient = await connection.connectedRpcClient()
+    return await rpcClient.engine_newPayloadV4(
+      payload, versioned_hashes, parent_beacon_block_root, executionRequests
+    )
+
+proc newPayload(
     connection: ELConnection,
     payload: engine_api.ExecutionPayloadV4,
     versioned_hashes: seq[engine_api.VersionedHash],
     parent_beacon_block_root: Hash32,
-    executionRequests: seq[seq[byte]]
+    executionRequests: seq[seq[byte]],
+    retry: bool,
 ): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let rpcClient = await connection.connectedRpcClient()
-  await rpcClient.engine_newPayloadV5(
-    payload, versioned_hashes, parent_beacon_block_root,
-    executionRequests)
+  retryUntilCancelled:
+    let rpcClient = await connection.connectedRpcClient()
+    return await rpcClient.engine_newPayloadV5(
+      payload, versioned_hashes, parent_beacon_block_root, executionRequests
+    )
 
-proc sendGetBlobsV2toSingleEl(
+proc getBlobsV2(
     connection: ELConnection,
     versioned_hashes: seq[engine_api.VersionedHash]
 ): Future[GetBlobsV2Response] {.async: (raises: [CatchableError]).} =
   let rpcClient = await connection.connectedRpcClient()
   await rpcClient.engine_getBlobsV2(versioned_hashes)
 
-proc sendGetBlobsV3toSingleEl(
+proc getBlobsV3(
     connection: ELConnection,
     versioned_hashes: seq[engine_api.VersionedHash]
 ): Future[GetBlobsV3Response] {.async: (raises: [CatchableError]).} =
@@ -725,15 +609,18 @@ func init(T: type ELConsensusViolationDetector): T =
     disagreementAlreadyDetected: false
   )
 
-proc processResponse(
+proc hasDisagreement(
     d: var ELConsensusViolationDetector,
     elResponseType: typedesc,
     connections: openArray[ELConnection],
     requests: auto,
-    idx: int) =
+    req: auto,
+): bool =
+  if not req.completed:
+    return false
 
-  if not requests[idx].completed:
-    return
+  let idx = requests.find(req)
+  doAssert idx != -1, "must find request in list"
 
   let status = requests[idx].value().status
   if d.selectedResponse.isNone:
@@ -755,107 +642,43 @@ proc processResponse(
             status1 = prevStatus,
             url2 = connections[idx].engineUrl.url,
             status2 = status
+  d.disagreementAlreadyDetected
 
-func couldBeBetter(d: ELConsensusViolationDetector): bool =
-  const
-    SyncingOrAccepted = {
-      PayloadExecutionStatus.syncing,
-      PayloadExecutionStatus.accepted
-    }
-  if d.disagreementAlreadyDetected:
-    return false
-  if d.selectedStatus.isNone():
-    return true
-  d.selectedStatus.get() in SyncingOrAccepted
+proc lazyWait[T: FutureBase](futures: seq[T], deadline: DeadlineFuture) {.async: (raises: []).} =
+  try:
+    discard await race(allFutures(futures), deadline)
+  except CancelledError:
+    discard
 
-proc lazyWait(futures: seq[FutureBase]) {.async: (raises: []).} =
-  block:
-    let pending = futures.filterIt(not(it.finished()))
-    if len(pending) > 0:
-      try:
-        await allFutures(pending).wait(30.seconds)
-      except CancelledError:
-        discard
-      except AsyncTimeoutError:
-        discard
+  await cancelAndWait(futures)
 
-  block:
-    let pending = futures.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
-    if len(pending) > 0:
-      await noCancel allFutures(pending)
+proc firstOrCancel[T; U: Future[T]](
+    requests: sink seq[U], deadline: DeadlineFuture
+): Future[Opt[T]] {.async: (raises: [CancelledError]).} =
+  defer:
+    await cancelAndWait(requests)
 
-proc sendGetBlobsV2*(
-    m: ELManager,
-    blck: fulu.SignedBeaconBlock | gloas.SignedBeaconBlock,
-): Future[Opt[seq[BlobAndProofV2]]] {.async: (raises: [CancelledError]).} =
-  if m.elConnections.len == 0:
-    return err()
+  while requests.len > 0:
+    # Wait for at least one requests or deadline to finish
+    discard await race(race(requests), deadline)
 
-  when blck is gloas.SignedBeaconBlock:
-    debugGloasComment "handle correctly for Gloas?"
-    return err()
-  else:
-    let deadline = sleepAsync(GETBLOBS_TIMEOUT)
+    requests = requests.filterIt:
+      if it.completed: # First successful response wins
+        return ok it.value()
+      if it.failed:
+        debug "Execution client request failed", error = it.error().msg
 
-    var bestIdx: Opt[int]
+      not it.finished
 
-    while true:
-      let requests = m.elConnections.mapIt(
-        sendGetBlobsV2toSingleEl(it,
-          mapIt(blck.message.body.blob_kzg_commitments,
-                kzg_commitment_to_versioned_hash(it))
-        )
-      )
+    if deadline.finished:
+      break
 
-      let timeoutExceeded =
-        try:
-          await allFutures(requests).wait(deadline)
-          false
-        except AsyncTimeoutError:
-          true
-        except CancelledError as exc:
-          # cancel anything still running, then re-raise
-          await noCancel allFutures(
-            requests.filterIt(not it.finished()).mapIt(it.cancelAndWait())
-          )
-          raise exc
+  Opt.none(T)
 
-      for idx, req in requests:
-        if req.finished():
-          # choose the first successful (not failed) response
-          if req.error.isNil and bestIdx.isNone:
-            bestIdx = Opt.some(idx)
-        else:
-          # finished == false
-          let errmsg =
-            if req.error.isNil: "request still pending"
-            else: req.error.msg
-          warn "Timeout while getting blobs & proofs",
-              url = m.elConnections[idx].engineUrl.url,
-              reason = errmsg
-
-      await noCancel allFutures(
-        requests.filterIt(not it.finished()).mapIt(it.cancelAndWait())
-      )
-
-      if bestIdx.isSome():
-        let chosen = requests[bestIdx.get()]
-        # chosen is finished; but could still be an error, so guard again
-        if chosen.error.isNil:
-          return ok(chosen.value())
-        else:
-          warn "Chosen EL failed unexpectedly", reason = chosen.error.msg
-      if timeoutExceeded:
-        break
-
-    err()
-
-proc sendGetBlobsV3*(
-    m: ELManager,
-    blck: fulu.SignedBeaconBlock
-): Future[Opt[seq[Opt[BlobAndProofV2]]]] {.async: (raises: [CancelledError]).} =
-  if m.elConnections.len == 0:
-    return err()
+proc getBlobsV2*(
+    m: ELManager, blck: fulu.SignedBeaconBlock | gloas.SignedBeaconBlock
+): Future[Opt[seq[BlobAndProofV2]]] {.async: (raises: [CancelledError], raw: true).} =
+  mixin getBlobsV2
 
   when blck is gloas.SignedBeaconBlock:
     debugGloasComment "handle correctly for Gloas?"
@@ -863,66 +686,46 @@ proc sendGetBlobsV3*(
   else:
     let deadline = sleepAsync(GETBLOBS_TIMEOUT)
 
-    var bestIdx: Opt[int]
-
-    while true:
-      let requests = m.elConnections.mapIt(
-        sendGetBlobsV3toSingleEl(it,
-          mapIt(blck.message.body.blob_kzg_commitments,
-                kzg_commitment_to_versioned_hash(it))
+    m.elConnections
+      .mapIt(
+        it.getBlobsV2(
+          blck.message.body.blob_kzg_commitments.mapIt(
+            kzg_commitment_to_versioned_hash(it)
+          )
         )
       )
+      .firstOrCancel(deadline)
 
-      let timeoutExceeded =
-        try:
-          await allFutures(requests).wait(deadline)
-          false
-        except AsyncTimeoutError:
-          true
-        except CancelledError as exc:
-          # cancel anything still running, then re-raise
-          await noCancel allFutures(
-            requests.filterIt(not it.finished()).mapIt(it.cancelAndWait())
+proc getBlobsV3*(
+    m: ELManager, blck: fulu.SignedBeaconBlock
+): Future[Opt[seq[Opt[BlobAndProofV2]]]] {.
+    async: (raises: [CancelledError], raw: true)
+.} =
+  mixin getBlobsV3
+
+  when blck is gloas.SignedBeaconBlock:
+    debugGloasComment "handle correctly for Gloas?"
+    return err()
+  else:
+    let deadline = sleepAsync(GETBLOBS_TIMEOUT)
+    m.elConnections
+      .mapIt(
+        it.getBlobsV3(
+          blck.message.body.blob_kzg_commitments.mapIt(
+            kzg_commitment_to_versioned_hash(it)
           )
-          raise exc
-
-      for idx, req in requests:
-        if req.finished():
-          # choose the first successful (not failed) response
-          if req.error.isNil and bestIdx.isNone:
-            bestIdx = Opt.some(idx)
-        else:
-          # finished == false
-          let errmsg =
-            if req.error.isNil: "request still pending"
-            else: req.error.msg
-          warn "Timeout while getting blobs & proofs",
-              url = m.elConnections[idx].engineUrl.url,
-              reason = errmsg
-
-      await noCancel allFutures(
-        requests.filterIt(not it.finished()).mapIt(it.cancelAndWait())
+        )
       )
+      .firstOrCancel(deadline)
 
-      if bestIdx.isSome():
-        let chosen = requests[bestIdx.get()]
-        # chosen is finished; but could still be an error, so guard again
-        if chosen.error.isNil:
-          return ok(chosen.value())
-        else:
-          warn "Chosen EL failed unexpectedly", reason = chosen.error.msg
-      if timeoutExceeded:
-        break
-
-    err()
-
-proc sendNewPayload*(
+proc newPayload*(
     m: ELManager,
     blck: SomeForkyBeaconBlock,
     envelope: NoEnvelope | gloas.ExecutionPayloadEnvelope,
     deadline: DeadlineFuture,
     retry: bool,
 ): Future[Opt[PayloadExecutionStatus]] {.async: (raises: [CancelledError]).} =
+  mixin newPayload
   const consensusFork = typeof(blck).kind
 
   template executionPayload(): auto =
@@ -941,7 +744,8 @@ proc sendNewPayload*(
     payload =
       when consensusFork >= ConsensusFork.Gloas:
         executionPayload.asEngineExecutionPayloadV4()
-      else: executionPayload.asEngineExecutionPayload()
+      else:
+        executionPayload.asEngineExecutionPayload()
 
   when consensusFork >= ConsensusFork.Deneb:
     let
@@ -968,113 +772,85 @@ proc sendNewPayload*(
 
   var
     responseProcessor = ELConsensusViolationDetector.init()
-    sleepCounter = 0
+    requests = m.elConnections.mapIt:
+      let req =
+        when consensusFork >= ConsensusFork.Electra:
+          it.newPayload(
+            payload, versioned_hashes, parent_root, execution_requests, retry
+          )
+        elif consensusFork >= ConsensusFork.Deneb:
+          it.newPayload(payload, versioned_hashes, parent_root, retry)
+        elif consensusFork >= ConsensusFork.Bellatrix:
+          it.newPayload(payload, retry)
+        else:
+          {.error: "Unsupported fork " & $consensusFork.}
 
-  while true:
-    block mainLoop:
-      let requests = m.elConnections.mapIt:
-        let req =
-          when consensusFork >= ConsensusFork.Electra:
-            sendNewPayloadToSingleEL(
-              it, payload, versioned_hashes, parent_root, execution_requests
-            )
-          elif consensusFork >= ConsensusFork.Deneb:
-            sendNewPayloadToSingleEL(it, payload, versioned_hashes, parent_root)
-          elif consensusFork >= ConsensusFork.Bellatrix:
-            sendNewPayloadToSingleEL(it, payload)
-          else:
-            {.error: "Unsupported fork " & $consensusFork.}
+      it.engineApiRequest(req, "newPayload", startTime)
 
-        engineApiRequest(it, req, "newPayload", startTime, noTimeout)
+    pending = requests
+    earlyDeadline = sleepAsync(multiTimeout)
 
-      var pendingRequests = requests
+  defer:
+    await cancelAndWait(pending)
 
-      while true:
-        let timeoutExceeded =
-          try:
-            discard await race(pendingRequests).wait(deadline)
-            false
-          except AsyncTimeoutError:
-            true
-          except ValueError:
-            raiseAssert "pendingRequests should not be empty!"
-          except CancelledError as exc:
-            let pending =
-              requests.filterIt(not(it.finished())).mapIt(it.cancelAndWait())
-            await noCancel allFutures(pending)
-            raise exc
+  while pending.len > 0:
+    try:
+      if responseProcessor.selectedResponse.isSome():
+        discard await race(race(pending), earlyDeadline)
+      else:
+        discard await race(pending)
+    except ValueError:
+      raiseAssert "race error cannot happen"
 
-        var stillPending: type(pendingRequests)
-        for request in pendingRequests:
-          if not(request.finished()):
-            stillPending.add(request)
-          elif request.completed():
-            let index = requests.find(request)
-            doAssert(index >= 0)
-            responseProcessor.processResponse(type(payload),
-                                              m.elConnections, requests, index)
-        pendingRequests = stillPending
+    if pending.anyIt(
+      responseProcessor.hasDisagreement(PayloadStatusV1, m.elConnections, requests, it)
+    ):
+      return Opt.some PayloadExecutionStatus.invalid
 
-        if responseProcessor.disagreementAlreadyDetected:
-          let pending =
-            pendingRequests.filterIt(not(it.finished())).
-              mapIt(it.cancelAndWait())
-          await noCancel allFutures(pending)
-          return Opt.some PayloadExecutionStatus.invalid
+    pending = pending.filterIt(not it.finished)
 
-        if responseProcessor.selectedResponse.isSome():
-          if (len(pendingRequests) == 0) or
-             not(responseProcessor.couldBeBetter()):
-            # We spawn task which will wait for all other responses which are
-            # still pending, after 30.seconds all pending requests will be
-            # cancelled.
-            asyncSpawn lazyWait(pendingRequests.mapIt(FutureBase(it)))
-            return
-              Opt.some requests[responseProcessor.selectedResponse.get].value().status
+    if earlyDeadline.finished and responseProcessor.selectedResponse.isSome():
+      # At the early deadline, we select the best response we've received so far
+      if pending.len > 0:
+        # Let the other requests run their course so they receive the update
+        asyncSpawn lazyWait(pending, deadline)
+        reset pending
+      break
 
-        if timeoutExceeded:
-          # Timeout exceeded, cancelling all pending requests.
-          let pending =
-            pendingRequests.filterIt(not(it.finished())).
-              mapIt(it.cancelAndWait())
-          await noCancel allFutures(pending)
-          return Opt.none(PayloadExecutionStatus)
+    if deadline.finished:
+      break
 
-        if len(pendingRequests) == 0:
-          # All requests failed.
-          if not retry:
-            return Opt.none(PayloadExecutionStatus)
+  if responseProcessor.selectedResponse.isSome():
+    Opt.some requests[responseProcessor.selectedResponse.get].value().status
+  else:
+    Opt.none PayloadExecutionStatus
 
-          # To avoid continous spam of requests when EL node is offline we
-          # going to sleep until next attempt.
-          await variedSleep(sleepCounter, SleepDurations)
-          break mainLoop
-
-proc forkchoiceUpdatedForSingleEL(
+proc forkchoiceUpdated(
     connection: ELConnection,
-    state: ref ForkchoiceStateV1,
+    state: ForkchoiceStateV1,
     payloadAttributes: Opt[PayloadAttributesV1] |
                        Opt[PayloadAttributesV2] |
-                       Opt[PayloadAttributesV3]
+                       Opt[PayloadAttributesV3],
+    retry: bool,
 ): Future[PayloadStatusV1] {.async: (raises: [CatchableError]).} =
-  let
-    rpcClient = await connection.connectedRpcClient()
-    response = await rpcClient.forkchoiceUpdated(state[], payloadAttributes)
+  retryUntilCancelled:
+    let
+      rpcClient = await connection.connectedRpcClient()
+      responseFut = rpcClient.forkchoiceUpdated(state, payloadAttributes)
 
-  if response.payloadStatus.status notin {syncing, valid, invalid}:
-    debug "Invalid fork-choice updated response from the EL",
-          payloadStatus = response.payloadStatus
-    return
+    when payloadAttributes is Opt[PayloadAttributesV3]:
+      if payloadAttributes.isSome:
+        # Saving the future here allows the getPayload request to latch on to
+        # an in-flight request and thus avoid concurrent payload requests with the
+        # same attributes
+        connection.lastPayloadReq =
+          (PayloadParams(state: state, attributes: payloadAttributes[]), responseFut)
 
-  if response.payloadStatus.status == PayloadExecutionStatus.valid and
-     response.payloadId.isSome:
-    connection.lastPayloadId = response.payloadId
-
-  return response.payloadStatus
+    return (await responseFut).payloadStatus
 
 proc forkchoiceUpdated*(
     m: ELManager,
-    headBlockHash, safeBlockHash, finalizedBlockHash: Eth2Digest,
+    state: ForkchoiceStateV1,
     payloadAttributes: Opt[PayloadAttributesV1] |
                        Opt[PayloadAttributesV2] |
                        Opt[PayloadAttributesV3],
@@ -1082,8 +858,6 @@ proc forkchoiceUpdated*(
     retry: bool,
 ): Future[(PayloadExecutionStatus, Opt[Hash32])] {.
    async: (raises: [CancelledError]).} =
-  doAssert not headBlockHash.isZero
-
   # Allow finalizedBlockHash to be 0 to avoid sync deadlocks.
   #
   # https://github.com/ethereum/EIPs/blob/master/EIPS/eip-3675.md#pos-events
@@ -1098,152 +872,65 @@ proc forkchoiceUpdated*(
   if m.elConnections.len == 0:
     return (PayloadExecutionStatus.syncing, Opt.none Hash32)
 
-  when payloadAttributes is Opt[PayloadAttributesV3]:
-    template payloadAttributesV3(): auto =
-      if payloadAttributes.isSome:
-        payloadAttributes.get
-      else:
-        # As timestamp and prevRandao are both 0, won't false-positive match
-        (static(default(PayloadAttributesV3)))
-  elif payloadAttributes is Opt[PayloadAttributesV2]:
-    template payloadAttributesV3(): auto =
-      if payloadAttributes.isSome:
-        PayloadAttributesV3(
-          timestamp: payloadAttributes.get.timestamp,
-          prevRandao: payloadAttributes.get.prevRandao,
-          suggestedFeeRecipient: payloadAttributes.get.suggestedFeeRecipient,
-          withdrawals: payloadAttributes.get.withdrawals,
-          parentBeaconBlockRoot: default(Hash32))
-      else:
-        # As timestamp and prevRandao are both 0, won't false-positive match
-        (static(default(PayloadAttributesV3)))
-  elif payloadAttributes is Opt[PayloadAttributesV1]:
-    template payloadAttributesV3(): auto =
-      if payloadAttributes.isSome:
-        PayloadAttributesV3(
-          timestamp: payloadAttributes.get.timestamp,
-          prevRandao: payloadAttributes.get.prevRandao,
-          suggestedFeeRecipient: payloadAttributes.get.suggestedFeeRecipient,
-          withdrawals: @[],
-          parentBeaconBlockRoot: default(Hash32))
-      else:
-        # As timestamp and prevRandao are both 0, won't false-positive match
-        (static(default(PayloadAttributesV3)))
-  else:
-    static: doAssert false
-
-  let
-    state = newClone ForkchoiceStateV1(
-      headBlockHash: headBlockHash.asBlockHash,
-      safeBlockHash: safeBlockHash.asBlockHash,
-      finalizedBlockHash: finalizedBlockHash.asBlockHash)
-    startTime = Moment.now
+  let startTime = Moment.now
 
   var
     responseProcessor = ELConsensusViolationDetector.init()
-    sleepCounter = 0
-    retriesCount = 0
+    requests = m.elConnections.mapIt:
+      let req = it.forkchoiceUpdated(state, payloadAttributes, retry)
+      engineApiRequest(it, req, "forkchoiceUpdated", startTime)
+    pending = requests
+    earlyDeadline = sleepAsync(multiTimeout)
 
-  while true:
-    block mainLoop:
-      let requests =
-        m.elConnections.mapIt:
-          let req = it.forkchoiceUpdatedForSingleEL(state, payloadAttributes)
-          engineApiRequest(it, req, "forkchoiceUpdated", startTime, noTimeout)
+  defer:
+    await cancelAndWait(pending)
 
-      var pendingRequests = requests
+  while pending.len > 0:
+    try:
+      if responseProcessor.selectedResponse.isSome():
+        discard await race(race(pending), earlyDeadline)
+      else:
+        discard await race(pending)
+    except ValueError:
+      raiseAssert "race error cannot happen"
 
-      while true:
-        let timeoutExceeded =
-          try:
-            discard await race(pendingRequests).wait(deadline)
-            false
-          except ValueError:
-            raiseAssert "pendingRequests should not be empty!"
-          except AsyncTimeoutError:
-            true
-          except CancelledError as exc:
-            let pending =
-              pendingRequests.filterIt(not(it.finished())).
-                mapIt(it.cancelAndWait())
-            await noCancel allFutures(pending)
-            raise exc
+    if pending.anyIt(
+      responseProcessor.hasDisagreement(PayloadStatusV1, m.elConnections, requests, it)
+    ):
+      return (PayloadExecutionStatus.invalid, Opt.none Hash32)
 
-        var stillPending: type(pendingRequests)
-        for request in pendingRequests:
-          if not(request.finished()):
-            stillPending.add(request)
-          elif request.completed():
-            let index = requests.find(request)
-            doAssert(index >= 0)
-            responseProcessor.processResponse(
-              PayloadStatusV1, m.elConnections, requests, index)
-        pendingRequests = stillPending
+    pending = pending.filterIt(not it.finished)
 
-        template assignNextExpectedPayloadParams() =
-          # Ensure that there's no race condition window where getPayload's
-          # check for whether it needs to trigger a new fcU payload, due to
-          # cache invalidation, falsely suggests that the expected payload
-          # matches, and similarly that if the fcU fails or times out for other
-          # reasons, the expected payload params remain synchronized with
-          # EL state.
-          m.nextExpectedPayloadParams = Opt.some NextExpectedPayloadParams(
-            headBlockHash: headBlockHash,
-            safeBlockHash: safeBlockHash,
-            finalizedBlockHash: finalizedBlockHash,
-            payloadAttributes: payloadAttributesV3)
+    if earlyDeadline.finished and responseProcessor.selectedResponse.isSome():
+      # At the early deadline, we select the best response we've received so far
+      if pending.len > 0:
+        # Let the other requests run their course so they receive the update
+        asyncSpawn lazyWait(pending, deadline)
+        reset pending
+      break
 
-        template getSelected: untyped =
-          let data = requests[responseProcessor.selectedResponse.get].value()
-          (data.status, data.latestValidHash)
+    if deadline.finished:
+      break
 
-        if responseProcessor.disagreementAlreadyDetected:
-          let pending =
-            pendingRequests.filterIt(not(it.finished())).
-              mapIt(it.cancelAndWait())
-          await noCancel allFutures(pending)
-          return (PayloadExecutionStatus.invalid, Opt.none Hash32)
-        elif responseProcessor.selectedResponse.isSome:
-          # We spawn task which will wait for all other responses which are
-          # still pending, after 30.seconds all pending requests will be
-          # cancelled.
-          asyncSpawn lazyWait(pendingRequests.mapIt(FutureBase(it)))
-          assignNextExpectedPayloadParams()
-          return getSelected()
-
-        if timeoutExceeded:
-          # Timeout exceeded, cancelling all pending requests.
-          let pending =
-            pendingRequests.filterIt(not(it.finished())).
-              mapIt(it.cancelAndWait())
-          await noCancel allFutures(pending)
-          return (PayloadExecutionStatus.syncing, Opt.none Hash32)
-
-        if len(pendingRequests) == 0:
-          # All requests failed, we will continue our attempts until deadline
-          # is not finished.
-          inc(retriesCount)
-          if not retry:
-            return (PayloadExecutionStatus.syncing, Opt.none Hash32)
-
-          # To avoid continous spam of requests when EL node is offline we
-          # going to sleep until next attempt.
-          await variedSleep(sleepCounter, SleepDurations)
-          break mainLoop
+  if responseProcessor.selectedResponse.isSome():
+    let data = requests[responseProcessor.selectedResponse.get].value()
+    (data.status, data.latestValidHash)
+  else:
+    (PayloadExecutionStatus.syncing, Opt.none Hash32)
 
 proc forkchoiceUpdated*(
     m: ELManager,
-    headBlockHash, safeBlockHash, finalizedBlockHash: Eth2Digest,
+    state: ForkchoiceStateV1,
     payloadAttributes: Opt[PayloadAttributesV1] |
                        Opt[PayloadAttributesV2] |
                        Opt[PayloadAttributesV3]
 ): Future[(PayloadExecutionStatus, Opt[Hash32])] {.
     async: (raises: [CancelledError], raw: true).} =
   forkchoiceUpdated(
-    m, headBlockHash, safeBlockHash, finalizedBlockHash,
-    payloadAttributes, sleepAsync(FORKCHOICEUPDATED_TIMEOUT), true)
+    m, state, payloadAttributes, sleepAsync(FORKCHOICEUPDATED_TIMEOUT), true
+  )
 
-proc checkChainIdWithSingleEL(
+proc checkChainId(
     m: ELManager,
     connection: ELConnection
 ) {.async: (raises: [CancelledError]).} =
@@ -1254,8 +941,8 @@ proc checkChainIdWithSingleEL(
     try:
       let
         providerChain = await connection.engineApiRequest(
-          rpcClient.eth_chainId(), "chainId", Moment.now(),
-          web3RequestsTimeout)
+          rpcClient.eth_chainId(), "chainId", Moment.now()
+        )
 
         # https://chainid.network/
         expectedChain = case m.eth1Network.get
@@ -1285,15 +972,13 @@ proc checkChainId(
   if m.elConnections.len == 0:
     return
 
-  let requests = m.elConnections.mapIt(m.checkChainIdWithSingleEL(it))
+  let requests = m.elConnections.mapIt(m.checkChainId(it))
   try:
     await allFutures(requests).wait(3.seconds)
   except AsyncTimeoutError:
     discard
   except CancelledError as exc:
-    let pending = requests.filterIt(not(it.finished())).
-                    mapIt(it.cancelAndWait())
-    await noCancel allFutures(pending)
+    await cancelAndWait(requests)
     raise exc
 
   let (pending, failed, finished) =
@@ -1312,7 +997,7 @@ proc checkChainId(
             inc(failed)
       (pending, failed, done)
 
-  await noCancel allFutures(pending)
+  await cancelAndWait(pending)
 
   if (len(pending) > 0) or (failed != 0):
     warn "Failed to exchange configuration with the configured EL end-points",
@@ -1342,23 +1027,16 @@ proc startCheckChainIdLoop(
     await m.checkChainId()
     await sleepAsync(60.seconds)
 
-proc start*(m: ELManager, syncChain = true) {.gcsafe.} =
+proc start*(m: ELManager) =
   if m.elConnections.len == 0:
     return
 
-  if m.hasJwtSecret and m.checkChainIdLoopFut.isNil:
+  if m.checkChainIdLoopFut.isNil:
     m.checkChainIdLoopFut = m.startCheckChainIdLoop()
-
-func `$`(x: Quantity): string =
-  $(x.uint64)
-
-func `$`(x: BlockObject): string =
-  $(x.number) & " [" & $(x.hash) & "]"
 
 proc testWeb3Provider*(
     web3Url: Uri, jwtSecret: Opt[JwtSharedKey]
 ) {.async: (raises: [CatchableError]).} =
-
   stdout.write "Establishing web3 connection..."
   let web3 =
     try:
@@ -1370,16 +1048,13 @@ proc testWeb3Provider*(
 
   stdout.write "\rEstablishing web3 connection: Connected\n"
 
-  template request(actionDesc: static string,
-                   action: untyped): untyped =
+  template request(actionDesc: static string, action: untyped): untyped =
     stdout.write actionDesc & "..."
     stdout.flushFile()
     var res: typeof(read action)
     try:
       let fut = action
       res = await fut.wait(web3RequestsTimeout)
-      when res is BlockObject:
-        res = raiseIfNil res
       stdout.write "\r" & actionDesc & ": " & $res
     except CatchableError as err:
       stdout.write "\r" & actionDesc & ": Error(" & err.msg & ")"

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -61,12 +61,22 @@ const
 type
   DeadlineFuture* = Future[void].Raising([CancelledError])
 
+  SomeEnginePayloadWithValue =
+    BellatrixExecutionPayloadWithValue |
+    GetPayloadV2Response |
+    GetPayloadV3Response |
+    GetPayloadV4Response |
+    GetPayloadV5Response |
+    GetPayloadV6Response
+
   PayloadParams = object
     ## Parameters given to the latest payload-preparing forkChoiceParameters
     ## call - if all parameters match, we can use the payload id given in
     ## response, else we have to make a new call
     state: ForkchoiceStateV1
     attributes: PayloadAttributesV3
+      # V3 is a superset of the earlier versions so we can use it for cache
+      # equivalence purposes
 
   PayloadReq = tuple[params: PayloadParams, resp: Future[ForkchoiceUpdatedResponse]]
 
@@ -335,6 +345,9 @@ proc getPayload(
         if useLastPayload:
           payloadReq.resp
         else:
+          engine_api_last_minute_forkchoice_updates_sent.inc(
+            1, [connection.engineUrl.url]
+          )
           notice "Payload not prepared, sending last-minute payload request",
             url = connection.engineUrl.url
 
@@ -353,7 +366,15 @@ proc getPayload(
       # Give the EL some time to build the block
       await sleepAsync(500.milliseconds)
 
-    payload = await rpcClient.getPayload(GetPayloadResponseType, payloadId)
+    payload =
+      when GetPayloadResponseType is BellatrixExecutionPayloadWithValue:
+        BellatrixExecutionPayloadWithValue(
+          executionPayload: await rpcClient.getPayload(ExecutionPayloadV1, payloadId),
+          blockValue: Wei.zero,
+        )
+      else:
+        await rpcClient.getPayload(GetPayloadResponseType, payloadId)
+
     break # retryUntilCancelled
 
   # Check that the execution payload matches the attributes we asked for, as
@@ -367,20 +388,39 @@ proc getPayload(
       limit = MAX_EXTRA_DATA_BYTES
     raise newException(CatchableError, "Execution payload extraData exceeds max size")
 
-  if params.attributes.withdrawals != payload.executionPayload.withdrawals:
-    warn "Execution client returned unexpected payload withdrawals",
-      url = connection.engineUrl.url,
-      payloadId,
-      withdrawals_from_cl_len = params.attributes.withdrawals.len,
-      withdrawals_from_el_len = payload.executionPayload.withdrawals.maybeDeref.len,
-      withdrawals_from_cl =
-        mapIt(params.attributes.withdrawals, it.asConsensusWithdrawal),
-      withdrawals_from_el =
-        mapIt(payload.executionPayload.withdrawals, it.asConsensusWithdrawal)
-    raise
-      newException(CatchableError, "Execution client returned mismatching withdrawals")
+  when compiles(payload.executionPayload.withdrawals):
+    when payload.executionPayload.withdrawals is Opt:
+      template maybeEmpty(v: Opt): untyped =
+        v.valueOr(@[])
+    else:
+      template maybeEmpty(v: auto): untyped =
+        v
+
+    if params.attributes.withdrawals != payload.executionPayload.withdrawals.maybeEmpty:
+      warn "Execution client returned unexpected payload withdrawals",
+        url = connection.engineUrl.url,
+        payloadId,
+        withdrawals_from_cl_len = params.attributes.withdrawals.len,
+        withdrawals_from_el_len = payload.executionPayload.withdrawals.maybeEmpty.len,
+        withdrawals_from_cl =
+          mapIt(params.attributes.withdrawals, it.asConsensusWithdrawal),
+        withdrawals_from_el = mapIt(
+          payload.executionPayload.withdrawals.maybeEmpty, it.asConsensusWithdrawal
+        )
+      raise newException(
+        CatchableError, "Execution client returned mismatching withdrawals"
+      )
 
   payload
+
+template EngineApiResponseType(T: type bellatrix.ExecutionPayloadForSigning): type =
+  BellatrixExecutionPayloadWithValue
+
+template EngineApiResponseType(T: type capella.ExecutionPayloadForSigning): type =
+  engine_api.GetPayloadV2Response
+
+template EngineApiResponseType(T: type deneb.ExecutionPayloadForSigning): type =
+  engine_api.GetPayloadV3Response
 
 template EngineApiResponseType(T: type electra.ExecutionPayloadForSigning): type =
   engine_api.GetPayloadV4Response
@@ -404,11 +444,37 @@ func init*(
   )
 
 func init*(
-    T: type PayloadAttributesV3,
+    T: type PayloadAttributesV1,
+    timestamp: uint64,
+    prevRandao: Eth2Digest,
+    suggestedFeeRecipient: Eth1Address,
+): T =
+  T(
+    timestamp: Quantity timestamp,
+    prevRandao: Bytes32 prevRandao.to(Hash32),
+    suggestedFeeRecipient: suggestedFeeRecipient,
+  )
+
+func init*(
+    T: type PayloadAttributesV2,
     timestamp: uint64,
     prevRandao: Eth2Digest,
     suggestedFeeRecipient: Eth1Address,
     withdrawals: seq[capella.Withdrawal],
+): T =
+  T(
+    timestamp: Quantity timestamp,
+    prevRandao: Bytes32 prevRandao.to(Hash32),
+    suggestedFeeRecipient: suggestedFeeRecipient,
+    withdrawals: withdrawals.toEngineWithdrawals(),
+  )
+
+func init*(
+    T: type PayloadAttributesV3,
+    timestamp: uint64,
+    prevRandao: Eth2Digest,
+    suggestedFeeRecipient: Eth1Address,
+    withdrawals: sink seq[capella.Withdrawal],
     consensusHead: Eth2Digest,
 ): T =
   T(
@@ -419,20 +485,49 @@ func init*(
     parentBeaconBlockRoot: consensusHead.to(Hash32),
   )
 
+func init(
+    T: type PayloadParams, state: ForkchoiceStateV1, attributes: PayloadAttributesV1
+): T =
+  PayloadParams(
+    state: state,
+    attributes: PayloadAttributesV3(
+      timestamp: attributes.timestamp,
+      prevRandao: attributes.prevRandao,
+      suggestedFeeRecipient: attributes.suggestedFeeRecipient,
+      withdrawals: @[],
+      parentBeaconBlockRoot: default(Hash32),
+    ),
+  )
+
+func init(
+    T: type PayloadParams, state: ForkchoiceStateV1, attributes: PayloadAttributesV2
+): T =
+  PayloadParams(
+    state: state,
+    attributes: PayloadAttributesV3(
+      timestamp: attributes.timestamp,
+      prevRandao: attributes.prevRandao,
+      suggestedFeeRecipient: attributes.suggestedFeeRecipient,
+      withdrawals: attributes.withdrawals,
+      parentBeaconBlockRoot: default(Hash32),
+    ),
+  )
+func init(
+    T: type PayloadParams, state: ForkchoiceStateV1, attributes: PayloadAttributesV3
+): T =
+  PayloadParams(state: state, attributes: attributes)
+
 proc getPayload*(
     m: ELManager,
     PayloadType: type ForkyExecutionPayloadForSigning,
     state: ForkchoiceStateV1,
-    payloadAttributes: PayloadAttributesV3,
+    payloadAttributes: PayloadAttributesV1 | PayloadAttributesV2 | PayloadAttributesV3,
 ): Future[Opt[PayloadType]] {.async: (raises: [CancelledError]).} =
   if m.elConnections.len == 0:
     notice "No engine configured, using empty payload"
     return Opt.none(PayloadType)
 
-  let params = PayloadParams(
-    state: state,
-    attributes: payloadAttributes,
-  )
+  let params = PayloadParams.init(state, payloadAttributes)
 
   # `getPayloadFromSingleEL` may introduce additional latency
   const extraProcessingOverhead = 500.milliseconds
@@ -449,7 +544,7 @@ proc getPayload*(
 
   # Of the payloads that arrived on time, select the one with the highest
   # block value
-  func betterThan(a, b: auto): bool =
+  func betterThan(a, b: SomeEnginePayloadWithValue): bool =
     a.blockValue > b.blockValue
 
   var bestPayloadIdx = Opt.none(int)
@@ -838,13 +933,12 @@ proc forkchoiceUpdated(
       rpcClient = await connection.connectedRpcClient()
       responseFut = rpcClient.forkchoiceUpdated(state, payloadAttributes)
 
-    when payloadAttributes is Opt[PayloadAttributesV3]:
-      if payloadAttributes.isSome:
-        # Saving the future here allows the getPayload request to latch on to
-        # an in-flight request and thus avoid concurrent payload requests with the
-        # same attributes
-        connection.lastPayloadReq =
-          (PayloadParams(state: state, attributes: payloadAttributes[]), responseFut)
+    if payloadAttributes.isSome:
+      # Saving the future here allows the getPayload request to latch on to
+      # an in-flight request and thus avoid concurrent payload requests with the
+      # same attributes
+      connection.lastPayloadReq =
+        (PayloadParams.init(state, payloadAttributes[]), responseFut)
 
     return (await responseFut).payloadStatus
 

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -325,7 +325,7 @@ proc storeBackfillBlock(
     res
 
 from web3/engine_api_types import PayloadExecutionStatus
-from ../el/el_manager import ELManager, DeadlineFuture, sendNewPayload
+from ../el/el_manager import ELManager, DeadlineFuture, newPayload
 from ../consensus_object_pools/attestation_pool import AttestationPool, addForkChoice
 from ../consensus_object_pools/spec_cache import get_attesting_indices
 
@@ -345,8 +345,7 @@ proc newExecutionPayload*(
   debug "newPayload: inserting block into execution engine",
     executionPayload = shortLog(executionPayload)
 
-  let payloadStatus = ?await elManager.sendNewPayload(
-    blck, envelope, deadline, retry)
+  let payloadStatus = ?await elManager.newPayload(blck, envelope, deadline, retry)
 
   debug "newPayload: succeeded",
     parentHash = executionPayload.parent_hash,
@@ -362,7 +361,7 @@ proc newExecutionPayload*(
 ): Future[Opt[PayloadExecutionStatus]] {.
   async: (raises: [CancelledError], raw: true).} =
   newExecutionPayload(
-    elManager, blck, noEnvelope, sleepAsync(FORKCHOICEUPDATED_TIMEOUT), true)
+    elManager, blck, noEnvelope, sleepAsync(NEWPAYLOAD_TIMEOUT), true)
 
 proc getExecutionValidity(
     elManager: ELManager,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2108,8 +2108,7 @@ proc attemptGetBlobs(node: BeaconNode,
     withBlck(columnless):
       when consensusFork >= ConsensusFork.Fulu and
            consensusFork < ConsensusFork.Gloas:
-        let blobsFromElOpt =
-          await elManager.sendGetBlobsV2(forkyBlck)
+        let blobsFromElOpt = await elManager.getBlobsV2(forkyBlck)
         if blobsFromElOpt.isSome():
           let blobsEl = blobsFromElOpt.get()
           # check lengths of array[BlobAndProofV2] with blobs

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -111,7 +111,7 @@ proc main() {.noinline, raises: [CatchableError].} =
 
   # Run `exchangeTransitionConfiguration` loop
   if elManager != nil:
-    elManager.start(syncChain = false)
+    elManager.start()
 
   info "Listening to incoming network requests"
   network.registerProtocol(

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -187,11 +187,15 @@ proc main() {.noinline, raises: [CatchableError].} =
             when lcDataForkAtConsensusFork(consensusFork) == lcDataFork:
               debug "Sending forkchoiceUpdated",
                 finalizedBlockHash = finalizedBlockHash
+
+              let state = ForkchoiceStateV1.init(
+                blockHash,
+                finalizedBlockHash, # justified not available
+                finalizedBlockHash
+              )
               optimisticFcuFut = elManager.forkchoiceUpdated(
-                headBlockHash = blockHash,
-                safeBlockHash = finalizedBlockHash,  # justified not available
-                finalizedBlockHash = finalizedBlockHash,
-                payloadAttributes = Opt.none(consensusFork.PayloadAttributes))
+                state, payloadAttributes = Opt.none(consensusFork.PayloadAttributes)
+              )
               optimisticFcuFut.addCallback do (future: pointer):
                 optimisticFcuFut = nil
         else:

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -343,12 +343,11 @@ proc getExecutionPayload*(
 
   type PayloadType = consensusFork.ExecutionPayloadForSigning
   let
-    eps = await(
-      node.elManager.getPayload(
-        PayloadType, beaconHead.blck.bid.root, executionHead, latestSafe,
-        latestFinalized, timestamp, prevRandao, feeRecipient, withdrawals,
-      )
-    ).valueOr:
+    state = ForkchoiceStateV1.init(executionHead, latestSafe, latestFinalized)
+    attributes = PayloadAttributesV3.init(
+      timestamp, prevRandao, feeRecipient, withdrawals, beaconHead.blck.bid.root
+    )
+    eps = await(node.elManager.getPayload(PayloadType, state, attributes)).valueOr:
       if not proposalState[].is_merge_transition_complete():
         # Pre-merge, an all-zeroes execution payload is used and there are no
         # requests, so default is fine here

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -127,10 +127,9 @@ cli do(validatorsDir: string, secretsDir: string,
               continue
 
             let (status, _) = waitFor noCancel elManager.forkchoiceUpdated(
-              headBlockHash = payload.block_hash,
-              safeBlockHash = payload.block_hash,
-              finalizedBlockHash = ZERO_HASH,
-              payloadAttributes = Opt.none(consensusFork.PayloadAttributes))
+              ForkchoiceStateV1.init(payload.block_hash, payload.block_hash, ZERO_HASH),
+              Opt.none(consensusFork.PayloadAttributes),
+            )
             if status != PayloadExecutionStatus.valid:
               continue
 
@@ -253,26 +252,37 @@ cli do(validatorsDir: string, secretsDir: string,
                 let
                   executionHead =
                     forkyState.data.latest_execution_payload_header.block_hash
-                  withdrawals =
-                    when consensusFork >= ConsensusFork.Capella:
-                      get_expected_withdrawals(forkyState.data)
-                    else:
-                      newSeq[capella.Withdrawal]()
+                  timestamp = cfg.timeParams.compute_timestamp_at_slot(
+                    forkyState.data, forkyState.data.slot
+                  )
+                  prevRandao =
+                    get_randao_mix(forkyState.data, get_current_epoch(forkyState.data))
+
+                when consensusFork >= ConsensusFork.Capella:
+                  let withdrawals = get_expected_withdrawals(forkyState.data)
+
+                when consensusFork >= ConsensusFork.Deneb:
+                  let attributes = PayloadAttributesV3.init(
+                    timestamp, prevRandao, feeRecipient, withdrawals,
+                    forkyState.latest_block_root,
+                  )
+                elif consensusFork >= ConsensusFork.Capella:
+                  let attributes = PayloadAttributesV2.init(
+                    timestamp, prevRandao, feeRecipient, withdrawals
+                  )
+                else:
+                  let attributes =
+                    PayloadAttributesV1.init(timestamp, prevRandao, feeRecipient)
 
                 var pl: consensusFork.ExecutionPayloadForSigning
                 while true:
-                  pl = (waitFor noCancel elManager.getPayload(
+                  pl = (
+                    waitFor noCancel elManager.getPayload(
                       consensusFork.ExecutionPayloadForSigning,
-                      consensusHead = forkyState.latest_block_root,
-                      headBlock = executionHead,
-                      safeBlock = executionHead,
-                      finalizedBlock = ZERO_HASH,
-                      timestamp = cfg.timeParams.compute_timestamp_at_slot(
-                        forkyState.data, forkyState.data.slot),
-                      prevRandao = get_randao_mix(
-                        forkyState.data, get_current_epoch(forkyState.data)),
-                      suggestedFeeRecipient = feeRecipient,
-                      withdrawals = withdrawals)).valueOr:
+                      ForkchoiceStateV1.init(executionHead, executionHead, ZERO_HASH),
+                      attributes,
+                    )
+                  ).valueOr:
                     waitFor noCancel sleepAsync(chronos.seconds(2))
                     continue
                   break

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -112,7 +112,7 @@ cli do(validatorsDir: string, secretsDir: string,
   # Sync EL to initial state. Note that to construct the new branch, the EL
   # should not have advanced to a later block via `engine_forkchoiceUpdated`.
   # The EL may otherwise refuse to produce new heads
-  elManager.start(syncChain = false)
+  elManager.start()
   withBlck(blck[]):
     debugGloasComment ""
     when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -5,6 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+{.push raises: [], gcsafe.}
 {.used.}
 
 import
@@ -20,7 +21,7 @@ import
   ../beacon_chain/networking/network_metadata,
   ./testutil
 
-proc allocatePort(): Port =
+proc allocatePort(): Port {.raises: [TransportError].} =
   ## Allocate a free port by using a counter starting from an unused port range
   ## Each allocation increments the counter
   let srv = createStreamServer(static(initTAddress("127.0.0.1:0")))
@@ -136,7 +137,9 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
 
     return state.chainId
 
-proc newMockRpcServer*(state: MockEngineState, port: Port): RpcHttpServer =
+proc newMockRpcServer*(
+    state: MockEngineState, port: Port
+): RpcHttpServer {.raises: [CatchableError].} =
   ## Create and start a new mock RPC server on the given port
   let server = newRpcHttpServer()
   setupMockEngineAPI(server, state)
@@ -154,7 +157,7 @@ proc createEngineApiUrl*(
   let urlStr = "http://127.0.0.1:" & $port.uint16
   EngineApiUrl.init(urlStr, jwtSecret)
 
-proc mockSetup(): MockSetup =
+proc mockSetup(): MockSetup {.raises: [CatchableError].}  =
   let
     port = allocatePort()
     state = createMockEngineState()

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -1,19 +1,174 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
 {.used.}
 
 import
+  std/[typetraits, net],
   unittest2,
-  ../beacon_chain/el/el_conf,
+  chronos,
+  chronicles,
+  json_rpc/[rpcserver, errors],
+  web3/[primitives, conversions, engine_api_types],
+  eth/common/eth_types,
+  ../beacon_chain/el/[el_conf, el_manager],
+  ../beacon_chain/spec/[digest, engine_authentication, forks],
+  ../beacon_chain/networking/network_metadata,
   ./testutil
 
-suite "Eth1 monitor":
+proc allocatePort(): Port =
+  ## Allocate a free port by using a counter starting from an unused port range
+  ## Each allocation increments the counter
+  let srv = createStreamServer(static(initTAddress("127.0.0.1:0")))
+  let port = srv.localAddress().port
+  waitFor srv.closeWait()
+  port
+
+# Mock execution client state for testing
+type
+  MockEngineState* = ref object
+    ## Tracks the state of a mock execution client for testing scenarios, mainly
+    ## for the purpose of testing failure, timeout and error scenarios (rather
+    ## than specific payload properties)
+    chainId*: UInt256
+    shouldFailNewPayload*: bool
+    shouldFailForkchoice*: bool
+    shouldFailGetPayload*: bool
+    shouldFailChainId*: bool
+    newPayloadCallCount*: int
+    forkchoiceCallCount*: int
+    getPayloadCallCount*: int
+    chainIdCallCount*: int
+    responseDelay*: Duration
+    blockNumber*: uint64
+
+  MockSetup* = ref object
+    state: MockEngineState
+    server: RpcHttpServer
+    url: EngineApiUrl
+
+proc createMockEngineState*(
+    chainId: UInt256 = 1.u256, initialBlockNumber: uint64 = 1000
+): MockEngineState =
+  ## Create a new mock engine state with default or custom values
+  MockEngineState(
+    chainId: chainId,
+    shouldFailNewPayload: false,
+    shouldFailForkchoice: false,
+    shouldFailGetPayload: false,
+    shouldFailChainId: false,
+    newPayloadCallCount: 0,
+    getPayloadCallCount: 0,
+    forkchoiceCallCount: 0,
+    chainIdCallCount: 0,
+    responseDelay: 0.milliseconds,
+    blockNumber: initialBlockNumber,
+  )
+
+proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
+  ## Setup a mock execution engine API on the RPC server
+  server.rpc("engine_newPayloadV4") do(
+    payload: ExecutionPayloadV3,
+    expectedBlobVersionedHashes: Opt[seq[Hash32]],
+    parentBeaconBlockRoot: Opt[Hash32],
+    executionRequests: Opt[seq[seq[byte]]]
+  ) -> PayloadStatusV1:
+    inc state.newPayloadCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailNewPayload:
+      raise
+        (ref ApplicationError)(code: -32603, msg: "Internal error: execution failed")
+
+    return PayloadStatusV1(
+      status: PayloadExecutionStatus.valid, latestValidHash: Opt.some(payload.blockHash)
+    )
+
+  server.rpc("engine_forkchoiceUpdatedV3") do(
+    fcState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV3]
+  ) -> ForkchoiceUpdatedResponse:
+    inc state.forkchoiceCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailForkchoice:
+      raise (ref ApplicationError)(
+        code: -32603, msg: "Internal error: forkchoice update failed"
+      )
+
+    return ForkchoiceUpdatedResponse(
+      payloadStatus: PayloadStatusV1(
+        status: PayloadExecutionStatus.valid,
+        latestValidHash: Opt.some(fcState.headBlockHash),
+      ),
+      payloadId:
+        if payloadAttributes.isSome:
+          Opt.some(Bytes8([1'u8, 2, 3, 4, 5, 6, 7, 8]))
+        else:
+          Opt.none(Bytes8),
+    )
+
+  server.rpc("engine_getPayloadV4") do(payloadId: Bytes8) -> GetPayloadV4Response:
+    inc state.getPayloadCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailGetPayload:
+      raise
+        (ref ApplicationError)(code: -32603, msg: "Internal error: getPayload failed")
+
+    return GetPayloadV4Response()
+
+  server.rpc("eth_chainId") do() -> UInt256:
+    inc state.chainIdCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailChainId:
+      raise (ref ApplicationError)(
+        code: -32603, msg: "Internal error: chain id query failed"
+      )
+
+    return state.chainId
+
+proc newMockRpcServer*(state: MockEngineState, port: Port): RpcHttpServer =
+  ## Create and start a new mock RPC server on the given port
+  let server = newRpcHttpServer()
+  setupMockEngineAPI(server, state)
+
+  server.addHttpServer(
+    address = initTAddress("127.0.0.1", port), maxRequestBodySize = 16 * 1024 * 1024
+  )
+
+  server.start()
+  return server
+
+proc createEngineApiUrl*(
+    port: Port, jwtSecret: Opt[JwtSharedKey] = Opt.none(JwtSharedKey)
+): EngineApiUrl =
+  let urlStr = "http://127.0.0.1:" & $port.uint16
+  EngineApiUrl.init(urlStr, jwtSecret)
+
+proc mockSetup(): MockSetup =
+  let
+    port = allocatePort()
+    state = createMockEngineState()
+    server = newMockRpcServer(state, port)
+
+  server.start()
+
+  MockSetup(state: state, server: server, url: createEngineApiUrl(port))
+
+proc close(setup: MockSetup) =
+  waitFor setup.server.stop()
+  waitFor setup.server.closeWait()
+
+suite "EL Manager - Helpers":
   test "Rewrite URLs":
     var
       gethHttpUrl = "http://localhost:8545"
@@ -32,3 +187,452 @@ suite "Eth1 monitor":
       unspecifiedProtocolUrl == "ws://localhost:8545"
 
       gethWsUrl == "ws://localhost:8545"
+
+proc createELManager*(
+    engines: seq[EngineApiUrl], eth1Network: Opt[Eth1Network] = Opt.none(Eth1Network)
+): ELManager =
+  ELManager.new(engines, eth1Network)
+
+suite "EL Manager - Async Operations":
+  setup:
+    var mockState = createMockEngineState(chainId = 1.u256)
+    var mockPort = allocatePort()
+    var server = newMockRpcServer(mockState, mockPort)
+
+  teardown:
+    try:
+      waitFor server.stop()
+      waitFor server.closeWait()
+    except CatchableError:
+      discard
+
+  test "ELManager can be started and stopped safely":
+    let engineUrl = createEngineApiUrl(mockPort)
+    let manager = createELManager(@[engineUrl])
+    manager.start()
+    check manager.hasConnection()
+    # Start is async-spawned internally, just verify no crash
+
+  test "ELManager with custom chain network":
+    mockState.chainId = 11155111.u256
+    let engineUrl = createEngineApiUrl(mockPort)
+    let manager = createELManager(@[engineUrl], Opt.some(sepolia))
+    manager.start()
+
+    check manager.hasConnection()
+
+suite "EL Manager - forkchoiceUpdated":
+  setup:
+    let setup = mockSetup()
+
+  teardown:
+    setup.close()
+
+  test "forkchoiceUpdated basic call":
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    check setup.state.forkchoiceCallCount == 0
+
+    let state =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status, payload) = waitFor manager.forkchoiceUpdated(
+      state, Opt.none(PayloadAttributesV3), sleepAsync(5.seconds), false
+    )
+
+    # Verify the call was made
+    check:
+      setup.state.forkchoiceCallCount == 1
+      status == PayloadExecutionStatus.valid
+
+  test "forkchoiceUpdated with payload attributes":
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let attributes = Opt.some(
+      PayloadAttributesV3.init(
+        1234567890, Eth2Digest.default, EthAddress.default, @[], Eth2Digest.default
+      )
+    )
+
+    check setup.state.forkchoiceCallCount == 0
+
+    let state =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status, payload) =
+      waitFor manager.forkchoiceUpdated(state, attributes, sleepAsync(5.seconds), false)
+
+    check:
+      setup.state.forkchoiceCallCount == 1
+      status == PayloadExecutionStatus.valid
+      # When attributes are provided, a payload ID should be assigned
+      payload.isSome
+
+  test "forkchoiceUpdated with response delay":
+    setup.state.responseDelay = 100.milliseconds
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let deadline = sleepAsync(5.seconds)
+
+    let startTime = Moment.now()
+    let state2 =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status2, payload2) = waitFor manager.forkchoiceUpdated(
+      state2, Opt.none(PayloadAttributesV3), deadline, false
+    )
+    let duration = Moment.now() - startTime
+
+    # Should have taken at least as long as the response delay
+    check duration >= setup.state.responseDelay
+    check status2 == PayloadExecutionStatus.valid
+
+  test "forkchoiceUpdated multiple sequential calls":
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let deadline = sleepAsync(5.seconds)
+
+    check setup.state.forkchoiceCallCount == 0
+
+    for i in 1 .. 3:
+      let state3 = ForkchoiceStateV1.init(
+        Eth2Digest.default, Eth2Digest.default, Eth2Digest.default
+      )
+      let (status3, _) = waitFor manager.forkchoiceUpdated(
+        state3, Opt.none(PayloadAttributesV3), deadline, false
+      )
+      check:
+        status3 == PayloadExecutionStatus.valid
+        setup.state.forkchoiceCallCount == i
+
+suite "EL Manager - getPayload":
+  setup:
+    var setup = mockSetup()
+
+  teardown:
+    setup.close()
+
+  test "success without retry":
+    let
+      manager = createELManager(@[setup.url])
+      state = ForkchoiceStateV1.init(
+        default(Eth2Digest), default(Eth2Digest), default(Eth2Digest)
+      )
+      attrs = PayloadAttributesV3.init(
+        default(uint64),
+        default(Eth2Digest),
+        default(Eth1Address),
+        default(seq[capella.Withdrawal]),
+        default(Eth2Digest),
+      )
+
+      resp =
+        waitFor manager.getPayload(electra.ExecutionPayloadForSigning, state, attrs)
+
+    check:
+      setup.state.getPayloadCallCount == 1
+      resp.isOk()
+
+suite "EL Manager - newPayload":
+  setup:
+    var setup = mockSetup()
+
+  teardown:
+    setup.close()
+
+  test "success without retry":
+    let
+      manager = createELManager(@[setup.url])
+
+      resp = waitFor manager.newPayload(
+        default(electra.BeaconBlock), noEnvelope, sleepAsync(10.seconds), false
+      )
+
+    check:
+      setup.state.newPayloadCallCount == 1
+      resp.isOk()
+
+suite "EL Manager - Payload Request Caching":
+  setup:
+    let setup = mockSetup()
+
+  teardown:
+    setup.close()
+
+  test "getPayload reuses cached forkchoiceUpdated when parameters match":
+    ## This test verifies that when getPayload is called with the same parameters
+    ## as the previous forkchoiceUpdated call, it reuses that cached response
+    ## instead of making a new forkchoiceUpdated call
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let attrsPayload = PayloadAttributesV3.init(
+      1234567890, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    let attributes = Opt.some(attrsPayload)
+
+    # First, make a forkchoiceUpdated call with payload attributes
+    check setup.state.forkchoiceCallCount == 0
+    let state =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status, payloadId) =
+      waitFor manager.forkchoiceUpdated(state, attributes, sleepAsync(5.seconds), false)
+
+    check:
+      setup.state.forkchoiceCallCount == 1
+      status == PayloadExecutionStatus.valid
+      payloadId.isSome
+
+    # Now call getPayload - this should reuse the cached forkchoiceUpdated result
+    let stateForGet =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let payload = waitFor manager.getPayload(
+      electra.ExecutionPayloadForSigning, stateForGet, attrsPayload
+    )
+
+    check:
+      # forkchoiceUpdated should still have been called only once
+      setup.state.forkchoiceCallCount == 1
+      setup.state.getPayloadCallCount == 1
+      payload.isSome
+
+  test "getPayload makes new forkchoiceUpdated when parameters change":
+    ## This test verifies that when getPayload is called with different parameters
+    ## than the previous forkchoiceUpdated call, it makes a new forkchoiceUpdated request
+    let manager = createELManager(@[setup.url])
+    manager.start()
+    let
+      attrs1 = PayloadAttributesV3.init(
+        1234567890, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+      )
+      attributes1 = Opt.some(attrs1)
+
+    # First forkchoiceUpdated call
+    let state1 =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status1, _) = waitFor manager.forkchoiceUpdated(
+      state1, attributes1, sleepAsync(5.seconds), false
+    )
+    check:
+      setup.state.forkchoiceCallCount == 1
+      status1 == PayloadExecutionStatus.valid
+
+    # Now change a parameter (timestamp) and call getPayload
+    let stateForGet2 =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let attrsGet2 = PayloadAttributesV3.init(
+      1234567999, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    let payload = waitFor manager.getPayload(
+      electra.ExecutionPayloadForSigning, stateForGet2, attrsGet2
+    )
+
+    check:
+      # Should have made a new forkchoiceUpdated call due to parameter mismatch
+      setup.state.forkchoiceCallCount == 2
+      setup.state.getPayloadCallCount == 1
+      payload.isSome
+
+  test "multiple sequential forkchoiceUpdated calls with payload attributes":
+    ## This test verifies that successive forkchoiceUpdated calls each update
+    ## the cached payload request appropriately
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let attrsSeq = PayloadAttributesV3.init(
+      1000, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    let attributes = Opt.some(attrsSeq)
+
+    # Make multiple sequential forkchoiceUpdated calls
+    for i in 1 .. 3:
+      let stateSeq = ForkchoiceStateV1.init(
+        Eth2Digest.default, Eth2Digest.default, Eth2Digest.default
+      )
+      let (status, payloadId) = waitFor manager.forkchoiceUpdated(
+        stateSeq, attributes, sleepAsync(5.seconds), false
+      )
+      check:
+        setup.state.forkchoiceCallCount == i
+        status == PayloadExecutionStatus.valid
+        payloadId.isSome
+
+  test "forkchoiceUpdated without payload attributes doesn't cache":
+    ## This test verifies that forkchoiceUpdated calls without payload attributes
+    ## don't cache a payload request (since they won't be used for payload preparation)
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    # Make a forkchoiceUpdated call WITHOUT payload attributes
+    let stateNoAttrs =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status, _) = waitFor manager.forkchoiceUpdated(
+      stateNoAttrs, Opt.none(PayloadAttributesV3), sleepAsync(5.seconds), false
+    )
+
+    check:
+      setup.state.forkchoiceCallCount == 1
+      status == PayloadExecutionStatus.valid
+
+  test "concurrent forkchoiceUpdated calls":
+    ## This test verifies that multiple concurrent forkchoiceUpdated calls
+    ## all complete successfully
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let attrsConcurrent = PayloadAttributesV3.init(
+      1000, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    let attributes = Opt.some(attrsConcurrent)
+
+    let
+      stateC = ForkchoiceStateV1.init(
+        Eth2Digest.default, Eth2Digest.default, Eth2Digest.default
+      )
+      fut1 = manager.forkchoiceUpdated(stateC, attributes, sleepAsync(5.seconds), false)
+      fut2 = manager.forkchoiceUpdated(stateC, attributes, sleepAsync(5.seconds), false)
+      fut3 = manager.forkchoiceUpdated(stateC, attributes, sleepAsync(5.seconds), false)
+
+    let
+      res1 = waitFor fut1
+      res2 = waitFor fut2
+      res3 = waitFor fut3
+
+    # All should complete successfully
+    for (status, payloadId) in [res1, res2, res3]:
+      check:
+        status == PayloadExecutionStatus.valid
+        payloadId.isSome
+
+    # Should have made 3 calls since they ran concurrently
+    check setup.state.forkchoiceCallCount == 3
+
+  test "getPayload with different forkchoiceUpdated attributes":
+    ## This test creates different scenarios where getPayload is called with
+    ## varying attributes to test the caching logic under different conditions
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    let withdrawals = seq[capella.Withdrawal] @[]
+
+    # Scenario 1: forkchoiceUpdated with attributes, then getPayload with same params
+    let attrsVar = PayloadAttributesV3.init(
+      1000, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    var attributes = Opt.some(attrsVar)
+
+    let stateA =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    discard waitFor manager.forkchoiceUpdated(
+      stateA, attributes, sleepAsync(5.seconds), false
+    )
+
+    check setup.state.forkchoiceCallCount == 1
+
+    let stateGet1 =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let attrsGet1 = PayloadAttributesV3.init(
+      1000, Eth2Digest.default, Eth1Address.default, withdrawals, Eth2Digest.default
+    )
+    discard waitFor manager.getPayload(
+      electra.ExecutionPayloadForSigning, stateGet1, attrsGet1
+    )
+
+    check setup.state.forkchoiceCallCount == 1 # Should still be 1
+
+    # Scenario 2: forkchoiceUpdated with different timestamp
+    let attrsVar2 = PayloadAttributesV3.init(
+      2000, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    attributes = Opt.some(attrsVar2)
+
+    let stateB =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    discard waitFor manager.forkchoiceUpdated(
+      stateB, attributes, sleepAsync(5.seconds), false
+    )
+
+    check setup.state.forkchoiceCallCount == 2
+
+    let stateGet2 =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let attrsGet2b = PayloadAttributesV3.init(
+      2000, Eth2Digest.default, Eth1Address.default, withdrawals, Eth2Digest.default
+    )
+    discard waitFor manager.getPayload(
+      electra.ExecutionPayloadForSigning, stateGet2, attrsGet2b
+    )
+
+    check setup.state.forkchoiceCallCount == 2 # Should still be 2
+
+suite "EL Manager - Multiple Engines":
+  setup:
+    var
+      setup1 = mockSetup()
+      setup2 = mockSetup()
+
+  teardown:
+    setup2.close()
+    setup1.close()
+
+  test "forkchoiceUpdated with multiple engines":
+    ## This test verifies that forkchoiceUpdated is sent to all configured engines
+    let manager = createELManager(@[setup1.url, setup2.url])
+    manager.start()
+
+    let stateMulti =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let (status, _) = waitFor manager.forkchoiceUpdated(
+      stateMulti, Opt.none(PayloadAttributesV3), sleepAsync(5.seconds), false
+    )
+
+    check:
+      status == PayloadExecutionStatus.valid
+      setup1.state.forkchoiceCallCount == 1
+      setup2.state.forkchoiceCallCount == 1
+
+  test "newPayload with multiple engines":
+    ## This test verifies that newPayload sends the payload to all configured engines
+    let manager = createELManager(@[setup1.url, setup2.url])
+
+    let resp = waitFor manager.newPayload(
+      default(electra.BeaconBlock), noEnvelope, sleepAsync(10.seconds), false
+    )
+
+    check:
+      setup1.state.newPayloadCallCount == 1
+      setup2.state.newPayloadCallCount == 1
+      resp.isOk()
+
+  test "getPayload with multiple engines":
+    ## This test verifies that getPayload properly handles multiple engines
+    let manager = createELManager(@[setup1.url, setup2.url])
+    manager.start()
+
+    let stateMultiGet =
+      ForkchoiceStateV1.init(Eth2Digest.default, Eth2Digest.default, Eth2Digest.default)
+    let attrsMulti = PayloadAttributesV3.init(
+      1000, Eth2Digest.default, Eth1Address.default, @[], Eth2Digest.default
+    )
+    let payload = waitFor manager.getPayload(
+      electra.ExecutionPayloadForSigning, stateMultiGet, attrsMulti
+    )
+
+    check:
+      # Should attempt to get payload from engines
+      setup1.state.getPayloadCallCount == 1
+      setup2.state.getPayloadCallCount == 1
+      payload.isSome
+
+  test "two engines, one broken, retry":
+    let manager = createELManager(@[setup1.url, setup2.url])
+    setup2.state.shouldFailNewPayload = true
+    let resp = waitFor manager.newPayload(
+      default(electra.BeaconBlock), noEnvelope, sleepAsync(10.seconds), true
+    )
+
+    check:
+      setup1.state.newPayloadCallCount == 1
+      setup2.state.newPayloadCallCount > 1
+      resp.isOk()


### PR DESCRIPTION
By changing the granularity of error and request handling, we can avoid redundant work in the case of partial failures:

* rework the payload id cache to store the latest `forkchoiceUpdated` call per connection - this reduces the risk of race conditions when payload requests are made close to the payload warmup call
* perform payload validation per-connection so that block production continues even if there's a flaky EL
* perform retries per-connection so that in the case of partial failure, we don't repeat requests redundantly
* when requesting blobs, don't wait for all requests to complete - instead, return as soon as a single EL has given a response
* [re-introduce](https://github.com/status-im/nimbus-eth2/pull/6228) short deadline for detecting consensus violations between execution clients
* remove pre-Electra payload production support
* reduce naming creativity with a preference for spec-derived names
* expand test suite to stress various failure scenarios