### PR TITLE
Use --http-port instead of --rpc-port when configuring Nimbus EL startup

### DIFF
--- a/scripts/start_nimbus_el_nodes.sh
+++ b/scripts/start_nimbus_el_nodes.sh
@@ -47,7 +47,7 @@ for NIMBUS_ETH1_NODE_IDX in $(seq 0 $NIMBUS_ETH1_LAST_NODE_IDX); do
     --tcp-port="${NIMBUS_ETH1_NET_PORTS[NIMBUS_ETH1_NODE_IDX]}"  \
     --jwt-secret="${JWT_FILE}" \
     --engine-api --engine-api-port="${NIMBUS_ETH1_AUTH_RPC_PORTS[NIMBUS_ETH1_NODE_IDX]}" \
-    --rpc --rpc-port="${NIMBUS_ETH1_RPC_PORTS[NIMBUS_ETH1_NODE_IDX]}" \
+    --rpc --http-port="${NIMBUS_ETH1_RPC_PORTS[NIMBUS_ETH1_NODE_IDX]}" \
       &> "${DATA_DIR}/logs/nimbus_eth1.${NIMBUS_ETH1_NODE_IDX}.txt" &
   PID=$!
   echo $PID > "${DATA_DIR}/pids/nimbus_eth1.${NIMBUS_ETH1_NODE_IDX}"


### PR DESCRIPTION
--rpc-port was replaced with --http-port:

- https://github.com/status-im/nimbus-eth1/pull/1992