### PR TITLE
Pass engine port to nimbus EL in local testnet

### DIFF
--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -1059,7 +1059,7 @@ for NUM_NODE in $(seq 1 "${NUM_NODES}"); do
 
   WEB3_ARG=()
   if [ "${RUN_NIMBUS_ETH1}" == "1" ]; then
-    WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODE - 1 ))]}")
+    WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_AUTH_RPC_PORTS[$(( NUM_NODE - 1 ))]}")
   fi
 
   if [ "${RUN_GETH}" == "1" ]; then
@@ -1171,7 +1171,7 @@ if [ "$LC_NODES" -ge "1" ]; then
 
     WEB3_ARG=()
     if [ "${RUN_NIMBUS_ETH1}" == "1" ]; then
-      WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
+      WEB3_ARG+=("--el=http://127.0.0.1:${NIMBUS_ETH1_AUTH_RPC_PORTS[$(( NUM_NODES + NUM_LC - 1 ))]}")
     fi
 
     if [ "${RUN_GETH}" == "1" ]; then


### PR DESCRIPTION
Configure CL to connect to engine API EL port when using Nimbus EL. The regular RPC port doesn't serve engine API (start_nimbus_el_nodes.sh)