### PR TITLE
Return read-only access to validators/balances data instead of HashList

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -111,7 +111,7 @@ proc addResolvedHeadBlock(
   # Regardless of the chain we're on, the deposits come in the same order so
   # as soon as we import a block, we'll also update the shared public key
   # cache
-  dag.updateValidatorKeys(state.validators.asSeq())
+  dag.updateValidatorKeys(state.validators)
 
   # Getting epochRef with the state will potentially create a new EpochRef
   let

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -689,7 +689,7 @@ func init*(
       raiseAssert err.msg
 
   epochRef.fork_choice_balances_bytes = snappyEncode(
-    SSZ.encode(get_fork_choice_balances(state.validators.asSeq, epoch)))
+    SSZ.encode(get_fork_choice_balances(state.validators, epoch)))
 
   epochRef
 
@@ -1367,7 +1367,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
 
   # Fill validator key cache in case we're loading an old database that doesn't
   # have a cache
-  dag.updateValidatorKeys(dag.headState.validators.asSeq())
+  dag.updateValidatorKeys(dag.headState.validators)
 
   # Initialize pruning such that when starting with a database that hasn't been
   # pruned, we work our way from the tail to the horizon in incremental steps

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1021,7 +1021,7 @@ proc init*(
     path = config.validatorsDir()
 
   func getValidatorAndIdx(pubkey: ValidatorPubKey): Opt[ValidatorAndIndex] =
-    getValidator(dag.headState.validators.asSeq, pubkey)
+    getValidator(dag.headState.validators, pubkey)
 
   func getCapellaForkVersion(): Opt[presets.Version] =
     Opt.some(metadata.cfg.CAPELLA_FORK_VERSION)

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1132,11 +1132,11 @@ func eth1_data*(state: ForkedHashedBeaconState): lent Eth1Data =
 func eth1_deposit_index*(state: ForkedHashedBeaconState): uint64 =
   withState(state): forkyState.data.eth1_deposit_index
 
-func validators*(state: ForkedHashedBeaconState): lent HashList[Validator, Limit VALIDATOR_REGISTRY_LIMIT] =
-  (block: withState(state): addr forkyState.data.validators)[]
+func validators*(state: ForkedHashedBeaconState): lent seq[Validator] =
+  (block: withState(state): addr forkyState.data.validators.asSeq)[]
 
-func balances*(state: ForkedHashedBeaconState): lent HashList[Gwei, Limit VALIDATOR_REGISTRY_LIMIT] =
-  (block: withState(state): addr forkyState.data.balances)[]
+func balances*(state: ForkedHashedBeaconState): lent seq[Gwei] =
+  (block: withState(state): addr forkyState.data.balances.asSeq)[]
 
 func previous_justified_checkpoint*(state: ForkedHashedBeaconState): lent Checkpoint =
   (block: withState(state): addr forkyState.data.previous_justified_checkpoint)[]

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -189,12 +189,12 @@ cli do(validatorsDir: string, secretsDir: string,
 
     var exited: seq[ValidatorIndex]
     for k, v in validators:
-      if state[].validators.asSeq[k].exit_epoch != FAR_FUTURE_EPOCH:
+      if state[].validators[k].exit_epoch != FAR_FUTURE_EPOCH:
         exited.add k
     for k in exited:
       warn "Validator exited", k
 
-      validatorKeys.del(state[].validators.asSeq[k].pubkey)
+      validatorKeys.del(state[].validators[k].pubkey)
       validators.del(k)
 
     if slot.epoch != (slot - 1).epoch:
@@ -204,13 +204,13 @@ cli do(validatorsDir: string, secretsDir: string,
         balance = block:
           var b: Gwei
           for k, _ in validators:
-            if is_active_validator(state[].validators.asSeq[k], slot.epoch):
-              b += state[].balances.asSeq[k]
+            if is_active_validator(state[].validators[k], slot.epoch):
+              b += state[].balances[k]
           b
         validators = block:
           var b: int
           for k, _ in validators:
-            if is_active_validator(state[].validators.asSeq[k], slot.epoch):
+            if is_active_validator(state[].validators[k], slot.epoch):
               b += 1
           b
         avgBalance = balance.int64 div validators.int64

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -239,7 +239,7 @@ suite "Gossip validation - Altair":
           continue
       let
         subcommitteeIndex = SyncSubcommitteeIndex(i div indicesPerSubcommittee)
-        pubkey = dag.headState.validators.item(index).pubkey
+        pubkey = dag.headState.validators[index].pubkey
         keystoreData = KeystoreData(
           kind: KeystoreKind.Local,
           pubkey: pubkey,
@@ -277,7 +277,7 @@ suite "Gossip validation - Altair":
       subcommittee = toSeq(syncCommittee.syncSubcommittee(subcommitteeIdx))
       index = subcommittee[indexInSubcommittee]
       numPresent = subcommittee.count(index)
-      pubkey = dag.headState.validators.item(index).pubkey
+      pubkey = dag.headState.validators[index].pubkey
       keystoreData = KeystoreData(
         kind: KeystoreKind.Local,
         pubkey: pubkey,

--- a/tests/test_statediff.nim
+++ b/tests/test_statediff.nim
@@ -65,7 +65,7 @@ suite "state diff tests" & preset():
         applyDiff(
           tmpStateApplyBase[],
           mapIt(
-            testStates[j][].validators.asSeq[
+            testStates[j][].validators[
               testStates[i][].validators.len ..
               testStates[j][].validators.len - 1],
             it.getImmutableValidatorData),


### PR DESCRIPTION
With 7688, validators/balances changes from HashList to HashSeq. To continue using the same validators/balances accessor, return the underlying data seq directly. As it's lent, should be safe as readonly. There is no hash_tree_root through that accessor, so the cache from HashList/HashSeq is not relevant for this access.