### PR TITLE
Remove weight of invalid blocks from ancestors

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -21,6 +21,7 @@ AllTests-mainnet
 + Everyone voting for something different [Preset: mainnet]                                  OK
 + Fork choice returns block with attestation                                                 OK
 + Fork choice returns latest block with no attestations                                      OK
++ Invalid block weight does not propagate to ancestors                                       OK
 + Simple add and get with electra nonzero committee [Preset: mainnet]                        OK
 + Trying to add a block twice tags the second as an error                                    OK
 + Trying to add a duplicate block from an old pruned epoch is tagged as an error             OK

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -219,31 +219,39 @@ func applyScoreChanges*(
     if node.bid.root.isZero:
       continue
 
-    var nodeDelta = deltas[nodePhysicalIdx]
+    var nodeDelta =
+      if node.invalid:
+        # If the node is invalid, remove its weight from ancestors.
+        # Note this makes future deltas for this node inconsistent,
+        # but that is not relevant as node.invalid can never be reset.
+        -node.weight
+      else:
+        deltas[nodePhysicalIdx]
 
-    # If we find the node for which the proposer boost was previously applied,
-    # decrease the delta by the previous score amount.
-    if  (not self.previousProposerBoostRoot.isZero) and
-        self.previousProposerBoostRoot == node.bid.root:
-          if  nodeDelta < 0 and
-              nodeDelta - low(Delta) < self.previousProposerBoostScore.int64:
-            return err ForkChoiceError(
+    if not node.invalid:
+      # If we find the node for which the proposer boost was previously applied,
+      # decrease the delta by the previous score amount.
+      if  (not self.previousProposerBoostRoot.isZero) and
+          self.previousProposerBoostRoot == node.bid.root:
+            if  nodeDelta < 0 and
+                nodeDelta - low(Delta) < self.previousProposerBoostScore.int64:
+              return err ForkChoiceError(
                 kind: fcDeltaUnderflow,
                 index: nodePhysicalIdx)
-          nodeDelta -= self.previousProposerBoostScore.int64
+            nodeDelta -= self.previousProposerBoostScore.int64
 
-    # If we find the node matching the current proposer boost root, increase
-    # the delta by the new score amount.
-    #
-    # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/phase0/fork-choice.md#get_weight
-    if (not proposerBoostRoot.isZero) and proposerBoostRoot == node.bid.root:
-      proposerBoostScore = compute_proposer_score(justifiedTotalActiveBalance)
-      if  nodeDelta >= 0 and
-          high(Delta) - nodeDelta < proposerBoostScore.int64:
-        return err ForkChoiceError(
+      # If we find the node matching the current proposer boost root, increase
+      # the delta by the new score amount.
+      #
+      # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.3/specs/phase0/fork-choice.md#get_weight
+      if (not proposerBoostRoot.isZero) and proposerBoostRoot == node.bid.root:
+        proposerBoostScore = compute_proposer_score(justifiedTotalActiveBalance)
+        if  nodeDelta >= 0 and
+            high(Delta) - nodeDelta < proposerBoostScore.int64:
+          return err ForkChoiceError(
             kind: fcDeltaOverflow,
             index: nodePhysicalIdx)
-      nodeDelta += proposerBoostScore.int64
+        nodeDelta += proposerBoostScore.int64
 
     # Apply the delta to the node
     # We fail fast if underflow, which shouldn't happen.
@@ -299,8 +307,9 @@ func applyScoreChanges*(
       continue
 
     if node.parent.isSome():
-      let parentLogicalIdx = node.parent.unsafeGet()
-      let parentPhysicalIdx = parentLogicalIdx - self.nodes.offset
+      let
+        parentLogicalIdx = node.parent.unsafeGet()
+        parentPhysicalIdx = parentLogicalIdx - self.nodes.offset
       if parentPhysicalIdx < 0:
         # Orphan
         continue

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -24,6 +24,7 @@ from std/sequtils import mapIt, toSeq
 from stew/byteutils import `<`
 from ../beacon_chain/consensus_object_pools/block_quarantine import
   Quarantine, init
+from ../beacon_chain/fork_choice/fork_choice import mark_root_invalid
 from ../beacon_chain/fork_choice/proto_array import checkpoints
 from ../beacon_chain/spec/beaconstate import
   attester_dependent_root, check_attestation, get_attesting_indices,
@@ -110,6 +111,22 @@ suite "Attestation pool electra processing" & preset():
 
     template startTime(attestation: electra.Attestation): BeaconTime =
       attestation.data.slot.start_beacon_time(cfg.timeParams)
+
+    template addHeadBlockToForkChoice(
+        blck: electra.SignedBeaconBlock,
+        wallTime: BeaconTime): Result[BlockRef, VerifierError] =
+      dag.addHeadBlock(verifier, blck) do (
+          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
+          state: electra.BeaconState,
+          epochRef: EpochRef, unrealized: FinalityCheckpoints):
+        # Callback add to fork choice if valid
+        pool[].addForkChoice(
+          epochRef, blckRef, unrealized, signedBlock.message, wallTime)
+
+    template addHeadBlockToForkChoice(
+        blck: electra.SignedBeaconBlock): Result[BlockRef, VerifierError] =
+      addHeadBlockToForkChoice(
+        blck, blck.message.slot.start_beacon_time(cfg.timeParams))
 
   test "Attestation from different branch" & preset():
     # Create two alternate histories with different shufflings
@@ -548,14 +565,7 @@ suite "Attestation pool electra processing" & preset():
     var cache = StateCache()
     let
       b1 = addTestBlock(state[], cache).electraData
-      b1Add = dag.addHeadBlock(verifier, b1) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+      b1Add = addHeadBlockToForkChoice(b1)
 
     let head = pool[].selectOptimisticHead(
       b1Add[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -564,14 +574,7 @@ suite "Attestation pool electra processing" & preset():
 
     let
       b2 = addTestBlock(state[], cache).electraData
-      b2Add = dag.addHeadBlock(verifier, b2) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+      b2Add = addHeadBlockToForkChoice(b2)
 
     let head2 = pool[].selectOptimisticHead(
       b2Add[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -583,14 +586,7 @@ suite "Attestation pool electra processing" & preset():
     var cache = StateCache()
     let
       b10 = makeTestBlock(state[], cache).electraData
-      b10Add = dag.addHeadBlock(verifier, b10) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+      b10Add = addHeadBlockToForkChoice(b10)
 
     let head = pool[].selectOptimisticHead(
       b10Add[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -602,17 +598,12 @@ suite "Attestation pool electra processing" & preset():
     # would otherwise cause it to be selected as head
     let
       b11 = makeTestBlock(state[], cache,
-        graffiti = GraffitiBytes [1'u8, 0, 0, 0 ,0 ,0 ,0 ,0 ,0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-      ).electraData
-      b11Add = dag.addHeadBlock(verifier, b11) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams) +
-          cfg.timeParams.SLOT_DURATION)
+        graffiti = GraffitiBytes [
+          1'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).electraData
+      b11Add = addHeadBlockToForkChoice(b11,
+        b11.message.slot.start_beacon_time(cfg.timeParams) +
+        cfg.timeParams.SLOT_DURATION)
 
       bc1 = get_beacon_committee(
         state[], state[].slot - 1, 1.CommitteeIndex,
@@ -656,18 +647,65 @@ suite "Attestation pool electra processing" & preset():
       # Two votes for b11
       head4 == b11Add[]
 
+  test "Invalid block weight does not propagate to ancestors":
+    var cache = StateCache()
+    let
+      b1 = addTestBlock(state[], cache).electraData
+      b1Add = addHeadBlockToForkChoice(b1)
+
+      forkState = assignClone(state[])
+
+      b2 = addTestBlock(state[], cache).electraData
+      b2Add = addHeadBlockToForkChoice(b2)
+
+      bInvalid = addTestBlock(state[], cache).electraData
+      bInvalidAdd = addHeadBlockToForkChoice(bInvalid)
+
+      b3 = makeTestBlock(forkState[], cache,
+        graffiti = GraffitiBytes [
+          1'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]).electraData
+      b3Add = addHeadBlockToForkChoice(b3,
+        b3.message.slot.start_beacon_time(cfg.timeParams) +
+        cfg.timeParams.SLOT_DURATION)
+
+    # Attest to (eventually) invalid block
+    block:
+      let bc = get_beacon_committee(
+        state[], state[].slot - 1, 0.CommitteeIndex, cache)
+      for i in 0 ..< min(4, bc.len):
+        let att = makeElectraAttestation(state[], bInvalid.root, bc[i], cache)
+        pool[].addAttestation(
+          att, @[bc[i]], att.aggregation_bits.len,
+          att.loadSig, att.startTime)
+
+    # Attest to canonical block with 1 validator
+    block:
+      let
+        bc = get_beacon_committee(
+          forkState[], forkState[].slot, 1.CommitteeIndex, cache)
+        att = makeElectraAttestation(forkState[], b3.root, bc[0], cache)
+      pool[].addAttestation(
+        att, @[bc[0]], att.aggregation_bits.len,
+        att.loadSig, att.startTime)
+
+    block:
+      let head = pool[].selectOptimisticHead(
+        bInvalidAdd[].slot.start_beacon_time(cfg.timeParams)).get().blck
+      check head == bInvalidAdd[]
+
+    pool[].forkChoice.mark_root_invalid(bInvalid.root)
+
+    block:
+      let head = pool[].selectOptimisticHead(
+        bInvalidAdd[].slot.start_beacon_time(cfg.timeParams)).get().blck
+      check head == b3Add[]
+
   test "Trying to add a block twice tags the second as an error":
     var cache = StateCache()
     let
       b10 = makeTestBlock(state[], cache).electraData
-      b10Add = dag.addHeadBlock(verifier, b10) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+      b10Add = addHeadBlockToForkChoice(b10)
 
     let head = pool[].selectOptimisticHead(
       b10Add[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -678,14 +716,7 @@ suite "Attestation pool electra processing" & preset():
     # -------------------------------------------------------------
     # Add back the old block to ensure we have a duplicate error
     let b10_clone = b10 # Assumes deep copy
-    let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+    let b10Add_clone = addHeadBlockToForkChoice(b10_clone)
 
     doAssert: b10Add_clone.error == VerifierError.Duplicate
 
@@ -696,14 +727,7 @@ suite "Attestation pool electra processing" & preset():
     var cache = StateCache()
     let
       b10 = addTestBlock(state[], cache).electraData
-      b10Add = dag.addHeadBlock(verifier, b10) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+      b10Add = addHeadBlockToForkChoice(b10)
 
     let head = pool[].selectOptimisticHead(
       b10Add[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -725,14 +749,7 @@ suite "Attestation pool electra processing" & preset():
         let new_block = addTestBlock(
           state[], cache, electraAttestations = attestations).electraData
 
-        let blockRef = dag.addHeadBlock(verifier, new_block) do (
-            blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-            state: electra.BeaconState,
-            epochRef: EpochRef, unrealized: FinalityCheckpoints):
-          # Callback add to fork choice if valid
-          pool[].addForkChoice(
-            epochRef, blckRef, unrealized, signedBlock.message,
-            blckRef.slot.start_beacon_time(cfg.timeParams))
+        let blockRef = addHeadBlockToForkChoice(new_block)
 
         let head = pool[].selectOptimisticHead(
           blockRef[].slot.start_beacon_time(cfg.timeParams)).get().blck
@@ -775,14 +792,7 @@ suite "Attestation pool electra processing" & preset():
     doAssert: b10.root notin pool.forkChoice.backend
 
     # Add back the old block to ensure we have a duplicate error
-    let b10Add_clone = dag.addHeadBlock(verifier, b10_clone) do (
-          blckRef: BlockRef, signedBlock: electra.TrustedSignedBeaconBlock,
-          state: electra.BeaconState,
-          epochRef: EpochRef, unrealized: FinalityCheckpoints):
-        # Callback add to fork choice if valid
-        pool[].addForkChoice(
-          epochRef, blckRef, unrealized, signedBlock.message,
-          blckRef.slot.start_beacon_time(cfg.timeParams))
+    let b10Add_clone = addHeadBlockToForkChoice(b10_clone)
 
     doAssert: b10Add_clone.error == VerifierError.Duplicate
 


### PR DESCRIPTION
When a node is invalid, it gets filtered as unviable head when running fork choice. But we still apply its weight to ancestors. To match the optimistic vs lockstep behaviour, force weight of invalid blocks to 0, regardless of proposer boosts or pre-existing votes, and remove the weight from ancestors via the propagation mechanism.