### PR TITLE
find_latest_confirmed_descendant

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -135,6 +135,7 @@ AllTests-mainnet
 + Adding the same block twice returns a Duplicate error [Preset: mainnet]                    OK
 + Simple block add&get [Preset: mainnet]                                                     OK
 + basic ops                                                                                  OK
++ isAncestorOf                                                                               OK
 + updateHead updates head and headState [Preset: mainnet]                                    OK
 + updateState sanity [Preset: mainnet]                                                       OK
 ```

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -929,8 +929,8 @@ proc selectOptimisticHead*(
   ? pool.willSelectNewHead(headBlock, wallTime)
   ok pool.getBeaconHead(headBlock)
 
-proc prune*(pool: var AttestationPool) =
-  if (let v = pool.forkChoice.prune(); v.isErr):
+proc prune*(pool: var AttestationPool, dag: ChainDAGRef) =
+  if (let v = pool.forkChoice.prune(dag); v.isErr):
     # If pruning fails, it's likely the result of a bug - this shouldn't happen
     # but we'll keep running hoping that the fork choice will recover eventually
     error "Couldn't prune fork choice, bug?", err = v.error()

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -438,6 +438,19 @@ func isFinalized*(dag: ChainDAGRef, bid: BlockId): bool =
   ## selected by `dag.finalizedHead`.
   dag.isCanonical(bid) and (bid.slot <= dag.finalizedHead.slot)
 
+func isAncestorOf*(dag: ChainDAGRef, a, b: BlockId): bool =
+  ## Returns `true` if the given `a` is part of the history selected by `b`.
+  ## Does not depend on `dag.head`.
+  if a == b: return true
+  if a.slot >= b.slot: return false
+  let
+    a_blck = dag.getBlockRef(a.root).valueOr:
+      return dag.isCanonical(a) and
+        (dag.getBlockRef(b.root).isOk or dag.isCanonical(b))
+    b_blck = dag.getBlockRef(b.root).valueOr:
+      return false
+  a_blck.isAncestorOf(b_blck)
+
 func parent*(dag: ChainDAGRef, bid: BlockId): Opt[BlockId] =
   if bid.slot == 0:
     return err()

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -26,10 +26,6 @@ logScope: topics = "chaindag"
 # https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#interop-metrics
 declareGauge beacon_head_root, "Root of the head block of the beacon chain"
 declareGauge beacon_head_slot, "Slot of the head block of the beacon chain"
-declareGauge beacon_safe_root, "Root of the safe block of the beacon chain"
-declareGauge beacon_safe_slot, "Slot of the safe block of the beacon chain"
-
-# https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#interop-metrics
 declareGauge beacon_finalized_epoch, "Current finalized epoch" # On epoch transition
 declareGauge beacon_finalized_root, "Current finalized root" # On epoch transition
 declareGauge beacon_current_justified_epoch, "Current justified epoch" # On epoch transition
@@ -39,6 +35,11 @@ declareGauge beacon_previous_justified_root, "Current previously justified root"
 
 declareGauge beacon_reorgs_total_total, "Total occurrences of reorganizations of the chain" # On fork choice; backwards-compat name (used to be a counter)
 declareGauge beacon_reorgs_total, "Total occurrences of reorganizations of the chain" # Interop copy
+
+declareGauge beacon_safe_root, "Root of the safe block"
+declareGauge beacon_safe_slot, "Slot of the safe block"
+declareGauge beacon_safe_reorgs_total, "Total occurrences of reorganizations of the safe block"
+
 declareCounter beacon_state_data_cache_hits, "EpochRef hits"
 declareCounter beacon_state_data_cache_misses, "EpochRef misses"
 declareCounter beacon_state_rewinds, "State database rewinds"
@@ -963,6 +964,9 @@ proc updateBeaconMetrics(
 proc updateSafeBlockMetrics*(safeBlockId: BlockId) =
   beacon_safe_root.set(safeBlockId.root.toGaugeValue)
   beacon_safe_slot.set(safeBlockId.slot.toGaugeValue)
+
+proc incSafeReorgs*() =
+  beacon_safe_reorgs_total.inc()
 
 import blockchain_dag_light_client
 

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -548,4 +548,4 @@ proc pruneStateCachesAndForkChoice*(self: var ConsensusManager) =
   # Cleanup DAG & fork choice if we have a finalized head
   if self.dag.needStateCachesAndForkChoicePruning():
     self.dag.pruneStateCachesDAG()
-    self.attestationPool[].prune()
+    self.attestationPool[].prune(self.dag)

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -516,9 +516,7 @@ type FcrDiagnostics* = object
   byzantine_threshold*: uint64
 
 func `$`*(diag: FcrDiagnostics): string =
-  let slot = diag.failed_block.slot
-  shortLog(diag.failed_block.root) & ":" &
-  $slot.epoch & ":" & $slot.since_epoch_start & ": " &
+  shortLog(diag.failed_block) & ": " &
   formatGwei(diag.support) & " <= " &
   formatGwei(diag.safety_threshold) & " (" &
   formatGwei(diag.total_active_balance) & " total, " &

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -493,7 +493,8 @@ func is_one_confirmed(
   support > safety_threshold
 
 func is_confirmed_chain_safe(
-    self: ForkChoiceBackend, dag: ChainDAGRef, current_slot: Slot): bool =
+    self: ForkChoiceBackend, dag: ChainDAGRef,
+    confirmed: BlockId, current_slot: Slot): bool =
   ## Return ``true`` if and only if all blocks of the confirmed chain starting
   ## from current_epoch_observed_justified.checkpoint are LMD-GHOST safe.
 
@@ -512,7 +513,7 @@ func is_confirmed_chain_safe(
   # Otherwise: Limit reconfirmation to the first block of the previous epoch
   # as if it's successful, reconfirmation of the ancestors is implied.
   let
-    confirmed = dag.getBlockRef(self.confirmed.root).valueOr:
+    confirmed = dag.getBlockRef(confirmed.root).valueOr:
       return false
     current_justified = BlockId(
       slot: current_epoch_justified.epoch.start_slot,
@@ -539,34 +540,36 @@ func is_confirmed_chain_safe(
   true
 
 proc should_revert_confirmed_on_new_epoch*(
-    self: var ForkChoiceBackend, dag: ChainDAGRef, current_slot: Slot): bool =
+    self: var ForkChoiceBackend, dag: ChainDAGRef,
+    confirmed: BlockId, current_slot: Slot): bool =
   # Revert to finalized block if either of the following is true:
   # 1) the latest confirmed block's epoch is older than the previous epoch,
   # 2) [...],
   # 3) the confirmed chain starting from the current epoch observed justified
   #    checkpoint cannot be re-confirmed at the start of the current epoch.
-  if self.confirmed.slot.epoch + 1 < current_slot.epoch:
+  if confirmed.slot.epoch + 1 < current_slot.epoch:
     return true
 
   template balance_source: BalanceSource = self.current_epoch_observed_justified
   balance_source.update_latest_shufflings(dag, current_slot).isOkOr:
     return true
 
-  not self.is_confirmed_chain_safe(dag, current_slot)
+  not self.is_confirmed_chain_safe(dag, confirmed, current_slot)
 
 func should_revert_confirmed_on_new_head*(
-    self: ForkChoiceBackend, blck: BlockRef, current_slot: Slot): bool =
+    self: ForkChoiceBackend, blck: BlockRef,
+    confirmed: BlockId, current_slot: Slot): bool =
   # Revert to finalized block if either of the following is true:
   # 1) [...],
   # 2) the latest confirmed block doesn't belong to the canonical chain,
   # 3) [...].
-  if self.confirmed.slot.epoch + 1 < current_slot.epoch:
+  if confirmed.slot.epoch + 1 < current_slot.epoch:
     return true
 
   var blck = blck
-  while blck != nil and blck.slot > self.confirmed.slot:
+  while blck != nil and blck.slot > confirmed.slot:
     blck = blck.parent
-  blck == nil or blck.root != self.confirmed.root
+  blck == nil or blck.root != confirmed.root
 
 func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
   self.previous_slot_head in self.proto_array and
@@ -574,7 +577,7 @@ func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
   self.current_epoch_observed_justified.checkpoint.root in self.proto_array
 
 func should_restart_confirmation_chain*(
-    self: ForkChoiceBackend, current_slot: Slot): bool =
+    self: ForkChoiceBackend, confirmed: BlockId, current_slot: Slot): bool =
   # Restart the confirmation chain if each of the following conditions are true:
   # 1) it is the start of the current epoch,
   # 2) epoch of self.current_epoch_observed_justified.checkpoint equals to the
@@ -596,7 +599,7 @@ func should_restart_confirmation_chain*(
   current_slot.is_epoch and
   current_epoch_justified.epoch + 1 == current_slot.epoch and
   current_epoch_justified == head_unrealized_justified and
-  self.confirmed.slot < current_epoch_justified_slot
+  confirmed.slot < current_epoch_justified_slot
 
 func get_current_target(blck: BlockRef, current_slot: Slot): Checkpoint =
   ## Return current epoch target.
@@ -735,10 +738,11 @@ func will_current_target_be_justified(
   3 * honest_ffg_support >= 2 * info.total_active_balance
 
 proc find_latest_confirmed_descendant*(
-    self: var ForkChoiceBackend, dag: ChainDAGRef, blck: BlockRef,
-    unrealized: Checkpoint, current_slot: Slot): Opt[BlockId] =
+    self: var ForkChoiceBackend, dag: ChainDAGRef,
+    blck: BlockRef, unrealized: Checkpoint,
+    confirmed: BlockId, current_slot: Slot): Opt[BlockId] =
   ## Return the most recent confirmed block in the suffix of the canonical chain
-  ## starting from ``self.confirmed.root``.
+  ## starting from ``confirmed.root``.
 
   template balance_source: BalanceSource =
     self.current_epoch_observed_justified
@@ -775,11 +779,11 @@ proc find_latest_confirmed_descendant*(
     if stored_chain.isNone:
       ? balance_source.update_latest_shufflings(dag, blck, current_slot)
       stored_chain.ok self.get_ancestor_support_by_slot(
-        balance_source, dag.heads, blck, self.confirmed, current_slot)
+        balance_source, dag.heads, blck, confirmed, current_slot)
       confirmed_i = chain.high
 
-  result.ok self.confirmed
-  if self.confirmed.slot.epoch + 1 == current_epoch and
+  result.ok confirmed
+  if confirmed.slot.epoch + 1 == current_epoch and
       previous.voting_source.epoch + 2 >= current_epoch and (
         current_slot.is_epoch or (
           will_no_conflicting_be_justified and (

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -376,6 +376,7 @@ func should_revert_confirmed_on_new_head*(
   blck == nil or blck.root != self.confirmed.root
 
 func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
+  self.previous_slot_head in self.proto_array and
   self.current_slot_head in self.proto_array and
   self.current_epoch_observed_justified.checkpoint.root in self.proto_array
 
@@ -403,6 +404,13 @@ func should_restart_confirmation_chain*(
   current_epoch_justified.epoch + 1 == current_slot.epoch and
   current_epoch_justified == head_unrealized_justified and
   self.confirmed.slot < current_epoch_justified_slot
+
+func get_current_target(blck: BlockRef, current_slot: Slot): Checkpoint =
+  ## Return current epoch target.
+  let current_epoch = current_slot.epoch
+  Checkpoint(
+    epoch: current_epoch,
+    root: blck.atSlot(current_epoch.start_slot).blck.root)
 
 type CurrentTargetInfo* = object
   total_active_balance*: Gwei
@@ -479,3 +487,180 @@ proc get_current_target_info*(
       return Opt.none CurrentTargetInfo
     result.ok self.get_current_target_info(
       roots, epochRef.shufflingRef, epochRef.fork_choice_balances, current_slot)
+
+func compute_honest_ffg_support_for_current_target(
+    info: CurrentTargetInfo, current_slot: Slot,
+    byzantine_threshold: uint64): Gwei =
+  ## Compute honest FFG support of the current epoch target.
+  let
+    slots = current_slot.epoch.start_slot ..< current_slot
+
+    # Compute FFG support for the target
+    ffg_support_for_checkpoint = info.total_support
+
+    # Compute total FFG weight till current slot exclusive
+    ffg_weight_till_now = estimate_committee_weight_between_slots(
+      info.total_active_balance, slots)
+
+    # Compute remaining honest FFG weight
+    remaining_ffg_weight = info.total_active_balance - ffg_weight_till_now
+    remaining_honest_ffg_weight =
+      remaining_ffg_weight div 100 * (100 - byzantine_threshold)
+
+    # Compute potential adversarial weight
+    adversarial_weight = info.total_adversarial.compute_adversarial_weight(
+      slots, info.total_active_balance, byzantine_threshold)
+
+    # Compute min honest FFG support
+    min_honest_ffg_support = ffg_support_for_checkpoint -
+      min(adversarial_weight, ffg_support_for_checkpoint)
+
+  min_honest_ffg_support + remaining_honest_ffg_weight
+
+func will_no_conflicting_checkpoint_be_justified(
+    info: CurrentTargetInfo, blck: BlockRef, unrealized: Checkpoint,
+    current_slot: Slot, byzantine_threshold: uint64): bool =
+  ## Return ``true`` if and only if no checkpoint conflicting with the
+  ## current target can ever be justified.
+
+  # If the target is unrealized justified then no conflicting checkpoint
+  # can be justified.
+  if blck.get_current_target(current_slot) == unrealized:
+    return true
+
+  let honest_ffg_support = info.compute_honest_ffg_support_for_current_target(
+    current_slot, byzantine_threshold)
+  3 * honest_ffg_support >= 1 * info.total_active_balance
+
+func will_current_target_be_justified(
+    info: CurrentTargetInfo,
+    current_slot: Slot, byzantine_threshold: uint64): bool =
+  ## Return ``true`` if and only if the current target will eventually
+  ## be justified.
+  let honest_ffg_support = info.compute_honest_ffg_support_for_current_target(
+    current_slot, byzantine_threshold)
+  3 * honest_ffg_support >= 2 * info.total_active_balance
+
+proc find_latest_confirmed_descendant*(
+    self: var ForkChoiceBackend, dag: ChainDAGRef, blck: BlockRef,
+    unrealized: Checkpoint, current_slot: Slot): Opt[BlockId] =
+  ## Return the most recent confirmed block in the suffix of the canonical chain
+  ## starting from ``self.confirmed.root``.
+
+  template balance_source: BalanceSource =
+    self.current_epoch_observed_justified
+
+  let
+    current_epoch = current_slot.epoch
+    total_active_balance = balance_source.total_active_balance
+    byzantine_threshold = self.confirmation_byzantine_threshold
+    previous = self.proto_array.checkpoints(self.previous_slot_head)
+      .expect("is_proto_array_consistent")
+    current = self.proto_array.checkpoints(self.current_slot_head)
+      .expect("is_proto_array_consistent")
+
+  var stored_info: Opt[CurrentTargetInfo]
+  template info: lent CurrentTargetInfo =
+    if stored_info.isNone:
+      stored_info = self.get_current_target_info(dag, blck, current_slot)
+      if stored_info.isNone:
+        return Opt.none BlockId
+    stored_info.unsafeGet
+
+  var stored_no_conflict: Opt[bool]
+  template will_no_conflicting_be_justified: bool =
+    if stored_no_conflict.isNone:
+      stored_no_conflict.ok info.will_no_conflicting_checkpoint_be_justified(
+        blck, unrealized, current_slot, byzantine_threshold)
+    stored_no_conflict.unsafeGet
+
+  var
+    stored_chain: Opt[seq[SlotInfo]]
+    confirmed_i = -1
+  template chain: lent seq[SlotInfo] = stored_chain.unsafeGet
+  template init_chain =
+    if stored_chain.isNone:
+      ? balance_source.update_latest_shufflings(dag, blck, current_slot)
+      stored_chain.ok self.get_ancestor_support_by_slot(
+        balance_source, dag.heads, blck, self.confirmed, current_slot)
+      confirmed_i = chain.high
+
+  result.ok self.confirmed
+  if self.confirmed.slot.epoch + 1 == current_epoch and
+      previous.voting_source.epoch + 2 >= current_epoch and (
+        current_slot.is_epoch or (
+          will_no_conflicting_be_justified and (
+            previous.unrealized.epoch + 1 >= current_epoch or
+            current.unrealized.epoch + 1 >= current_epoch))):
+    # Get suffix of the canonical chain
+    init_chain()
+
+    if chain.len > 0:
+      # The algorithm can only rely on the previous head
+      # if it is a descendant of the block that is attempted to be confirmed
+      var
+        blck = ? dag.getBlockRef(self.previous_slot_head)
+        j = chain.index(blck.slot, current_slot)
+      while j < chain.high and chain[j].blck != blck:
+        blck = blck.parent
+        j =
+          if blck != nil:
+            chain.index(blck.slot, current_slot)
+          else:
+            chain.high
+
+      # If the current epoch is reached, exit the loop
+      # as this code is meant to confirm blocks from the previous epoch
+      let prev_epoch_end = max(current_epoch, 1.Epoch).start_slot - 1
+      j = max(j, chain.index(prev_epoch_end, current_slot))
+
+      # Starting with the child of the latest_confirmed_root
+      # move towards the head in attempt to advance confirmed block
+      # and stop when the first unconfirmed descendant is encountered
+      for i in countdown(confirmed_i - 1, j):
+        if chain[i].blck == chain[i + 1].blck:
+          continue
+        if not chain.is_one_confirmed(
+            i, current_slot, total_active_balance, byzantine_threshold):
+          break
+        result.ok chain[i].blck.bid
+        confirmed_i = i
+
+  if current_slot.is_epoch or
+      current.unrealized.epoch + 1 >= current_epoch:
+    # Get suffix of the canonical chain
+    init_chain()
+
+    var tentative_confirmed = result.unsafeGet
+
+    for i in countdown(confirmed_i - 1, 0):
+      if chain[i].blck == chain[i + 1].blck:
+        continue
+      let
+        block_epoch = chain[i].blck.slot.epoch
+        tentative_confirmed_epoch = tentative_confirmed.slot.epoch
+
+      # The following condition can only be true the first time
+      # the algorithm advances to a block from the current epoch
+      if block_epoch > tentative_confirmed_epoch:
+        # To confirm blocks from the current epoch ensure that
+        # current epoch target will be justified
+        if not info.will_current_target_be_justified(
+            current_slot, byzantine_threshold):
+          break
+
+      if not chain.is_one_confirmed(
+          i, current_slot, total_active_balance, byzantine_threshold):
+        break
+
+      tentative_confirmed = chain[i].blck.bid
+
+    # The tentative_confirmed.root can only be confirmed if it is for sure
+    # not going to be reorged out in either the current or next epoch.
+    template tentative_voting_source: Checkpoint =
+      (? self.proto_array.checkpoints(tentative_confirmed.root)).voting_source
+    if tentative_confirmed.slot.epoch == current_epoch or (
+        tentative_voting_source.epoch + 2 >= current_epoch and (
+          current_slot.is_epoch or
+          will_no_conflicting_be_justified)):
+      result.ok tentative_confirmed

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -515,22 +515,21 @@ type FcrDiagnostics* = object
   total_active_balance*: Gwei
   byzantine_threshold*: uint64
 
-func shortLog*(diag: FcrDiagnostics): auto =
-  (
-    chain_len: diag.chain_len,
-    failed_block: shortLog(diag.failed_block),
-    support: diag.support,
-    safety_threshold: diag.safety_threshold,
-    total_active_balance: diag.total_active_balance,
-    byzantine_threshold: diag.byzantine_threshold,
-  )
+func `$`*(diag: FcrDiagnostics): string =
+  let slot = diag.failed_block.slot
+  shortLog(diag.failed_block.root) & ":" &
+  $slot.epoch & ":" & $slot.since_epoch_start & ": " &
+  formatGwei(diag.support) & " <= " &
+  formatGwei(diag.safety_threshold) & " (" &
+  formatGwei(diag.total_active_balance) & " total, " &
+  $diag.byzantine_threshold & "% byz, " &
+  $diag.chain_len & " blks)"
 
-chronicles.formatIt FcrDiagnostics: it.shortLog
+chronicles.formatIt FcrDiagnostics: $it
 
 func is_confirmed_chain_safe(
-    self: ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot,
-    diag: var FcrDiagnostics): FcResult[bool] =
+    self: ForkChoiceBackend, dag: ChainDAGRef, confirmed: BlockId,
+    current_slot: Slot, diag: var FcrDiagnostics): FcResult[bool] =
   ## Return ``true`` if and only if all blocks of the confirmed chain starting
   ## from current_epoch_observed_justified.checkpoint are LMD-GHOST safe.
 
@@ -586,9 +585,8 @@ func is_confirmed_chain_safe(
   ok true
 
 proc should_revert_confirmed_on_new_epoch*(
-    self: var ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot,
-    diag: var FcrDiagnostics): FcResult[bool] =
+    self: var ForkChoiceBackend, dag: ChainDAGRef, confirmed: BlockId,
+    current_slot: Slot, diag: var FcrDiagnostics): FcResult[bool] =
   # Revert to finalized block if either of the following is true:
   # 1) the latest confirmed block's epoch is older than the previous epoch,
   # 2) [...],

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -21,6 +21,9 @@ from ../spec/beaconstate import latest_block_root
 
 export fork_choice_types
 
+# FCR research paper: https://arxiv.org/abs/2405.00549
+# Primary spec PR: https://github.com/ethereum/consensus-specs/pull/4747
+
 const
   AttesterDutyOffsets* = [
     ForkChoiceInfoOffset + 1,
@@ -82,7 +85,7 @@ func record_shuffling(
 
 proc do_update_shufflings(
     balance_source: var BalanceSource, dag: ChainDAGRef,
-    blck: BlockRef, current_slot: Slot): Opt[void] =
+    blck: BlockRef, current_slot: Slot): FcResult[void] =
   var
     blck = blck
     epoch = current_slot.epoch
@@ -95,11 +98,22 @@ proc do_update_shufflings(
           blck = dependent_blck
           blck.bid.root
         else:
-          (? dag.getBlockIdAtSlot(dependent_slot)).bid.root
-    if balance_source.has_shuffling(epoch, dependent_root):
-      return ok()
-    balance_source.record_shuffling(
-      ? dag.getShufflingRef(blck, epoch, preFinalized = true))
+          let bsi = dag.getBlockIdAtSlot(dependent_slot).valueOr:
+            return err ForkChoiceError(
+              kind: fcUnknownBlockIdAtSlot,
+              shufflingRoot: blck.bid.root,
+              shufflingEpoch: epoch)
+          bsi.bid.root
+      shufflingRef =
+        if balance_source.has_shuffling(epoch, dependent_root):
+          return ok()
+        else:
+          dag.getShufflingRef(blck, epoch, preFinalized = true).valueOr:
+            return err ForkChoiceError(
+              kind: fcUnknownShufflingRef,
+              shufflingRoot: blck.bid.root,
+              shufflingEpoch: epoch)
+    balance_source.record_shuffling(shufflingRef)
     if epoch <= GENESIS_EPOCH:
       return ok()
     dec epoch
@@ -107,14 +121,14 @@ proc do_update_shufflings(
 
 proc update_latest_shufflings(
     balance_source: var BalanceSource, dag: ChainDAGRef,
-    blck: BlockRef, current_slot: Slot): Opt[void] =
+    blck: BlockRef, current_slot: Slot): FcResult[void] =
   result = balance_source.do_update_shufflings(dag, dag.head, current_slot)
   if result.isErr:
     balance_source.shuffling_epochs = DefaultShufflingEpochs
 
 proc update_latest_shufflings*(
     balance_source: var BalanceSource, dag: ChainDAGRef,
-    current_slot: Slot): Opt[void] =
+    current_slot: Slot): FcResult[void] =
   balance_source.update_latest_shufflings(dag, dag.head, current_slot)
 
 func assign_shufflings*(dst: var BalanceSource, src: BalanceSource) =
@@ -427,12 +441,13 @@ func compute_empty_slot_support_discount(
   ## Return weight that can be discounted during the safety threshold
   ## computation if there are empty slots preceding the block.
 
+  let parent_blck = chain[i + 1].blck
   # No empty slot.
-  if chain[i + 1].blck.slot + 1 == chain[i].blck.slot:
+  if parent_blck.slot + 1 == chain[i].blck.slot:
     return 0.Gwei
 
   let
-    empty_slots = chain[i + 1].blck.slot + 1 ..< chain[i].blck.slot
+    empty_slots = parent_blck.slot + 1 ..< chain[i].blck.slot
     # Discount votes supporting the parent block if they are from
     # the committees of empty slots.
     parent_support_in_empty_slots = chain.get_block_support_between_slots(
@@ -571,10 +586,22 @@ func should_revert_confirmed_on_new_head*(
     blck = blck.parent
   blck == nil or blck.root != confirmed.root
 
-func is_proto_array_consistent*(self: ForkChoiceBackend): bool =
-  self.previous_slot_head in self.proto_array and
-  self.current_slot_head in self.proto_array and
-  self.current_epoch_observed_justified.checkpoint.root in self.proto_array
+func check_proto_array_consistency*(self: ForkChoiceBackend): FcResult[void] =
+  if self.previous_slot_head notin self.proto_array:
+    return err ForkChoiceError(
+      kind: fcPreviousHeadUnknown,
+      blockRoot: self.previous_slot_head)
+  if self.current_slot_head notin self.proto_array:
+    return err ForkChoiceError(
+      kind: fcCurrentHeadUnknown,
+      blockRoot: self.current_slot_head)
+  template current_epoch_justified: Checkpoint =
+    self.current_epoch_observed_justified.checkpoint
+  if current_epoch_justified.root notin self.proto_array:
+    return err ForkChoiceError(
+      kind: fcJustifiedNodeUnknown,
+      blockRoot: current_epoch_justified.root)
+  ok()
 
 func should_restart_confirmation_chain*(
     self: ForkChoiceBackend, confirmed: BlockId, current_slot: Slot): bool =
@@ -590,11 +617,11 @@ func should_restart_confirmation_chain*(
     self.current_epoch_observed_justified.checkpoint
   template current_epoch_justified_slot: Slot =
     self.proto_array.slot(current_epoch_justified.root)
-      .expect("is_proto_array_consistent")
+      .expect("check_proto_array_consistency")
 
   template head_unrealized_justified: Checkpoint =
-    self.proto_array.checkpoints(self.current_slot_head)
-      .expect("is_proto_array_consistent").unrealized
+    self.proto_array.unrealized_justified(self.current_slot_head)
+      .expect("check_proto_array_consistency")
 
   current_slot.is_epoch and
   current_epoch_justified.epoch + 1 == current_slot.epoch and
@@ -653,12 +680,16 @@ func get_current_target_info*[T: Validator | ForkChoiceBalance](
 
 proc get_current_target_info*(
     self: ForkChoiceBackend, dag: ChainDAGRef,
-    blck: BlockRef, current_slot: Slot): Opt[CurrentTargetInfo] =
+    blck: BlockRef, current_slot: Slot): FcResult[CurrentTargetInfo] =
   ## Return the estimate of FFG support of the current epoch target
   ## by using LMD-GHOST votes.
   let
     current_epoch = current_slot.epoch
-    shufflingRef = ? dag.getShufflingRef(blck, current_epoch, false)
+    shufflingRef = dag.getShufflingRef(blck, current_epoch, false).valueOr:
+      return err ForkChoiceError(
+        kind: fcUnknownShufflingRef,
+        shufflingRoot: blck.root,
+        shufflingEpoch: current_epoch)
     roots = blck.all_current_target_descendants(dag.heads, current_slot)
 
   template isCompatible(state: ForkedHashedBeaconState): bool =
@@ -680,7 +711,10 @@ proc get_current_target_info*(
       roots, shufflingRef, state[].validators, current_slot)
   else:
     let epochRef = dag.getEpochRef(blck, current_epoch, false).valueOr:
-      return Opt.none CurrentTargetInfo
+      return err ForkChoiceError(
+        kind: fcUnknownShufflingRef,
+        shufflingRoot: blck.root,
+        shufflingEpoch: current_epoch)
     result.ok self.get_current_target_info(
       roots, epochRef.shufflingRef, epochRef.fork_choice_balances, current_slot)
 
@@ -740,7 +774,7 @@ func will_current_target_be_justified(
 proc find_latest_confirmed_descendant*(
     self: var ForkChoiceBackend, dag: ChainDAGRef,
     blck: BlockRef, unrealized: Checkpoint,
-    confirmed: BlockId, current_slot: Slot): Opt[BlockId] =
+    confirmed: BlockId, current_slot: Slot): FcResult[BlockId] =
   ## Return the most recent confirmed block in the suffix of the canonical chain
   ## starting from ``confirmed.root``.
 
@@ -752,16 +786,14 @@ proc find_latest_confirmed_descendant*(
     total_active_balance = balance_source.total_active_balance
     byzantine_threshold = self.confirmation_byzantine_threshold
     previous = self.proto_array.checkpoints(self.previous_slot_head)
-      .expect("is_proto_array_consistent")
+      .expect("check_proto_array_consistency")
     current = self.proto_array.checkpoints(self.current_slot_head)
-      .expect("is_proto_array_consistent")
+      .expect("check_proto_array_consistency")
 
   var stored_info: Opt[CurrentTargetInfo]
   template info: lent CurrentTargetInfo =
     if stored_info.isNone:
-      stored_info = self.get_current_target_info(dag, blck, current_slot)
-      if stored_info.isNone:
-        return Opt.none BlockId
+      stored_info.ok(? self.get_current_target_info(dag, blck, current_slot))
     stored_info.unsafeGet
 
   var stored_no_conflict: Opt[bool]
@@ -787,8 +819,8 @@ proc find_latest_confirmed_descendant*(
       previous.voting_source.epoch + 2 >= current_epoch and (
         current_slot.is_epoch or (
           will_no_conflicting_be_justified and (
-            previous.unrealized.epoch + 1 >= current_epoch or
-            current.unrealized.epoch + 1 >= current_epoch))):
+            previous.unrealized_justified.epoch + 1 >= current_epoch or
+            current.unrealized_justified.epoch + 1 >= current_epoch))):
     # Get suffix of the canonical chain
     init_chain()
 
@@ -796,7 +828,10 @@ proc find_latest_confirmed_descendant*(
       # The algorithm can only rely on the previous head
       # if it is a descendant of the block that is attempted to be confirmed
       var
-        blck = ? dag.getBlockRef(self.previous_slot_head)
+        blck = dag.getBlockRef(self.previous_slot_head).valueOr:
+          return err ForkChoiceError(
+            kind: fcPreviousHeadUnknown,
+            blockRoot: self.previous_slot_head)
         j = chain.index(blck.slot, current_slot)
       while j < chain.high and chain[j].blck != blck:
         blck = blck.parent
@@ -824,7 +859,7 @@ proc find_latest_confirmed_descendant*(
         confirmed_i = i
 
   if current_slot.is_epoch or
-      current.unrealized.epoch + 1 >= current_epoch:
+      current.unrealized_justified.epoch + 1 >= current_epoch:
     # Get suffix of the canonical chain
     init_chain()
 
@@ -855,7 +890,10 @@ proc find_latest_confirmed_descendant*(
     # The tentative_confirmed.root can only be confirmed if it is for sure
     # not going to be reorged out in either the current or next epoch.
     template tentative_voting_source: Checkpoint =
-      (? self.proto_array.checkpoints(tentative_confirmed.root)).voting_source
+      self.proto_array.voting_source(tentative_confirmed.root).valueOr:
+        return err ForkChoiceError(
+          kind: fcConfirmedNodeUnknown,
+          blockRoot: tentative_confirmed.root)
     if tentative_confirmed.slot.epoch == current_epoch or (
         tentative_voting_source.epoch + 2 >= current_epoch and (
           current_slot.is_epoch or

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -509,7 +509,7 @@ func is_one_confirmed(
 
 func is_confirmed_chain_safe(
     self: ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot): bool =
+    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
   ## Return ``true`` if and only if all blocks of the confirmed chain starting
   ## from current_epoch_observed_justified.checkpoint are LMD-GHOST safe.
 
@@ -529,7 +529,9 @@ func is_confirmed_chain_safe(
   # as if it's successful, reconfirmation of the ancestors is implied.
   let
     confirmed = dag.getBlockRef(confirmed.root).valueOr:
-      return false
+      return err ForkChoiceError(
+        kind: fcConfirmedNodeUnknown,
+        blockRoot: confirmed.root)
     current_justified = BlockId(
       slot: current_epoch_justified.epoch.start_slot,
       root: current_epoch_justified.root)
@@ -539,7 +541,7 @@ func is_confirmed_chain_safe(
   # Check if the confirmed.root is descendant of
   # current_epoch_observed_justified.checkpoint.
   if chain.len == 0:
-    return false
+    return ok false
 
   # Run is_one_confirmed for each block in the confirmed chain with the
   # previous epoch balance source.
@@ -551,8 +553,8 @@ func is_confirmed_chain_safe(
       continue
     if not chain.is_one_confirmed(
         i, current_slot, total_active_balance, byzantine_threshold):
-      return false
-  true
+      return ok false
+  ok true
 
 proc should_revert_confirmed_on_new_epoch*(
     self: var ForkChoiceBackend, dag: ChainDAGRef,
@@ -568,7 +570,7 @@ proc should_revert_confirmed_on_new_epoch*(
   template balance_source: BalanceSource = self.current_epoch_observed_justified
   ? balance_source.update_latest_shufflings(dag, current_slot)
 
-  ok not self.is_confirmed_chain_safe(dag, confirmed, current_slot)
+  ok not ? self.is_confirmed_chain_safe(dag, confirmed, current_slot)
 
 func should_revert_confirmed_on_new_head*(
     self: ForkChoiceBackend, blck: BlockRef,

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -556,55 +556,38 @@ func is_confirmed_chain_safe(
 
 proc should_revert_confirmed_on_new_epoch*(
     self: var ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot): bool =
+    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
   # Revert to finalized block if either of the following is true:
   # 1) the latest confirmed block's epoch is older than the previous epoch,
   # 2) [...],
   # 3) the confirmed chain starting from the current epoch observed justified
   #    checkpoint cannot be re-confirmed at the start of the current epoch.
   if confirmed.slot.epoch + 1 < current_slot.epoch:
-    return true
+    return ok true
 
   template balance_source: BalanceSource = self.current_epoch_observed_justified
-  balance_source.update_latest_shufflings(dag, current_slot).isOkOr:
-    return true
+  ? balance_source.update_latest_shufflings(dag, current_slot)
 
-  not self.is_confirmed_chain_safe(dag, confirmed, current_slot)
+  ok not self.is_confirmed_chain_safe(dag, confirmed, current_slot)
 
 func should_revert_confirmed_on_new_head*(
     self: ForkChoiceBackend, blck: BlockRef,
-    confirmed: BlockId, current_slot: Slot): bool =
+    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
   # Revert to finalized block if either of the following is true:
   # 1) [...],
   # 2) the latest confirmed block doesn't belong to the canonical chain,
   # 3) [...].
   if confirmed.slot.epoch + 1 < current_slot.epoch:
-    return true
+    return ok true
 
   var blck = blck
   while blck != nil and blck.slot > confirmed.slot:
     blck = blck.parent
-  blck == nil or blck.root != confirmed.root
-
-func check_proto_array_consistency*(self: ForkChoiceBackend): FcResult[void] =
-  if self.previous_slot_head notin self.proto_array:
-    return err ForkChoiceError(
-      kind: fcPreviousHeadUnknown,
-      blockRoot: self.previous_slot_head)
-  if self.current_slot_head notin self.proto_array:
-    return err ForkChoiceError(
-      kind: fcCurrentHeadUnknown,
-      blockRoot: self.current_slot_head)
-  template current_epoch_justified: Checkpoint =
-    self.current_epoch_observed_justified.checkpoint
-  if current_epoch_justified.root notin self.proto_array:
-    return err ForkChoiceError(
-      kind: fcJustifiedNodeUnknown,
-      blockRoot: current_epoch_justified.root)
-  ok()
+  ok(blck == nil or blck.root != confirmed.root)
 
 func should_restart_confirmation_chain*(
-    self: ForkChoiceBackend, confirmed: BlockId, current_slot: Slot): bool =
+    self: ForkChoiceBackend,
+    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
   # Restart the confirmation chain if each of the following conditions are true:
   # 1) it is the start of the current epoch,
   # 2) epoch of self.current_epoch_observed_justified.checkpoint equals to the
@@ -616,17 +599,21 @@ func should_restart_confirmation_chain*(
   template current_epoch_justified: Checkpoint =
     self.current_epoch_observed_justified.checkpoint
   template current_epoch_justified_slot: Slot =
-    self.proto_array.slot(current_epoch_justified.root)
-      .expect("check_proto_array_consistency")
+    self.proto_array.slot(current_epoch_justified.root).valueOr:
+      return err ForkChoiceError(
+        kind: fcJustifiedNodeUnknown,
+        blockRoot: current_epoch_justified.root)
 
   template head_unrealized_justified: Checkpoint =
-    self.proto_array.unrealized_justified(self.current_slot_head)
-      .expect("check_proto_array_consistency")
+    self.proto_array.unrealized_justified(self.current_slot_head).valueOr:
+      return err ForkChoiceError(
+        kind: fcCurrentHeadUnknown,
+        blockRoot: self.current_slot_head)
 
-  current_slot.is_epoch and
-  current_epoch_justified.epoch + 1 == current_slot.epoch and
-  current_epoch_justified == head_unrealized_justified and
-  confirmed.slot < current_epoch_justified_slot
+  ok(current_slot.is_epoch and
+    current_epoch_justified.epoch + 1 == current_slot.epoch and
+    current_epoch_justified == head_unrealized_justified and
+    confirmed.slot < current_epoch_justified_slot)
 
 func get_current_target(blck: BlockRef, current_slot: Slot): Checkpoint =
   ## Return current epoch target.
@@ -785,10 +772,14 @@ proc find_latest_confirmed_descendant*(
     current_epoch = current_slot.epoch
     total_active_balance = balance_source.total_active_balance
     byzantine_threshold = self.confirmation_byzantine_threshold
-    previous = self.proto_array.checkpoints(self.previous_slot_head)
-      .expect("check_proto_array_consistency")
-    current = self.proto_array.checkpoints(self.current_slot_head)
-      .expect("check_proto_array_consistency")
+    previous = self.proto_array.checkpoints(self.previous_slot_head).valueOr:
+      return err ForkChoiceError(
+        kind: fcPreviousHeadUnknown,
+        blockRoot: self.previous_slot_head)
+    current = self.proto_array.checkpoints(self.current_slot_head).valueOr:
+      return err ForkChoiceError(
+        kind: fcCurrentHeadUnknown,
+        blockRoot: self.current_slot_head)
 
   var stored_info: Opt[CurrentTargetInfo]
   template info: lent CurrentTargetInfo =

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -8,7 +8,7 @@
 {.push raises: [].}
 
 import
-  std/[sets, tables], stew/bitops2,
+  std/[sets, tables], stew/bitops2, chronicles,
   ../consensus_object_pools/spec_cache,
   "."/[fork_choice_types, proto_array]
 
@@ -507,9 +507,30 @@ func is_one_confirmed(
 
   support > safety_threshold
 
+type FcrDiagnostics* = object
+  chain_len*: int
+  failed_block*: BlockId
+  support*: Gwei
+  safety_threshold*: Gwei
+  total_active_balance*: Gwei
+  byzantine_threshold*: uint64
+
+func shortLog*(diag: FcrDiagnostics): auto =
+  (
+    chain_len: diag.chain_len,
+    failed_block: shortLog(diag.failed_block),
+    support: diag.support,
+    safety_threshold: diag.safety_threshold,
+    total_active_balance: diag.total_active_balance,
+    byzantine_threshold: diag.byzantine_threshold,
+  )
+
+chronicles.formatIt FcrDiagnostics: it.shortLog
+
 func is_confirmed_chain_safe(
     self: ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
+    confirmed: BlockId, current_slot: Slot,
+    diag: var FcrDiagnostics): FcResult[bool] =
   ## Return ``true`` if and only if all blocks of the confirmed chain starting
   ## from current_epoch_observed_justified.checkpoint are LMD-GHOST safe.
 
@@ -553,12 +574,21 @@ func is_confirmed_chain_safe(
       continue
     if not chain.is_one_confirmed(
         i, current_slot, total_active_balance, byzantine_threshold):
+      diag = FcrDiagnostics(
+        chain_len: chain.len,
+        failed_block: chain[i].blck.bid,
+        support: chain[i].total_support,
+        safety_threshold: chain.compute_safety_threshold(
+          i, current_slot, total_active_balance, byzantine_threshold),
+        total_active_balance: total_active_balance,
+        byzantine_threshold: byzantine_threshold)
       return ok false
   ok true
 
 proc should_revert_confirmed_on_new_epoch*(
     self: var ForkChoiceBackend, dag: ChainDAGRef,
-    confirmed: BlockId, current_slot: Slot): FcResult[bool] =
+    confirmed: BlockId, current_slot: Slot,
+    diag: var FcrDiagnostics): FcResult[bool] =
   # Revert to finalized block if either of the following is true:
   # 1) the latest confirmed block's epoch is older than the previous epoch,
   # 2) [...],
@@ -570,7 +600,7 @@ proc should_revert_confirmed_on_new_epoch*(
   template balance_source: BalanceSource = self.current_epoch_observed_justified
   ? balance_source.update_latest_shufflings(dag, current_slot)
 
-  ok not ? self.is_confirmed_chain_safe(dag, confirmed, current_slot)
+  ok not ? self.is_confirmed_chain_safe(dag, confirmed, current_slot, diag)
 
 func should_revert_confirmed_on_new_head*(
     self: ForkChoiceBackend, blck: BlockRef,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -182,8 +182,12 @@ proc update_confirmed(
   template prev: BlockId = self.confirmed
   template curr: BlockId = confirmed
   if reason != "" and (prev.slot > curr.slot or not dag.isCanonical(prev)):
-    notice "Previous 'safe' block no longer safe",
-      previousSafe = prev, currentSafe = curr, reason, diag
+    if diag.chain_len > 0:
+      notice "Previous 'safe' block no longer safe",
+        previousSafe = prev, currentSafe = curr, reason, diag
+    else:
+      notice "Previous 'safe' block no longer safe",
+        previousSafe = prev, currentSafe = curr, reason
   elif confirmed != prev:
     trace "Updating 'safe' block",
       previousSafe = prev, currentSafe = curr

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -191,11 +191,6 @@ proc to_block_id(self: ForkChoiceBackend, checkpoint: Checkpoint): BlockId =
     checkpoint.epoch.start_slot
   result.root = checkpoint.root
 
-proc update_confirmed(self: var ForkChoiceBackend, confirmed: Checkpoint) =
-  self.update_confirmed BlockId(
-    slot: self.proto_array.slot(confirmed.root).get(confirmed.epoch.start_slot),
-    root: confirmed.root)
-
 proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
   let unrealized = self.backend.previous_epoch_greatest_unrealized_checkpoint
   if unrealized == self.backend.current_epoch_observed_justified.checkpoint:
@@ -238,6 +233,7 @@ proc reconfirm_fcr(
   else:
     if fcr.should_restart_confirmation_chain(confirmed, current_slot):
       confirmed = fcr.to_block_id(current_epoch_justified)
+  ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/fork-choice.md#on_tick_per_slot
 proc on_tick(

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -176,13 +176,15 @@ proc update_checkpoints(
 
   ok()
 
-proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
+proc update_confirmed(
+    self: var ForkChoiceBackend, confirmed: BlockId,
+    reason = "ok", diag = default(FcrDiagnostics)) =
   if confirmed.slot < self.confirmed.slot:
-    notice "'Safe' block was unconfirmed",
-      old_confirmed = self.confirmed, new_confirmed = confirmed
-  if confirmed != self.confirmed:
+    notice "Rewinding 'safe' block",
+      old_confirmed = self.confirmed, new_confirmed = confirmed, reason, diag
+  elif confirmed != self.confirmed:
     trace "Updating 'safe' block",
-      old_confirmed = self.confirmed, new_confirmed = confirmed
+      old_confirmed = self.confirmed, new_confirmed = confirmed, reason
   self.confirmed = confirmed
 
 proc to_block_id(self: ForkChoiceBackend, checkpoint: Checkpoint): BlockId =
@@ -212,13 +214,16 @@ proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
 
 proc reconfirm_fcr(
     self: var ForkChoice, dag: ChainDAGRef,
-    confirmed: var BlockId, current_slot: Slot): FcResult[void] =
+    confirmed: var BlockId, current_slot: Slot,
+    reason: var string, diag: var FcrDiagnostics): FcResult[void] =
   template fcr: ForkChoiceBackend = self.backend
 
   # Reconfirm with previous balance source after attestations
   # from past slots have been applied
   self.process_attestation_queue(current_slot)
-  if ? fcr.should_revert_confirmed_on_new_epoch(dag, confirmed, current_slot):
+  if ? fcr.should_revert_confirmed_on_new_epoch(
+      dag, confirmed, current_slot, diag):
+    reason = "epoch"
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
 
   # Update observed justified checkpoints at the start of an epoch
@@ -229,6 +234,7 @@ proc reconfirm_fcr(
   # Restart confirmation chain if necessary
   fcr.current_slot_head = ? fcr.find_head(current_slot, self.checkpoints)
   if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
+    reason = "restart/e"
     confirmed = fcr.to_block_id(current_epoch_justified)
   ok()
 
@@ -270,12 +276,16 @@ proc on_tick(
           finalized: self.checkpoints.finalized))
       ? self.update_checkpoints(dag, realized, current_slot)
 
-      var confirmed = self.backend.confirmed
-      self.reconfirm_fcr(dag, confirmed, current_slot).isOkOr:
+      var
+        confirmed = self.backend.confirmed
+        reason: string
+        diag: FcrDiagnostics
+      self.reconfirm_fcr(dag, confirmed, current_slot, reason, diag).isOkOr:
         warn "Failed to reconfirm 'safe' block - report bug",
           current_slot, reason = error
+        reason = "reconfirm"
         confirmed = self.backend.to_block_id(self.checkpoints.finalized)
-      self.backend.update_confirmed(confirmed)
+      self.backend.update_confirmed(confirmed, reason, diag)
 
     else:
       discard
@@ -483,16 +493,19 @@ proc get_head*(
 
 proc advance_fcr(
     self: var ForkChoice, dag: ChainDAGRef, blckRef: BlockRef,
-    confirmed: var BlockId, current_slot: Slot): FcResult[void] =
+    confirmed: var BlockId, current_slot: Slot,
+    reason: var string): FcResult[void] =
   template fcr: ForkChoiceBackend = self.backend
   template current_epoch_justified: Checkpoint =
     fcr.current_epoch_observed_justified.checkpoint
 
   if ? fcr.should_revert_confirmed_on_new_head(
       blckRef, confirmed, current_slot):
+    reason = "head"
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
 
   if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
+    reason = "restart/h"
     confirmed = fcr.to_block_id(current_epoch_justified)
 
   # Attempt to further advance the latest confirmed block.
@@ -514,12 +527,15 @@ proc will_select_head*(
   if self.checkpoints.time < threshold:
     self.backend.current_slot_head = blckRef.root
 
-  var confirmed = self.backend.confirmed
-  self.advance_fcr(dag, blckRef, confirmed, current_slot).isOkOr:
+  var
+    confirmed = self.backend.confirmed
+    reason: string
+  self.advance_fcr(dag, blckRef, confirmed, current_slot, reason).isOkOr:
     warn "Failed to advance 'safe' block - report bug",
       blckRef, current_slot, reason = error
+    reason = "advance"
     confirmed = self.backend.to_block_id(self.checkpoints.finalized)
-  self.backend.update_confirmed(confirmed)
+  self.backend.update_confirmed(confirmed, reason)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
@@ -539,7 +555,7 @@ proc prune(
   if self.current_slot_head notin self.proto_array:
     self.current_slot_head = checkpoints.finalized.root
   if self.confirmed.root notin self.proto_array:
-    self.update_confirmed(self.to_block_id(checkpoints.finalized))
+    self.update_confirmed(self.to_block_id(checkpoints.finalized), "prune")
   ok()
 
 proc prune*(self: var ForkChoice): FcResult[void] =

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -506,7 +506,7 @@ proc will_select_head*(
     if fcr.should_restart_confirmation_chain(confirmed, current_slot):
       confirmed = fcr.to_block_id(current_epoch_justified)
     # Attempt to further advance the latest confirmed block.
-    if fcr.confirmed.slot.epoch + 1 >= current_slot.epoch:
+    if confirmed.slot.epoch + 1 >= current_slot.epoch:
       template justified: Checkpoint = self.checkpoints.justified.checkpoint
       let unrealized = fcr.proto_array.unrealized_justified(justified)
       confirmed = fcr.find_latest_confirmed_descendant(

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -177,15 +177,17 @@ proc update_checkpoints(
   ok()
 
 proc update_confirmed(
-    self: var ForkChoiceBackend, confirmed: BlockId,
-    reason = "ok", diag = default(FcrDiagnostics)) =
-  if confirmed.slot < self.confirmed.slot:
-    notice "Rewinding 'safe' block",
-      old_confirmed = self.confirmed, new_confirmed = confirmed, reason, diag
-  elif confirmed != self.confirmed:
+    self: var ForkChoiceBackend, dag: ChainDAGRef, confirmed: BlockId,
+    reason = "", diag = default(FcrDiagnostics)) =
+  template prev: BlockId = self.confirmed
+  template curr: BlockId = confirmed
+  if reason != "" and (prev.slot > curr.slot or not dag.isCanonical(prev)):
+    notice "Previous 'safe' block no longer safe",
+      previousSafe = prev, currentSafe = curr, reason, diag
+  elif confirmed != prev:
     trace "Updating 'safe' block",
-      old_confirmed = self.confirmed, new_confirmed = confirmed, reason
-  self.confirmed = confirmed
+      previousSafe = prev, currentSafe = curr
+  prev = curr
 
 proc to_block_id(self: ForkChoiceBackend, checkpoint: Checkpoint): BlockId =
   result.slot = self.proto_array.slot(checkpoint.root).valueOr:
@@ -285,7 +287,7 @@ proc on_tick(
           current_slot, reason = error
         reason = "reconfirm"
         confirmed = self.backend.to_block_id(self.checkpoints.finalized)
-      self.backend.update_confirmed(confirmed, reason, diag)
+      self.backend.update_confirmed(dag, confirmed, reason, diag)
 
     else:
       discard
@@ -535,7 +537,7 @@ proc will_select_head*(
       blckRef, current_slot, reason = error
     reason = "advance"
     confirmed = self.backend.to_block_id(self.checkpoints.finalized)
-  self.backend.update_confirmed(confirmed, reason)
+  self.backend.update_confirmed(dag, confirmed, reason)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
@@ -546,7 +548,7 @@ func get_safe_beacon_block_root*(self: ForkChoice): lent Eth2Digest =
   self.get_safe_beacon_block_id.root
 
 proc prune(
-    self: var ForkChoiceBackend,
+    self: var ForkChoiceBackend, dag: ChainDAGRef,
     checkpoints: FinalityCheckpoints): FcResult[void] =
   ## Prune blocks preceding the finalized root as they are now unneeded.
   ? self.proto_array.prune(checkpoints)
@@ -555,14 +557,14 @@ proc prune(
   if self.current_slot_head notin self.proto_array:
     self.current_slot_head = checkpoints.finalized.root
   if self.confirmed.root notin self.proto_array:
-    self.update_confirmed(self.to_block_id(checkpoints.finalized), "prune")
+    self.update_confirmed(
+      dag, self.to_block_id(checkpoints.finalized), "prune")
   ok()
 
-proc prune*(self: var ForkChoice): FcResult[void] =
-  self.backend.prune(
-    FinalityCheckpoints(
-      justified: self.checkpoints.justified.checkpoint,
-      finalized: self.checkpoints.finalized))
+proc prune*(self: var ForkChoice, dag: ChainDAGRef): FcResult[void] =
+  self.backend.prune(dag, FinalityCheckpoints(
+    justified: self.checkpoints.justified.checkpoint,
+    finalized: self.checkpoints.finalized))
 
 func mark_root_invalid*(self: var ForkChoice, root: Eth2Digest) =
   try:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -178,7 +178,7 @@ proc update_checkpoints(
 
 proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
   if confirmed.slot < self.confirmed.slot:
-    warn "Confirmed block was unconfirmed",
+    notice "Confirmed block was unconfirmed",
       old_confirmed = self.confirmed, new_confirmed = confirmed
   if confirmed != self.confirmed:
     trace "Updating confirmed block",
@@ -228,11 +228,12 @@ proc reconfirm_fcr(
 
   # Restart confirmation chain if necessary
   fcr.current_slot_head = ? fcr.find_head(current_slot, self.checkpoints)
-  if not fcr.is_proto_array_consistent:
+  fcr.check_proto_array_consistency.isOkOr:
+    warn "Proto array inconsistent - report bug", reason = error
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
-  else:
-    if fcr.should_restart_confirmation_chain(confirmed, current_slot):
-      confirmed = fcr.to_block_id(current_epoch_justified)
+    return ok()
+  if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+    confirmed = fcr.to_block_id(current_epoch_justified)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/fork-choice.md#on_tick_per_slot
@@ -500,19 +501,22 @@ proc will_select_head*(
     fcr.current_slot_head = blckRef.root
   if fcr.should_revert_confirmed_on_new_head(blckRef, confirmed, current_slot):
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
-  if not fcr.is_proto_array_consistent:
+  fcr.check_proto_array_consistency.isOkOr:
+    warn "Proto array inconsistent - report bug", reason = error
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
-  else:
-    if fcr.should_restart_confirmation_chain(confirmed, current_slot):
-      confirmed = fcr.to_block_id(current_epoch_justified)
-    # Attempt to further advance the latest confirmed block.
-    if confirmed.slot.epoch + 1 >= current_slot.epoch:
-      template justified: Checkpoint = self.checkpoints.justified.checkpoint
-      let unrealized = fcr.proto_array.unrealized_justified(justified)
-      confirmed = fcr.find_latest_confirmed_descendant(
-          dag, blckRef, unrealized, confirmed, current_slot).valueOr:
-        error "EpochRef / ShufflingRef unavailable", blckRef, current_slot
-        fcr.to_block_id(self.checkpoints.finalized)
+    fcr.update_confirmed(confirmed)
+    return ok()
+  if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+    confirmed = fcr.to_block_id(current_epoch_justified)
+  # Attempt to further advance the latest confirmed block.
+  if confirmed.slot.epoch + 1 >= current_slot.epoch:
+    template justified: Checkpoint = self.checkpoints.justified.checkpoint
+    let unrealized = fcr.proto_array.unrealized_justified(justified)
+    confirmed = fcr.find_latest_confirmed_descendant(
+        dag, blckRef, unrealized, confirmed, current_slot).valueOr:
+      warn "Failed to advance 'safe' block - report bug",
+        blckRef, unrealized, confirmed, current_slot, reason = error
+      fcr.to_block_id(self.checkpoints.finalized)
   fcr.update_confirmed(confirmed)
   ok()
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -218,7 +218,7 @@ proc reconfirm_fcr(
   # Reconfirm with previous balance source after attestations
   # from past slots have been applied
   self.process_attestation_queue(current_slot)
-  if fcr.should_revert_confirmed_on_new_epoch(dag, confirmed, current_slot):
+  if ? fcr.should_revert_confirmed_on_new_epoch(dag, confirmed, current_slot):
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
 
   # Update observed justified checkpoints at the start of an epoch
@@ -228,11 +228,7 @@ proc reconfirm_fcr(
 
   # Restart confirmation chain if necessary
   fcr.current_slot_head = ? fcr.find_head(current_slot, self.checkpoints)
-  fcr.check_proto_array_consistency.isOkOr:
-    warn "Proto array inconsistent - report bug", reason = error
-    confirmed = fcr.to_block_id(self.checkpoints.finalized)
-    return ok()
-  if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+  if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
     confirmed = fcr.to_block_id(current_epoch_justified)
   ok()
 
@@ -275,10 +271,11 @@ proc on_tick(
       ? self.update_checkpoints(dag, realized, current_slot)
 
       var confirmed = self.backend.confirmed
-      result = self.reconfirm_fcr(dag, confirmed, current_slot)
+      self.reconfirm_fcr(dag, confirmed, current_slot).isOkOr:
+        warn "Failed to reconfirm 'safe' block - report bug",
+          current_slot, reason = error
+        confirmed = self.backend.to_block_id(self.checkpoints.finalized)
       self.backend.update_confirmed(confirmed)
-      if result.isErr:
-        return result
 
     else:
       discard
@@ -484,40 +481,45 @@ proc get_head*(
     self.checkpoints.time.slotOrZero(dag.timeParams),
     self.checkpoints)
 
-proc will_select_head*(
-    self: var ForkChoice, dag: ChainDAGRef,
-    blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
-  ? self.update_time(dag, wallTime)
-
-  var confirmed = self.backend.confirmed
+proc advance_fcr(
+    self: var ForkChoice, dag: ChainDAGRef, blckRef: BlockRef,
+    confirmed: var BlockId, current_slot: Slot): FcResult[void] =
   template fcr: ForkChoiceBackend = self.backend
   template current_epoch_justified: Checkpoint =
     fcr.current_epoch_observed_justified.checkpoint
+
   let
-    current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
     consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
     threshold = current_slot.attestation_deadline(dag.timeParams, consensusFork)
   if self.checkpoints.time < threshold:
     fcr.current_slot_head = blckRef.root
-  if fcr.should_revert_confirmed_on_new_head(blckRef, confirmed, current_slot):
+
+  if ? fcr.should_revert_confirmed_on_new_head(blckRef, confirmed, current_slot):
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
-  fcr.check_proto_array_consistency.isOkOr:
-    warn "Proto array inconsistent - report bug", reason = error
-    confirmed = fcr.to_block_id(self.checkpoints.finalized)
-    fcr.update_confirmed(confirmed)
-    return ok()
-  if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+
+  if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
     confirmed = fcr.to_block_id(current_epoch_justified)
+
   # Attempt to further advance the latest confirmed block.
   if confirmed.slot.epoch + 1 >= current_slot.epoch:
     template justified: Checkpoint = self.checkpoints.justified.checkpoint
     let unrealized = fcr.proto_array.unrealized_justified(justified)
-    confirmed = fcr.find_latest_confirmed_descendant(
-        dag, blckRef, unrealized, confirmed, current_slot).valueOr:
-      warn "Failed to advance 'safe' block - report bug",
-        blckRef, unrealized, confirmed, current_slot, reason = error
-      fcr.to_block_id(self.checkpoints.finalized)
-  fcr.update_confirmed(confirmed)
+    confirmed = ? fcr.find_latest_confirmed_descendant(
+      dag, blckRef, unrealized, confirmed, current_slot)
+  ok()
+
+proc will_select_head*(
+    self: var ForkChoice, dag: ChainDAGRef,
+    blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
+  ? self.update_time(dag, wallTime)
+  let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+
+  var confirmed = self.backend.confirmed
+  self.advance_fcr(dag, blckRef, confirmed, current_slot).isOkOr:
+    warn "Failed to advance 'safe' block - report bug",
+      blckRef, current_slot, reason = error
+    confirmed = self.backend.to_block_id(self.checkpoints.finalized)
+  self.backend.update_confirmed(confirmed)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -182,6 +182,7 @@ proc update_confirmed(
   template prev: BlockId = self.confirmed
   template curr: BlockId = confirmed
   if reason != "" and (prev.slot > curr.slot or not dag.isCanonical(prev)):
+    incSafeReorgs()
     if diag.chain_len > 0:
       notice "Previous 'safe' block no longer safe",
         previousSafe = prev, currentSafe = curr, reason, diag

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -179,8 +179,17 @@ proc update_checkpoints(
 proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
   if confirmed.slot < self.confirmed.slot:
     warn "Confirmed block was unconfirmed",
-      old_confirmed = shortLog(self.confirmed), new_confirmed = confirmed
+      old_confirmed = self.confirmed, new_confirmed = confirmed
+  if confirmed != self.confirmed:
+    trace "Updating confirmed block",
+      old_confirmed = self.confirmed, new_confirmed = confirmed
   self.confirmed = confirmed
+
+proc to_block_id(self: ForkChoiceBackend, checkpoint: Checkpoint): BlockId =
+  result.slot = self.proto_array.slot(checkpoint.root).valueOr:
+    warn "Checkpoint not in proto array", checkpoint
+    checkpoint.epoch.start_slot
+  result.root = checkpoint.root
 
 proc update_confirmed(self: var ForkChoiceBackend, confirmed: Checkpoint) =
   self.update_confirmed BlockId(
@@ -201,10 +210,34 @@ proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
       warn "Skipping unrealized justified checkpoint update - no EpochRef",
         unrealized, blck, error
       return
-  let old_source = move(self.backend.current_epoch_observed_justified)
+    old_source = move(self.backend.current_epoch_observed_justified)
   self.backend.current_epoch_observed_justified.info =
     epochRef.to_balance_checkpoint(blck)
   self.backend.current_epoch_observed_justified.assign_shufflings(old_source)
+
+proc reconfirm_fcr(
+    self: var ForkChoice, dag: ChainDAGRef,
+    confirmed: var BlockId, current_slot: Slot): FcResult[void] =
+  template fcr: ForkChoiceBackend = self.backend
+
+  # Reconfirm with previous balance source after attestations
+  # from past slots have been applied
+  self.process_attestation_queue(current_slot)
+  if fcr.should_revert_confirmed_on_new_epoch(dag, confirmed, current_slot):
+    confirmed = fcr.to_block_id(self.checkpoints.finalized)
+
+  # Update observed justified checkpoints at the start of an epoch
+  self.update_unrealized_justified(dag)
+  template current_epoch_justified: Checkpoint =
+    fcr.current_epoch_observed_justified.checkpoint
+
+  # Restart confirmation chain if necessary
+  fcr.current_slot_head = ? fcr.find_head(current_slot, self.checkpoints)
+  if not fcr.is_proto_array_consistent:
+    confirmed = fcr.to_block_id(self.checkpoints.finalized)
+  else:
+    if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+      confirmed = fcr.to_block_id(current_epoch_justified)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.1/specs/phase0/fork-choice.md#on_tick_per_slot
 proc on_tick(
@@ -244,24 +277,11 @@ proc on_tick(
           finalized: self.checkpoints.finalized))
       ? self.update_checkpoints(dag, realized, current_slot)
 
-      # Reconfirm with previous balance source after attestations
-      # from past slots have been applied
-      self.process_attestation_queue(current_slot)
-      if self.backend.should_revert_confirmed_on_new_epoch(dag, current_slot):
-        self.backend.update_confirmed(self.checkpoints.finalized)
-
-      # Update observed justified checkpoints at the start of an epoch
-      self.update_unrealized_justified(dag)
-
-      # Restart confirmation chain if necessary
-      self.backend.current_slot_head =
-        ? self.backend.find_head(current_slot, self.checkpoints)
-      if not self.backend.is_proto_array_consistent:
-        self.backend.update_confirmed(self.checkpoints.finalized)
-      else:
-        if self.backend.should_restart_confirmation_chain(current_slot):
-          self.backend.update_confirmed(
-            self.backend.current_epoch_observed_justified.checkpoint)
+      var confirmed = self.backend.confirmed
+      result = self.reconfirm_fcr(dag, confirmed, current_slot)
+      self.backend.update_confirmed(confirmed)
+      if result.isErr:
+        return result
 
     else:
       discard
@@ -472,32 +492,32 @@ proc will_select_head*(
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
 
+  var confirmed = self.backend.confirmed
+  template fcr: ForkChoiceBackend = self.backend
+  template current_epoch_justified: Checkpoint =
+    fcr.current_epoch_observed_justified.checkpoint
   let
     current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
     consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
     threshold = current_slot.attestation_deadline(dag.timeParams, consensusFork)
   if self.checkpoints.time < threshold:
-    self.backend.current_slot_head = blckRef.root
-  if self.backend.should_revert_confirmed_on_new_head(blckRef, current_slot):
-    self.backend.update_confirmed(self.checkpoints.finalized)
-  if not self.backend.is_proto_array_consistent:
-    self.backend.update_confirmed(self.checkpoints.finalized)
+    fcr.current_slot_head = blckRef.root
+  if fcr.should_revert_confirmed_on_new_head(blckRef, confirmed, current_slot):
+    confirmed = fcr.to_block_id(self.checkpoints.finalized)
+  if not fcr.is_proto_array_consistent:
+    confirmed = fcr.to_block_id(self.checkpoints.finalized)
   else:
-    if self.backend.should_restart_confirmation_chain(current_slot):
-      self.backend.update_confirmed(
-        self.backend.current_epoch_observed_justified.checkpoint)
+    if fcr.should_restart_confirmation_chain(confirmed, current_slot):
+      confirmed = fcr.to_block_id(current_epoch_justified)
     # Attempt to further advance the latest confirmed block.
-    if self.backend.confirmed.slot.epoch + 1 >= current_slot.epoch:
+    if fcr.confirmed.slot.epoch + 1 >= current_slot.epoch:
       template justified: Checkpoint = self.checkpoints.justified.checkpoint
-      let
-        unrealized = self.backend.proto_array.unrealized_justified(justified)
-        confirmed = self.backend.find_latest_confirmed_descendant(
-          dag, blckRef, unrealized, current_slot)
-      if confirmed.isErr:
+      let unrealized = fcr.proto_array.unrealized_justified(justified)
+      confirmed = fcr.find_latest_confirmed_descendant(
+          dag, blckRef, unrealized, confirmed, current_slot).valueOr:
         error "EpochRef / ShufflingRef unavailable", blckRef, current_slot
-        self.backend.update_confirmed(self.checkpoints.finalized)
-      else:
-        self.backend.update_confirmed(confirmed.unsafeGet)
+        fcr.to_block_id(self.checkpoints.finalized)
+  fcr.update_confirmed(confirmed)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -178,10 +178,10 @@ proc update_checkpoints(
 
 proc update_confirmed(self: var ForkChoiceBackend, confirmed: BlockId) =
   if confirmed.slot < self.confirmed.slot:
-    notice "Confirmed block was unconfirmed",
+    notice "'Safe' block was unconfirmed",
       old_confirmed = self.confirmed, new_confirmed = confirmed
   if confirmed != self.confirmed:
-    trace "Updating confirmed block",
+    trace "Updating 'safe' block",
       old_confirmed = self.confirmed, new_confirmed = confirmed
   self.confirmed = confirmed
 
@@ -488,13 +488,8 @@ proc advance_fcr(
   template current_epoch_justified: Checkpoint =
     fcr.current_epoch_observed_justified.checkpoint
 
-  let
-    consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
-    threshold = current_slot.attestation_deadline(dag.timeParams, consensusFork)
-  if self.checkpoints.time < threshold:
-    fcr.current_slot_head = blckRef.root
-
-  if ? fcr.should_revert_confirmed_on_new_head(blckRef, confirmed, current_slot):
+  if ? fcr.should_revert_confirmed_on_new_head(
+      blckRef, confirmed, current_slot):
     confirmed = fcr.to_block_id(self.checkpoints.finalized)
 
   if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
@@ -512,7 +507,12 @@ proc will_select_head*(
     self: var ForkChoice, dag: ChainDAGRef,
     blckRef: BlockRef, wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag, wallTime)
-  let current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+  let
+    current_slot = self.checkpoints.time.slotOrZero(dag.timeParams)
+    consensusFork = dag.cfg.consensusForkAtEpoch(current_slot.epoch)
+    threshold = current_slot.attestation_deadline(dag.timeParams, consensusFork)
+  if self.checkpoints.time < threshold:
+    self.backend.current_slot_head = blckRef.root
 
   var confirmed = self.backend.confirmed
   self.advance_fcr(dag, blckRef, confirmed, current_slot).isOkOr:
@@ -529,7 +529,7 @@ func get_safe_beacon_block_id*(self: ForkChoice): lent BlockId =
 func get_safe_beacon_block_root*(self: ForkChoice): lent Eth2Digest =
   self.get_safe_beacon_block_id.root
 
-func prune(
+proc prune(
     self: var ForkChoiceBackend,
     checkpoints: FinalityCheckpoints): FcResult[void] =
   ## Prune blocks preceding the finalized root as they are now unneeded.
@@ -538,9 +538,11 @@ func prune(
     self.previous_slot_head = checkpoints.finalized.root
   if self.current_slot_head notin self.proto_array:
     self.current_slot_head = checkpoints.finalized.root
+  if self.confirmed.root notin self.proto_array:
+    self.update_confirmed(self.to_block_id(checkpoints.finalized))
   ok()
 
-func prune*(self: var ForkChoice): FcResult[void] =
+proc prune*(self: var ForkChoice): FcResult[void] =
   self.backend.prune(
     FinalityCheckpoints(
       justified: self.checkpoints.justified.checkpoint,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -486,11 +486,18 @@ proc will_select_head*(
     if self.backend.should_restart_confirmation_chain(current_slot):
       self.backend.update_confirmed(
         self.backend.current_epoch_observed_justified.checkpoint)
-
-  # TODO: Replace placeholder
-  self.backend.update_confirmed BlockId(
-    slot: self.checkpoints.justified.checkpoint.epoch.start_slot,
-    root: self.checkpoints.justified.checkpoint.root)
+    # Attempt to further advance the latest confirmed block.
+    if self.backend.confirmed.slot.epoch + 1 >= current_slot.epoch:
+      template justified: Checkpoint = self.checkpoints.justified.checkpoint
+      let
+        unrealized = self.backend.proto_array.unrealized_justified(justified)
+        confirmed = self.backend.find_latest_confirmed_descendant(
+          dag, blckRef, unrealized, current_slot)
+      if confirmed.isErr:
+        error "EpochRef / ShufflingRef unavailable", blckRef, current_slot
+        self.backend.update_confirmed(self.checkpoints.finalized)
+      else:
+        self.backend.update_confirmed(confirmed.unsafeGet)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -38,6 +38,9 @@ type
     ## Fork Choice Error Kinds
     fcFinalizedNodeUnknown
     fcJustifiedNodeUnknown
+    fcConfirmedNodeUnknown
+    fcPreviousHeadUnknown
+    fcCurrentHeadUnknown
     fcInvalidNodeIndex
     fcInvalidJustifiedIndex
     fcInvalidBestDescendant
@@ -50,7 +53,8 @@ type
     fcInconsistentTick
     fcUnknownParent
     fcPruningFromOutdatedFinalizedRoot
-    fcInvalidEpochRef
+    fcUnknownBlockIdAtSlot
+    fcUnknownShufflingRef
 
   Index* = int
   Delta* = int64
@@ -59,9 +63,12 @@ type
   ForkChoiceError* = object
     case kind*: fcKind
     of fcFinalizedNodeUnknown,
-       fcJustifiedNodeUnknown:
+       fcJustifiedNodeUnknown,
+       fcConfirmedNodeUnknown,
+       fcPreviousHeadUnknown,
+       fcCurrentHeadUnknown:
          blockRoot*: Eth2Digest
-    of fcInconsistentTick, fcInvalidEpochRef:
+    of fcInconsistentTick:
       discard
     of fcInvalidNodeIndex,
        fcInvalidJustifiedIndex,
@@ -84,6 +91,10 @@ type
       parentRoot*: Eth2Digest
     of fcPruningFromOutdatedFinalizedRoot:
       finalizedRoot*: Eth2Digest
+    of fcUnknownBlockIdAtSlot,
+       fcUnknownShufflingRef:
+         shufflingRoot*: Eth2Digest
+         shufflingEpoch*: Epoch
 
   FcResult*[T] = Result[T, ForkChoiceError]
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -87,9 +87,19 @@ func contains*(self: ProtoArray, root: Eth2Digest): bool =
 func slot*(self: ProtoArray, root: Eth2Digest): Opt[Slot] =
   ok (? self.nodes[self.find(root)]).bid.slot
 
+func voting_source*(self: ProtoArray, root: Eth2Digest): Opt[Checkpoint] =
+  ok (? self.nodes[self.find(root)]).checkpoints.justified
+
+func unrealized_justified*(
+    self: ProtoArray, root: Eth2Digest): Opt[Checkpoint] =
+  let
+    idx = self.find(root)
+    checkpoints = (? self.nodes[idx]).checkpoints
+  ok self.unrealized.getOrDefault(idx, checkpoints).justified
+
 type NodeCheckpoints* = object
   voting_source*: Checkpoint
-  unrealized*: Checkpoint
+  unrealized_justified*: Checkpoint
 
 func checkpoints*(self: ProtoArray, root: Eth2Digest): Opt[NodeCheckpoints] =
   let
@@ -97,7 +107,8 @@ func checkpoints*(self: ProtoArray, root: Eth2Digest): Opt[NodeCheckpoints] =
     checkpoints = (? self.nodes[idx]).checkpoints
   result.ok NodeCheckpoints(
     voting_source: checkpoints.justified,
-    unrealized: self.unrealized.getOrDefault(idx, checkpoints).justified)
+    unrealized_justified:
+      self.unrealized.getOrDefault(idx, checkpoints).justified)
 
 # Forward declarations
 # ----------------------------------------------------------------------

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2662,24 +2662,6 @@ proc run*(node: BeaconNode, stopper: StopFuture) {.raises: [CatchableError].} =
   # time to say goodbye
   node.stop()
 
-func formatGwei(amount: Gwei): string =
-  # TODO This is implemented in a quite a silly way.
-  # Better routines for formatting decimal numbers
-  # should exists somewhere else.
-  let
-    eth = distinctBase(amount) div 1000000000
-    remainder = distinctBase(amount) mod 1000000000
-
-  result = $eth
-  if remainder != 0:
-    result.add '.'
-    let remainderStr = $remainder
-    for i in remainderStr.len ..< 9:
-      result.add '0'
-    result.add remainderStr
-    while result[^1] == '0':
-      result.setLen(result.len - 1)
-
 when not defined(windows):
   proc initStatusBar(node: BeaconNode) {.raises: [ValueError].} =
     if not isatty(stdout): return

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -29,11 +29,28 @@ export
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/phase0/weak-subjectivity.md#constants
 const ETH_TO_GWEI = 1_000_000_000.Gwei
 
+func toGwei*(eth: Ether): Gwei =
+  distinctBase(eth) * ETH_TO_GWEI
+
 func toEther*(gwei: Gwei): Ether =
   (gwei div ETH_TO_GWEI).Ether
 
-func toGwei*(eth: Ether): Gwei =
-  distinctBase(eth) * ETH_TO_GWEI
+func toEtherWithRemainder*(gwei: Gwei): (Ether, Gwei) =
+  (gwei.toEther, gwei mod ETH_TO_GWEI)
+
+func formatGwei*(amount: Gwei): string =
+  ## Display Gwei as ETH with up through 9 decimal digits,
+  ## without trailing zeros.
+  let (eth, remainder) = amount.toEtherWithRemainder
+  result = $eth
+  if remainder != 0.Gwei:
+    result.add '.'
+    let remainderStr = $remainder
+    for i in remainderStr.len ..< 9:
+      result.add '0'
+    result.add remainderStr
+    while result[^1] == '0':
+      result.setLen(result.len - 1)
 
 type
   FinalityCheckpoints* = object

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -403,7 +403,7 @@ cli do(
     dag.updateHead(added[], quarantine[], [])
     if dag.needStateCachesAndForkChoicePruning():
       dag.pruneStateCachesDAG()
-      attPool.prune()
+      attPool.prune(dag)
 
   for i in 0 ..< slots:
     let

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -220,7 +220,7 @@ proc updateHead(
   dag.updateHead(newHead, quarantine, [])
   if dag.needStateCachesAndForkChoicePruning():
     dag.pruneStateCachesDAG()
-    let pruneRes = fkChoice[].prune()
+    let pruneRes = fkChoice[].prune(dag)
     doAssert pruneRes.isOk()
 
 proc stepOnBlock(

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -59,7 +59,7 @@ func loadSig(a: electra.Attestation): CookedSig =
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
     dag.pruneStateCachesDAG()
-    # pool[].prune() # We test logic without attestation pool / fork choice pruning
+    # pool[].prune(dag) # We test without attestation pool / fork choice pruning
 
 # -1 here is the notional index in committee for which the attestation pool
 # only requires external input regarding SingleAttestation messages. If, or
@@ -788,7 +788,7 @@ suite "Attestation pool electra processing" & preset():
 
     doAssert: dag.finalizedHead.slot != 0
 
-    pool[].prune()
+    pool[].prune(dag)
     doAssert: b10.root notin pool.forkChoice.backend
 
     # Add back the old block to ensure we have a duplicate error

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -847,7 +847,7 @@ suite "Attestation pool electra processing" & preset():
 
     let
       root = dag.head.root
-      unrealized = proto_array.checkpoints(root).get().unrealized
+      unrealized = proto_array.checkpoints(root).get().unrealized_justified
     check unrealized.epoch >
       proto_array.checkpoints(root).get().voting_source.epoch
 
@@ -861,7 +861,7 @@ suite "Attestation pool electra processing" & preset():
       dag, pool, verifier, quarantine, cache,
       validator_changes = validator_changes)
 
-    check proto_array.checkpoints(root).get().unrealized == unrealized
+    check proto_array.checkpoints(root).get().unrealized_justified == unrealized
 
   test "Working with electra aggregates" & preset():
     let

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -88,7 +88,7 @@ suite "Block pool processing" & preset():
       b1Fork = addTestBlock(tmpState[], cache).phase0Data
       b1ForkAdd = dag.addHeadBlock(verifier, b1Fork, nilPhase0Callback)
       unknown = BlockId(slot: 1.Slot, root: Eth2Digest.fromHex("0x01"))
-    template do_checks: untyped =
+    template do_checks(didPruneFork: bool): untyped =
       check:
         # Same block
         dag.isAncestorOf(genesisBid, genesisBid)
@@ -104,7 +104,7 @@ suite "Block pool processing" & preset():
         not dag.isAncestorOf(b1Add[].bid, genesisBid)
 
         # Fork
-        dag.isAncestorOf(genesisBid, b1ForkAdd[].bid)
+        dag.isAncestorOf(genesisBid, b1ForkAdd[].bid) == not didPruneFork
         not dag.isAncestorOf(b1Add[].bid, b1ForkAdd[].bid)
         not dag.isAncestorOf(b1ForkAdd[].bid, b1Add[].bid)
         not dag.isAncestorOf(b1ForkAdd[].bid, b2Add[].bid)
@@ -114,7 +114,7 @@ suite "Block pool processing" & preset():
         not dag.isAncestorOf(unknown, b2Add[].bid)
         not dag.isAncestorOf(b2Add[].bid, unknown)
         dag.isAncestorOf(unknown, unknown)
-    do_checks()
+    do_checks(didPruneFork = false)
 
     # Build enough blocks to finalize, then test with pruned blocks
     let
@@ -142,7 +142,7 @@ suite "Block pool processing" & preset():
 
       # Pruned orphaned fork is not ancestor of head
       not dag.isAncestorOf(b1ForkBid, dag.head.bid)
-    do_checks()
+    do_checks(didPruneFork = true)
 
   test "Simple block add&get" & preset():
     let

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -79,6 +79,71 @@ suite "Block pool processing" & preset():
         dag.finalizedHead.blck
       dag.getBlockRef(dag.head.root).get() == dag.head
 
+  test "isAncestorOf":
+    var tmpState = newClone(dag.headState)
+    let
+      genesisBid = dag.head.bid
+      b1Add = dag.addHeadBlock(verifier, b1, nilPhase0Callback)
+      b2Add = dag.addHeadBlock(verifier, b2, nilPhase0Callback)
+      b1Fork = addTestBlock(tmpState[], cache).phase0Data
+      b1ForkAdd = dag.addHeadBlock(verifier, b1Fork, nilPhase0Callback)
+      unknown = BlockId(slot: 1.Slot, root: Eth2Digest.fromHex("0x01"))
+    template do_checks: untyped =
+      check:
+        # Same block
+        dag.isAncestorOf(genesisBid, genesisBid)
+        dag.isAncestorOf(b1Add[].bid, b1Add[].bid)
+        dag.isAncestorOf(b2Add[].bid, b2Add[].bid)
+
+        # Linear chain
+        dag.isAncestorOf(genesisBid, b1Add[].bid)
+        dag.isAncestorOf(genesisBid, b2Add[].bid)
+        dag.isAncestorOf(b1Add[].bid, b2Add[].bid)
+        not dag.isAncestorOf(b2Add[].bid, genesisBid)
+        not dag.isAncestorOf(b2Add[].bid, b1Add[].bid)
+        not dag.isAncestorOf(b1Add[].bid, genesisBid)
+
+        # Fork
+        dag.isAncestorOf(genesisBid, b1ForkAdd[].bid)
+        not dag.isAncestorOf(b1Add[].bid, b1ForkAdd[].bid)
+        not dag.isAncestorOf(b1ForkAdd[].bid, b1Add[].bid)
+        not dag.isAncestorOf(b1ForkAdd[].bid, b2Add[].bid)
+        not dag.isAncestorOf(b2Add[].bid, b1ForkAdd[].bid)
+
+        # Unknown root
+        not dag.isAncestorOf(unknown, b2Add[].bid)
+        not dag.isAncestorOf(b2Add[].bid, unknown)
+        dag.isAncestorOf(unknown, unknown)
+    do_checks()
+
+    # Build enough blocks to finalize, then test with pruned blocks
+    let
+      b1Bid = b1Add[].bid
+      b1ForkBid = b1ForkAdd[].bid
+    dag.updateHead(b2Add[], quarantine, [])
+    tmpState = assignClone(dag.headState)
+    for i in 0 ..< (SLOTS_PER_EPOCH * 4):
+      let
+        blck = addTestBlock(
+          tmpState[], cache,
+          attestations = makeFullAttestations(
+            tmpState[], dag.head.root, tmpState[].slot, cache, {})).phase0Data
+        added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
+      check: added.isOk()
+      dag.updateHead(added[], quarantine, [])
+      dag.pruneAtFinalization()
+    check:
+      dag.finalizedHead.slot > b1Bid.slot
+      dag.getBlockRef(b1Bid.root).isErr  # pruned
+
+      # Pruned canonical block is ancestor of head
+      dag.isAncestorOf(b1Bid, dag.head.bid)
+      not dag.isAncestorOf(dag.head.bid, b1Bid)
+
+      # Pruned orphaned fork is not ancestor of head
+      not dag.isAncestorOf(b1ForkBid, dag.head.bid)
+    do_checks()
+
   test "Simple block add&get" & preset():
     let
       b1Add = dag.addHeadBlock(verifier, b1, nilPhase0Callback)

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -33,7 +33,7 @@ from ./testbcutil import addHeadBlock
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
     dag.pruneStateCachesDAG()
-    # pool[].prune() # We test logic without att_1_0 pool / fork choice pruning
+    # pool[].prune(dag) # We test without att_1_0 pool / fork choice pruning
 
 suite "Gossip validation " & preset():
   setup:


### PR DESCRIPTION
Implement the main FCR spec function for advancing the EL safe block:

- https://github.com/ethereum/consensus-specs/pull/4747

Note this replaces previous behaviour where the justified checkpoint was tracked as the "safe" block. That was never safe, as justified does not come with reorg guarantees, but it's what the spec mandated.