### PR TITLE
Revert confirmed to finalize conditions

### DIFF
--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -212,3 +212,33 @@ func get_ancestor_support_by_slot*(
   for i in 1 ..< result.len:
     result[i].total_support = result[i].support + result[i - 1].total_support
     result[i].total_adversarial += result[i - 1].total_adversarial
+
+proc should_revert_confirmed_on_new_epoch*(
+    self: var ForkChoiceBackend, dag: ChainDAGRef, current_slot: Slot): bool =
+  # Revert to finalized block if either of the following is true:
+  # 1) the latest confirmed block's epoch is older than the previous epoch,
+  # 2) [...],
+  # 3) the confirmed chain starting from the current epoch observed justified
+  #    checkpoint cannot be re-confirmed at the start of the current epoch.
+  if self.confirmed.slot.epoch + 1 < current_slot.epoch:
+    return true
+
+  template balance_source: BalanceSource = self.current_epoch_observed_justified
+  balance_source.update_latest_shufflings(dag, current_slot).isOkOr:
+    return true
+
+  false  # TODO: not self.is_confirmed_chain_safe
+
+func should_revert_confirmed_on_new_head*(
+    self: var ForkChoiceBackend, blck: BlockRef, current_slot: Slot): bool =
+  # Revert to finalized block if either of the following is true:
+  # 1) [...],
+  # 2) the latest confirmed block doesn't belong to the canonical chain,
+  # 3) [...].
+  if self.confirmed.slot.epoch + 1 < current_slot.epoch:
+    return true
+
+  var blck = blck
+  while blck != nil and blck.slot > self.confirmed.slot:
+    blck = blck.parent
+  blck == nil or blck.root != self.confirmed.root

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -188,6 +188,12 @@ proc on_tick(
       for realized in self.backend.proto_array.realizePendingCheckpoints():
         ? self.update_checkpoints(dag, realized, current_slot)
 
+      # Reconfirm with previous balance source
+      if self.backend.should_revert_confirmed_on_new_epoch(dag, current_slot):
+        self.backend.update_confirmed BlockId(
+          slot: self.checkpoints.finalized.epoch.start_slot,
+          root: self.checkpoints.finalized.root)
+
       # Update observed justified checkpoints at the start of an epoch
       self.update_unrealized_justified(dag)
 
@@ -411,7 +417,15 @@ proc will_select_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
-  self.backend.current_slot_head = dag.head.root
+  self.backend.current_slot_head = blckRef.root
+
+  let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+  if self.backend.should_revert_confirmed_on_new_head(blckRef, current_slot):
+    self.backend.update_confirmed BlockId(
+      slot: self.checkpoints.finalized.epoch.start_slot,
+      root: self.checkpoints.finalized.root)
+
+  # TODO: Replace placeholder
   self.backend.update_confirmed BlockId(
     slot: self.checkpoints.justified.checkpoint.epoch.start_slot,
     root: self.checkpoints.justified.checkpoint.root)


### PR DESCRIPTION
Implement the `get_latest_confirmed` conditions that revert the fast confirmation rule to the finalized checkpoint. Generally, confirmed still tracks the justified checkpoint, but may at times jump back; this should not affect the cases with an actually safe justified cp.

- https://github.com/ethereum/consensus-specs/pull/4747