### PR TITLE
Track support from empty slots and from equivocating validators for FCR

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1244,12 +1244,29 @@ AllTests-mainnet
 + Gap in current epoch                                                                       OK
 + Mid epoch 0                                                                                OK
 + Only genesis                                                                               OK
++ Only one block after genesis                                                               OK
 + Sparse chain with terminal mid-gap                                                         OK
 + Start of epoch 1                                                                           OK
 + Start of epoch 2                                                                           OK
 + Terminal in current epoch                                                                  OK
 + Terminal in prev epoch                                                                     OK
 + Terminal not an ancestor                                                                   OK
+```
+## get_ancestor_support_by_slot
+```diff
++ Basic support                                                                              OK
++ Early epochs                                                                               OK
++ Empty result                                                                               OK
++ Equivocating, assigned slot at current_slot                                                OK
++ Equivocating, cross-epoch, different blocks                                                OK
++ Equivocating, cross-epoch, same block                                                      OK
++ Equivocating, single slot in range                                                         OK
++ Gap in chain                                                                               OK
++ Mixed validators                                                                           OK
++ No match                                                                                   OK
++ Running totals verification                                                                OK
++ Slashed validator                                                                          OK
++ Votes outside range                                                                        OK
 ```
 ## removeValidatorFiles()
 ```diff

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -95,7 +95,7 @@ const
   ForkChoiceInfoMask =
     ((distinctBase(1.Gwei) shl NumInfoBits) - 1) shl ForkChoiceInfoOffset
   EffectiveBalanceMask = not ForkChoiceInfoMask
-  SlashedBit = distinctBase(1.Gwei) shl ForkChoiceInfoOffset
+  SlashedBit* = distinctBase(1.Gwei) shl ForkChoiceInfoOffset
 static: doAssert(
   max(MAX_EFFECTIVE_BALANCE, MAX_EFFECTIVE_BALANCE_ELECTRA) < SlashedBit)
 

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -13,12 +13,13 @@ import
   "."/fork_choice_types
 
 from ../consensus_object_pools/blockchain_dag import
+  effective_balance, unslashed_balance,
   fork_choice_balances, getShufflingRef, ForkChoiceInfoOffset
 
 export fork_choice_types
 
 const
-  AttesterDutyOffsets = [
+  AttesterDutyOffsets* = [
     ForkChoiceInfoOffset + 1,
     ForkChoiceInfoOffset + 1 + SLOTS_PER_EPOCH.bitWidth]
   AttesterDutyMask = (distinctBase(1.Gwei) shl SLOTS_PER_EPOCH.bitWidth) - 1
@@ -32,13 +33,12 @@ const
     not AttesterDutyMasks[1]]
   ClearAllAttesterDutiesMask =
     ClearAttesterDutyMasks[0] or ClearAttesterDutyMasks[1]
+  DefaultShufflingEpochs = [FAR_FUTURE_EPOCH, FAR_FUTURE_EPOCH]
 
 func balance_source*(checkpoint: BalanceCheckpoint): BalanceSource =
-  BalanceSource(
-    info: checkpoint,
-    shuffling_epochs: [FAR_FUTURE_EPOCH, FAR_FUTURE_EPOCH])
+  BalanceSource(info: checkpoint, shuffling_epochs: DefaultShufflingEpochs)
 
