### PR TITLE
Exclude nim-libp2p from Dependabot managed dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ version: 2
 updates:
   - package-ecosystem: gitsubmodule
     directory: /
+    ignore:
+      # nim-libp2p releases are not always on master, avoid daily spam
+      - dependency-name: vendor/nim-libp2p
     schedule:
       interval: daily
     target-branch: unstable


### PR DESCRIPTION
nim-libp2p is to be managed manually, their releases are not on trunk.