### PR TITLE
Reintroduce support to initialize Nimbus in single command

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -213,7 +213,7 @@ proc setupDatabase(
         if tmp[].slot > checkpointState[].slot:
           checkpointState = tmp
       else:
-        discard  # State from era is newer than the sync target
+        discard  # Remain on state from era (if any)
     else:
       warn "Ignoring `--external-beacon-api-url`, neither " &
         "`--trusted-block-root` nor `--trusted-state-root` provided",

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -179,16 +179,16 @@ proc setupDatabase(
   if config.externalBeaconApiUrl.isSome():
     # When using an external beacon api, require that the checkpoint state is
     # verified with the light client by always using a verified sync target
+    template isGenesisPostAltair: bool =
+      metadata.cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH
     let syncTarget =
       if config.trustedBlockRoot.isSome:
         Opt.some TrustedNodeSyncTarget.fromTrustedBlockRoot(
-          config.trustedBlockRoot.get()
-        )
+          config.trustedBlockRoot.get())
       elif config.trustedStateRoot.isSome:
         Opt.some TrustedNodeSyncTarget.fromStateId(
-          config.trustedStateRoot.get().data.to0xHex()
-        )
-      elif metadata.cfg.ALTAIR_FORK_EPOCH == GENESIS_EPOCH and not genesisState.isNil:
+          config.trustedStateRoot.get().data.to0xHex())
+      elif isGenesisPostAltair and not genesisState.isNil:
         # Sync can be bootstrapped from the genesis block root
         let genesisBlockRoot = get_initial_beacon_block(genesisState[]).root
         notice "Neither `--trusted-block-root` nor `--trusted-state-root` " &
@@ -203,15 +203,17 @@ proc setupDatabase(
         Opt.none TrustedNodeSyncTarget
 
     if syncTarget.isSome():
-      let tmp = await fetchCheckpointState(
-        metadata.cfg, config.externalBeaconApiUrl.get(), syncTarget[], genesisState
-      )
-
-      if checkpointState != nil and tmp != nil:
+      let tmp = await metadata.cfg.fetchCheckpointState(
+        config.externalBeaconApiUrl.get(), syncTarget[], genesisState)
+      if checkpointState == nil:
+        checkpointState = tmp
+      elif tmp != nil:
         # Special case: we loaded a checkpoint state (for example from era
         # files) and then the remote beacon api gave us a newer one!
         if tmp[].slot > checkpointState[].slot:
           checkpointState = tmp
+      else:
+        discard  # State from era is newer than the sync target
     else:
       warn "Ignoring `--external-beacon-api-url`, neither " &
         "`--trusted-block-root` nor `--trusted-state-root` provided",
@@ -220,8 +222,8 @@ proc setupDatabase(
         trustedStateRoot = config.trustedStateRoot
 
   if genesisState.isNil and checkpointState.isNil:
-    fatal "No database and no genesis snapshot found. Please supply a genesis.ssz " &
-      "with the network configuration"
+    fatal "No database and no genesis snapshot found. " &
+      "Please supply a genesis.ssz with the network configuration"
     return Opt.none(BeaconChainDB)
 
   if not genesisState.isNil and config.longRangeSync == LongRangeSyncMode.Light:


### PR DESCRIPTION
#7888 introduced a regression where the `--external-beacon-api-url` state (combined with `--trusted-state-root` / `--trusted-block-root`) was discarded if not also using Era files. Re-add support.