### PR TITLE
Advance FCR previous greatest checkpoint if it gets pruned

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -167,6 +167,13 @@ proc update_checkpoints(
       store = self.checkpoints.finalized, state = checkpoints.finalized
     self.checkpoints.finalized = checkpoints.finalized
 
+    template previous_epoch_justified: Checkpoint =
+      self.backend.previous_epoch_greatest_unrealized_checkpoint
+    if self.checkpoints.finalized.epoch >= previous_epoch_justified.epoch:
+      trace "Pruned previous_epoch_greatest_unrealized_checkpoint",
+        store = previous_epoch_justified, state = self.checkpoints.finalized
+      previous_epoch_justified = self.checkpoints.finalized
+
   ok()
 
 proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =


### PR DESCRIPTION
During sync, finality can advance beyond the pending checkpoint to which FCR will be updated. As we won't revert finality, just treat that cp as the best one to use.