### PR TITLE
Init proto_array with correct finalized slot on gap

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -50,11 +50,12 @@ logScope: topics = "fork_choice"
 
 func init*(
     T: type ForkChoiceBackend, confirmation_byzantine_threshold: uint64,
-    finalized: BalanceCheckpoint, currentSlot: Slot): T =
+    finalized: BalanceCheckpoint, finalizedSlot, currentSlot: Slot): T =
   T(confirmation_byzantine_threshold: confirmation_byzantine_threshold,
-    proto_array: ProtoArray.init(finalized.checkpoint, currentSlot),
+    proto_array: ProtoArray.init(
+      finalized.checkpoint, finalizedSlot, currentSlot),
     confirmed: BlockId(
-      slot: finalized.checkpoint.epoch.start_slot,
+      slot: finalizedSlot,
       root: finalized.checkpoint.root),
     current_epoch_observed_justified: finalized.balance_source,
     previous_epoch_greatest_unrealized_checkpoint: finalized.checkpoint,
@@ -71,10 +72,12 @@ proc init*(
   debug "Initializing fork choice",
     epoch = epochRef.epoch, blck = shortLog(blck)
 
-  let finalized = to_balance_checkpoint(epochRef, blck)
+  let
+    finalized = to_balance_checkpoint(epochRef, blck)
+    finalizedSlot = blck.slot
   ForkChoice(
     backend: ForkChoiceBackend.init(
-      confirmation_byzantine_threshold, finalized, currentSlot),
+      confirmation_byzantine_threshold, finalized, finalizedSlot, currentSlot),
     checkpoints: Checkpoints(
       time: wallTime,
       justified: finalized,

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -88,11 +88,11 @@ func nodeLeadsToViableHead(
 # ProtoArray routines
 # ----------------------------------------------------------------------
 
-func init*(T: type ProtoArray, finalized: Checkpoint, currentSlot: Slot): T =
+func init*(
+    T: type ProtoArray,
+    finalized: Checkpoint, finalizedSlot, currentSlot: Slot): T =
   let node = ProtoNode(
-    bid: BlockId(
-      slot: finalized.epoch.start_slot,
-      root: finalized.root),
+    bid: BlockId(slot: finalizedSlot, root: finalized.root),
     parent: Opt.none(int),
     checkpoints: FinalityCheckpoints(
       justified: finalized,


### PR DESCRIPTION
During initialization, we put finalized_checkpoint.epoch.start_slot instead of finalized_blck into the proto_array, which isn't correct when the initial epoch slot was empty. We actually have access to the correct slot in fork_choice, just pass it through.