### PR TITLE
Restart confirmation chain as needed by fast confirmation conditions

### DIFF
--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -259,7 +259,7 @@ proc should_revert_confirmed_on_new_epoch*(
   false  # TODO: not self.is_confirmed_chain_safe
 
 func should_revert_confirmed_on_new_head*(
-    self: var ForkChoiceBackend, blck: BlockRef, current_slot: Slot): bool =
+    self: ForkChoiceBackend, blck: BlockRef, current_slot: Slot): bool =
   # Revert to finalized block if either of the following is true:
   # 1) [...],
   # 2) the latest confirmed block doesn't belong to the canonical chain,
@@ -277,7 +277,7 @@ func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
   self.current_epoch_observed_justified.checkpoint.root in self.proto_array
 
 func should_restart_confirmation_chain*(
-    self: var ForkChoiceBackend, current_slot: Slot): bool =
+    self: ForkChoiceBackend, current_slot: Slot): bool =
   # Restart the confirmation chain if each of the following conditions are true:
   # 1) it is the start of the current epoch,
   # 2) epoch of self.current_epoch_observed_justified.checkpoint equals to the

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -10,7 +10,7 @@
 import
   std/sets, stew/bitops2,
   ../consensus_object_pools/spec_cache,
-  "."/fork_choice_types
+  "."/[fork_choice_types, proto_array]
 
 from ../consensus_object_pools/blockchain_dag import
   effective_balance, unslashed_balance,
