### PR TITLE
Make unrealized_justified deterministic across calls

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -185,8 +185,11 @@ proc on_tick(
 
     elif current_slot.is_epoch:
       # Pull-up unrealized justified / finalized checkpoints from previous epoch
-      for realized in self.backend.proto_array.realizePendingCheckpoints():
-        ? self.update_checkpoints(dag, realized, current_slot)
+      let realized = self.backend.proto_array.realizePendingCheckpoints(
+        FinalityCheckpoints(
+          justified: self.checkpoints.justified.checkpoint,
+          finalized: self.checkpoints.finalized))
+      ? self.update_checkpoints(dag, realized, current_slot)
 
       # Reconfirm with previous balance source
       if self.backend.should_revert_confirmed_on_new_epoch(dag, current_slot):

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -106,9 +106,12 @@ func init*(T: type ProtoArray, finalized: Checkpoint, currentSlot: Slot): T =
 func unrealized_justified*(
     self: ProtoArray, justified: Checkpoint): Checkpoint =
   result = justified
-  for unrealized in self.currentEpochTips.values:
-    if unrealized.justified.epoch > result.epoch:
+  var bestIdx = Index.high
+  for idx, unrealized in self.currentEpochTips:
+    if unrealized.justified.epoch > result.epoch or
+        (unrealized.justified.epoch == result.epoch and idx < bestIdx):
       result = unrealized.justified
+      bestIdx = idx
 
 iterator realizePendingCheckpoints*(
     self: var ProtoArray): FinalityCheckpoints =

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -103,19 +103,27 @@ func init*(T: type ProtoArray, finalized: Checkpoint, currentSlot: Slot): T =
     nodes: ProtoNodes(buf: @[node], offset: 0),
     indices: {node.bid.root: 0}.toTable())
 
+template updateIfBetter(
+    best: var Checkpoint, bestIdx: var Index,
+    unrealized: Checkpoint, unrealizedIdx: Index) =
+  if unrealized.epoch > best.epoch or
+      (unrealized.epoch == best.epoch and unrealizedIdx < bestIdx):
+    best = unrealized
+    bestIdx = unrealizedIdx
+
 func unrealized_justified*(
     self: ProtoArray, justified: Checkpoint): Checkpoint =
   result = justified
   var bestIdx = Index.high
   for idx, unrealized in self.currentEpochTips:
-    if unrealized.justified.epoch > result.epoch or
-        (unrealized.justified.epoch == result.epoch and idx < bestIdx):
-      result = unrealized.justified
-      bestIdx = idx
+    result.updateIfBetter(bestIdx, unrealized.justified, idx)
 
-iterator realizePendingCheckpoints*(
-    self: var ProtoArray): FinalityCheckpoints =
+func realizePendingCheckpoints*(
+    self: var ProtoArray,
+    checkpoints: FinalityCheckpoints): FinalityCheckpoints =
   # Pull-up chain tips from previous epoch
+  var jIdx, fIdx = Index.high
+  result = checkpoints
   for idx, unrealized in self.currentEpochTips:
     let physicalIdx = idx - self.nodes.offset
     if unrealized != self.nodes.buf[physicalIdx].checkpoints:
@@ -124,8 +132,8 @@ iterator realizePendingCheckpoints*(
         checkpoints = self.nodes.buf[physicalIdx].checkpoints,
         unrealized
       self.nodes.buf[physicalIdx].checkpoints = unrealized
-
-    yield unrealized
+    result.justified.updateIfBetter(jIdx, unrealized.justified, idx)
+    result.finalized.updateIfBetter(fIdx, unrealized.finalized, idx)
 
   # Reset tip tracking for new epoch
   self.currentEpochTips.clear()


### PR DESCRIPTION
When there are multiple unrealized justified checkpoints at same epoch, fast confirmation rule expects the oldest one to win.