### PR TITLE
Collect fast confirmation rule data for get_attestation_score

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1271,6 +1271,7 @@ AllTests-mainnet
 + Non-canonical, three forks                                                                 OK
 + Running totals verification                                                                OK
 + Slashed validator                                                                          OK
++ Stale view, no assigned slot at stale block                                                OK
 + Votes outside range                                                                        OK
 + assign_shufflings replaces duties                                                          OK
 ```

--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1264,6 +1264,11 @@ AllTests-mainnet
 + Gap in chain                                                                               OK
 + Mixed validators                                                                           OK
 + No match                                                                                   OK
++ Non-canonical, deep fork                                                                   OK
++ Non-canonical, fork before range                                                           OK
++ Non-canonical, mixed with canonical                                                        OK
++ Non-canonical, single vote                                                                 OK
++ Non-canonical, three forks                                                                 OK
 + Running totals verification                                                                OK
 + Slashed validator                                                                          OK
 + Votes outside range                                                                        OK

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -227,8 +227,8 @@ func get_ancestor_support_by_slot*(
           result[i].total_support += balance.unslashed_balance
     elif vote.slot == FAR_FUTURE_SLOT:
       # Collect weight of equivocating participants:
+      # - get_equivocation_score (per slot, between blocks)
       # - get_adversarial_weight (total, to current_slot)
-      # - compute_empty_slot_support_discount (per slot, between blocks)
       var old_i = -1
       let
         eb = balance.effective_balance

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -184,6 +184,9 @@ func noncanonical_ancestors(
   if chain.len == 0:
     return result
 
+  for i in 0 ..< chain.high:
+    result[chain[i].blck.root] = i
+
   for head in heads:
     var blck = head
     while blck != nil and blck.slot in low_slot .. current_slot:
@@ -224,7 +227,7 @@ func get_ancestor_support_by_slot*(
       if vote.current_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
 
-      # Collect noncanonical support of the block:
+      # Collect noncanonical (or stale) support of the block:
       # - get_attestation_score (total, including non-canonical)
       else:
         let ancestor_i = noncanonical.getOrDefault(vote.current_root, -1)

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -166,6 +166,9 @@ func get_ancestor_info*(
   if bs.blck == nil or bs.blck.root != terminal_bid.root:
     result.reset()
 
+func index(chain: seq[SlotInfo], slot, current_slot: Slot): int =
+  min(current_slot - slot, chain.high.uint64).int
+
 func low_slot(chain: seq[SlotInfo], current_slot: Slot): Slot =
   let
     prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
@@ -185,7 +188,7 @@ func noncanonical_ancestors(
     var blck = head
     while blck != nil and blck.slot in low_slot .. current_slot:
       let
-        i = min(current_slot - blck.slot, chain.high.uint64).int
+        i = chain.index(blck.slot, current_slot)
         ancestor =
           if blck == chain[i].blck:
             i
@@ -217,7 +220,7 @@ func get_ancestor_support_by_slot*(
     if vote.slot in low_slot .. current_slot:
       # Collect support of the block per slot:
       # - get_block_support_between_slots (per slot, canonical only)
-      let i = min(current_slot - vote.slot, result.high.uint64).int
+      let i = result.index(vote.slot, current_slot)
       if vote.current_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
 
@@ -237,7 +240,7 @@ func get_ancestor_support_by_slot*(
         o = current_slot.epoch.shuffling_index
       for slot in balance_source.assigned_slots(val.ValidatorIndex, o):
         if slot in low_slot ..< current_slot:
-          let i = min(current_slot - slot, result.high.uint64).int
+          let i = result.index(slot, current_slot)
           if old_i == -1 or result[i].blck != result[old_i].blck:
             result[i].adversarial += eb
             if old_i == -1:

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/sets, stew/bitops2,
+  std/[sets, tables], stew/bitops2,
   ../consensus_object_pools/spec_cache,
   "."/fork_choice_types
 
@@ -166,35 +166,68 @@ func get_ancestor_info*(
   if bs.blck == nil or bs.blck.root != terminal_bid.root:
     result.reset()
 
+func low_slot(chain: seq[SlotInfo], current_slot: Slot): Slot =
+  let
+    prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
+    last_slot = chain[^1].blck.slot
+  if last_slot >= prev_epoch_start:
+    last_slot
+  else:
+    last_slot + 1
+
+func noncanonical_ancestors(
+    chain: seq[SlotInfo], heads: seq[BlockRef],
+    low_slot, current_slot: Slot): Table[Eth2Digest, int] =
+  if chain.len == 0:
+    return result
+
+  for head in heads:
+    var blck = head
+    while blck != nil and blck.slot in low_slot .. current_slot:
+      let
+        i = min(current_slot - blck.slot, chain.high.uint64).int
+        ancestor =
+          if blck == chain[i].blck:
+            i
+          else:
+            result.getOrDefault(blck.root, -1)
+      if ancestor != -1:
+        var b = head
+        while b != blck:
+          result[b.root] = ancestor
+          b = b.parent
+        break
+      blck = blck.parent
+
 func get_ancestor_support_by_slot*(
     self: ForkChoiceBackend, balance_source: BalanceSource,
-    blck: BlockRef, terminal_bid: BlockId, current_slot: Slot): seq[SlotInfo] =
+    heads: seq[BlockRef], blck: BlockRef, terminal_bid: BlockId,
+    current_slot: Slot): seq[SlotInfo] =
   ## Return support of the ancestors of ``blck`` grouped by originating slot.
   result = blck.get_ancestor_info(terminal_bid, current_slot)
   if result.len == 0:
     return result
 
   let
-    prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
-    last_slot = result[^1].blck.slot
-    low_slot =
-      if last_slot >= prev_epoch_start:
-        last_slot
-      else:
-        last_slot + 1
+    low_slot = result.low_slot(current_slot)
+    noncanonical = result.noncanonical_ancestors(heads, low_slot, current_slot)
   for val_index in 0 ..< min(self.votes.len, balance_source.balances.len):
     template balance: ForkChoiceBalance = balance_source.balances[val_index]
     template vote: VoteTracker = self.votes[val_index]
     if vote.slot in low_slot .. current_slot:
       # Collect support of the block per slot:
-      # - get_block_support_between_slots
-      # - get_current_target_score
+      # - get_block_support_between_slots (per slot, canonical only)
+      # - get_attestation_score (total, including non-canonical)
       let i = min(current_slot - vote.slot, result.high.uint64).int
       if vote.current_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
+      else:
+        let i = noncanonical.getOrDefault(vote.current_root, -1)
+        if i != -1:
+          result[i].total_support += balance.unslashed_balance
     elif vote.slot == FAR_FUTURE_SLOT:
-      # Collect total weight of equivocating participants:
-      # - get_adversarial_weight (to current_slot)
+      # Collect weight of equivocating participants:
+      # - get_adversarial_weight (total, to current_slot)
       # - compute_empty_slot_support_discount (per slot, between blocks)
       var old_i = -1
       let
@@ -211,9 +244,9 @@ func get_ancestor_support_by_slot*(
     else:
       discard
 
-  result[0].total_support = result[0].support
+  result[0].total_support += result[0].support
   for i in 1 ..< result.len:
-    result[i].total_support = result[i].support + result[i - 1].total_support
+    result[i].total_support += result[i].support + result[i - 1].total_support
     result[i].total_adversarial += result[i - 1].total_adversarial
 
 func get_current_target_score*(

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -227,7 +227,7 @@ func get_ancestor_support_by_slot*(
       if vote.current_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
 
-      # Collect noncanonical (or stale) support of the block:
+      # Collect noncanonical (and stale) support of the block:
       # - get_attestation_score (total, including non-canonical)
       else:
         let ancestor_i = noncanonical.getOrDefault(vote.current_root, -1)

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -211,20 +211,22 @@ func get_ancestor_support_by_slot*(
   let
     low_slot = result.low_slot(current_slot)
     noncanonical = result.noncanonical_ancestors(heads, low_slot, current_slot)
-  for val_index in 0 ..< min(self.votes.len, balance_source.balances.len):
-    template balance: ForkChoiceBalance = balance_source.balances[val_index]
-    template vote: VoteTracker = self.votes[val_index]
+  for val in 0 ..< min(self.votes.len, balance_source.balances.len):
+    template balance: ForkChoiceBalance = balance_source.balances[val]
+    template vote: VoteTracker = self.votes[val]
     if vote.slot in low_slot .. current_slot:
       # Collect support of the block per slot:
       # - get_block_support_between_slots (per slot, canonical only)
-      # - get_attestation_score (total, including non-canonical)
       let i = min(current_slot - vote.slot, result.high.uint64).int
       if vote.current_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
+
+      # Collect noncanonical support of the block:
+      # - get_attestation_score (total, including non-canonical)
       else:
-        let i = noncanonical.getOrDefault(vote.current_root, -1)
-        if i != -1:
-          result[i].total_support += balance.unslashed_balance
+        let ancestor_i = noncanonical.getOrDefault(vote.current_root, -1)
+        if ancestor_i != -1:
+          result[ancestor_i].total_support += balance.unslashed_balance
     elif vote.slot == FAR_FUTURE_SLOT:
       # Collect weight of equivocating participants:
       # - get_equivocation_score (per slot, between blocks)
@@ -233,7 +235,7 @@ func get_ancestor_support_by_slot*(
       let
         eb = balance.effective_balance
         o = current_slot.epoch.shuffling_index
-      for slot in balance_source.assigned_slots(val_index.ValidatorIndex, o):
+      for slot in balance_source.assigned_slots(val.ValidatorIndex, o):
         if slot in low_slot ..< current_slot:
           let i = min(current_slot - slot, result.high.uint64).int
           if old_i == -1 or result[i].blck != result[old_i].blck:

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -224,13 +224,13 @@ func get_ancestor_support_by_slot*(
       # Collect support of the block per slot:
       # - get_block_support_between_slots (per slot, canonical only)
       let i = result.index(vote.slot, current_slot)
-      if vote.current_root == result[i].blck.root:
+      if vote.next_root == result[i].blck.root:
         result[i].support += balance.unslashed_balance
 
       # Collect noncanonical (and stale) support of the block:
       # - get_attestation_score (total, including non-canonical)
       else:
-        let ancestor_i = noncanonical.getOrDefault(vote.current_root, -1)
+        let ancestor_i = noncanonical.getOrDefault(vote.next_root, -1)
         if ancestor_i != -1:
           result[ancestor_i].total_support += balance.unslashed_balance
     elif vote.slot == FAR_FUTURE_SLOT:
@@ -280,7 +280,7 @@ func get_current_target_score*(
     template vote: VoteTracker = self.votes[val_index]
     if vote.slot.epoch == current_epoch and
         validator.is_active_validator(current_epoch) and
-        not validator.slashed and vote.current_root in roots:
+        not validator.slashed and vote.next_root in roots:
       result += validator.effective_balance
 
 proc should_revert_confirmed_on_new_epoch*(

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -356,6 +356,13 @@ suite "get_ancestor_info":
       res[^1].blck == chain[0]
 
 suite "get_ancestor_support_by_slot":
+  func get_ancestor_support_by_slot(
+      self: ForkChoiceBackend, balance_source: BalanceSource,
+      blck: BlockRef, terminal_bid: BlockId,
+      current_slot: Slot): seq[SlotInfo] =
+    self.get_ancestor_support_by_slot(
+      balance_source, @[blck], blck, terminal_bid, current_slot)
+
   func makeBalance(eb: Gwei): ForkChoiceBalance =
     ForkChoiceBalance(distinctBase(eb))
 
@@ -749,6 +756,133 @@ suite "get_ancestor_support_by_slot":
       res[current_slot - (3.Epoch.start_slot + 1)].total_adversarial == 40.Gwei
       res[current_slot - 3.Epoch.start_slot].total_adversarial == 90.Gwei
       res[^1].total_adversarial == 90.Gwei
+
+  test "Non-canonical, single vote":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      fork_slot = 3.Epoch.start_slot
+      head2 = BlockRef(
+        bid: BlockId(slot: fork_slot + 1, root: makeRoot(200)),
+        parent: chain[distinctBase(fork_slot)])
+      backend = makeBackend(@[
+        makeVote(head2.bid.root, fork_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(fork_slot + 1)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, @[chain[^1], head2],
+        chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - fork_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Non-canonical, deep fork":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      fork_slot = 2.Epoch.start_slot + 4
+      fork_blck = BlockRef(
+        bid: BlockId(slot: fork_slot + 1, root: makeRoot(200)),
+        parent: chain[distinctBase(fork_slot)])
+      head2 = BlockRef(
+        bid: BlockId(slot: fork_slot + 2, root: makeRoot(201)),
+        parent: fork_blck)
+      backend = makeBackend(@[
+        makeVote(head2.bid.root, fork_slot + 2),
+        makeVote(fork_blck.bid.root, fork_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(fork_slot + 2),
+          makeBalance(20.Gwei).withAssignedSlots(fork_slot + 1)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, @[chain[^1], head2],
+        chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - fork_slot].total_support == 30.Gwei
+      res[^1].total_support == 30.Gwei
+
+  test "Non-canonical, three forks":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      fork_slot = 3.Epoch.start_slot
+      head2 = BlockRef(
+        bid: BlockId(slot: fork_slot + 1, root: makeRoot(200)),
+        parent: chain[distinctBase(fork_slot)])
+      head3 = BlockRef(
+        bid: BlockId(slot: fork_slot + 1, root: makeRoot(201)),
+        parent: chain[distinctBase(fork_slot)])
+      head4 = BlockRef(
+        bid: BlockId(slot: fork_slot + 2, root: makeRoot(202)),
+        parent: head2)
+      backend = makeBackend(@[
+        makeVote(head2.bid.root, fork_slot + 1),
+        makeVote(head3.bid.root, fork_slot + 1),
+        makeVote(head4.bid.root, fork_slot + 2)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(fork_slot + 1),
+          makeBalance(20.Gwei).withAssignedSlots(fork_slot + 1),
+          makeBalance(30.Gwei).withAssignedSlots(fork_slot + 2)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, @[chain[^1], head2, head3, head4],
+        chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - fork_slot].total_support == 60.Gwei
+      res[^1].total_support == 60.Gwei
+
+  test "Non-canonical, mixed with canonical":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      fork_slot = 3.Epoch.start_slot
+      head2 = BlockRef(
+        bid: BlockId(slot: fork_slot + 1, root: makeRoot(200)),
+        parent: chain[distinctBase(fork_slot)])
+      backend = makeBackend(@[
+        chain.makeVote(fork_slot + 1),
+        makeVote(head2.bid.root, fork_slot + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(fork_slot + 1),
+          makeBalance(20.Gwei).withAssignedSlots(fork_slot + 1)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, @[chain[^1], head2],
+        chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (fork_slot + 1)].support == 10.Gwei
+      res[current_slot - (fork_slot + 0)].total_support == 30.Gwei
+      res[^1].total_support == 30.Gwei
+
+  test "Non-canonical, fork before range":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      head2 = BlockRef(
+        bid: BlockId(
+          slot: prev_epoch_start + 1, root: makeRoot(200)),
+        parent: chain[distinctBase(prev_epoch_start) - 2])
+      backend = makeBackend(@[
+        makeVote(head2.bid.root, prev_epoch_start + 1)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(prev_epoch_start + 1)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, @[chain[^1], head2],
+        chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[^1].total_support == 0.Gwei
 
   test "assign_shufflings replaces duties":
     var dst = makeBalanceSource(

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -151,7 +151,7 @@ func makeFullChain(last: Slot): seq[BlockRef] =
   makeChain(toSeq(0.Slot .. last))
 
 func makeVote(root: Eth2Digest, slot: Slot): VoteTracker =
-  VoteTracker(current_root: root, slot: slot)
+  VoteTracker(current_root: root, next_root: root, slot: slot)
 
 func makeVote(chain: seq[BlockRef], slot: Slot): VoteTracker =
   doAssert chain[distinctBase(slot)].bid.slot == slot

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -692,9 +692,8 @@ suite "get_ancestor_support_by_slot":
       chain = makeChain(
         toSeq(0.Slot .. 3.Epoch.start_slot) &
         toSeq(gap_slot + 1 .. current_slot))
-      parent_index = distinctBase(3.Epoch.start_slot)
       backend = makeBackend(@[
-        makeVote(chain[parent_index].bid.root, gap_slot)])
+        makeVote(chain[distinctBase(3.Epoch.start_slot)].bid.root, gap_slot)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(gap_slot)],
         3.Epoch)
@@ -705,6 +704,24 @@ suite "get_ancestor_support_by_slot":
       res[current_slot - gap_slot].support == 10.Gwei
       res[current_slot - 3.Epoch.start_slot].total_support == 10.Gwei
       res[^1].total_support == 10.Gwei
+
+  test "Stale view, no assigned slot at stale block":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      stale_slot = 2.Epoch.start_slot + 4
+      vote_slot = 3.Epoch.start_slot + 2
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        makeVote(chain[distinctBase(stale_slot)].bid.root, vote_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(vote_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - stale_slot].total_support == 10.Gwei
 
   test "Running totals verification":
     let
@@ -872,8 +889,7 @@ suite "get_ancestor_support_by_slot":
         bid: BlockId(
           slot: prev_epoch_start + 1, root: makeRoot(200)),
         parent: chain[distinctBase(prev_epoch_start) - 2])
-      backend = makeBackend(@[
-        makeVote(head2.bid.root, prev_epoch_start + 1)])
+      backend = makeBackend(@[makeVote(head2.bid.root, prev_epoch_start + 1)])
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(prev_epoch_start + 1)],
         3.Epoch)


### PR DESCRIPTION
get_attestation_score needs support from attestations to noncanonical descendants of the blocks of interest. Use the existing loop that already collects the other data in a single pass to also collect this.