-func shuffling_index(epoch: Epoch): int =
+func shuffling_index*(epoch: Epoch): int =
   (distinctBase(epoch) and distinctBase(1.Epoch)).int
 
 func has_shuffling(
@@ -89,7 +89,7 @@ proc do_update_latest_shufflings(
 proc update_latest_shufflings*(
     balance_source: var BalanceSource, dag: ChainDAGRef, current_slot: Slot) =
   balance_source.do_update_latest_shufflings(dag, current_slot).isOkOr:
-    balance_source.shuffling_epochs = [FAR_FUTURE_EPOCH, FAR_FUTURE_EPOCH]
+    balance_source.shuffling_epochs = DefaultShufflingEpochs
 
 func assign_shufflings*(dst: var BalanceSource, src: BalanceSource) =
   if dst.balances.len > src.balances.len:
@@ -107,7 +107,7 @@ func assigned_slot_into_epoch(
   (distinctBase(balance) shr AttesterDutyOffsets[i]) and AttesterDutyMask
 
 iterator assigned_slots*(
-    balance_source: var BalanceSource, val_index: ValidatorIndex): Slot =
+    balance_source: BalanceSource, val_index: ValidatorIndex): Slot =
   if val_index < balance_source.balances.len.ValidatorIndex:
     for i in 0 .. 1:
       if balance_source.shuffling_epochs[i] != FAR_FUTURE_EPOCH:
@@ -116,6 +116,10 @@ iterator assigned_slots*(
 
 type SlotInfo* = object
   blck*: BlockRef
+  support*: Gwei
+  adversarial*: Gwei
+  total_support*: Gwei
+  total_adversarial*: Gwei
 
 func get_ancestor_info*(
     blck: BlockRef, terminal_bid: BlockId, current_slot: Slot): seq[SlotInfo] =
@@ -145,3 +149,64 @@ func get_ancestor_info*(
     bs = bs.parent
   if bs.blck == nil or bs.blck.root != terminal_bid.root:
     result.reset()
+
+func get_ancestor_support_by_slot*(
+    self: ForkChoiceBackend, balance_source: BalanceSource,
+    blck: BlockRef, terminal_bid: BlockId, current_slot: Slot): seq[SlotInfo] =
+  ## Return support of the ancestors of ``blck`` grouped by originating slot.
+  result = blck.get_ancestor_info(terminal_bid, current_slot)
+  if result.len == 0:
+    return result
+
+  let
+    prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
+    last_slot = result[^1].blck.slot
+    low_slot =
+      if last_slot >= prev_epoch_start:
+        last_slot
+      else:
+        last_slot + 1
+  for val_index in 0 ..< min(self.votes.len, balance_source.balances.len):
+    template balance: ForkChoiceBalance = balance_source.balances[val_index]
+    template vote: VoteTracker = self.votes[val_index]
+    if vote.slot in low_slot .. current_slot:
+      # Collect support of the block per slot:
+      # - get_block_support_between_slots
+      # - get_current_target_score
+      let i = min(current_slot - vote.slot, result.high.uint64).int
+      if vote.current_root == result[i].blck.root:
+        result[i].support += balance.unslashed_balance
+    elif vote.slot == FAR_FUTURE_SLOT:
+      # Collect total weight of equivocating participants:
+      # - get_adversarial_weight (to current_slot)
+      # - compute_empty_slot_support_discount (per slot, between blocks)
+      var
+        i = -1
+        j = -1
+      for slot in balance_source.assigned_slots(val_index.ValidatorIndex):
+        if slot in low_slot ..< current_slot:
+          if i == -1:
+            i = min(current_slot - slot, result.high.uint64).int
+          else:
+            doAssert j == -1
+            j = min(current_slot - slot, result.high.uint64).int
+      if i != -1:
+        let eb = balance.effective_balance
+        if j == -1:
+          result[i].adversarial += eb
+          result[i].total_adversarial += eb
+        else:
+          let latest = min(i, j)
+          if result[i].blck == result[j].blck:
+            result[latest].adversarial += eb
+          else:
+            result[i].adversarial += eb
+            result[j].adversarial += eb
+          result[latest].total_adversarial += eb
+    else:
+      discard
+
+  result[0].total_support = result[0].support
+  for i in 1 ..< result.len:
+    result[i].total_support = result[i].support + result[i - 1].total_support
+    result[i].total_adversarial += result[i - 1].total_adversarial

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -141,6 +141,7 @@ template ethAmountUnit*(typ: type) {.dirty.} =
   func `mod`*(x, y: typ): typ {.borrow.}
 
   func `+=`*(x: var typ, y: typ) {.borrow.}
+  func `-=`*(x: var typ, y: typ) {.borrow.}
 
   func `<`*(x, y: typ): bool {.borrow.}
   func `<=`*(x, y: typ): bool {.borrow.}

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -14,6 +14,9 @@ import
   ../beacon_chain/consensus_object_pools/block_dag,
   ../beacon_chain/fork_choice/fast_confirmation
 
+from ../beacon_chain/consensus_object_pools/blockchain_dag import
+  ForkChoiceBalance, SlashedBit
+
 func `$`(x: BlockRef): string = shortLog(x)
 
 suite "BlockRef and helpers":
@@ -129,23 +132,23 @@ suite "BlockId and helpers":
       s24.parent == BlockSlot(blck: s2, slot: Slot(3))
       s24.parent.parent == s22
 
+func makeRoot(v: byte): Eth2Digest =
+  result.data[0] = v
+
+func makeBlock(slot: Slot, parent: BlockRef): BlockRef =
+  BlockRef(
+    bid: BlockId(slot: slot, root: makeRoot(byte(distinctBase(slot) + 1))),
+    parent: parent)
+
+func makeChain(slots: openArray[Slot]): seq[BlockRef] =
+  result.setLen(slots.len)
+  for i, s in slots:
+    result[i] = makeBlock(s, if i > 0: result[i - 1] else: nil)
+
+func makeFullChain(last: Slot): seq[BlockRef] =
+  makeChain(toSeq(0.Slot .. last))
+
 suite "get_ancestor_info":
-  func makeRoot(v: byte): Eth2Digest =
-    result.data[0] = v
-
-  func makeBlock(slot: Slot, parent: BlockRef): BlockRef =
-    BlockRef(
-      bid: BlockId(slot: slot, root: makeRoot(byte(distinctBase(slot) + 1))),
-      parent: parent)
-
-  func makeChain(slots: openArray[Slot]): seq[BlockRef] =
-    result.setLen(slots.len)
-    for i, s in slots:
-      result[i] = makeBlock(s, if i > 0: result[i - 1] else: nil)
-
-  func makeFullChain(last: Slot): seq[BlockRef] =
-    makeChain(toSeq(0.Slot .. last))
-
   template checkAllSlotsFilled(current_slot: Slot) =
     let
       prev_epoch_start = (current_slot.epoch - 1).start_slot
@@ -191,8 +194,8 @@ suite "get_ancestor_info":
     let
       current_slot = 3.Epoch.start_slot + 3
       chain = makeFullChain(current_slot)
-      fakeBid = BlockId(slot: 1.Epoch.start_slot + 2, root: makeRoot(255))
-      res = get_ancestor_info(chain[^1], fakeBid, current_slot)
+      fake_bid = BlockId(slot: 1.Epoch.start_slot + 2, root: makeRoot(255))
+      res = get_ancestor_info(chain[^1], fake_bid, current_slot)
     check res.lenu64 == 0
 
   test "Gap in current epoch":
@@ -323,3 +326,342 @@ suite "get_ancestor_info":
       res.lenu64 == current_slot - prev_epoch_start + 2
       res[0].blck == chain[0]
       res[^1].blck == chain[0]
+
+  test "Only one block after genesis":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [
+        #[0]# 0.Slot,
+        #[1]# 2.Epoch.start_slot + 2]
+      res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].blck == chain[1]
+      res[current_slot - (2.Epoch.start_slot + 2)].blck == chain[1]
+      res[current_slot - (2.Epoch.start_slot + 1)].blck == chain[0]
+      res[^1].blck == chain[0]
+
+suite "get_ancestor_support_by_slot":
+  func makeBalance(eb: Gwei): ForkChoiceBalance =
+    ForkChoiceBalance(distinctBase(eb))
+
+  func asSlashed(balance: ForkChoiceBalance): ForkChoiceBalance =
+    ForkChoiceBalance(distinctBase(balance) or SlashedBit)
+
+  func withAssignedSlots(
+      balance: ForkChoiceBalance, slots: varargs[Slot]): ForkChoiceBalance =
+    result = balance
+    for slot in slots:
+      let
+        i = slot.epoch.shuffling_index
+        offset = AttesterDutyOffsets[i]
+        duty_mask = slot.since_epoch_start shl offset
+      result = ForkChoiceBalance(distinctBase(result) or duty_mask)
+
+  func makeVote(root: Eth2Digest, slot: Slot): VoteTracker =
+    VoteTracker(current_root: root, slot: slot)
+
+  func makeVote(chain: seq[BlockRef], slot: Slot): VoteTracker =
+    doAssert chain[distinctBase(slot)].bid.slot == slot
+    makeVote(chain[distinctBase(slot)].bid.root, slot)
+
+  func makeEquivocation(): VoteTracker =
+    makeVote(ZERO_HASH, FAR_FUTURE_SLOT)
+
+  func makeBackend(votes: seq[VoteTracker]): ForkChoiceBackend =
+    ForkChoiceBackend(votes: votes)
+
+  func makeBalanceSource(
+      balances: seq[ForkChoiceBalance],
+      shuffling_epochs: array[2, Epoch]): BalanceSource =
+    BalanceSource(
+      info: BalanceCheckpoint(balances: balances),
+      shuffling_epochs: shuffling_epochs)
+
+  test "Basic support":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        chain.makeVote(current_slot - 1),
+        chain.makeVote(current_slot - 2),
+        chain.makeVote(prev_epoch_start + 4)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(current_slot - 1),
+          makeBalance(20.Gwei).withAssignedSlots(current_slot - 2),
+          makeBalance(30.Gwei).withAssignedSlots(prev_epoch_start + 4)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].support == 0.Gwei
+      res[1].support == 10.Gwei
+      res[2].support == 20.Gwei
+      res[current_slot - (prev_epoch_start + 4)].support == 30.Gwei
+      res[0].total_support == 0.Gwei
+      res[1].total_support == 10.Gwei
+      res[2].total_support == 30.Gwei
+      res[current_slot - (prev_epoch_start + 4)].total_support == 60.Gwei
+      res[^1].total_support == 60.Gwei
+      res[0].adversarial == 0.Gwei
+      res[^1].total_adversarial == 0.Gwei
+
+  test "No match":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[makeVote(makeRoot(255), 3.Epoch.start_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].support == 0.Gwei
+      res[2].support == 0.Gwei
+      res[^1].total_support == 0.Gwei
+
+  test "Votes outside range":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        chain.makeVote(1.Epoch.start_slot),
+        chain.makeVote(prev_epoch_start - 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(1.Epoch.start_slot),
+          makeBalance(20.Gwei).withAssignedSlots(prev_epoch_start - 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[^1].total_support == 0.Gwei
+
+  test "Slashed validator":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[chain.makeVote(3.Epoch.start_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).asSlashed.withAssignedSlots(
+          3.Epoch.start_slot + 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[2].support == 0.Gwei
+      res[^1].total_support == 0.Gwei
+      res[^1].total_adversarial == 0.Gwei
+
+  test "Equivocating, single slot in range":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(2.Epoch.start_slot + 4)],
+        [2.Epoch, FAR_FUTURE_EPOCH])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
+      res[0].total_adversarial == 0.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].total_adversarial == 10.Gwei
+      res[^1].total_adversarial == 10.Gwei
+
+  test "Equivocating, cross-epoch, same block":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [
+        #[0]# 0.Slot,
+        #[1]# 2.Epoch.start_slot - 1,
+        #[2]# current_slot]
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(
+          2.Epoch.start_slot + 1, 3.Epoch.start_slot + 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 1)].adversarial == 0.Gwei
+      res[0].total_adversarial == 0.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial == 10.Gwei
+      res[^1].total_adversarial == 10.Gwei
+
+  test "Equivocating, cross-epoch, different blocks":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(
+          2.Epoch.start_slot + 4, 3.Epoch.start_slot + 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
+      res[0].total_adversarial == 0.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial == 10.Gwei
+      res[^1].total_adversarial == 10.Gwei
+
+  test "Equivocating, assigned slot at current_slot":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(
+          2.Epoch.start_slot + 4, 3.Epoch.start_slot + 3)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[0].adversarial == 0.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
+      res[0].total_adversarial == 0.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].total_adversarial == 10.Gwei
+
+  test "Mixed validators":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        chain.makeVote(3.Epoch.start_slot + 1),
+        makeEquivocation(),
+        chain.makeVote(1.Epoch.start_slot),
+        chain.makeVote(2.Epoch.start_slot + 4)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1),
+          makeBalance(20.Gwei).withAssignedSlots(2.Epoch.start_slot + 2),
+          makeBalance(30.Gwei).withAssignedSlots(1.Epoch.start_slot),
+          makeBalance(40.Gwei).asSlashed.withAssignedSlots(
+            2.Epoch.start_slot + 4)],
+        [2.Epoch, FAR_FUTURE_EPOCH])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].support == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 2)].adversarial == 20.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].support == 0.Gwei
+      res[^1].total_support == 10.Gwei
+      res[^1].total_adversarial == 20.Gwei
+
+  test "Empty result":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      chain = makeFullChain(current_slot)
+      fake_bid = BlockId(slot: 1.Epoch.start_slot + 2, root: makeRoot(255))
+      backend = makeBackend(@[chain.makeVote(3.Epoch.start_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], fake_bid, current_slot)
+    check res.len == 0
+
+  test "Early epochs":
+    let
+      current_slot = (SLOTS_PER_EPOCH div 2).Slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[chain.makeVote(2.Slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(2.Slot)],
+        [0.Epoch, FAR_FUTURE_EPOCH])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == distinctBase(current_slot) + 1
+      res[current_slot - 2.Slot].support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Gap in chain":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      gap_slot = 3.Epoch.start_slot + 1
+      chain = makeChain(
+        toSeq(0.Slot .. 3.Epoch.start_slot) &
+        toSeq(gap_slot + 1 .. current_slot))
+      parent_index = distinctBase(3.Epoch.start_slot)
+      backend = makeBackend(@[
+        makeVote(chain[parent_index].bid.root, gap_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(gap_slot)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - gap_slot].support == 10.Gwei
+      res[current_slot - 3.Epoch.start_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Running totals verification":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        chain.makeVote(current_slot - 1),
+        chain.makeVote(3.Epoch.start_slot + 1),
+        chain.makeVote(2.Epoch.start_slot + 4),
+        makeEquivocation(),
+        makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(current_slot - 1),
+          makeBalance(20.Gwei).withAssignedSlots(3.Epoch.start_slot + 1),
+          makeBalance(30.Gwei).withAssignedSlots(2.Epoch.start_slot + 4),
+          makeBalance(40.Gwei).withAssignedSlots(
+            2.Epoch.start_slot + 2, 3.Epoch.start_slot + 1),
+          makeBalance(50.Gwei).withAssignedSlots(
+            2.Epoch.start_slot + 6, 3.Epoch.start_slot + 0)],
+        [2.Epoch, 3.Epoch])
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+
+      res[0].support == 0.Gwei
+      res[1].support == 10.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].support == 20.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].support == 30.Gwei
+
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 40.Gwei
+      res[current_slot - (3.Epoch.start_slot + 0)].adversarial == 50.Gwei
+      res[current_slot - (2.Epoch.start_slot + 6)].adversarial == 50.Gwei
+      res[current_slot - (2.Epoch.start_slot + 2)].adversarial == 40.Gwei
+
+      res[0].total_support == 0.Gwei
+      res[1].total_support == 10.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_support == 30.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].total_support == 60.Gwei
+      res[^1].total_support == 60.Gwei
+
+      res[0].total_adversarial == 0.Gwei
+      res[1].total_adversarial == 0.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial == 40.Gwei
+      res[current_slot - 3.Epoch.start_slot].total_adversarial == 90.Gwei
+      res[^1].total_adversarial == 90.Gwei


### PR DESCRIPTION
Fast Confirmation Rule requires weights collected during empty slots, and also needs to know effective balances of equivocating validators. Collect that info in one call (get_ancestor_support_by_slot) rather than having several loops across the validators as in the spec.

This should collect all the info needed to implement:
- get_block_support_between_slots
- get_current_target_score
- get_adversarial_weight
- compute_empty_slot_support_discount

From the spec:
- https://github.com/ethereum/consensus-specs/pull/4747

In this PR, the goal is to capture everything related to the canonical branch. get_current_target_score is out of scope for this PR as it also needs data from non-canonical branches.