### PR TITLE
Track inactive validators for fast confirmation rule

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1267,6 +1267,7 @@ AllTests-mainnet
 + Running totals verification                                                                OK
 + Slashed validator                                                                          OK
 + Votes outside range                                                                        OK
++ assign_shufflings dst longer than src                                                      OK
 + assign_shufflings replaces duties                                                          OK
 ```
 ## get_current_target_score

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -65,14 +65,15 @@ func record_shuffling(
     i = shufflingRef.epoch.shuffling_index
     offset = AttesterDutyOffsets[i]
     clear_mask = ClearAttesterDutyMasks[i]
+  for balance in balance_source.balances.mitems:
+    balance = ForkChoiceBalance(distinctBase(balance) and clear_mask)
   for slot in shufflingRef.epoch.slots:
-    let duty_mask = slot.since_epoch_start shl offset
+    let duty_mask = (slot.since_epoch_start + 1) shl offset
     for committee_index in get_committee_indices(shufflingRef):
       for _, val in shufflingRef.get_beacon_committee(slot, committee_index):
         balance_source.balances.extend(val.int + 1)
         template balance: ForkChoiceBalance = balance_source.balances[val]
-        balance_source.balances[val] = ForkChoiceBalance(
-          (distinctBase(balance) and clear_mask) or duty_mask)
+        balance = ForkChoiceBalance(distinctBase(balance) or duty_mask)
   balance_source.shuffling_epochs[i] = shufflingRef.epoch
   balance_source.shuffling_roots[i] = shufflingRef.attester_dependent_root
 
@@ -102,18 +103,26 @@ proc update_latest_shufflings*(
     balance_source.shuffling_epochs = DefaultShufflingEpochs
 
 func assign_shufflings*(dst: var BalanceSource, src: BalanceSource) =
+  let
+    clear_mask = ClearAllAttesterDutiesMask
+    duty_mask = AllAttesterDutiesMask
   if dst.balances.len > src.balances.len:
-    return
-  dst.balances.extend(src.balances.len)
+    for val in src.balances.len ..< dst.balances.len:
+      template balance: ForkChoiceBalance = dst.balances[val]
+      balance = ForkChoiceBalance(distinctBase(balance) and clear_mask)
+  else:
+    dst.balances.extend(src.balances.len)
   for val, balance in dst.balances.mpairs:
     balance = ForkChoiceBalance(
-      (distinctBase(balance) and ClearAllAttesterDutiesMask) or
-      (distinctBase(src.balances[val]) and AllAttesterDutiesMask))
+      (distinctBase(balance) and clear_mask) or
+      (distinctBase(src.balances[val]) and duty_mask))
   dst.shuffling_epochs = src.shuffling_epochs
   dst.shuffling_roots = src.shuffling_roots
 
-func assigned_slot_into_epoch(
+func attester_duty(
     balance: ForkChoiceBalance, i: int): uint64 =
+  # 0: Validator was not assigned duties in this epoch (inactive)
+  # 1-SLOTS_PER_EPOOCH: (1 + since_epoch_start) of attester duty assignment
   (distinctBase(balance) shr AttesterDutyOffsets[i]) and AttesterDutyMask
 
 iterator assigned_slots*(
@@ -122,8 +131,9 @@ iterator assigned_slots*(
     var i = o
     while true:
       if balance_source.shuffling_epochs[i] != FAR_FUTURE_EPOCH:
-        yield balance_source.shuffling_epochs[i].start_slot +
-          balance_source.balances[val_index].assigned_slot_into_epoch(i)
+        let duty = balance_source.balances[val_index].attester_duty(i)
+        if duty != 0:
+          yield balance_source.shuffling_epochs[i].start_slot + duty - 1
       if i == 0:
         i = NumAttesterDuties
       dec i

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -112,7 +112,8 @@ func assign_shufflings*(dst: var BalanceSource, src: BalanceSource) =
       balance = ForkChoiceBalance(distinctBase(balance) and clear_mask)
   else:
     dst.balances.extend(src.balances.len)
-  for val, balance in dst.balances.mpairs:
+  for val in 0 ..< src.balances.len:
+    template balance: ForkChoiceBalance = dst.balances[val]
     balance = ForkChoiceBalance(
       (distinctBase(balance) and clear_mask) or
       (distinctBase(src.balances[val]) and duty_mask))

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -123,7 +123,7 @@ func assign_shufflings*(dst: var BalanceSource, src: BalanceSource) =
 func attester_duty(
     balance: ForkChoiceBalance, i: int): uint64 =
   # 0: Validator was not assigned duties in this epoch (inactive)
-  # 1-SLOTS_PER_EPOOCH: (1 + since_epoch_start) of attester duty assignment
+  # 1-SLOTS_PER_EPOCH: (1 + since_epoch_start) of attester duty assignment
   (distinctBase(balance) shr AttesterDutyOffsets[i]) and AttesterDutyMask
 
 iterator assigned_slots*(
@@ -160,7 +160,7 @@ func get_ancestor_info*(
   let
     prev_epoch_start = (max(current_slot.epoch, 1.Epoch) - 1).start_slot
     low_slot = max(terminal_bid.slot, max(prev_epoch_start, 1.Slot) - 1)
-  result = newSeqOfCap[SlotInfo](current_slot  - low_slot + 1)
+  result = newSeqOfCap[SlotInfo](current_slot - low_slot + 1)
 
   var bs = blck.atSlot(current_slot)
   while bs.blck != nil and bs.slot > low_slot:

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -369,7 +369,7 @@ suite "get_ancestor_support_by_slot":
       let
         i = slot.epoch.shuffling_index
         offset = AttesterDutyOffsets[i]
-        duty_mask = slot.since_epoch_start shl offset
+        duty_mask = (slot.since_epoch_start + 1) shl offset
       result = ForkChoiceBalance(distinctBase(result) or duty_mask)
 
   func makeBalanceSource(
@@ -473,16 +473,16 @@ suite "get_ancestor_support_by_slot":
       balance_source = makeBalanceSource(
         @[makeBalance(10.Gwei).withAssignedSlots(
             1.Epoch.start_slot + 2,
-            2.Epoch.start_slot + 4,
+            2.Epoch.start_slot,
             3.Epoch.start_slot + 1)],
         3.Epoch)
       res = backend.get_ancestor_support_by_slot(
         balance_source, chain[^1], chain[0].bid, current_slot)
     check:
       res.lenu64 == current_slot - prev_epoch_start + 2
-      res[current_slot - (2.Epoch.start_slot + 4)].adversarial == 10.Gwei
+      res[current_slot - 2.Epoch.start_slot].adversarial == 10.Gwei
       res[0].total_adversarial == 0.Gwei
-      res[current_slot - (2.Epoch.start_slot + 4)].total_adversarial == 10.Gwei
+      res[current_slot - 2.Epoch.start_slot].total_adversarial == 10.Gwei
       res[^1].total_adversarial == 10.Gwei
 
   test "Equivocating, cross-epoch, same block":
@@ -768,6 +768,31 @@ suite "get_ancestor_support_by_slot":
       3.Epoch.start_slot + 3,
       2.Epoch.start_slot + 2,
       1.Epoch.start_slot + 5]
+
+  test "assign_shufflings dst longer than src":
+    var dst = makeBalanceSource(
+      @[makeBalance(10.Gwei).withAssignedSlots(
+          3.Epoch.start_slot + 1,
+          2.Epoch.start_slot + 4,
+          1.Epoch.start_slot + 2),
+        makeBalance(20.Gwei).withAssignedSlots(
+          3.Epoch.start_slot + 3,
+          2.Epoch.start_slot + 2,
+          1.Epoch.start_slot + 5)],
+      3.Epoch)
+    let src = makeBalanceSource(
+      @[makeBalance(10.Gwei).withAssignedSlots(
+          3.Epoch.start_slot + 5,
+          2.Epoch.start_slot + 1,
+          1.Epoch.start_slot + 7)],
+      3.Epoch)
+    dst.assign_shufflings(src)
+    check:
+      toSeq(dst.assigned_slots(0.ValidatorIndex)) == @[
+        3.Epoch.start_slot + 5,
+        2.Epoch.start_slot + 1,
+        1.Epoch.start_slot + 7]
+      toSeq(dst.assigned_slots(1.ValidatorIndex)).len == 0
 
 suite "get_current_target_score":
   func makeValidator(eb: Gwei, slashed = false, active = true): Validator =


### PR DESCRIPTION
Validators that become inactive between the balance source snapshot being taken and the current/prev/prev-prev epoch no longer have any duties in some of these epochs. Rebase stored info to 1 instead of 0; 0 = inactive (default initialized), 1-32 = slot into epoch offset by 1.

Likewise for validators that become active _after_ the snapshot. For these, we'll have to track the effective balances too, as EB is already tracked while the validator is still inactive.