### PR TITLE
Remove broken dag.head template

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -348,8 +348,6 @@ func proposer_dependent_slot*(epochRef: EpochRef): Slot =
 func attester_dependent_slot*(shufflingRef: ShufflingRef): Slot =
   shufflingRef.epoch.attester_dependent_slot()
 
-template head*(dag: ChainDAGRef): BlockRef = dag.headState.blck
-
 template frontfill*(dagParam: ChainDAGRef): Opt[BlockId] =
   ## When there's a gap in the block database, this is the most recent block
   ## that we know of _before_ the gap - after a checkpoint sync, this will


### PR DESCRIPTION
ChainDAGRef has a head field that is used when dag.head is called. There is a broken template that tries to go via dag.headState.blck which cannot work as states don't have BlockRef. Remove the template.