### PR TITLE
Add fast confirmation API for obtaining recent ancestors

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1196,6 +1196,25 @@ AllTests-mainnet
 + restoring mnemonic with password                                                           OK
 + restoring mnemonic without password                                                        OK
 ```
+## get_ancestor_info
+```diff
++ All slots filled - end of epoch                                                            OK
++ All slots filled - mid epoch                                                               OK
++ All slots filled - start of epoch                                                          OK
++ Current_slot = 0                                                                           OK
++ Current_slot = 1                                                                           OK
++ Entire prev epoch empty                                                                    OK
++ Gap crossing epoch boundary                                                                OK
++ Gap in current epoch                                                                       OK
++ Mid epoch 0                                                                                OK
++ Only genesis                                                                               OK
++ Sparse chain with terminal mid-gap                                                         OK
++ Start of epoch 1                                                                           OK
++ Start of epoch 2                                                                           OK
++ Terminal in current epoch                                                                  OK
++ Terminal in prev epoch                                                                     OK
++ Terminal not an ancestor                                                                   OK
+```
 ## removeValidatorFiles()
 ```diff
 + Remove nonexistent validator                                                               OK

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -113,3 +113,35 @@ iterator assigned_slots*(
       if balance_source.shuffling_epochs[i] != FAR_FUTURE_EPOCH:
         yield balance_source.shuffling_epochs[i].start_slot +
           balance_source.balances[val_index].assigned_slot_into_epoch(i)
+
+type SlotInfo* = object
+  blck*: BlockRef
+
+func get_ancestor_info*(
+    blck: BlockRef, terminal_bid: BlockId, current_slot: Slot): seq[SlotInfo] =
+  ## Return a list of ancestors of ``blck`` inclusive back through the last
+  ## slot of ``current_slot.epoch - 2``, or ``terminal_bid``, whichever is
+  ## encountered first, iff ``terminal_bid`` is an ancestor of ``blck``.
+  ## Otherwise, return an empty list.
+  ## For slots within the previous and current epoch, an entry is emitted
+  ## per slot, even when there are slots without a block. A single extra entry
+  ## is emitted for the last block, if it was proposed during an earlier epoch.
+  let
+    prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
+    low_slot = max(terminal_bid.slot, max(prev_epoch_start, 1.Slot) - 1)
+  result = newSeqOfCap[SlotInfo](current_slot  - low_slot + 1)
+
+  var bs = blck.atSlot(current_slot)
+  while bs.blck != nil and bs.slot > low_slot:
+    result.add SlotInfo(blck: bs.blck)
+    bs = bs.parent
+  while bs.blck != nil and not bs.isProposed and bs.slot >= prev_epoch_start:
+    result.add SlotInfo(blck: bs.blck)
+    bs = bs.parent
+  if bs.blck != nil:
+    result.add SlotInfo(blck: bs.blck)
+
+  while bs.blck != nil and bs.slot > terminal_bid.slot:
+    bs = bs.parent
+  if bs.blck == nil or bs.blck.root != terminal_bid.root:
+    result.reset()

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -9,8 +9,10 @@
 {.used.}
 
 import
+  std/sequtils,
   unittest2,
-  ../beacon_chain/consensus_object_pools/block_dag
+  ../beacon_chain/consensus_object_pools/block_dag,
+  ../beacon_chain/fork_choice/fast_confirmation
 
 func `$`(x: BlockRef): string = shortLog(x)
 
@@ -126,3 +128,198 @@ suite "BlockId and helpers":
       s22.parentOrSlot == BlockSlot(blck: s0, slot: Slot(2))
       s24.parent == BlockSlot(blck: s2, slot: Slot(3))
       s24.parent.parent == s22
+
+suite "get_ancestor_info":
+  func makeRoot(v: byte): Eth2Digest =
+    result.data[0] = v
+
+  func makeBlock(slot: Slot, parent: BlockRef): BlockRef =
+    BlockRef(
+      bid: BlockId(slot: slot, root: makeRoot(byte(distinctBase(slot) + 1))),
+      parent: parent)
+
+  func makeChain(slots: openArray[Slot]): seq[BlockRef] =
+    result.setLen(slots.len)
+    for i, s in slots:
+      result[i] = makeBlock(s, if i > 0: result[i - 1] else: nil)
+
+  func makeFullChain(last: Slot): seq[BlockRef] =
+    makeChain(toSeq(0.Slot .. last))
+
+  template checkAllSlotsFilled(current_slot: Slot) =
+    let
+      prev_epoch_start = (current_slot.epoch - 1).start_slot
+      chain = makeFullChain(current_slot)
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[^1]
+      res[^2].blck == chain[distinctBase(prev_epoch_start)]
+      res[^1].blck == chain[distinctBase(prev_epoch_start) - 1]
+
+  test "All slots filled - mid epoch":
+    checkAllSlotsFilled(3.Epoch.start_slot + 3)
+
+  test "All slots filled - start of epoch":
+    checkAllSlotsFilled(3.Epoch.start_slot)
+
+  test "All slots filled - end of epoch":
+    checkAllSlotsFilled(4.Epoch.start_slot - 1)
+
+  template checkTerminal(current_slot, terminal_slot: Slot) =
+    let
+      chain = makeFullChain(current_slot)
+      terminal_bid = chain[distinctBase(terminal_slot)].bid
+      res = get_ancestor_info(chain[^1], terminal_bid, current_slot)
+    check:
+      res.lenu64 == current_slot - terminal_slot + 1
+      res[0].blck == chain[^1]
+      res[1].blck == chain[^2]
+      res[^1].blck == chain[distinctBase(terminal_slot)]
+
+  test "Terminal in prev epoch":
+    checkTerminal(
+      current_slot = 3.Epoch.start_slot + 3,
+      terminal_slot = 2.Epoch.start_slot + 4)
+
+  test "Terminal in current epoch":
+    checkTerminal(
+      current_slot = 3.Epoch.start_slot + 3,
+      terminal_slot = 3.Epoch.start_slot + 1)
+
+  test "Terminal not an ancestor":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      chain = makeFullChain(current_slot)
+      fakeBid = BlockId(slot: 1.Epoch.start_slot + 2, root: makeRoot(255))
+      res = get_ancestor_info(chain[^1], fakeBid, current_slot)
+    check res.lenu64 == 0
+
+  test "Gap in current epoch":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain(
+        toSeq(0.Slot .. 3.Epoch.start_slot) &
+        toSeq(3.Epoch.start_slot + 2 .. 3.Epoch.start_slot + 3))
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[^1]
+      res[1].blck == chain[^2]
+      res[current_slot - (3.Epoch.start_slot + 1)].blck ==
+        chain[distinctBase(3.Epoch.start_slot)]
+      res[current_slot - (3.Epoch.start_slot + 0)].blck ==
+        chain[distinctBase(3.Epoch.start_slot)]
+      res[^1].blck == chain[distinctBase(prev_epoch_start) - 1]
+
+  test "Gap crossing epoch boundary":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain(
+        toSeq(0.Slot .. 2.Epoch.start_slot - 3) &
+        toSeq(2.Epoch.start_slot + 2 .. 3.Epoch.start_slot + 3))
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[^1]
+      res[current_slot - (2.Epoch.start_slot + 2)].blck ==
+        chain[distinctBase(2.Epoch.start_slot) - 2]
+      res[current_slot - (2.Epoch.start_slot + 1)].blck ==
+        chain[distinctBase(2.Epoch.start_slot) - 3]
+      res[^2].blck == chain[distinctBase(2.Epoch.start_slot) - 3]
+      res[^1].blck == chain[distinctBase(2.Epoch.start_slot) - 3]
+
+  test "Entire prev epoch empty":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [
+        #[0]# 0.Slot,
+        #[1]# 1.Epoch.start_slot - 1,
+        #[2]# 3.Epoch.start_slot,
+        #[3]# 3.Epoch.start_slot + 1,
+        #[4]# 3.Epoch.start_slot + 2,
+        #[5]# 3.Epoch.start_slot + 3]
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[^1]
+      res[current_slot - (3.Epoch.start_slot + 0)].blck == chain[2]
+      res[current_slot - (3.Epoch.start_slot - 1)].blck == chain[1]
+      res[^2].blck == chain[1]
+      res[^1].blck == chain[1]
+
+  test "Sparse chain with terminal mid-gap":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [
+        #[0]# 0.Slot,
+        #[1]# 1.Epoch.start_slot - 3,
+        #[2]# 1.Epoch.start_slot + 2,
+        #[3]# 2.Epoch.start_slot + 4,
+        #[4]# 3.Epoch.start_slot,
+        #[5]# 3.Epoch.start_slot + 3]
+      terminal = BlockId(slot: 2.Epoch.start_slot + 2, root: chain[2].bid.root)
+      res = get_ancestor_info(chain[^1], terminal, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[^1]
+      res[current_slot - (3.Epoch.start_slot + 2)].blck == chain[4]
+      res[current_slot - (3.Epoch.start_slot + 0)].blck == chain[4]
+      res[current_slot - (3.Epoch.start_slot - 1)].blck == chain[3]
+      res[current_slot - (2.Epoch.start_slot + 4)].blck == chain[3]
+      res[current_slot - (2.Epoch.start_slot + 3)].blck == chain[2]
+      res[current_slot - (2.Epoch.start_slot + 2)].blck == chain[2]
+      res[^2].blck == chain[2]
+      res[^1].blck == chain[2]
+
+  template checkEarlyEpoch(current_slot: Slot) =
+    let
+      chain = makeFullChain(current_slot)
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == distinctBase(current_slot) + 1
+      res[0].blck == chain[^1]
+      res[^1].blck == chain[0]
+
+  test "Current_slot = 0":
+    let
+      current_slot = 0.Slot
+      chain = makeFullChain(current_slot)
+      res = get_ancestor_info(chain[0], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == 1
+      res[0].blck == chain[0]
+
+  test "Current_slot = 1":
+    let
+      current_slot = 1.Slot
+      chain = makeFullChain(current_slot)
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == 2
+      res[0].blck == chain[^1]
+      res[1].blck == chain[0]
+
+  test "Mid epoch 0":
+    checkEarlyEpoch((SLOTS_PER_EPOCH div 2).Slot)
+
+  test "Start of epoch 1":
+    checkEarlyEpoch(1.Epoch.start_slot)
+
+  test "Start of epoch 2":
+    checkAllSlotsFilled(2.Epoch.start_slot)
+
+  test "Only genesis":
+    let
+      current_slot = 2.Epoch.start_slot
+      prev_epoch_start = 1.Epoch.start_slot
+      chain = makeChain [0.Slot]
+      res = get_ancestor_info(chain[0], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[0]
+      res[^1].blck == chain[0]


### PR DESCRIPTION
Fast Confirmation Rule runs `is_one_confirmed` on `get_ancestor_roots`, collecting info per slot regarding support (effective balances of votes during block's slot, during empty slots, and from equivocating vals). Rather than repeating loops for `is_ancestor` / `get_ancestor_roots`, do a single pass to collect the structure of the most recent 2 epochs into a list that's easily indexable by slot (relative to current slot).

- https://github.com/ethereum/consensus-specs/pull/4747/changes