### PR TITLE
Show /opt when backfilling while optimistically synced

### DIFF
--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -582,7 +582,7 @@ proc syncStatusMessage*(
           ""
       of SyncKind.TrustedNodeSync:
         if overseer.backwardSync.inProgress:
-          "backfill: " & overseer.backwardSync.syncStatus
+          "backfill: " & overseer.backwardSync.syncStatus & optSuffix
         else:
           if overseer.forwardSync.inProgress:
             overseer.forwardSync.syncStatus & optSuffix & lcSuffix


### PR DESCRIPTION
When forward sync finishes, EL may still be syncing, but status bar does not indicate that while backfilling. Display /opt in that case.