### PR TITLE
Set amsterdamTime in local testnets

### DIFF
--- a/scripts/execution_genesis.json.template
+++ b/scripts/execution_genesis.json.template
@@ -33,6 +33,7 @@
     },
     "pragueTime":PRAGUE_FORK_TIME,
     "osakaTime":OSAKA_FORK_TIME,
+    "amsterdamTime":AMSTERDAM_FORK_TIME,
     "mergeForkBlock":0,
     "mergeNetsplitBlock":0,
     "terminalTotalDifficulty":0,

--- a/scripts/execution_genesis.json.template
+++ b/scripts/execution_genesis.json.template
@@ -29,6 +29,11 @@
         "target": 6,
         "max": 9,
         "baseFeeUpdateFraction": 5007716
+      },
+      "amsterdam": {
+        "target": 6,
+        "max": 9,
+        "baseFeeUpdateFraction": 5007716
       }
     },
     "pragueTime":PRAGUE_FORK_TIME,


### PR DESCRIPTION
In #7931, AMSTERDAM_FORK_TIME was introduced but it is not actually part of the template. Add it there so it can be configured.