### PR TITLE
remove ambigious overloads

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -802,6 +802,8 @@ proc processSyncCommitteeMessage*(
   let
     wallTime = self.getCurrentBeaconTime()
     wallSlot = wallTime.slotOrZero(self.dag.timeParams)
+    consensusFork =
+      self.dag.cfg.consensusForkAtEpoch(syncCommitteeMsg.slot.epoch)
 
   logScope:
     syncCommitteeMsg = shortLog(syncCommitteeMsg)
@@ -810,7 +812,8 @@ proc processSyncCommitteeMessage*(
 
   # Potential under/overflows are fine; would just create odd metrics and logs
   let delay = wallTime -
-    syncCommitteeMsg.slot.sync_committee_message_deadline(self.dag.timeParams)
+    syncCommitteeMsg.slot.sync_committee_message_deadline(
+      self.dag.timeParams, consensusFork)
   debug "Sync committee message received", delay
 
   # Now proceed to validation
@@ -858,7 +861,9 @@ proc processSignedContributionAndProof*(
   # Potential under/overflows are fine; would just create odd metrics and logs
   let
     slot = contributionAndProof.message.contribution.slot
-    delay = wallTime - slot.sync_contribution_deadline(self.dag.timeParams)
+    consensusFork = self.dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = wallTime - slot.sync_contribution_deadline(
+      self.dag.timeParams, consensusFork)
   debug "Contribution received",
     delay, contribution = shortLog(contributionAndProof.message.contribution)
 

--- a/beacon_chain/spec/beacon_time.nim
+++ b/beacon_chain/spec/beacon_time.nim
@@ -203,22 +203,22 @@ func start_beacon_time*(s: Slot, timeParams: TimeParams): BeaconTime =
 func block_deadline*(s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams)
 
-func attestation_deadline*(
+func attestation_deadline_legacy*(
     s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams) +
     timeParams.attestationSlotOffset
 
-func aggregate_deadline*(
+func aggregate_deadline_legacy*(
     s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams) +
     timeParams.aggregateSlotOffset
 
-func sync_committee_message_deadline*(
+func sync_committee_message_deadline_legacy*(
     s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams) +
     timeParams.syncCommitteeMessageSlotOffset
 
-func sync_contribution_deadline*(
+func sync_contribution_deadline_legacy*(
     s: Slot, timeParams: TimeParams): BeaconTime =
   s.start_beacon_time(timeParams) +
     timeParams.syncContributionSlotOffset

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -598,7 +598,7 @@ func attestation_deadline*(
   if consensusFork >= ConsensusFork.Gloas:
     attestation_deadline_gloas(s, timeParams)
   else:
-    attestation_deadline(s, timeParams)
+    attestation_deadline_legacy(s, timeParams)
 
 func aggregate_deadline*(
     s: Slot, timeParams: TimeParams,
@@ -606,7 +606,7 @@ func aggregate_deadline*(
   if consensusFork >= ConsensusFork.Gloas:
     aggregate_deadline_gloas(s, timeParams)
   else:
-    aggregate_deadline(s, timeParams)
+    aggregate_deadline_legacy(s, timeParams)
 
 func sync_committee_message_deadline*(
     s: Slot, timeParams: TimeParams,
@@ -614,7 +614,7 @@ func sync_committee_message_deadline*(
   if consensusFork >= ConsensusFork.Gloas:
     sync_committee_message_deadline_gloas(s, timeParams)
   else:
-    sync_committee_message_deadline(s, timeParams)
+    sync_committee_message_deadline_legacy(s, timeParams)
 
 func sync_contribution_deadline*(
     s: Slot, timeParams: TimeParams,
@@ -622,4 +622,4 @@ func sync_contribution_deadline*(
   if consensusFork >= ConsensusFork.Gloas:
     sync_contribution_deadline_gloas(s, timeParams)
   else:
-    sync_contribution_deadline(s, timeParams)
+    sync_contribution_deadline_legacy(s, timeParams)

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -324,7 +324,9 @@ proc routeAttestation*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = attestation.data.slot
-    delay = sendTime - slot.attestation_deadline(router[].dag.timeParams)
+    consensusFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = sendTime - slot.attestation_deadline(
+      router[].dag.timeParams, consensusFork)
     res = await router[].network.broadcastAttestation(subnet_id, attestation)
 
   if res.isOk():
@@ -392,7 +394,9 @@ proc routeSignedAggregateAndProof*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = proof.message.aggregate.data.slot
-    delay = sendTime - slot.aggregate_deadline(router[].dag.timeParams)
+    consensusFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = sendTime - slot.aggregate_deadline(
+      router[].dag.timeParams, consensusFork)
     res = await router[].network.broadcastAggregateAndProof(proof)
 
   if res.isOk():
@@ -427,8 +431,10 @@ proc routeSyncCommitteeMessage*(
 
   let
     sendTime = router[].processor.getCurrentBeaconTime()
+    consensusFork = router[].dag.cfg.consensusForkAtEpoch(msg.slot.epoch)
     delay = sendTime -
-      msg.slot.sync_committee_message_deadline(router[].dag.timeParams)
+      msg.slot.sync_committee_message_deadline(
+        router[].dag.timeParams, consensusFork)
 
     res = await router[].network.broadcastSyncCommitteeMessage(
       msg, subcommitteeIdx)
@@ -550,7 +556,9 @@ proc routeSignedContributionAndProof*(
   let
     sendTime = router[].processor.getCurrentBeaconTime()
     slot = msg.message.contribution.slot
-    delay = sendTime - slot.sync_contribution_deadline(router[].dag.timeParams)
+    consensusFork = router[].dag.cfg.consensusForkAtEpoch(slot.epoch)
+    delay = sendTime - slot.sync_contribution_deadline(
+      router[].dag.timeParams, consensusFork)
 
   let res = await router[].network.broadcastSignedContributionAndProof(msg)
   if res.isOk():


### PR DESCRIPTION
These (previous API) were dangerous as they were and could lead to unnecessary bugs.  Forgetting to pass 'consensusFork' parameter at call sites could fall back to incorrect logic and produce wrong time values.
Thanks to @etan-status 