### PR TITLE
Use [] on balances/validators instead of item

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -358,7 +358,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                 # validators.
                 for index, validator in state.validators:
                   let
-                    balance = state.balances.item(index)
+                    balance = state.balances[index]
                     status = validator.getStatus(stateEpoch).valueOr:
                       return RestApiResponse.jsonError(
                         Http400, ValidatorStatusNotFoundError, $error)
@@ -368,8 +368,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             else:
               for index in indices:
                 let
-                  validator = state.validators.item(index)
-                  balance = state.balances.item(index)
+                  validator = state.validators[index]
+                  balance = state.balances[index]
                   status = validator.getStatus(stateEpoch).valueOr:
                     return RestApiResponse.jsonError(
                       Http400, ValidatorStatusNotFoundError, $error)
@@ -410,7 +410,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             else:
               for index in indices:
                 let
-                  validator = state.validators.item(index)
+                  validator = state.validators[index]
                 res.add(RestValidatorIdentity.init(index,
                                                    validator.pubkeyData.pubkey(),
                                                    validator.activation_epoch))
@@ -446,7 +446,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                                     balance))
             else:
               for index in indices:
-                let balance = state.balances.item(index)
+                let balance = state.balances[index]
                 res.add(RestValidatorBalance.init(index, balance))
             res
 
@@ -576,8 +576,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             index
 
       let
-        validator = state.validators.item(vindex)
-        balance = state.balances.item(vindex)
+        validator = state.validators[vindex]
+        balance = state.balances[vindex]
         status =
           block:
             let sres = validator.getStatus(current_epoch)

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -716,7 +716,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         request.committee_index)
 
       if not is_active_validator(
-          node.dag.headState.validators.item(request.validator_index),
+          node.dag.headState.validators[request.validator_index],
           request.slot.epoch):
         return RestApiResponse.jsonError(Http400, ValidatorNotActive)
 
@@ -725,7 +725,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         request.is_aggregator)
 
       let validator_pubkey =
-        node.dag.headState.validators.item(request.validator_index).pubkey
+        node.dag.headState.validators[request.validator_index].pubkey
 
       node.validatorMonitor[].addAutoMonitor(
         validator_pubkey, request.validator_index)
@@ -761,7 +761,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
     for item in subscriptions:
       let validator_pubkey =
-        node.dag.headState.validators.item(item.validator_index).pubkey
+        node.dag.headState.validators[item.validator_index].pubkey
 
       node.consensusManager[].actionTracker.registerSyncDuty(
         validator_pubkey, item.until_epoch)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1097,7 +1097,7 @@ proc updateValidatorMetrics*(node: BeaconNode) =
           stateRoot = node.dag.headState.root
         0.Gwei
       else:
-        node.dag.headState.balances.item(v.index.get())
+        node.dag.headState.balances[v.index.get()]
 
     if i < 64:
       attached_validator_balance.set(


### PR DESCRIPTION
#7903 forces `balances` / `validators` lookup through a func returning `lent`, implying readonly access. So, we don't need to use `.item` anymore, which is only needed on `var HashList|...` to distinguish read/write access.