### PR TITLE
Allow passing custom validator changes when making test blocks

### DIFF
--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -95,7 +95,7 @@ suite "Validator change pool testing suite":
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS_ELECTRA + 5:
       for j in 0'u64 .. i:
         let msg = dag.headState.makeElectraAttesterSlashing(
-          j, Slot(1), makeFakeHash(0), makeFakeHash(1))
+          [j], Slot(1), makeFakeHash(0), makeFakeHash(1))
 
         if i == 0:
           check not pool[].isSeen(msg)

--- a/tests/test_validator_change_pool.nim
+++ b/tests/test_validator_change_pool.nim
@@ -26,21 +26,6 @@ func makeSignedBeaconBlockHeader(
       fork, genesis_validators_root, slot, hash_tree_root(tmp),
       MockPrivKeys[proposer_index]).toValidatorSig())
 
-func makeElectraIndexedAttestation(
-    fork: Fork, genesis_validators_root: Eth2Digest, slot: Slot,
-    validator_index: uint64, beacon_block_root: Eth2Digest):
-    electra.IndexedAttestation =
-  let tmp = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
-
-  electra.IndexedAttestation(
-    data: tmp,
-    attesting_indices:
-      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT](
-        @[validator_index]),
-    signature: get_attestation_signature(
-      fork, genesis_validators_root, tmp,
-      MockPrivKeys[validator_index]).toValidatorSig)
-
 func makeSignedVoluntaryExit(
     fork: Fork, genesis_validators_root: Eth2Digest, epoch: Epoch,
     validator_index: uint64): SignedVoluntaryExit =
@@ -106,16 +91,11 @@ suite "Validator change pool testing suite":
       dag.cfg, dag.headState,
       Epoch(dag.cfg.SHARD_COMMITTEE_PERIOD).start_slot + 1 + SLOTS_PER_EPOCH * 5,
       cache, info, {}).expect("ok")
-    let fork = dag.forkAtEpoch(dag.headState.get_current_epoch())
 
     for i in 0'u64 .. MAX_ATTESTER_SLASHINGS_ELECTRA + 5:
       for j in 0'u64 .. i:
