### PR TITLE
rm non-state transition function phase0 attester slashing support

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1178,9 +1178,7 @@ AllTests-mainnet
 ## Validator change pool testing suite
 ```diff
 + addValidatorChangeMessage/getAttesterSlashingMessage (Electra)                             OK
-+ addValidatorChangeMessage/getAttesterSlashingMessage (Phase 0)                             OK
-+ addValidatorChangeMessage/getBlsToExecutionChange (post-capella)                           OK
-+ addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)                            OK
++ addValidatorChangeMessage/getBlsToExecutionChange                                          OK
 + addValidatorChangeMessage/getProposerSlashingMessage                                       OK
 + addValidatorChangeMessage/getVoluntaryExitMessage                                          OK
 + pre-pre-fork voluntary exit                                                                OK

--- a/beacon_chain.nimble
+++ b/beacon_chain.nimble
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -7,13 +7,13 @@
 
 mode = ScriptMode.Verbose
 
-version       = "25.11.0"
+version       = "26.2.1"
 author        = "Status Research & Development GmbH"
 description   = "The Nimbus beacon chain node is a highly efficient Ethereum 2.0 client"
 license       = "MIT or Apache License 2.0"
 
 requires(
-  "nim == 2.2.4",
+  "nim == 2.2.8",
   "bearssl",
   "blscurve",
   "chronicles",

--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 # Everything needed to run a full Beacon Node
 
@@ -54,8 +54,7 @@ type
     exitQueue*: AsyncEventQueue[SignedVoluntaryExit]
     blsToExecQueue*: AsyncEventQueue[SignedBLSToExecutionChange]
     propSlashQueue*: AsyncEventQueue[ProposerSlashing]
-    phase0AttSlashQueue*: AsyncEventQueue[phase0.AttesterSlashing]
-    electraAttSlashQueue*: AsyncEventQueue[electra.AttesterSlashing]
+    attSlashQueue*: AsyncEventQueue[electra.AttesterSlashing]
     blobSidecarQueue*: AsyncEventQueue[BlobSidecarInfoObject]
     columnSidecarQueue*: AsyncEventQueue[DataColumnSidecarInfoObject]
     finalQueue*: AsyncEventQueue[FinalizationInfoObject]
@@ -195,8 +194,7 @@ func init*(T: type EventBus): T =
     exitQueue: newAsyncEventQueue[SignedVoluntaryExit](),
     blsToExecQueue: newAsyncEventQueue[SignedBLSToExecutionChange](),
     propSlashQueue: newAsyncEventQueue[ProposerSlashing](),
-    phase0AttSlashQueue: newAsyncEventQueue[phase0.AttesterSlashing](),
-    electraAttSlashQueue: newAsyncEventQueue[electra.AttesterSlashing](),
+    attSlashQueue: newAsyncEventQueue[electra.AttesterSlashing](),
     blobSidecarQueue: newAsyncEventQueue[BlobSidecarInfoObject](),
     columnSidecarQueue: newAsyncEventQueue[DataColumnSidecarInfoObject](),
     finalQueue: newAsyncEventQueue[FinalizationInfoObject](),

--- a/beacon_chain/consensus_object_pools/validator_change_pool.nim
+++ b/beacon_chain/consensus_object_pools/validator_change_pool.nim
@@ -5,17 +5,19 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   # Standard libraries
   std/[deques, sets],
   # Internal
   ../spec/datatypes/base,
-  ../spec/[helpers, state_transition_block],
+  ../spec/helpers,
   "."/[attestation_pool, blockchain_dag]
 
 from ../spec/beaconstate import check_bls_to_execution_change
+from ../spec/state_transition_block import
+  check_attester_slashing, check_proposer_slashing, check_voluntary_exit
 
 export base, deques, blockchain_dag
 
@@ -34,9 +36,7 @@ type
     proc(data: SignedBLSToExecutionChange) {.gcsafe, raises: [].}
   OnProposerSlashingCallback =
     proc(data: ProposerSlashing) {.gcsafe, raises: [].}
-  OnPhase0AttesterSlashingCallback =
-    proc(data: phase0.AttesterSlashing) {.gcsafe, raises: [].}
-  OnElectraAttesterSlashingCallback =
+  OnAttesterSlashingCallback =
     proc(data: electra.AttesterSlashing) {.gcsafe, raises: [].}
 
   ValidatorChangePool* = object
@@ -44,10 +44,7 @@ type
     ## voluntary exits, and BLS to execution changes that could be added to a
     ## proposed block.
 
-    phase0_attester_slashings*: Deque[phase0.AttesterSlashing]  ## \
-    ## Not a function of chain DAG branch; just used as a FIFO queue for blocks
-
-    electra_attester_slashings*: Deque[electra.AttesterSlashing]  ## \
+    attester_slashings*: Deque[electra.AttesterSlashing]  ## \
     ## Not a function of chain DAG branch; just used as a FIFO queue for blocks
 
     proposer_slashings*: Deque[ProposerSlashing]  ## \
@@ -80,26 +77,20 @@ type
     onVoluntaryExitReceived*: OnVoluntaryExitCallback
     onBLSToExecutionChangeReceived*: OnBLSToExecutionChangeCallback
     onProposerSlashingReceived*: OnProposerSlashingCallback
-    onPhase0AttesterSlashingReceived*: OnPhase0AttesterSlashingCallback
-    onElectraAttesterSlashingReceived*: OnElectraAttesterSlashingCallback
+    onAttesterSlashingReceived*: OnAttesterSlashingCallback
 
 func init*(T: type ValidatorChangePool, dag: ChainDAGRef,
            attestationPool: ref AttestationPool = nil,
            onVoluntaryExit: OnVoluntaryExitCallback = nil,
            onBLSToExecutionChange: OnBLSToExecutionChangeCallback = nil,
            onProposerSlashing: OnProposerSlashingCallback = nil,
-           onPhase0AttesterSlashing: OnPhase0AttesterSlashingCallback = nil,
-           onElectraAttesterSlashing: OnElectraAttesterSlashingCallback = nil):
+           onAttesterSlashing: OnAttesterSlashingCallback = nil):
            T =
   ## Initialize an ValidatorChangePool from the dag `headState`
   T(
     # Allow filtering some validator change messages during block production
-    phase0_attester_slashings:
-      initDeque[phase0.AttesterSlashing](
-        initialSize = ATTESTER_SLASHINGS_BOUND.int),
-    electra_attester_slashings:
-      initDeque[electra.AttesterSlashing](
-        initialSize = ATTESTER_SLASHINGS_BOUND.int),
+    attester_slashings: initDeque[electra.AttesterSlashing](
+      initialSize = ATTESTER_SLASHINGS_BOUND.int),
     proposer_slashings:
       initDeque[ProposerSlashing](initialSize = PROPOSER_SLASHINGS_BOUND.int),
     voluntary_exits:
@@ -119,8 +110,7 @@ func init*(T: type ValidatorChangePool, dag: ChainDAGRef,
     onVoluntaryExitReceived: onVoluntaryExit,
     onBLSToExecutionChangeReceived: onBLSToExecutionChange,
     onProposerSlashingReceived: onProposerSlashing,
-    onPhase0AttesterSlashingReceived: onPhase0AttesterSlashing,
-    onElectraAttesterSlashingReceived: onElectraAttesterSlashing)
+    onAttesterSlashingReceived: onAttesterSlashing)
 
 func addValidatorChangeMessage(
     subpool: var auto, seenpool: var auto, validatorChangeMessage: auto,
@@ -166,17 +156,6 @@ func isSeen*(pool: ValidatorChangePool, msg: SignedBLSToExecutionChange): bool =
   msg.message.validator_index in
     pool.prior_seen_bls_to_execution_change_indices
 
-func addMessage*(pool: var ValidatorChangePool, msg: phase0.AttesterSlashing) =
-  for idx in getValidatorIndices(msg):
-    pool.prior_seen_attester_slashed_indices.incl idx
-    if not pool.attestationPool.isNil:
-      let i = ValidatorIndex.init(idx).valueOr:
-        continue
-      pool.attestationPool.forkChoice.process_equivocation(i)
-
-  pool.phase0_attester_slashings.addValidatorChangeMessage(
-    pool.prior_seen_attester_slashed_indices, msg, ATTESTER_SLASHINGS_BOUND)
-
 func addMessage*(pool: var ValidatorChangePool, msg: electra.AttesterSlashing) =
   for idx in getValidatorIndices(msg):
     pool.prior_seen_attester_slashed_indices.incl idx
@@ -185,7 +164,7 @@ func addMessage*(pool: var ValidatorChangePool, msg: electra.AttesterSlashing) =
         continue
       pool.attestationPool.forkChoice.process_equivocation(i)
 
-  pool.electra_attester_slashings.addValidatorChangeMessage(
+  pool.attester_slashings.addValidatorChangeMessage(
     pool.prior_seen_attester_slashed_indices, msg, ATTESTER_SLASHINGS_BOUND)
 
 func addMessage*(pool: var ValidatorChangePool, msg: ProposerSlashing) =
@@ -271,21 +250,17 @@ proc getValidatorChangeMessagesForBlock(
       break
 
 proc getBeaconBlockValidatorChanges*(
-    pool: var ValidatorChangePool, cfg: RuntimeConfig, state: ForkyBeaconState):
+    pool: var ValidatorChangePool, cfg: RuntimeConfig,
+    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState):
     BeaconBlockValidatorChanges =
   var res: BeaconBlockValidatorChanges
 
   # Exits (with priority on slashings)
   block:
     var indices: HashSet[uint64]
-    when typeof(state).kind >= ConsensusFork.Electra:
-      getValidatorChangeMessagesForBlock(
-        pool.electra_attester_slashings, cfg, state, indices,
-        res.electra_attester_slashings)
-    else:
-      getValidatorChangeMessagesForBlock(
-        pool.phase0_attester_slashings, cfg, state, indices,
-        res.phase0_attester_slashings)
+    getValidatorChangeMessagesForBlock(
+      pool.attester_slashings, cfg, state, indices,
+      res.electra_attester_slashings)
     getValidatorChangeMessagesForBlock(
       pool.proposer_slashings, cfg, state, indices, res.proposer_slashings)
     getValidatorChangeMessagesForBlock(

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -93,7 +93,6 @@ type
     # Consumer
     # ----------------------------------------------------------------
     consensusManager*: ref ConsensusManager
-      ## Blockchain DAG, AttestationPool and Quarantine
       ## Blockchain DAG, AttestationPool, Quarantine, and ELManager
     validatorMonitor: ref ValidatorMonitor
     getBeaconTime: GetBeaconTimeFn

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -706,7 +706,7 @@ proc checkKnownValidatorSlashing(
 
 proc processAttesterSlashing*(
     self: var Eth2Processor, src: MsgSource,
-    attesterSlashing: phase0.AttesterSlashing | electra.AttesterSlashing):
+    attesterSlashing: electra.AttesterSlashing):
     ValidationRes =
   logScope:
     attesterSlashing = shortLog(attesterSlashing)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1570,8 +1570,7 @@ proc validateBlsToExecutionChange*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.10/specs/phase0/p2p-interface.md#attester_slashing
 proc validateAttesterSlashing*(
-    pool: ValidatorChangePool,
-    attester_slashing: phase0.AttesterSlashing | electra.AttesterSlashing):
+    pool: ValidatorChangePool, attester_slashing: electra.AttesterSlashing):
     Result[void, ValidationError] =
   # [IGNORE] At least one index in the intersection of the attesting indices of
   # each attestation has not yet been seen in any prior attester_slashing (i.e.
@@ -1589,14 +1588,8 @@ proc validateAttesterSlashing*(
     return pool.checkedReject(attester_slashing_validity.error)
 
   # Send notification about new attester slashing via callback
-  when attester_slashing is phase0.AttesterSlashing:
-    if not(isNil(pool.onPhase0AttesterSlashingReceived)):
-      pool.onPhase0AttesterSlashingReceived(attester_slashing)
-  elif attester_slashing is electra.AttesterSlashing:
-    if not(isNil(pool.onElectraAttesterSlashingReceived)):
-      pool.onElectraAttesterSlashingReceived(attester_slashing)
-  else:
-    static: doAssert false
+  if not(isNil(pool.onAttesterSlashingReceived)):
+    pool.onAttesterSlashingReceived(attester_slashing)
 
   ok()
 

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -2774,8 +2774,7 @@ func forkDigestAtEpoch*(node: Eth2Node, epoch: Epoch): ForkDigest =
   node.forkDigests[].atEpoch(epoch, node.cfg)
 
 proc broadcastAttestation*(
-    node: Eth2Node, subnet_id: SubnetId,
-    attestation: phase0.Attestation | SingleAttestation):
+    node: Eth2Node, subnet_id: SubnetId, attestation: SingleAttestation):
     Future[SendResult] {.async: (raises: [CancelledError], raw: true).} =
   # Regardless of the contents of the attestation,
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/altair/p2p-interface.md#transitioning-the-gossip
@@ -2795,8 +2794,7 @@ proc broadcastVoluntaryExit*(
   node.broadcast(topic, exit)
 
 proc broadcastAttesterSlashing*(
-    node: Eth2Node,
-    slashing: phase0.AttesterSlashing | electra.AttesterSlashing):
+    node: Eth2Node, slashing: electra.AttesterSlashing):
     Future[SendResult] {.async: (raises: [CancelledError], raw: true).} =
   let topic = getAttesterSlashingsTopic(
     node.forkDigestAtEpoch(node.getWallEpoch))

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -456,10 +456,8 @@ proc initFullNode(
     node.eventBus.blsToExecQueue.emit(data)
   proc onProposerSlashingAdded(data: ProposerSlashing) =
     node.eventBus.propSlashQueue.emit(data)
-  proc onPhase0AttesterSlashingAdded(data: phase0.AttesterSlashing) =
-    node.eventBus.phase0AttSlashQueue.emit(data)
-  proc onElectraAttesterSlashingAdded(data: electra.AttesterSlashing) =
-    node.eventBus.electraAttSlashQueue.emit(data)
+  proc onAttesterSlashingAdded(data: electra.AttesterSlashing) =
+    node.eventBus.attSlashQueue.emit(data)
   proc onBlobSidecarAdded(data: BlobSidecarInfoObject) =
     node.eventBus.blobSidecarQueue.emit(data)
   proc onColumnSidecarAdded(data: DataColumnSidecarInfoObject) =
@@ -563,8 +561,7 @@ proc initFullNode(
       LightClientPool())
     validatorChangePool = newClone(ValidatorChangePool.init(
       dag, attestationPool, onVoluntaryExitAdded, onBLSToExecutionChangeAdded,
-      onProposerSlashingAdded, onPhase0AttesterSlashingAdded,
-      onElectraAttesterSlashingAdded))
+      onProposerSlashingAdded, onAttesterSlashingAdded))
     executionPayloadBidPool = newClone(ExecutionPayloadBidPool.init(dag))
     payloadAttestationPool = newClone(PayloadAttestationPool.init(dag))
     blobQuarantine = newClone(BlobQuarantine.init(
@@ -2413,15 +2410,6 @@ proc installMessageValidators(node: BeaconNode) =
           node.network.addValidator(
             getAttesterSlashingsTopic(digest), proc (
               attesterSlashing: electra.AttesterSlashing,
-              src: PeerId
-            ): ValidationResult =
-              toValidationResult(
-                node.processor[].processAttesterSlashing(
-                  MsgSource.gossip, attesterSlashing)))
-        else:
-          node.network.addValidator(
-            getAttesterSlashingsTopic(digest), proc (
-              attesterSlashing: phase0.AttesterSlashing,
               src: PeerId
             ): ValidationResult =
               toValidationResult(

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1427,11 +1427,11 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     withConsensusFork(contextFork):
       when consensusFork < ConsensusFork.Electra:
         RestApiResponse.jsonResponseWVersion(
-          toSeq(node.validatorChangePool.phase0_attester_slashings),
+          default(seq[phase0.AttesterSlashing]),
           contextFork, node.hasRestAllowedOrigin)
       else:
         RestApiResponse.jsonResponseWVersion(
-          toSeq(node.validatorChangePool.electra_attester_slashings),
+          toSeq(node.validatorChangePool.attester_slashings),
           contextFork, node.hasRestAllowedOrigin)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashingsV2
@@ -1451,18 +1451,19 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       let dres = decodeBody(AttesterSlashingType, contentBody.get())
       if dres.isErr():
         return RestApiResponse.jsonError(Http400,
-                                          InvalidAttesterSlashingObjectError,
-                                          $dres.error)
+                                         InvalidAttesterSlashingObjectError,
+                                         $dres.error)
       let res = await node.router.routeAttesterSlashing(dres.get())
       if res.isErr():
         return RestApiResponse.jsonError(Http400,
-                                       AttesterSlashingValidationError,
-                                       $res.error)
+                                         AttesterSlashingValidationError,
+                                         $res.error)
       return RestApiResponse.jsonMsgResponse(AttesterSlashingValidationSuccess)
 
     case consensusVersion.get():
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
-        decodeAttesterSlashing(phase0.AttesterSlashing)
+        RestApiResponse.jsonError(Http400, SlotFromTheIncorrectForkError,
+                                  $error)
       of ConsensusFork.Electra .. ConsensusFork.Gloas:
         decodeAttesterSlashing(electra.AttesterSlashing)
 

--- a/beacon_chain/rpc/rest_event_api.nim
+++ b/beacon_chain/rpc/rest_event_api.nim
@@ -146,15 +146,9 @@ proc installEventApiHandlers*(router: var RestRouter, node: BeaconNode) =
                                               "proposer_slashing")
           res.add(handler)
         if EventTopic.AttesterSlashing in eventTopics:
-          block:
-            let handler = response.eventHandler(node.eventBus.phase0AttSlashQueue,
-                                                "attester_slashing")
-            res.add(handler)
-
-          block:
-            let handler = response.eventHandler(node.eventBus.electraAttSlashQueue,
-                                                "attester_slashing")
-            res.add(handler)
+          let handler = response.eventHandler(node.eventBus.attSlashQueue,
+                                              "attester_slashing")
+          res.add(handler)
         if EventTopic.BlobSidecar in eventTopics:
           let handler = response.eventHandler(node.eventBus.blobSidecarQueue,
                                               "blob_sidecar")

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -585,8 +585,6 @@ type
   BeaconBlockValidatorChanges* = object
     # Collection of exits that are suitable for block production
     proposer_slashings*: List[ProposerSlashing, Limit MAX_PROPOSER_SLASHINGS]
-    phase0_attester_slashings*:
-      List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS]
     electra_attester_slashings*:
       List[electra.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS_ELECTRA]
     voluntary_exits*: List[SignedVoluntaryExit, Limit MAX_VOLUNTARY_EXITS]

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -321,7 +321,7 @@ template attester_slashings(changes: BeaconBlockValidatorChanges, consensusFork)
   when consensusFork >= ConsensusFork.Electra:
     changes.electra_attester_slashings
   else:
-    changes.phase0_attester_slashings
+    default(List[phase0.AttesterSlashing, Limit MAX_ATTESTER_SLASHINGS])
 
 template BeaconBlock(fork: ConsensusFork, EPOH: type): type =
   when EPOH is ForkyExecutionPayloadHeader:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -715,7 +715,6 @@ proc sendAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
         return
     committees_per_slot = get_committee_count_per_slot(epochRef.shufflingRef)
     fork = node.dag.forkAtEpoch(slot.epoch)
-    consensusFork = node.dag.cfg.consensusForkAtEpoch(slot.epoch)
     genesis_validators_root = node.dag.genesis_validators_root
     data = makeAttestationData(epochRef, attestationHead, CommitteeIndex(0))
     # TODO signing_root is recomputed in produceAndSignAttestation/signAttestation just after

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -598,8 +598,7 @@ proc routeSignedVoluntaryExit*(
   return ok()
 
 proc routeAttesterSlashing*(
-    router: ref MessageRouter,
-    slashing: phase0.AttesterSlashing | electra.AttesterSlashing):
+    router: ref MessageRouter, slashing: electra.AttesterSlashing):
     Future[SendResult] {.async: (raises: [CancelledError]).} =
   block:
     let res =

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2020-2025 Status Research & Development GmbH
+# Copyright (c) 2020-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -25,20 +25,6 @@ func makeSignedBeaconBlockHeader(
     signature: get_block_signature(
       fork, genesis_validators_root, slot, hash_tree_root(tmp),
       MockPrivKeys[proposer_index]).toValidatorSig())
-
-func makePhase0IndexedAttestation(
-    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    validator_index: uint64, beacon_block_root: Eth2Digest):
-    phase0.IndexedAttestation =
-  let tmp = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
-
-  phase0.IndexedAttestation(
-    data: tmp,
-    attesting_indices:
-      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE](@[validator_index]),
-    signature: get_attestation_signature(
-      fork, genesis_validators_root, tmp,
-      MockPrivKeys[validator_index]).toValidatorSig)
 
 func makeElectraIndexedAttestation(
     fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
@@ -106,31 +92,11 @@ suite "Validator change pool testing suite":
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).proposer_slashings.lenu64 ==
-            min(i + 1, MAX_PROPOSER_SLASHINGS)
-
-  test "addValidatorChangeMessage/getAttesterSlashingMessage (Phase 0)":
-    for i in 0'u64 .. MAX_ATTESTER_SLASHINGS + 5:
-      for j in 0'u64 .. i:
-        let
-          msg = phase0.AttesterSlashing(
-            attestation_1: makePhase0IndexedAttestation(
-              fork, genesis_validators_root, Slot(1), j, makeFakeHash(0)),
-            attestation_2: makePhase0IndexedAttestation(
-              fork, genesis_validators_root, Slot(1), j, makeFakeHash(1)))
-
-        if i == 0:
-          check not pool[].isSeen(msg)
-
-        pool[].addMessage(msg)
-        check: pool[].isSeen(msg)
-      withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).phase0_attester_slashings.lenu64 ==
-            min(i + 1, MAX_ATTESTER_SLASHINGS)
+        when consensusFork >= ConsensusFork.Electra:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).proposer_slashings.lenu64 ==
+              min(i + 1, MAX_PROPOSER_SLASHINGS)
 
   test "addValidatorChangeMessage/getAttesterSlashingMessage (Electra)":
     var
@@ -157,10 +123,11 @@ suite "Validator change pool testing suite":
         pool[].addMessage(msg)
         check: pool[].isSeen(msg)
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).electra_attester_slashings.lenu64 ==
-            min(i + 1, MAX_ATTESTER_SLASHINGS_ELECTRA)
+        when consensusFork >= ConsensusFork.Electra:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).electra_attester_slashings.lenu64 ==
+              min(i + 1, MAX_ATTESTER_SLASHINGS_ELECTRA)
 
   test "addValidatorChangeMessage/getVoluntaryExitMessage":
     # Need to advance state or it will not accept voluntary exits
@@ -184,42 +151,13 @@ suite "Validator change pool testing suite":
         check: pool[].isSeen(msg)
 
       withState(dag.headState):
-        check:
-          pool[].getBeaconBlockValidatorChanges(
-              cfg, forkyState.data).voluntary_exits.lenu64 ==
-            min(i + 1, MAX_VOLUNTARY_EXITS)
+        when consensusFork >= ConsensusFork.Electra:
+          check:
+            pool[].getBeaconBlockValidatorChanges(
+                cfg, forkyState.data).voluntary_exits.lenu64 ==
+              min(i + 1, MAX_VOLUNTARY_EXITS)
 
-  test "addValidatorChangeMessage/getBlsToExecutionChange (pre-capella)":
-    # Need to advance state or it will not accept execution changes
-    var
-      cache: StateCache
-      info: ForkedEpochInfo
-    process_slots(
-      dag.cfg, dag.headState,
-      Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 1,
-      cache, info, {}).expect("ok")
-
-    for i in 0'u64 .. MAX_BLS_TO_EXECUTION_CHANGES + 5:
-      for j in 0'u64 .. i:
-        var msg = SignedBLSToExecutionChange(
-          message: BLSToExecutionChange(
-            validator_index: j,
-            from_bls_pubkey: MockPubKeys[j]))
-        msg.signature = toValidatorSig(get_bls_to_execution_change_signature(
-          dag.cfg.GENESIS_FORK_VERSION, dag.genesis_validators_root, msg.message,
-          MockPrivKeys[msg.message.validator_index]))
-        if i == 0:
-          check not pool[].isSeen(msg)
-
-        pool[].addMessage(msg, false)
-        check: pool[].isSeen(msg)
-
-      withState(dag.headState):
-        # Too early to get BLS to execution changes for blocks
-        check pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).bls_to_execution_changes.len == 0
-
-  test "addValidatorChangeMessage/getBlsToExecutionChange (post-capella)":
+  test "addValidatorChangeMessage/getBlsToExecutionChange":
     # Need to advance state or it will not accept execution changes
     var
       cache: StateCache
@@ -249,13 +187,14 @@ suite "Validator change pool testing suite":
         check: pool[].isSeen(msg)
 
       withState(dag.headState):
-        let blsToExecutionChanges = pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).bls_to_execution_changes
-        check:
-          blsToExecutionChanges.lenu64 == min(i + 1, MAX_BLS_TO_EXECUTION_CHANGES)
+        when consensusFork >= ConsensusFork.Electra:
+          let blsToExecutionChanges = pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).bls_to_execution_changes
+          check:
+            blsToExecutionChanges.lenu64 == min(i + 1, MAX_BLS_TO_EXECUTION_CHANGES)
 
-          # Ensure priority of API to gossip messages is observed
-          allIt(priorityMessages, pool[].isSeen(it))
+            # Ensure priority of API to gossip messages is observed
+            allIt(priorityMessages, pool[].isSeen(it))
 
   test "pre-pre-fork voluntary exit":
     var
@@ -278,8 +217,9 @@ suite "Validator change pool testing suite":
       {}).expect("ok")
 
     withState(dag.headState):
-      check:
-        # Message signed with a (fork-2) domain can no longer be added as that
-        # fork is not present in the BeaconState and thus fails transition
-        pool[].getBeaconBlockValidatorChanges(
-          cfg, forkyState.data).voluntary_exits.lenu64 == 0
+      when consensusFork >= ConsensusFork.Electra:
+        check:
+          # Message signed with a (fork-2) domain can no longer be added as that
+          # fork is not present in the BeaconState and thus fails transition
+          pool[].getBeaconBlockValidatorChanges(
+            cfg, forkyState.data).voluntary_exits.len == 0


### PR DESCRIPTION
Followup to:
- https://github.com/status-im/nimbus-eth2/pull/7999

Which removed phase0 attestation but not phase0 attestation slashing infrastructure.