### PR TITLE
Expose safe block in status bar

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -487,8 +487,11 @@ proc will_select_head*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
-func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
-  self.backend.confirmed.root
+func get_safe_beacon_block_id*(self: ForkChoice): lent BlockId =
+  self.backend.confirmed
+
+func get_safe_beacon_block_root*(self: ForkChoice): lent Eth2Digest =
+  self.get_safe_beacon_block_id.root
 
 func prune(
     self: var ForkChoiceBackend,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2690,9 +2690,17 @@ when not defined(windows):
     except Exception as exc: # TODO Exception
       error "Couldn't enable colors", err = exc.msg
 
+    template safe: lent BlockId =
+      node.attestationPool[].forkChoice.get_safe_beacon_block_id()
+
+    var stored_justified: Opt[Checkpoint]
+    template justified: lent Checkpoint =
+      if stored_justified.isNone:
+        stored_justified.ok node.dag.head.atEpochStart(
+          node.dag.headState.current_justified_checkpoint.epoch)
+      stored_justified.unsafeGet
+
     proc dataResolver(expr: string): string {.raises: [].} =
-      template justified: untyped = node.dag.head.atEpochStart(
-        node.dag.headState.current_justified_checkpoint.epoch)
       # TODO:
       # We should introduce a general API for resolving dot expressions
       # such as `db.latest_block.slot` or `metrics.connected_peers`.
@@ -2718,6 +2726,15 @@ when not defined(windows):
         $(node.dag.head.slot.since_epoch_start)
       of "head_slot":
         $(node.dag.head.slot)
+
+      of "safe_root":
+        shortLog(safe.root)
+      of "safe_epoch":
+        $(safe.slot.epoch)
+      of "safe_epoch_slot":
+        $(safe.slot.since_epoch_start)
+      of "safe_slot":
+        $(safe.slot)
 
       of "justifed_root":
         shortLog(justified.blck.root)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2693,8 +2693,8 @@ when not defined(windows):
     template safe: lent BlockId =
       node.attestationPool[].forkChoice.get_safe_beacon_block_id()
 
-    var stored_justified: Opt[Checkpoint]
-    template justified: lent Checkpoint =
+    var stored_justified: Opt[BlockSlot]
+    template justified: lent BlockSlot =
       if stored_justified.isNone:
         stored_justified.ok node.dag.head.atEpochStart(
           node.dag.headState.current_justified_checkpoint.epoch)


### PR DESCRIPTION
On top of introspection via `/eth/v1/debug/fork_choice` extra data, also allow displaying of safe block via `--status-bar-contents`.

Example config:

```sh
build/nimbus_beacon_node \
    '--status-bar-contents=peers: $connected_peers;finalized: $finalized_root:$finalized_epoch;safe: $safe_root:$safe_epoch:$safe_epoch_slot;head: $head_root:$head_epoch:$head_epoch_slot$next_consensus_fork;time: $epoch:$epoch_slot ($slot);sync: $sync_status|ETH: $attached_validators_balance'
```