### PR TITLE
Revert "update to Nim v2.2.8"

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -131,10 +131,6 @@ switch("passL", "-fno-omit-frame-pointer")
 # for heap-usage-by-instance-type metrics and object base-type strings
 --define:nimTypeNames
 
-# Workaround for v2.2.8 regression; remove with v2.2.10
-# https://github.com/nim-lang/Nim/pull/25343
---mangle:cpp
-
 switch("define", "nim_compiler_path=" & currentDir & "env.sh nim")
 switch("define", "withoutPCRE")
 


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#8010

Causes large increases in memory usage.
<img width="2738" height="983" alt="image" src="https://github.com/user-attachments/assets/7e2c4399-da89-484d-8969-54de0ce1b4c3" />
