### PR TITLE
fix: call process_payload_attestation in Gloas process_operations

### DIFF
--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -871,6 +871,11 @@ proc process_operations(
       # [New in Electra:EIP7251]
       process_consolidation_request(cfg, state, bsv[], op, cache)
 
+  when consensusFork >= ConsensusFork.Gloas:
+    for op in body.payload_attestations:
+      # [New in Gloas:EIP7732]
+      ? process_payload_attestation(state, op, cache)
+
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#sync-aggregate-processing


### PR DESCRIPTION
The consensus spec (gloas/beacon-chain.md line 1187) requires:

      for_ops(body.payload_attestations, process_payload_attestation)

  The function process_payload_attestation exists (line 749) but is never called from process_operations. The Electra..Fulu range at line 864 excludes Gloas, and no Gloas-specific block was added.

  Without this fix, Nimbus would accept Gloas blocks without validating payload attestations.

  AI Assistance Disclosure:  This bug was identified with the assistance of Claude Code during a cross-client security audit. The fix was reviewed manually.