### PR TITLE
Retain unrealized checkpoints for all blocks in current epoch

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -14,6 +14,8 @@ AllTests-mainnet
 + Attestations may overlap, smaller first [Preset: mainnet]                                  OK
 + Attestations should be combined [Preset: mainnet]                                          OK
 + Attestations with disjoint comittee bits and equal data into single on-chain aggregate [Pr OK
++ Attester slashing marks validator as equivocating                                          OK
++ Attester slashing retains unrealized checkpoints                                           OK
 + Cache coherence on chain aggregates [Preset: mainnet]                                      OK
 + Can add and retrieve simple electra attestations [Preset: mainnet]                         OK
 + Everyone voting for something different [Preset: mainnet]                                  OK

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -396,8 +396,8 @@ func should_restart_confirmation_chain*(
       .expect("is_proto_array_consistent")
 
   template head_unrealized_justified: Checkpoint =
-    self.proto_array.unrealized(self.current_slot_head)
-      .expect("is_proto_array_consistent").justified
+    self.proto_array.checkpoints(self.current_slot_head)
+      .expect("is_proto_array_consistent").unrealized
 
   current_slot.is_epoch and
   current_epoch_justified.epoch + 1 == current_slot.epoch and

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -97,7 +97,7 @@ type
     checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]
-    currentEpochTips*: Table[Index, FinalityCheckpoints]
+    unrealized*: Table[Index, FinalityCheckpoints]
     previousProposerBoostRoot*: Eth2Digest
     previousProposerBoostScore*: Gwei
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -87,9 +87,17 @@ func contains*(self: ProtoArray, root: Eth2Digest): bool =
 func slot*(self: ProtoArray, root: Eth2Digest): Opt[Slot] =
   ok (? self.nodes[self.find(root)]).bid.slot
 
-func unrealized*(self: ProtoArray, root: Eth2Digest): Opt[FinalityCheckpoints] =
-  let idx = self.find(root)
-  ok self.currentEpochTips.getOrDefault(idx, (? self.nodes[idx]).checkpoints)
+type NodeCheckpoints* = object
+  voting_source*: Checkpoint
+  unrealized*: Checkpoint
+
+func checkpoints*(self: ProtoArray, root: Eth2Digest): Opt[NodeCheckpoints] =
+  let
+    idx = self.find(root)
+    checkpoints = (? self.nodes[idx]).checkpoints
+  result.ok NodeCheckpoints(
+    voting_source: checkpoints.justified,
+    unrealized: self.unrealized.getOrDefault(idx, checkpoints).justified)
 
 # Forward declarations
 # ----------------------------------------------------------------------
@@ -133,7 +141,7 @@ func unrealized_justified*(
     self: ProtoArray, justified: Checkpoint): Checkpoint =
   result = justified
   var bestIdx = Index.high
-  for idx, unrealized in self.currentEpochTips:
+  for idx, unrealized in self.unrealized:
     result.updateIfBetter(bestIdx, unrealized.justified, idx)
 
 func realizePendingCheckpoints*(
@@ -142,7 +150,7 @@ func realizePendingCheckpoints*(
   # Pull-up chain tips from previous epoch
   var jIdx, fIdx = Index.high
   result = checkpoints
-  for idx, unrealized in self.currentEpochTips:
+  for idx, unrealized in self.unrealized:
     let physicalIdx = idx - self.nodes.offset
     if unrealized != self.nodes.buf[physicalIdx].checkpoints:
       trace "Pulling up chain tip",
@@ -154,7 +162,7 @@ func realizePendingCheckpoints*(
     result.finalized.updateIfBetter(fIdx, unrealized.finalized, idx)
 
   # Reset tip tracking for new epoch
-  self.currentEpochTips.clear()
+  self.unrealized.clear()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/specs/phase0/fork-choice.md#compute_proposer_score
 func compute_proposer_score*(total_active_balance: Gwei): Gwei =
@@ -337,9 +345,8 @@ func onBlock*(
   self.indices[node.bid.root] = nodeLogicalIdx
   self.nodes.add node
 
-  self.currentEpochTips.del parentIdx
   if unrealized.isSome:
-    self.currentEpochTips[nodeLogicalIdx] = unrealized.get
+    self.unrealized[nodeLogicalIdx] = unrealized.get
 
   ? self.maybeUpdateBestChildAndDescendant(parentIdx, nodeLogicalIdx)
 
@@ -414,7 +421,7 @@ func prune*(
   let finalPhysicalIdx = finalizedIdx - self.nodes.offset
   for nodePhysicalIdx in 0 ..< finalPhysicalIdx:
     let nodeLogicalIdx = nodePhysicalIdx + self.nodes.offset
-    self.currentEpochTips.del nodeLogicalIdx
+    self.unrealized.del nodeLogicalIdx
     self.indices.del(self.nodes.buf[nodePhysicalIdx].bid.root)
 
   # Drop all nodes prior to finalization.
@@ -648,8 +655,8 @@ iterator items*(self: ProtoArray): ProtoArrayItem =
 
     let unrealized = block:
       let nodeLogicalIdx = nodePhysicalIdx + self.nodes.offset
-      if self.currentEpochTips.hasKey(nodeLogicalIdx):
-        Opt.some self.currentEpochTips.unsafeGet(nodeLogicalIdx)
+      if self.unrealized.hasKey(nodeLogicalIdx):
+        Opt.some self.unrealized.unsafeGet(nodeLogicalIdx)
       else:
         Opt.none(FinalityCheckpoints)
 

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -24,6 +24,7 @@ from std/sequtils import mapIt, toSeq
 from stew/byteutils import `<`
 from ../beacon_chain/consensus_object_pools/block_quarantine import
   Quarantine, init
+from ../beacon_chain/fork_choice/proto_array import checkpoints
 from ../beacon_chain/spec/beaconstate import
   attester_dependent_root, check_attestation, get_attesting_indices,
   latest_block_root
@@ -784,6 +785,73 @@ suite "Attestation pool electra processing" & preset():
           blckRef.slot.start_beacon_time(cfg.timeParams))
 
     doAssert: b10Add_clone.error == VerifierError.Duplicate
+
+  proc addElectraBlock(
+      state: var ForkedHashedBeaconState, dag: ChainDAGRef,
+      pool: ref AttestationPool, verifier: var BatchVerifier,
+      quarantine: ref Quarantine, cache: var StateCache,
+      attested = true, validator_changes = BeaconBlockValidatorChanges()) =
+    let
+      attestations =
+        if attested:
+          makeFullElectraAttestations(
+            state, dag.head.root, state.slot, cache)
+        else:
+          newSeq[electra.Attestation]()
+      blck = addTestBlock(
+        state, cache, electraAttestations = attestations,
+        validator_changes = validator_changes,
+        cfg = dag.cfg).electraData
+      added = dag.addHeadBlock(verifier, blck) do (
+          blckRef: BlockRef,
+          signedBlock: electra.TrustedSignedBeaconBlock,
+          state: electra.BeaconState,
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
+        pool[].addForkChoice(
+          epochRef, blckRef, unrealized, signedBlock.message,
+          blckRef.slot.start_beacon_time(dag.cfg.timeParams))
+    doAssert added.isOk
+    dag.updateHead(added[], quarantine[], [])
+
+  test "Attester slashing marks validator as equivocating":
+    check process_slots(
+      cfg, state[], state[].slot + 1, cache, info, {}).isOk
+
+    var validator_changes: BeaconBlockValidatorChanges
+    doAssert validator_changes.electra_attester_slashings.add(
+      state[].makeElectraAttesterSlashing([0'u64], state[].slot))
+    state[].addElectraBlock(
+      dag, pool, verifier, quarantine, cache,
+      attested = false, validator_changes = validator_changes)
+
+    check:
+      pool[].forkChoice.backend.votes.len > 0
+      pool[].forkChoice.backend.votes[0].slot == FAR_FUTURE_SLOT
+
+  test "Attester slashing retains unrealized checkpoints":
+    template proto_array: ProtoArray =
+      pool[].forkChoice.backend.proto_array
+
+    for i in 0 ..< SLOTS_PER_EPOCH * 2 + 1:
+      state[].addElectraBlock(dag, pool, verifier, quarantine, cache)
+
+    let
+      root = dag.head.root
+      unrealized = proto_array.checkpoints(root).get().unrealized
+    check unrealized.epoch >
+      proto_array.checkpoints(root).get().voting_source.epoch
+
+    var slashed_indices: seq[uint64]
+    for i in 0'u64 ..< dag.headState.validators.lenu64 div 2:
+      slashed_indices.add i
+    var validator_changes: BeaconBlockValidatorChanges
+    doAssert validator_changes.electra_attester_slashings.add(
+      state[].makeElectraAttesterSlashing(slashed_indices, state[].slot))
+    state[].addElectraBlock(
+      dag, pool, verifier, quarantine, cache,
+      validator_changes = validator_changes)
+
+    check proto_array.checkpoints(root).get().unrealized == unrealized
 
   test "Working with electra aggregates" & preset():
     let


### PR DESCRIPTION
Fast Confirmation Rule accesses unrealized checkpoints for each block within the current epoch, and also indirectly previous epoch, via voting source which is the pulled-up unrealized checkpoint. Retain that information, it's mainly a function of SLOTS_PER_EPOCH, can be higher with proposer equivocations (proto array isn't the bottlneck).