### PR TITLE
Track shuffling for current_epoch - 2 for FCR

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1254,10 +1254,13 @@ AllTests-mainnet
 ```diff
 + Basic support                                                                              OK
 + Early epochs                                                                               OK
++ Early epochs with 3 shufflings                                                             OK
 + Empty result                                                                               OK
 + Equivocating, assigned slot at current_slot                                                OK
 + Equivocating, cross-epoch, different blocks                                                OK
 + Equivocating, cross-epoch, same block                                                      OK
++ Equivocating, duties on different blocks                                                   OK
++ Equivocating, last block before previous epoch                                             OK
 + Equivocating, single slot in range                                                         OK
 + Gap in chain                                                                               OK
 + Mixed validators                                                                           OK
@@ -1265,6 +1268,7 @@ AllTests-mainnet
 + Running totals verification                                                                OK
 + Slashed validator                                                                          OK
 + Votes outside range                                                                        OK
++ assign_shufflings replaces duties                                                          OK
 ```
 ## removeValidatorFiles()
 ```diff

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -90,7 +90,7 @@ template withUpdatedState*(
 template toSszType*(v: ForkChoiceBalance): auto = uint64(v)
 
 const
-  NumInfoBits = (2 * SLOTS_PER_EPOCH.bitWidth) + 1  # See fast_confirmation.nim
+  NumInfoBits = (3 * SLOTS_PER_EPOCH.bitWidth) + 1  # See fast_confirmation.nim
   ForkChoiceInfoOffset* = bitsof(distinctBase(Gwei)) - NumInfoBits
   ForkChoiceInfoMask =
     ((distinctBase(1.Gwei) shl NumInfoBits) - 1) shl ForkChoiceInfoOffset

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -21,25 +21,36 @@ export fork_choice_types
 const
   AttesterDutyOffsets* = [
     ForkChoiceInfoOffset + 1,
-    ForkChoiceInfoOffset + 1 + SLOTS_PER_EPOCH.bitWidth]
+    ForkChoiceInfoOffset + 1 + SLOTS_PER_EPOCH.bitWidth,
+    ForkChoiceInfoOffset + 1 + SLOTS_PER_EPOCH.bitWidth * 2]
+  NumAttesterDuties* = AttesterDutyOffsets.len
   AttesterDutyMask = (distinctBase(1.Gwei) shl SLOTS_PER_EPOCH.bitWidth) - 1
   AttesterDutyMasks = [
     AttesterDutyMask shl AttesterDutyOffsets[0],
-    AttesterDutyMask shl AttesterDutyOffsets[1]]
+    AttesterDutyMask shl AttesterDutyOffsets[1],
+    AttesterDutyMask shl AttesterDutyOffsets[2]]
   AllAttesterDutiesMask =
-    AttesterDutyMasks[0] or AttesterDutyMasks[1]
+    AttesterDutyMasks[0] or
+    AttesterDutyMasks[1] or
+    AttesterDutyMasks[2]
   ClearAttesterDutyMasks = [
     not AttesterDutyMasks[0],
-    not AttesterDutyMasks[1]]
+    not AttesterDutyMasks[1],
+    not AttesterDutyMasks[2]]
   ClearAllAttesterDutiesMask =
-    ClearAttesterDutyMasks[0] or ClearAttesterDutyMasks[1]
-  DefaultShufflingEpochs = [FAR_FUTURE_EPOCH, FAR_FUTURE_EPOCH]
+    ClearAttesterDutyMasks[0] and
+    ClearAttesterDutyMasks[1] and
+    ClearAttesterDutyMasks[2]
+  DefaultShufflingEpochs* = [
+    FAR_FUTURE_EPOCH,
+    FAR_FUTURE_EPOCH,
+    FAR_FUTURE_EPOCH]
 
 func balance_source*(checkpoint: BalanceCheckpoint): BalanceSource =
   BalanceSource(info: checkpoint, shuffling_epochs: DefaultShufflingEpochs)
 
 func shuffling_index*(epoch: Epoch): int =
-  (distinctBase(epoch) and distinctBase(1.Epoch)).int
+  (epoch mod NumAttesterDuties.uint64).int
 
 func has_shuffling(
     balance_source: BalanceSource,
@@ -70,20 +81,17 @@ proc do_update_latest_shufflings(
     dag: ChainDAGRef, current_slot: Slot): Opt[void] =
   var
     epoch = current_slot.epoch
-    blck = dag.head.atSlot(epoch.attester_dependent_slot).blck
-  if blck == nil:
-    return err()
-  if not balance_source.has_shuffling(epoch, blck.bid.root):
-    balance_source.record_shuffling(
-      ? dag.getShufflingRef(blck, epoch, preFinalized = false))
-  if epoch > GENESIS_EPOCH:
-    dec epoch
+    blck = dag.head
+  for i in 0 ..< NumAttesterDuties:
     blck = blck.atSlot(epoch.attester_dependent_slot).blck
     if blck == nil:
       return err()
     if not balance_source.has_shuffling(epoch, blck.bid.root):
       balance_source.record_shuffling(
         ? dag.getShufflingRef(blck, epoch, preFinalized = false))
+    if epoch <= GENESIS_EPOCH:
+      return ok()
+    dec epoch
   ok()
 
 proc update_latest_shufflings*(
@@ -109,12 +117,18 @@ func assigned_slot_into_epoch(
   (distinctBase(balance) shr AttesterDutyOffsets[i]) and AttesterDutyMask
 
 iterator assigned_slots*(
-    balance_source: BalanceSource, val_index: ValidatorIndex): Slot =
+    balance_source: BalanceSource, val_index: ValidatorIndex, o = 0): Slot =
   if val_index < balance_source.balances.len.ValidatorIndex:
-    for i in 0 .. 1:
+    var i = o
+    while true:
       if balance_source.shuffling_epochs[i] != FAR_FUTURE_EPOCH:
         yield balance_source.shuffling_epochs[i].start_slot +
           balance_source.balances[val_index].assigned_slot_into_epoch(i)
+      if i == 0:
+        i = NumAttesterDuties
+      dec i
+      if i == o:
+        break
 
 type SlotInfo* = object
   blck*: BlockRef
@@ -182,29 +196,18 @@ func get_ancestor_support_by_slot*(
       # Collect total weight of equivocating participants:
       # - get_adversarial_weight (to current_slot)
       # - compute_empty_slot_support_discount (per slot, between blocks)
-      var
-        i = -1
-        j = -1
-      for slot in balance_source.assigned_slots(val_index.ValidatorIndex):
+      var old_i = -1
+      let
+        eb = balance.effective_balance
+        o = current_slot.epoch.shuffling_index
+      for slot in balance_source.assigned_slots(val_index.ValidatorIndex, o):
         if slot in low_slot ..< current_slot:
-          if i == -1:
-            i = min(current_slot - slot, result.high.uint64).int
-          else:
-            doAssert j == -1
-            j = min(current_slot - slot, result.high.uint64).int
-      if i != -1:
-        let eb = balance.effective_balance
-        if j == -1:
-          result[i].adversarial += eb
-          result[i].total_adversarial += eb
-        else:
-          let latest = min(i, j)
-          if result[i].blck == result[j].blck:
-            result[latest].adversarial += eb
-          else:
+          let i = min(current_slot - slot, result.high.uint64).int
+          if old_i == -1 or result[i].blck != result[old_i].blck:
             result[i].adversarial += eb
-            result[j].adversarial += eb
-          result[latest].total_adversarial += eb
+            if old_i == -1:
+              result[i].total_adversarial += eb
+          old_i = i
     else:
       discard
 

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -137,8 +137,8 @@ type
     # and overlap the top bits of `info.balances`. `fork_choice.nim` transfers
     # them from the old to the new `BalanceSource` when it changes.
     info*: BalanceCheckpoint
-    shuffling_epochs*: array[2, Epoch]
-    shuffling_roots*: array[2, Eth2Digest]
+    shuffling_epochs*: array[3, Epoch]
+    shuffling_roots*: array[3, Eth2Digest]
 
   ForkChoiceBackend* = object
     confirmation_byzantine_threshold*: uint64

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -331,9 +331,7 @@ suite "get_ancestor_info":
     let
       current_slot = 3.Epoch.start_slot + 3
       prev_epoch_start = 2.Epoch.start_slot
-      chain = makeChain [
-        #[0]# 0.Slot,
-        #[1]# 2.Epoch.start_slot + 2]
+      chain = makeChain [0.Slot, 2.Epoch.start_slot + 2]
       res = get_ancestor_info(chain[^1], chain[0].bid, current_slot)
     check:
       res.lenu64 == current_slot - prev_epoch_start + 2
@@ -374,10 +372,12 @@ suite "get_ancestor_support_by_slot":
 
   func makeBalanceSource(
       balances: seq[ForkChoiceBalance],
-      shuffling_epochs: array[2, Epoch]): BalanceSource =
-    BalanceSource(
+      current_epoch: Epoch): BalanceSource =
+    result = BalanceSource(
       info: BalanceCheckpoint(balances: balances),
-      shuffling_epochs: shuffling_epochs)
+      shuffling_epochs: DefaultShufflingEpochs)
+    for epoch in countdown(current_epoch, max(current_epoch, 2.Epoch) - 2):
+      result.shuffling_epochs[epoch.shuffling_index] = epoch
 
   test "Basic support":
     let
@@ -392,7 +392,7 @@ suite "get_ancestor_support_by_slot":
         @[makeBalance(10.Gwei).withAssignedSlots(current_slot - 1),
           makeBalance(20.Gwei).withAssignedSlots(current_slot - 2),
           makeBalance(30.Gwei).withAssignedSlots(prev_epoch_start + 4)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -417,7 +417,7 @@ suite "get_ancestor_support_by_slot":
       backend = makeBackend(@[makeVote(makeRoot(255), 3.Epoch.start_slot + 1)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -437,7 +437,7 @@ suite "get_ancestor_support_by_slot":
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(1.Epoch.start_slot),
           makeBalance(20.Gwei).withAssignedSlots(prev_epoch_start - 1)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -453,7 +453,7 @@ suite "get_ancestor_support_by_slot":
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).asSlashed.withAssignedSlots(
           3.Epoch.start_slot + 1)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -469,8 +469,11 @@ suite "get_ancestor_support_by_slot":
       chain = makeFullChain(current_slot)
       backend = makeBackend(@[makeEquivocation()])
       balance_source = makeBalanceSource(
-        @[makeBalance(10.Gwei).withAssignedSlots(2.Epoch.start_slot + 4)],
-        [2.Epoch, FAR_FUTURE_EPOCH])
+        @[makeBalance(10.Gwei).withAssignedSlots(
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 4,
+            3.Epoch.start_slot + 1)],
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -484,15 +487,14 @@ suite "get_ancestor_support_by_slot":
     let
       current_slot = 3.Epoch.start_slot + 3
       prev_epoch_start = 2.Epoch.start_slot
-      chain = makeChain [
-        #[0]# 0.Slot,
-        #[1]# 2.Epoch.start_slot - 1,
-        #[2]# current_slot]
+      chain = makeChain [0.Slot, 2.Epoch.start_slot - 1, current_slot]
       backend = makeBackend(@[makeEquivocation()])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(
-          2.Epoch.start_slot + 1, 3.Epoch.start_slot + 1)],
-        [2.Epoch, 3.Epoch])
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 1,
+            3.Epoch.start_slot + 1)],
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -511,8 +513,10 @@ suite "get_ancestor_support_by_slot":
       backend = makeBackend(@[makeEquivocation()])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(
-          2.Epoch.start_slot + 4, 3.Epoch.start_slot + 1)],
-        [2.Epoch, 3.Epoch])
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 4,
+            3.Epoch.start_slot + 1)],
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -531,8 +535,10 @@ suite "get_ancestor_support_by_slot":
       backend = makeBackend(@[makeEquivocation()])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(
-          2.Epoch.start_slot + 4, 3.Epoch.start_slot + 3)],
-        [2.Epoch, 3.Epoch])
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 4,
+            3.Epoch.start_slot + 3)],
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -541,6 +547,54 @@ suite "get_ancestor_support_by_slot":
       res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
       res[0].total_adversarial == 0.Gwei
       res[current_slot - (2.Epoch.start_slot + 4)].total_adversarial == 10.Gwei
+
+  test "Equivocating, last block before previous epoch":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [0.Slot, 2.Epoch.start_slot, current_slot]
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(
+            3.Epoch.start_slot + 1,
+            2.Epoch.start_slot + 4,
+            1.Epoch.start_slot + 2)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 0.Gwei
+      res[^1].adversarial == 10.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial ==
+        10.Gwei
+      res[^1].total_adversarial == 10.Gwei
+
+  test "Equivocating, duties on different blocks":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeChain [
+        0.Slot, 5.Slot, 2.Epoch.start_slot,
+        2.Epoch.start_slot + 6, current_slot]
+      backend = makeBackend(@[makeEquivocation()])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(
+            3.Epoch.start_slot + 1,
+            2.Epoch.start_slot + 4,
+            1.Epoch.start_slot + 2)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
+      res[^1].adversarial == 10.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial ==
+        10.Gwei
+      res[^1].total_adversarial == 10.Gwei
 
   test "Mixed validators":
     let
@@ -554,16 +608,20 @@ suite "get_ancestor_support_by_slot":
         chain.makeVote(2.Epoch.start_slot + 4)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1),
-          makeBalance(20.Gwei).withAssignedSlots(2.Epoch.start_slot + 2),
+          makeBalance(20.Gwei).withAssignedSlots(
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 2,
+            3.Epoch.start_slot + 1),
           makeBalance(30.Gwei).withAssignedSlots(1.Epoch.start_slot),
           makeBalance(40.Gwei).asSlashed.withAssignedSlots(
             2.Epoch.start_slot + 4)],
-        [2.Epoch, FAR_FUTURE_EPOCH])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
       res.lenu64 == current_slot - prev_epoch_start + 2
       res[current_slot - (3.Epoch.start_slot + 1)].support == 10.Gwei
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 20.Gwei
       res[current_slot - (2.Epoch.start_slot + 2)].adversarial == 20.Gwei
       res[current_slot - (2.Epoch.start_slot + 4)].support == 0.Gwei
       res[^1].total_support == 10.Gwei
@@ -577,7 +635,7 @@ suite "get_ancestor_support_by_slot":
       backend = makeBackend(@[chain.makeVote(3.Epoch.start_slot + 1)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(3.Epoch.start_slot + 1)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], fake_bid, current_slot)
     check res.len == 0
@@ -589,13 +647,33 @@ suite "get_ancestor_support_by_slot":
       backend = makeBackend(@[chain.makeVote(2.Slot)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(2.Slot)],
-        [0.Epoch, FAR_FUTURE_EPOCH])
+        0.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
       res.lenu64 == distinctBase(current_slot) + 1
       res[current_slot - 2.Slot].support == 10.Gwei
       res[^1].total_support == 10.Gwei
+
+  test "Early epochs with 3 shufflings":
+    let
+      current_slot = 2.Epoch.start_slot + 3
+      prev_epoch_start = 1.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        chain.makeVote(1.Epoch.start_slot + 2),
+        chain.makeVote(2.Epoch.start_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(1.Epoch.start_slot + 2),
+          makeBalance(20.Gwei).withAssignedSlots(2.Epoch.start_slot + 1)],
+        2.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (1.Epoch.start_slot + 2)].support == 10.Gwei
+      res[current_slot - (2.Epoch.start_slot + 1)].support == 20.Gwei
+      res[^1].total_support == 30.Gwei
 
   test "Gap in chain":
     let
@@ -610,7 +688,7 @@ suite "get_ancestor_support_by_slot":
         makeVote(chain[parent_index].bid.root, gap_slot)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(gap_slot)],
-        [2.Epoch, 3.Epoch])
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -635,10 +713,14 @@ suite "get_ancestor_support_by_slot":
           makeBalance(20.Gwei).withAssignedSlots(3.Epoch.start_slot + 1),
           makeBalance(30.Gwei).withAssignedSlots(2.Epoch.start_slot + 4),
           makeBalance(40.Gwei).withAssignedSlots(
-            2.Epoch.start_slot + 2, 3.Epoch.start_slot + 1),
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 2,
+            3.Epoch.start_slot + 1),
           makeBalance(50.Gwei).withAssignedSlots(
-            2.Epoch.start_slot + 6, 3.Epoch.start_slot + 0)],
-        [2.Epoch, 3.Epoch])
+            1.Epoch.start_slot + 2,
+            2.Epoch.start_slot + 6,
+            3.Epoch.start_slot + 0)],
+        3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
@@ -665,3 +747,22 @@ suite "get_ancestor_support_by_slot":
       res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial == 40.Gwei
       res[current_slot - 3.Epoch.start_slot].total_adversarial == 90.Gwei
       res[^1].total_adversarial == 90.Gwei
+
+  test "assign_shufflings replaces duties":
+    var dst = makeBalanceSource(
+      @[makeBalance(10.Gwei).withAssignedSlots(
+          3.Epoch.start_slot + 1,
+          2.Epoch.start_slot + 4,
+          1.Epoch.start_slot + 2)],
+      3.Epoch)
+    let src = makeBalanceSource(
+      @[makeBalance(10.Gwei).withAssignedSlots(
+          3.Epoch.start_slot + 3,
+          2.Epoch.start_slot + 2,
+          1.Epoch.start_slot + 5)],
+      3.Epoch)
+    dst.assign_shufflings(src)
+    check toSeq(dst.assigned_slots(0.ValidatorIndex)) == @[
+      3.Epoch.start_slot + 3,
+      2.Epoch.start_slot + 2,
+      1.Epoch.start_slot + 5]

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -244,7 +244,7 @@ suite "Block pool processing" & preset():
 
     # Skip slots
     check:
-      dag.updateState(tmpState[], bs1_3, false, cache, dag.updateFlags) # skip slots
+      dag.updateState(tmpState[], bs1_3, false, cache, dag.updateFlags)
       tmpState[].latest_block_root == b1Add[].root
       tmpState[].slot == bs1_3.slot
 
@@ -421,7 +421,8 @@ suite "chain DAG finalization tests" & preset():
       not dag.containsForkBlock(dag.getBlockIdAtSlot(5.Slot).get().bid.root)
       dag.containsForkBlock(dag.finalizedHead.blck.root)
 
-      dag.getBlockRef(dag.getBlockIdAtSlot(0.Slot).get().bid.root).isNone() # Finalized - no BlockRef
+      # Finalized - no BlockRef
+      dag.getBlockRef(dag.getBlockIdAtSlot(0.Slot).get().bid.root).isNone()
 
       dag.getBlockRef(dag.finalizedHead.blck.root).isSome()
 
@@ -1911,20 +1912,20 @@ suite "Fast confirmation" & preset():
 
   test "Update shufflings for current and previous epoch" & preset():
     let
-      headEpoch = dag.head.slot.epoch
-      epochRef = dag.getEpochRef(dag.head, headEpoch, false).get
+      epoch = dag.head.slot.epoch
+      epochRef = dag.getEpochRef(dag.head, epoch, false).get
     var balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
     check:
       balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
-      balance_source.shuffling_epochs[0] in [headEpoch - 1, headEpoch]
-      balance_source.shuffling_epochs[1] in [headEpoch - 1, headEpoch]
-      balance_source.shuffling_epochs[0] != balance_source.shuffling_epochs[1]
+      balance_source.shuffling_epochs[(epoch - 0).shuffling_index] == epoch - 0
+      balance_source.shuffling_epochs[(epoch - 1).shuffling_index] == epoch - 1
+      balance_source.shuffling_epochs[(epoch - 2).shuffling_index] == epoch - 2
 
   test "Shuffling dependent roots" & preset():
     let epochRef = dag.getEpochRef(dag.head, dag.head.slot.epoch, false).get
     var balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
     check balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
-    for i in 0 .. 1:
+    for i in 0 ..< NumAttesterDuties:
       let shufflingRef = dag.getShufflingRef(
         dag.head, balance_source.shuffling_epochs[i], false).get
       check balance_source.shuffling_roots[i] ==
@@ -1936,20 +1937,23 @@ suite "Fast confirmation" & preset():
     check balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
 
     let
-      headEpoch = dag.head.slot.epoch
-      prevShuffling =
-        dag.getShufflingRef(dag.head, headEpoch - 1, false).get
-      curShuffling =
-        dag.getShufflingRef(dag.head, headEpoch, false).get
+      epoch = dag.head.slot.epoch
+      prevPrevShuffling = dag.getShufflingRef(dag.head, epoch - 2, false).get
+      prevShuffling = dag.getShufflingRef(dag.head, epoch - 1, false).get
+      curShuffling = dag.getShufflingRef(dag.head, epoch, false).get
 
     for valIdx in 0 ..< balance_source.balances.len:
       let slots = toSeq(balance_source.assigned_slots(valIdx.ValidatorIndex))
       check:
-        slots.len == 2
+        slots.len == 3
         slots[0].epoch != slots[1].epoch
+        slots[0].epoch != slots[2].epoch
+        slots[1].epoch != slots[2].epoch
       for slot in slots:
         let shuffling =
-          if slot.epoch == prevShuffling.epoch:
+          if slot.epoch == prevPrevShuffling.epoch:
+            prevPrevShuffling
+          elif slot.epoch == prevShuffling.epoch:
             prevShuffling
           else:
             curShuffling
@@ -1980,31 +1984,27 @@ suite "Fast confirmation" & preset():
     let epochRef = dag.getEpochRef(dag.head, dag.head.slot.epoch, false).get
     var balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
 
-    # First update to epoch 3 (populates epochs 2 and 3)
+    # First update to epoch 3 (populates epochs 1, 2 and 3)
     let epoch3Slot = (SLOTS_PER_EPOCH * 3).Slot
     check:
       balance_source.update_latest_shufflings(dag, epoch3Slot).isOk
-      balance_source.shuffling_epochs[0] in [Epoch(2), Epoch(3)]
-      balance_source.shuffling_epochs[1] in [Epoch(2), Epoch(3)]
-      balance_source.shuffling_epochs[0] != balance_source.shuffling_epochs[1]
+      balance_source.shuffling_epochs[Epoch(1).shuffling_index] == Epoch(1)
+      balance_source.shuffling_epochs[Epoch(2).shuffling_index] == Epoch(2)
+      balance_source.shuffling_epochs[Epoch(3).shuffling_index] == Epoch(3)
 
-    # Now update to latest (epoch 4), populates epochs 3 and 4
+    # Now update to latest (epoch 4), populates epochs 2, 3 and 4
     check:
       balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
-      # Epoch 2 gone
-      balance_source.shuffling_epochs[0] != Epoch(2)
-      balance_source.shuffling_epochs[1] != Epoch(2)
-      # Epochs 3 and 4 present
-      balance_source.shuffling_epochs[0] in [Epoch(3), Epoch(4)]
-      balance_source.shuffling_epochs[1] in [Epoch(3), Epoch(4)]
-      balance_source.shuffling_epochs[0] != balance_source.shuffling_epochs[1]
+      balance_source.shuffling_epochs[Epoch(2).shuffling_index] == Epoch(2)
+      balance_source.shuffling_epochs[Epoch(3).shuffling_index] == Epoch(3)
+      balance_source.shuffling_epochs[Epoch(4).shuffling_index] == Epoch(4)
 
-    # Verify assigned_slots yields slots for epochs 3 and 4 only
+    # Verify assigned_slots yields slots for epochs 2, 3 and 4
     for valIdx in 0 ..< balance_source.balances.len:
       let slots = toSeq(balance_source.assigned_slots(valIdx.ValidatorIndex))
-      check slots.len == 2
+      check slots.len == 3
       for slot in slots:
-        check slot.epoch in [Epoch(3), Epoch(4)]
+        check slot.epoch in [Epoch(2), Epoch(3), Epoch(4)]
 
   test "Assign shufflings" & preset():
     let epochRef = dag.getEpochRef(dag.head, dag.head.slot.epoch, false).get
@@ -2028,21 +2028,21 @@ suite "Fast confirmation" & preset():
 
   test "Older epochRef with current shufflings" & preset():
     let
-      headEpoch = dag.head.slot.epoch
-      epochRef = dag.getEpochRef(dag.head, headEpoch, false).get
+      epoch = dag.head.slot.epoch
+      epochRef = dag.getEpochRef(dag.head, epoch, false).get
       oldEpochRef = dag.getEpochRef(
         dag.finalizedHead.blck, dag.finalizedHead.slot.epoch, false).get
     var
-      balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
+      balance_source =
+        epochRef.to_balance_checkpoint(dag.head).balance_source
       old_balance_source =
-        oldEpochRef.to_balance_checkpoint(
-          dag.finalizedHead.blck).balance_source
+        oldEpochRef.to_balance_checkpoint(dag.finalizedHead.blck).balance_source
     check:
       balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
       old_balance_source.update_latest_shufflings(dag, dag.head.slot).isOk
-      balance_source.shuffling_epochs[0] in [headEpoch - 1, headEpoch]
-      balance_source.shuffling_epochs[1] in [headEpoch - 1, headEpoch]
-      balance_source.shuffling_epochs[0] != balance_source.shuffling_epochs[1]
+      balance_source.shuffling_epochs[(epoch - 0).shuffling_index] == epoch - 0
+      balance_source.shuffling_epochs[(epoch - 1).shuffling_index] == epoch - 1
+      balance_source.shuffling_epochs[(epoch - 2).shuffling_index] == epoch - 2
       balance_source.shuffling_epochs == old_balance_source.shuffling_epochs
       balance_source.shuffling_roots == old_balance_source.shuffling_roots
 
@@ -2058,8 +2058,9 @@ suite "Fast confirmation" & preset():
     var balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
     check:
       balance_source.update_latest_shufflings(dag, GENESIS_SLOT).isOk
-      balance_source.shuffling_epochs[0] in [GENESIS_EPOCH, FAR_FUTURE_EPOCH]
-      balance_source.shuffling_epochs[1] in [GENESIS_EPOCH, FAR_FUTURE_EPOCH]
+      balance_source.shuffling_epochs[0] == GENESIS_EPOCH
+      balance_source.shuffling_epochs[1] == FAR_FUTURE_EPOCH
+      balance_source.shuffling_epochs[2] == FAR_FUTURE_EPOCH
     for valIdx in 0 ..< balance_source.balances.len:
       let slots = toSeq(balance_source.assigned_slots(valIdx.ValidatorIndex))
       check:
@@ -2071,9 +2072,9 @@ suite "Fast confirmation" & preset():
     var balance_source = epochRef.to_balance_checkpoint(dag.head).balance_source
     check:
       balance_source.update_latest_shufflings(dag, SLOTS_PER_EPOCH.Slot).isOk
-      balance_source.shuffling_epochs[0] in [GENESIS_EPOCH, Epoch(1)]
-      balance_source.shuffling_epochs[1] in [GENESIS_EPOCH, Epoch(1)]
-      balance_source.shuffling_epochs[0] != balance_source.shuffling_epochs[1]
+      balance_source.shuffling_epochs[0] == GENESIS_EPOCH
+      balance_source.shuffling_epochs[1] == Epoch(1)
+      balance_source.shuffling_epochs[2] == FAR_FUTURE_EPOCH
       balance_source.shuffling_roots[0] == balance_source.shuffling_roots[1]
     for valIdx in 0 ..< balance_source.balances.len:
       let slots = toSeq(balance_source.assigned_slots(valIdx.ValidatorIndex))


### PR DESCRIPTION
Fast Confirmation Rule is getting updated to also require tracking slot assignments for current_epoch - 2 to cover certain edge cases:

- https://github.com/mkalinin/eth2.0-specs/pull/29

We can use the same mechanism that we already had in place, where slot assignments are stored in the upper bits of effective balances. Updated to be generally workable if the number of slot assignments to track keeps changing again. The approach works fine if it's only a few.