### PR TITLE
Switch FCR balance source on epoch start rather than epoch end

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -57,6 +57,7 @@ func init*(
       slot: finalized.checkpoint.epoch.start_slot,
       root: finalized.checkpoint.root),
     current_epoch_observed_justified: finalized.balance_source,
+    previous_epoch_greatest_unrealized_checkpoint: finalized.checkpoint,
     previous_slot_head: finalized.checkpoint.root,
     current_slot_head: finalized.checkpoint.root)
 
@@ -135,8 +136,7 @@ proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
   self.confirmed = confirmed
 
 proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
-  template justified: Checkpoint = self.checkpoints.justified.checkpoint
-  let unrealized = self.backend.proto_array.unrealized_justified(justified)
+  let unrealized = self.backend.previous_epoch_greatest_unrealized_checkpoint
   if unrealized == self.backend.current_epoch_observed_justified.checkpoint:
     return
 
@@ -177,14 +177,19 @@ proc on_tick(
     self.backend.previous_slot_head = self.backend.current_slot_head
 
     if (current_slot + 1).is_epoch:
-      # Update observed justified checkpoint at the beginning of the
-      # last slot of an epoch
-      self.update_unrealized_justified(dag)
+      # Update greatest unrealized justified checkpoint
+      # at the last slot of an epoch
+      template justified: Checkpoint = self.checkpoints.justified.checkpoint
+      self.backend.previous_epoch_greatest_unrealized_checkpoint =
+        self.backend.proto_array.unrealized_justified(justified)
 
     elif current_slot.is_epoch:
       # Pull-up unrealized justified / finalized checkpoints from previous epoch
       for realized in self.backend.proto_array.realizePendingCheckpoints():
         ? self.update_checkpoints(dag, realized, current_slot)
+
+      # Update observed justified checkpoints at the start of an epoch
+      self.update_unrealized_justified(dag)
 
     else:
       discard

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -145,6 +145,7 @@ type
     proto_array*: ProtoArray
     confirmed*: BlockId
     current_epoch_observed_justified*: BalanceSource
+    previous_epoch_greatest_unrealized_checkpoint*: Checkpoint
     previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -107,6 +107,8 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
         confirmed_root: forkChoice.get_safe_beacon_block_root,
         current_epoch_observed_justified_checkpoint:
           forkChoice.backend.current_epoch_observed_justified.checkpoint,
+        previous_epoch_greatest_unrealized_checkpoint:
+          forkChoice.backend.previous_epoch_greatest_unrealized_checkpoint,
         previous_slot_head: forkChoice.backend.previous_slot_head,
         current_slot_head: forkChoice.backend.current_slot_head))
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -594,6 +594,7 @@ type
   RestExtraData* = object
     confirmed_root*: Eth2Digest
     current_epoch_observed_justified_checkpoint*: Checkpoint
+    previous_epoch_greatest_unrealized_checkpoint*: Checkpoint
     previous_slot_head*, current_slot_head*: Eth2Digest
 
   GetForkChoiceResponse* = object


### PR DESCRIPTION
Balance source is now captured only when the new epoch starts, based on the historical checkpoint locked in at slot 31.

See `get_previous_balance_source`, `update_fast_confirmation_variables`:

- https://github.com/ethereum/consensus-specs/pull/4747