### PR TITLE
chore: use newer docker base images

### DIFF
--- a/docker/dist/Dockerfile.amd64
+++ b/docker/dist/Dockerfile.amd64
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260227032500
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_amd64_v2@sha256:0600991a291d02c11c69f7934951cb840c369f6c2ea82b231577cc30091b71b0
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.amd64-opt
+++ b/docker/dist/Dockerfile.amd64-opt
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260227032500
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_amd64_v2@sha256:0600991a291d02c11c69f7934951cb840c369f6c2ea82b231577cc30091b71b0
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.arm
+++ b/docker/dist/Dockerfile.arm
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260227024254_arm_v3
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_arm_v4@sha256:f5b834982e74b66bdd3238fd068a4c1c1021442994868e11462cd896718eaf3a
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.arm64
+++ b/docker/dist/Dockerfile.arm64
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260227030200_arm64_v5
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_arm64_v6@sha256:a84d262e05d3587b981fc635f45364c448b913c4247d94940b8cfa4ad7ff9bbf
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/dist/Dockerfile.macos-arm64
+++ b/docker/dist/Dockerfile.macos-arm64
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260302164453_macos
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_macos_v2@sha256:7074006e79dd39897689938ee214164b7b1ac4126f74ca7ee4a80639aa65efd5
 SHELL ["/bin/bash", "-c"]
 
 ARG USER_ID

--- a/docker/dist/Dockerfile.win64
+++ b/docker/dist/Dockerfile.win64
@@ -6,7 +6,7 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 # The build is reproducible only if this base image stays the same.
-FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260227041347_win64_v2
+FROM docker.io/statusteam/nimbus_beacon_node:dist_base_20260308134335_win64_v3@sha256:f315f79e00c4dd9ed846ff2d782c2125d07c661edacaa7d3f17168f2456f99d9
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Uses imgs published in https://github.com/status-im/nimbus-eth2/pull/8063