### PR TITLE
Match get_block_support_between_slots over-count from FCR spec

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1251,6 +1251,7 @@ AllTests-mainnet
 ```
 ## get_ancestor_support_by_slot
 ```diff
++ Balance source, all validator states                                                       OK
 + Basic support                                                                              OK
 + Early epochs                                                                               OK
 + Early epochs with 3 shufflings                                                             OK
@@ -1262,6 +1263,9 @@ AllTests-mainnet
 + Equivocating, last block before previous epoch                                             OK
 + Equivocating, single slot in range                                                         OK
 + Gap in chain                                                                               OK
++ Gap in chain, vote from earlier epoch                                                      OK
++ Gap in chain, vote from later epoch                                                        OK
++ Gap in chain, vote in both epochs                                                          OK
 + Mixed validators                                                                           OK
 + No match                                                                                   OK
 + Non-canonical, deep fork                                                                   OK
@@ -1272,6 +1276,8 @@ AllTests-mainnet
 + Running totals verification                                                                OK
 + Slashed validator                                                                          OK
 + Stale view, no assigned slot at stale block                                                OK
++ Stale view, vote from later epoch                                                          OK
++ Vote at terminal slot, duty in gap                                                         OK
 + Votes outside range                                                                        OK
 + assign_shufflings dst longer than src                                                      OK
 + assign_shufflings replaces duties                                                          OK

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -242,20 +242,32 @@ func get_ancestor_support_by_slot*(
   for val in 0 ..< min(self.votes.len, balance_source.balances.len):
     template balance: ForkChoiceBalance = balance_source.balances[val]
     template vote: VoteTracker = self.votes[val]
-    if vote.slot in low_slot .. current_slot:
+    if vote.slot != FAR_FUTURE_SLOT:
       # Collect support of the block per slot:
       # - get_block_support_between_slots (per slot, canonical only)
-      let i = result.index(vote.slot, current_slot)
-      if vote.next_root == result[i].blck.root:
-        result[i].support += balance.unslashed_balance
+      #
+      # Spec get_block_support_between_slots over-counts support
+      # when a validator was assigned during an empty slot, but actually
+      # voted for the root at a different slot (only assignment slot matters).
+      # Deliberately ignoring vote.slot to match spec over-count
+      var found = false
+      let o = current_slot.epoch.shuffling_index
+      for slot in balance_source.assigned_slots(val.ValidatorIndex, o):
+        if slot in low_slot .. current_slot:
+          let i = result.index(slot, current_slot)
+          if vote.next_root == result[i].blck.root:
+            result[i].support += balance.unslashed_balance
+            found = true
+            break
 
       # Collect noncanonical (and stale) support of the block:
       # - get_attestation_score (total, including non-canonical)
-      else:
+      if not found:
         let ancestor_i = noncanonical.getOrDefault(vote.next_root, -1)
         if ancestor_i != -1:
           result[ancestor_i].total_support += balance.unslashed_balance
-    elif vote.slot == FAR_FUTURE_SLOT:
+
+    else:
       # Collect weight of equivocating participants:
       # - get_equivocation_score (per slot, between blocks)
       # - get_adversarial_weight (total, to current_slot)
@@ -271,8 +283,6 @@ func get_ancestor_support_by_slot*(
             if old_i == -1:
               result[i].total_adversarial += eb
           old_i = i
-    else:
-      discard
 
   result[0].total_support += result[0].support
   for i in 1 ..< result.len:

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -471,6 +471,41 @@ suite "get_ancestor_support_by_slot":
       res[^1].total_support == 0.Gwei
       res[^1].total_adversarial == 0.Gwei
 
+  test "Balance source, all validator states":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        makeEquivocation(), makeEquivocation(),
+        makeEquivocation(), makeEquivocation()])
+      balances = get_fork_choice_balances([
+        Validator(
+          effective_balance: 10.Gwei, slashed: false,
+          activation_epoch: 0.Epoch, exit_epoch: FAR_FUTURE_EPOCH),
+        Validator(
+          effective_balance: 20.Gwei, slashed: false,
+          activation_epoch: 3.Epoch, exit_epoch: FAR_FUTURE_EPOCH),
+        Validator(
+          effective_balance: 30.Gwei, slashed: true,
+          activation_epoch: 0.Epoch, exit_epoch: FAR_FUTURE_EPOCH),
+        Validator(
+          effective_balance: 40.Gwei, slashed: true,
+          activation_epoch: 3.Epoch, exit_epoch: FAR_FUTURE_EPOCH)],
+        2.Epoch)
+      balance_source = makeBalanceSource(
+        @[balances[0].withAssignedSlots(3.Epoch.start_slot + 1),
+          balances[1].withAssignedSlots(3.Epoch.start_slot + 1),
+          balances[2].withAssignedSlots(3.Epoch.start_slot + 1),
+          balances[3].withAssignedSlots(3.Epoch.start_slot + 1)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - (3.Epoch.start_slot + 1)].adversarial == 40.Gwei
+      res[^1].total_adversarial == 40.Gwei
+
   test "Equivocating, single slot in range":
     let
       current_slot = 3.Epoch.start_slot + 3
@@ -705,6 +740,97 @@ suite "get_ancestor_support_by_slot":
       res[current_slot - 3.Epoch.start_slot].total_support == 10.Gwei
       res[^1].total_support == 10.Gwei
 
+  test "Gap in chain, vote from later epoch":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      gap_slot = 2.Epoch.start_slot + 1
+      vote_slot = 3.Epoch.start_slot + 2
+      chain = makeChain(
+        toSeq(0.Slot .. 2.Epoch.start_slot) &
+        toSeq(gap_slot + 1 .. current_slot))
+      backend = makeBackend(@[
+        makeVote(chain[distinctBase(2.Epoch.start_slot)].bid.root, vote_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(gap_slot, vote_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - gap_slot].support == 10.Gwei
+      res[current_slot - vote_slot].support == 0.Gwei
+      res[current_slot - gap_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Gap in chain, vote from earlier epoch":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      gap_slot = 3.Epoch.start_slot
+      vote_slot = 2.Epoch.start_slot + 1
+      chain = makeChain(
+        toSeq(0.Slot .. vote_slot) &
+        toSeq(gap_slot + 1 .. current_slot))
+      backend = makeBackend(@[
+        makeVote(chain[distinctBase(vote_slot)].bid.root, vote_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(gap_slot, vote_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - gap_slot].support == 10.Gwei
+      res[current_slot - vote_slot].support == 0.Gwei
+      res[current_slot - gap_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Gap in chain, vote in both epochs":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      gap_slot = 3.Epoch.start_slot + 1
+      prev_vote_slot = 2.Epoch.start_slot + 4
+      parent_slot = 2.Epoch.start_slot + 2
+      chain = makeChain(
+        toSeq(0.Slot .. parent_slot) &
+        toSeq(gap_slot + 1 .. current_slot))
+      backend = makeBackend(@[
+        makeVote(chain[distinctBase(parent_slot)].bid.root, gap_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(prev_vote_slot, gap_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - gap_slot].support == 10.Gwei
+      res[current_slot - prev_vote_slot].support == 0.Gwei
+      res[current_slot - gap_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
+  test "Stale view, vote from later epoch":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      stale_slot = 2.Epoch.start_slot + 4
+      vote_slot = 3.Epoch.start_slot + 2
+      chain = makeFullChain(current_slot)
+      backend = makeBackend(@[
+        makeVote(chain[distinctBase(stale_slot)].bid.root, vote_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(stale_slot, vote_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], chain[0].bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - stale_slot].support == 10.Gwei
+      res[current_slot - vote_slot].support == 0.Gwei
+      res[current_slot - stale_slot].total_support == 10.Gwei
+      res[^1].total_support == 10.Gwei
+
   test "Stale view, no assigned slot at stale block":
     let
       current_slot = 3.Epoch.start_slot + 3
@@ -722,6 +848,25 @@ suite "get_ancestor_support_by_slot":
     check:
       res.lenu64 == current_slot - prev_epoch_start + 2
       res[current_slot - stale_slot].total_support == 10.Gwei
+
+  test "Vote at terminal slot, duty in gap":
+    let
+      current_slot = 3.Epoch.start_slot + 3
+      prev_epoch_start = 2.Epoch.start_slot
+      terminal_slot = 1.Epoch.start_slot + 2
+      gap_slot = 2.Epoch.start_slot + 4
+      chain = makeChain(toSeq(0.Slot .. terminal_slot) & @[current_slot])
+      terminal_bid = chain[distinctBase(terminal_slot)].bid
+      backend = makeBackend(@[makeVote(terminal_bid.root, terminal_slot)])
+      balance_source = makeBalanceSource(
+        @[makeBalance(10.Gwei).withAssignedSlots(terminal_slot, gap_slot)],
+        3.Epoch)
+      res = backend.get_ancestor_support_by_slot(
+        balance_source, chain[^1], terminal_bid, current_slot)
+    check:
+      res.lenu64 == current_slot - prev_epoch_start + 2
+      res[current_slot - gap_slot].support == 10.Gwei
+      res[^1].total_support == 10.Gwei
 
   test "Running totals verification":
     let

--- a/tests/test_block_dag.nim
+++ b/tests/test_block_dag.nim
@@ -11,13 +11,9 @@
 import
   std/sequtils,
   unittest2,
-  ../beacon_chain/consensus_object_pools/block_dag,
+  ../beacon_chain/consensus_object_pools/[
+    block_dag, blockchain_dag, spec_cache],
   ../beacon_chain/fork_choice/fast_confirmation
-
-from ../beacon_chain/consensus_object_pools/blockchain_dag import
-  ForkChoiceBalance, SlashedBit
-
-from ../beacon_chain/spec/datatypes/phase0 import BeaconState
 
 func `$`(x: BlockRef): string = shortLog(x)
 


### PR DESCRIPTION
In Fast Confirmation Rule specs, `get_block_support_between_slots` ignores the slot at which a validator actually voted, and solely looks at the committee assignment. It then over-counts support even if the validator actually voted outside the requested range. This was confirmed in the PR discussion to be intentional and safe. Update the Nimbus implementation to match the counting behaviour of the spec.

- https://github.com/ethereum/consensus-specs/pull/4747