### PR TITLE
proxy: re-arrange imports and exports to drop `miniupnpc` dep

### DIFF
--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -12,9 +12,9 @@ import
   ../spec/light_client_sync,
   ../consensus_object_pools/block_pools_types,
   ".."/[beacon_clock, sszdump],
-  "."/[eth2_processor, gossip_validation]
+  "."/gossip_validation
 
-export sszdump, eth2_processor, gossip_validation
+export sszdump, gossip_validation, light_client_sync, block_pools_types
 
 logScope: topics = "gossip_lc"
 

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -8,6 +8,7 @@
 {.push raises: [].}
 
 import
+  metrics,
   chronicles,
   ./gossip_processing/[eth2_processor, light_client_processor],
   ./networking/[eth2_network, topic_params],
@@ -234,12 +235,6 @@ proc resetToFinalizedHeader*(
     current_sync_committee: altair.SyncCommittee) =
   lightClient.processor[].resetToFinalizedHeader(header, current_sync_committee)
 
-import metrics
-
-from
-  ./gossip_processing/eth2_processor
-import
-  processLightClientFinalityUpdate, processLightClientOptimisticUpdate
 
 declareCounter beacon_light_client_finality_updates_received,
   "Number of valid LC finality updates processed by this node"

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -9,7 +9,7 @@
 
 import
   chronicles,
-  ./gossip_processing/light_client_processor,
+  ./gossip_processing/[eth2_processor, light_client_processor],
   ./networking/[eth2_network, topic_params],
   ./spec/datatypes/altair,
   ./spec/helpers,


### PR DESCRIPTION
### Description

The `nimbus_verified_proxy` implements its own transport for light client updates and hence doesn't depend on the p2p layer. However, it does depend on the `light_client_processor.nim` to process those updates which in turn imports and re-exports `eth2_processor.nim` which again in turn has a dependency on `miniupnpc` (proxy -> light_client_processor -> eth2_processor -> ...(nat and etc.) -> miniupnpc). This PR removes this import and re-export by directly importing it in `light_client.nim`. Removing `eth2_processor.nim` re-export removes proxy's dependency on `miniupnpc`. 

NOTE: the issue only pops up when building the proxy for WASM because we split the build process (Nim to C first, then C to WASM). Due to this, Nim sees miniupnpc as a dependency (because it is imported) and generates C files that depend on miniupnp