### PR TITLE
Add metrics to track safe block

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -947,6 +947,10 @@ proc updateBeaconMetrics(
         0'u64.toGaugeValue
     )
 
+proc updateSafeBlockMetrics*(safeBlockId: BlockId) =
+  beacon_safe_root.set(safeBlockId.root.toGaugeValue)
+  beacon_safe_slot.set(safeBlockId.slot.toGaugeValue)
+
 import blockchain_dag_light_client
 
 export

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -26,6 +26,8 @@ logScope: topics = "chaindag"
 # https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#interop-metrics
 declareGauge beacon_head_root, "Root of the head block of the beacon chain"
 declareGauge beacon_head_slot, "Slot of the head block of the beacon chain"
+declareGauge beacon_safe_root, "Root of the safe block of the beacon chain"
+declareGauge beacon_safe_slot, "Slot of the safe block of the beacon chain"
 
 # https://github.com/ethereum/beacon-metrics/blob/master/metrics.md#interop-metrics
 declareGauge beacon_finalized_epoch, "Current finalized epoch" # On epoch transition
@@ -1306,6 +1308,8 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     dag.validatorMonitor[].registerState(forkyState.data)
 
   updateBeaconMetrics(dag.headState, dag.head.bid, cache)
+  beacon_safe_root.set(dag.finalizedHead.blck.bid.root.toGaugeValue)
+  beacon_safe_slot.set(dag.finalizedHead.blck.bid.slot.toGaugeValue)
 
   let finalizedTick = Moment.now()
 

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -203,6 +203,11 @@ proc updateHead(self: var ConsensusManager, newHead: BlockRef) =
   self.dag.updateHead(
     newHead, self.quarantine[],
     self.getKnownValidatorsForBlsChangeTracking(newHead))
+
+  let safeBlockId = self.attestationPool[].forkChoice.get_safe_beacon_block_id
+  beacon_safe_root.set(safeBlockId.root.toGaugeValue)
+  beacon_safe_slot.set(safeBlockId.slot.toGaugeValue)
+
   self.checkExpectedBlock()
 
 proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -203,11 +203,8 @@ proc updateHead(self: var ConsensusManager, newHead: BlockRef) =
   self.dag.updateHead(
     newHead, self.quarantine[],
     self.getKnownValidatorsForBlsChangeTracking(newHead))
-
-  let safeBlockId = self.attestationPool[].forkChoice.get_safe_beacon_block_id
-  beacon_safe_root.set(safeBlockId.root.toGaugeValue)
-  beacon_safe_slot.set(safeBlockId.slot.toGaugeValue)
-
+  updateSafeBlockMetrics(
+    self.attestationPool[].forkChoice.get_safe_beacon_block_id)
   self.checkExpectedBlock()
 
 proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -494,8 +494,11 @@ proc will_select_head*(
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
-func get_safe_beacon_block_root*(self: ForkChoice): Eth2Digest =
-  self.backend.confirmed.root
+func get_safe_beacon_block_id*(self: ForkChoice): lent BlockId =
+  self.backend.confirmed
+
+func get_safe_beacon_block_root*(self: ForkChoice): lent Eth2Digest =
+  self.get_safe_beacon_block_id.root
 
 func prune(
     self: var ForkChoiceBackend,


### PR DESCRIPTION
Allow tracking the safe block via nim-metrics, same as head/finalized.