-        let
-          msg = electra.AttesterSlashing(
-            attestation_1: makeElectraIndexedAttestation(
-              fork, genesis_validators_root, Slot(1), j, makeFakeHash(0)),
-            attestation_2: makeElectraIndexedAttestation(
-              fork, genesis_validators_root, Slot(1), j, makeFakeHash(1)))
+        let msg = dag.headState.makeElectraAttesterSlashing(
+          j, Slot(1), makeFakeHash(0), makeFakeHash(1))
 
         if i == 0:
           check not pool[].isSeen(msg)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -723,20 +723,26 @@ func makeFullElectraAttestations*(
     result.add attestation
 
 func makeElectraIndexedAttestation*(
-    state: ForkedHashedBeaconState, slot: Slot, validator_index: uint64,
+    state: ForkedHashedBeaconState, slot: Slot,
+    validator_indices: openArray[uint64],
     beacon_block_root: Eth2Digest): electra.IndexedAttestation =
-  let data = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
+  let
+    data = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
+    committee = validator_indices.mapIt(it.ValidatorIndex)
+  var bits = ElectraCommitteeValidatorsBits.init(committee.len)
+  for i in 0 ..< committee.len:
+    bits.setBit i
   electra.IndexedAttestation(
     data: data,
     attesting_indices:
       List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT](
-        @[validator_index]),
-    signature: get_attestation_signature(
-      state.fork, state.genesis_validators_root, data,
-      MockPrivKeys[validator_index]).toValidatorSig)
+        @validator_indices),
+    signature: makeAttestationSig(
+      state.fork, state.genesis_validators_root, data, committee, bits))
 
 func makeElectraAttesterSlashing*(
-    state: ForkedHashedBeaconState, validator_index: uint64, slot: Slot,
+    state: ForkedHashedBeaconState,
+    validator_indices: openArray[uint64], slot: Slot,
     root_a = Eth2Digest.fromHex(
       "0x0100000000000000000000000000000000000000000000000000000000000000"),
     root_b = Eth2Digest.fromHex(
@@ -744,9 +750,9 @@ func makeElectraAttesterSlashing*(
 ): electra.AttesterSlashing =
   electra.AttesterSlashing(
     attestation_1: makeElectraIndexedAttestation(
-      state, slot, validator_index, root_a),
+      state, slot, validator_indices, root_a),
     attestation_2: makeElectraIndexedAttestation(
-      state, slot, validator_index, root_b))
+      state, slot, validator_indices, root_b))
 
 proc makeSyncAggregate(
     state: ForkedHashedBeaconState,

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -298,6 +298,7 @@ proc addTestEngineBlock*(
     attestations: seq[phase0.Attestation] = newSeq[phase0.Attestation](),
     electraAttestations: seq[electra.Attestation] = newSeq[electra.Attestation](),
     deposits: seq[Deposit] = newSeq[Deposit](),
+    validator_changes = BeaconBlockValidatorChanges(),
     sync_aggregate: SyncAggregate = SyncAggregate.init(),
     graffiti: GraffitiBytes = default(GraffitiBytes),
     flags: set[UpdateFlag] = {},
@@ -351,7 +352,7 @@ proc addTestEngineBlock*(
         graffiti,
         attestations,
         deposits,
-        BeaconBlockValidatorChanges(),
+        validator_changes,
         sync_aggregate,
         eps,
         verificationFlags = {skipBlsValidation},
@@ -376,6 +377,7 @@ proc addTestEngineBlockWithBlobs*(
     attestations: seq[phase0.Attestation] = newSeq[phase0.Attestation](),
     electraAttestations: seq[electra.Attestation] = newSeq[electra.Attestation](),
     deposits: seq[Deposit] = newSeq[Deposit](),
+    validator_changes = BeaconBlockValidatorChanges(),
     sync_aggregate: SyncAggregate = SyncAggregate.init(),
     graffiti: GraffitiBytes = default(GraffitiBytes),
     flags: set[UpdateFlag] = {},
@@ -429,7 +431,7 @@ proc addTestEngineBlockWithBlobs*(
         graffiti,
         attestations,
         deposits,
-        BeaconBlockValidatorChanges(),
+        validator_changes,
         sync_aggregate,
         eps,
         verificationFlags = {skipBlsValidation},
@@ -466,6 +468,7 @@ proc addTestBlock*(
     attestations: seq[phase0.Attestation] = newSeq[phase0.Attestation](),
     electraAttestations: seq[electra.Attestation] = newSeq[electra.Attestation](),
     deposits: seq[Deposit] = newSeq[Deposit](),
+    validator_changes = BeaconBlockValidatorChanges(),
     sync_aggregate: SyncAggregate = SyncAggregate.init(),
     graffiti: GraffitiBytes = default(GraffitiBytes),
     flags: set[UpdateFlag] = {},
@@ -482,9 +485,8 @@ proc addTestBlock*(
     ForkedSignedBeaconBlock.init(
       addTestEngineBlock(
         cfg, consensusFork, forkyState, cache, eth1_data, attestations,
-        electraAttestations, deposits, sync_aggregate, graffiti, flags,
-      ).blck
-    )
+        electraAttestations, deposits, validator_changes, sync_aggregate,
+        graffiti, flags).blck)
 
 proc makeTestBlock*(
     state: ForkedHashedBeaconState,
@@ -493,6 +495,7 @@ proc makeTestBlock*(
     attestations = newSeq[phase0.Attestation](),
     electraAttestations = newSeq[electra.Attestation](),
     deposits = newSeq[Deposit](),
+    validator_changes = BeaconBlockValidatorChanges(),
     sync_aggregate = SyncAggregate.init(),
     graffiti = default(GraffitiBytes),
     cfg = defaultRuntimeConfig): ForkedSignedBeaconBlock =
@@ -502,9 +505,8 @@ proc makeTestBlock*(
   # because the block includes the state root.
   let tmpState = assignClone(state)
   addTestBlock(
-    tmpState[], cache, eth1_data,
-    attestations, electraAttestations, deposits, sync_aggregate, graffiti,
-    cfg = cfg)
+    tmpState[], cache, eth1_data, attestations, electraAttestations,
+    deposits, validator_changes, sync_aggregate, graffiti, cfg = cfg)
 
 func makeAttestationData*(
     state: ForkyBeaconState, slot: Slot, committee_index: CommitteeIndex,
@@ -719,6 +721,32 @@ func makeFullElectraAttestations*(
         attestation.aggregation_bits)
 
     result.add attestation
+
+func makeElectraIndexedAttestation*(
+    state: ForkedHashedBeaconState, slot: Slot, validator_index: uint64,
+    beacon_block_root: Eth2Digest): electra.IndexedAttestation =
+  let data = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
+  electra.IndexedAttestation(
+    data: data,
+    attesting_indices:
+      List[uint64, Limit MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT](
+        @[validator_index]),
+    signature: get_attestation_signature(
+      state.fork, state.genesis_validators_root, data,
+      MockPrivKeys[validator_index]).toValidatorSig)
+
+func makeElectraAttesterSlashing*(
+    state: ForkedHashedBeaconState, validator_index: uint64, slot: Slot,
+    root_a = Eth2Digest.fromHex(
+      "0x0100000000000000000000000000000000000000000000000000000000000000"),
+    root_b = Eth2Digest.fromHex(
+      "0x0200000000000000000000000000000000000000000000000000000000000000")
+): electra.AttesterSlashing =
+  electra.AttesterSlashing(
+    attestation_1: makeElectraIndexedAttestation(
+      state, slot, validator_index, root_a),
+    attestation_2: makeElectraIndexedAttestation(
+      state, slot, validator_index, root_b))
 
 proc makeSyncAggregate(
     state: ForkedHashedBeaconState,


### PR DESCRIPTION
Move the helpers to create Electra `AttesterSlashing` into the generic test block module to enable reuse in future tests.