@@ -271,3 +271,32 @@ func should_revert_confirmed_on_new_head*(
   while blck != nil and blck.slot > self.confirmed.slot:
     blck = blck.parent
   blck == nil or blck.root != self.confirmed.root
+
+func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
+  self.current_slot_head in self.proto_array and
+  self.current_epoch_observed_justified.checkpoint.root in self.proto_array
+
+func should_restart_confirmation_chain*(
+    self: var ForkChoiceBackend, current_slot: Slot): bool =
+  # Restart the confirmation chain if each of the following conditions are true:
+  # 1) it is the start of the current epoch,
+  # 2) epoch of self.current_epoch_observed_justified.checkpoint equals to the
+  #    previous epoch,
+  # 3) self.current_epoch_observed_justified.checkpoint equals to unrealized
+  #    justification of the head,
+  # 4) confirmed block is older than the block of
+  #    self.current_epoch_observed_justified.checkpoint.
+  template current_epoch_justified: Checkpoint =
+    self.current_epoch_observed_justified.checkpoint
+  template current_epoch_justified_slot: Slot =
+    self.proto_array.slot(current_epoch_justified.root)
+      .expect("is_proto_array_consistent")
+
+  template head_unrealized_justified: Checkpoint =
+    self.proto_array.unrealized(self.current_slot_head)
+      .expect("is_proto_array_consistent").justified
+
+  current_slot.is_epoch and
+  current_epoch_justified.epoch + 1 == current_slot.epoch and
+  current_epoch_justified == head_unrealized_justified and
+  self.confirmed.slot < current_epoch_justified_slot

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -210,8 +210,9 @@ proc on_tick(
     # Reset store.proposer_boost_root
     self.checkpoints.proposer_boost_root = ZERO_HASH
 
-    # Update prev slot head
+    # Update prev and curr slot head
     self.backend.previous_slot_head = self.backend.current_slot_head
+    self.backend.current_slot_head = dag.head.root
 
     if (current_slot + 1).is_epoch:
       # Update greatest unrealized justified checkpoint
@@ -430,9 +431,13 @@ proc will_select_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
-  self.backend.current_slot_head = blckRef.root
 
-  let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+  let
+    current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+    consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
+    deadline = current_slot.attestation_deadline(dag.timeParams, consensusFork)
+  if wallTime < deadline:
+    self.backend.current_slot_head = blckRef.root
   if self.backend.should_revert_confirmed_on_new_head(blckRef, current_slot):
     self.backend.update_confirmed(self.checkpoints.finalized)
   if not self.backend.is_proto_array_consistent:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -135,6 +135,11 @@ proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
       old_confirmed = shortLog(self.confirmed), new_confirmed = confirmed
   self.confirmed = confirmed
 
+proc update_confirmed(self: var ForkChoiceBackend, confirmed: Checkpoint) =
+  self.update_confirmed BlockId(
+    slot: self.proto_array.slot(confirmed.root).get(confirmed.epoch.start_slot),
+    root: confirmed.root)
+
 proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
   let unrealized = self.backend.previous_epoch_greatest_unrealized_checkpoint
   if unrealized == self.backend.current_epoch_observed_justified.checkpoint:
@@ -190,12 +195,18 @@ proc on_tick(
 
       # Reconfirm with previous balance source
       if self.backend.should_revert_confirmed_on_new_epoch(dag, current_slot):
-        self.backend.update_confirmed BlockId(
-          slot: self.checkpoints.finalized.epoch.start_slot,
-          root: self.checkpoints.finalized.root)
+        self.backend.update_confirmed(self.checkpoints.finalized)
 
       # Update observed justified checkpoints at the start of an epoch
       self.update_unrealized_justified(dag)
+
+      # Restart confirmation chain if necessary
+      if not self.backend.is_proto_array_consistent:
+        self.backend.update_confirmed(self.checkpoints.finalized)
+      else:
+        if self.backend.should_restart_confirmation_chain(current_slot):
+          self.backend.update_confirmed(
+            self.backend.current_epoch_observed_justified.checkpoint)
 
     else:
       discard
@@ -421,9 +432,13 @@ proc will_select_head*(
 
   let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
   if self.backend.should_revert_confirmed_on_new_head(blckRef, current_slot):
-    self.backend.update_confirmed BlockId(
-      slot: self.checkpoints.finalized.epoch.start_slot,
-      root: self.checkpoints.finalized.root)
+    self.backend.update_confirmed(self.checkpoints.finalized)
+  if not self.backend.is_proto_array_consistent:
+    self.backend.update_confirmed(self.checkpoints.finalized)
+  else:
+    if self.backend.should_restart_confirmation_chain(current_slot):
+      self.backend.update_confirmed(
+        self.backend.current_epoch_observed_justified.checkpoint)
 
   # TODO: Replace placeholder
   self.backend.update_confirmed BlockId(

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -236,6 +236,8 @@ proc on_tick(
       self.update_unrealized_justified(dag)
 
       # Restart confirmation chain if necessary
+      self.backend.current_slot_head =
+        ? self.backend.find_head(current_slot, self.checkpoints)
       if not self.backend.is_proto_array_consistent:
         self.backend.update_confirmed(self.checkpoints.finalized)
       else:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -80,6 +80,38 @@ proc init*(
       justified: finalized,
       finalized: finalized.checkpoint))
 
+func process_attestation(
+    self: var ForkChoiceBackend,
+    validator_index: ValidatorIndex, block_root: Eth2Digest, slot: Slot) =
+  ## Add an attestation to the fork choice context
+  self.votes.extend(validator_index.int + 1)
+
+  template vote: untyped = self.votes[validator_index]
+  if vote.slot != FAR_FUTURE_SLOT:
+    if slot.epoch > vote.slot.epoch or vote.next_root.isZero:
+      vote.next_root = block_root
+      vote.slot = slot
+
+      trace "Integrating vote in fork choice",
+        validator_index = validator_index,
+        new_vote = shortLog(vote)
+
+proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
+  # Spec:
+  # Attestations can only affect the fork choice of subsequent slots.
+  # Delay consideration in the fork choice until their slot is in the past.
+  let startTick = Moment.now()
+  self.queuedAttestations.keepItIf:
+    if it.slot < slot:
+      for validator_index in it.attesting_indices:
+        self.backend.process_attestation(
+          validator_index, it.block_root, it.slot)
+      false
+    else:
+      true
+  let endTick = Moment.now()
+  debug "Processed attestation queue", processDur = endTick - startTick
+
 proc update_justified(
     self: var Checkpoints, dag: ChainDAGRef,
     epoch: Epoch, blck: BlockRef, current_slot: Slot) =
@@ -193,7 +225,9 @@ proc on_tick(
       for realized in self.backend.proto_array.realizePendingCheckpoints():
         ? self.update_checkpoints(dag, realized, current_slot)
 
-      # Reconfirm with previous balance source
+      # Reconfirm with previous balance source after attestations
+      # from past slots have been applied
+      self.process_attestation_queue(current_slot)
       if self.backend.should_revert_confirmed_on_new_epoch(dag, current_slot):
         self.backend.update_confirmed(self.checkpoints.finalized)
 
@@ -211,38 +245,6 @@ proc on_tick(
     else:
       discard
   ok()
-
-func process_attestation(
-    self: var ForkChoiceBackend,
-    validator_index: ValidatorIndex, block_root: Eth2Digest, slot: Slot) =
-  ## Add an attestation to the fork choice context
-  self.votes.extend(validator_index.int + 1)
-
-  template vote: untyped = self.votes[validator_index]
-  if vote.slot != FAR_FUTURE_SLOT:
-    if slot.epoch > vote.slot.epoch or vote.next_root.isZero:
-      vote.next_root = block_root
-      vote.slot = slot
-
-      trace "Integrating vote in fork choice",
-        validator_index = validator_index,
-        new_vote = shortLog(vote)
-
-proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
-  # Spec:
-  # Attestations can only affect the fork choice of subsequent slots.
-  # Delay consideration in the fork choice until their slot is in the past.
-  let startTick = Moment.now()
-  self.queuedAttestations.keepItIf:
-    if it.slot < slot:
-      for validator_index in it.attesting_indices:
-        self.backend.process_attestation(
-          validator_index, it.block_root, it.slot)
-      false
-    else:
-      true
-  let endTick = Moment.now()
-  debug "Processed attestation queue", processDur = endTick - startTick
 
 func contains*(self: ForkChoiceBackend, block_root: Eth2Digest): bool =
   ## Returns `true` if a block is known to the fork choice

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -43,6 +43,11 @@ func compute_deltas(
     old_balances: openArray[ForkChoiceBalance],
     new_balances: openArray[ForkChoiceBalance]): FcResult[void]
 
+func find_head(
+    self: var ForkChoiceBackend,
+    current_slot: Slot,
+    checkpoints: Checkpoints): FcResult[Eth2Digest]
+
 # Fork choice routines
 # ----------------------------------------------------------------------
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -494,7 +494,12 @@ func prune(
     self: var ForkChoiceBackend,
     checkpoints: FinalityCheckpoints): FcResult[void] =
   ## Prune blocks preceding the finalized root as they are now unneeded.
-  self.proto_array.prune(checkpoints)
+  ? self.proto_array.prune(checkpoints)
+  if self.previous_slot_head notin self.proto_array:
+    self.previous_slot_head = checkpoints.finalized.root
+  if self.current_slot_head notin self.proto_array:
+    self.current_slot_head = checkpoints.finalized.root
+  ok()
 
 func prune*(self: var ForkChoice): FcResult[void] =
   self.backend.prune(

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -64,6 +64,14 @@ func `[]`(nodes: ProtoNodes, idx: Index): Opt[ProtoNode] =
     return Opt.none(ProtoNode)
   Opt.some(nodes.buf[i])
 
+func contains(nodes: ProtoNodes, idx: Index): bool =
+  if idx < nodes.offset:
+    return false
+  let i = idx - nodes.offset
+  if i >= nodes.buf.len:
+    return false
+  true
+
 func len*(nodes: ProtoNodes): int =
   nodes.buf.len
 
@@ -72,6 +80,16 @@ func add(nodes: var ProtoNodes, node: ProtoNode) =
 
 func find(self: ProtoArray, root: Eth2Digest): Index =
   self.indices.getOrDefault(root, -1)
+
+func contains*(self: ProtoArray, root: Eth2Digest): bool =
+  self.find(root) in self.nodes
+
+func slot*(self: ProtoArray, root: Eth2Digest): Opt[Slot] =
+  ok (? self.nodes[self.find(root)]).bid.slot
+
+func unrealized*(self: ProtoArray, root: Eth2Digest): Opt[FinalityCheckpoints] =
+  let idx = self.find(root)
+  ok self.currentEpochTips.getOrDefault(idx, (? self.nodes[idx]).checkpoints)
 
 # Forward declarations
 # ----------------------------------------------------------------------

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -147,7 +147,7 @@ func makeFullChain(last: Slot): seq[BlockRef] =
   makeChain(toSeq(0.Slot .. last))
 
 func makeVote(root: Eth2Digest, slot: Slot): VoteTracker =
-  VoteTracker(current_root: root, next_root: root, slot: slot)
+  VoteTracker(next_root: root, slot: slot)
 
 func makeVote(chain: seq[BlockRef], slot: Slot): VoteTracker =
   doAssert chain[distinctBase(slot)].bid.slot == slot


### PR DESCRIPTION
`get_latest_confirmed` defines a combination of conditions under which the confirmation chain is restarted from the current epoch observed justified checkpoint:

- https://github.com/ethereum/consensus-specs/pull/4747

Add the checks, both for when epoch advances (first check), and when head changes. Should not trigger under finalizing (safe) conditions, and if it does, gets overwritten by current mainnet logic of simply tracking the justified checkpoint anyway.