### PR TITLE
Only update current_slot_head if before attestation deadline

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -173,8 +173,9 @@ proc on_tick(
     # Reset store.proposer_boost_root
     self.checkpoints.proposer_boost_root = ZERO_HASH
 
-    # Update prev slot head
+    # Update prev and curr slot head
     self.backend.previous_slot_head = self.backend.current_slot_head
+    self.backend.current_slot_head = dag.head.root
 
     if (current_slot + 1).is_epoch:
       # Update greatest unrealized justified checkpoint
@@ -417,9 +418,13 @@ proc will_select_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
-  self.backend.current_slot_head = blckRef.root
 
-  let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+  let
+    current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+    consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
+    deadline = current_slot.attestation_deadline(dag.timeParams, consensusFork)
+  if wallTime < deadline:
+    self.backend.current_slot_head = blckRef.root
   if self.backend.should_revert_confirmed_on_new_head(blckRef, current_slot):
     self.backend.update_confirmed BlockId(
       slot: self.checkpoints.finalized.epoch.start_slot,

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -208,18 +208,33 @@ proc loadOps(
       doAssert step.len == 1 + numExtraFields
       result[^1].valid = true
 
+proc updateHead(
+    dag: ChainDAGRef, fkChoice: ref ForkChoice, time: BeaconTime,
+    updateFastConfirm = false) =
+  var quarantine = Quarantine.init(dag.cfg)
+  let
+    newHeadRoot = fkChoice[].get_head(dag, time).get()
+    newHead = dag.getBlockRef(newHeadRoot).get()
+  if updateFastConfirm:
+    doAssert fkChoice[].will_select_head(dag, newHead, time).isOk
+  dag.updateHead(newHead, quarantine, [])
+  if dag.needStateCachesAndForkChoicePruning():
+    dag.pruneStateCachesDAG()
+    let pruneRes = fkChoice[].prune()
+    doAssert pruneRes.isOk()
+
 proc stepOnBlock(
-       dag: ChainDAGRef,
-       fkChoice: ref ForkChoice,
-       verifier: var BatchVerifier,
-       state: var ForkedHashedBeaconState,
-       stateCache: var StateCache,
-       signedBlock: ForkySignedBeaconBlock,
-       blobData: Opt[BlobData],
-       columnsValid: bool,
-       time: BeaconTime,
-       invalidatedHashes: Table[Eth2Digest, Eth2Digest]):
-       Result[BlockRef, VerifierError] =
+    dag: ChainDAGRef,
+    fkChoice: ref ForkChoice,
+    verifier: var BatchVerifier,
+    state: var ForkedHashedBeaconState,
+    stateCache: var StateCache,
+    signedBlock: ForkySignedBeaconBlock,
+    blobData: Opt[BlobData],
+    columnsValid: bool,
+    time: BeaconTime,
+    invalidatedHashes: Table[Eth2Digest, Eth2Digest]
+): Result[BlockRef, VerifierError] =
   # 1. Validate blobs and columns
   when typeof(signedBlock).kind in [ConsensusFork.Deneb, ConsensusFork.Electra]:
     let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
@@ -280,16 +295,7 @@ proc stepOnBlock(
     doAssert status.isOk()
 
     # 5. Update DAG with new head
-    var quarantine = Quarantine.init(dag.cfg)
-    let
-      newHeadRoot = fkChoice[].get_head(dag, time).get()
-      newHead = dag.getBlockRef(newHeadRoot).get()
-    discard fkChoice[].will_select_head(dag, newHead, time)
-    dag.updateHead(newHead, quarantine, [])
-    if dag.needStateCachesAndForkChoicePruning():
-      dag.pruneStateCachesDAG()
-      let pruneRes = fkChoice[].prune()
-      doAssert pruneRes.isOk()
+    dag.updateHead(fkChoice, time)
 
   blockAdded
 
@@ -364,6 +370,8 @@ proc doRunTest(
       time = BeaconTime(ns_since_genesis: step.tick.seconds.nanoseconds)
       let status = stores.fkChoice[].update_time(stores.dag, time)
       doAssert status.isOk == step.valid
+      if status.isOk:
+        stores.dag.updateHead(stores.fkChoice, time, updateFastConfirm = true)
     of opOnPhase0Attestation:
       let status = stores.fkChoice[].on_attestation(
         stores.dag, step.phase0Att.data.slot, step.phase0Att.data.beacon_block_root,


### PR DESCRIPTION
Fast Confirmation Rule needs to capture slot no later than at the attestation deadline. Restrict current_slot_head to that.

Test needs a bump because they run fast confirmation at slot start rather than at the block reception. We don't want to run fork choice multiple time through each slot (expensive), use the flow in test only.