### PR TITLE
test(ci): check if macos build is stable on nix-darwin host

### DIFF
--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -29,7 +29,7 @@ pipeline {
     disableRestartFromStage()
     timestamps()
     ansiColor('xterm')
-    /* This also includes wait time in the queue. */
+    /* This also includes wait time in the queue.*/
     timeout(time: 24, unit: 'HOURS')
     /* Limit builds retained. */
     buildDiscarder(logRotator(

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -29,7 +29,7 @@ pipeline {
     disableRestartFromStage()
     timestamps()
     ansiColor('xterm')
-    /* This also includes wait time in the queue.*/
+    /* This also includes wait time in the queue. */
     timeout(time: 24, unit: 'HOURS')
     /* Limit builds retained. */
     buildDiscarder(logRotator(

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -36,7 +36,6 @@ in pkgs.mkShell {
     # will erase `-march=native` because this introduces impurity in the build.
     # For the purposes of compiling Nimbus, this behavior is not desired:
     export NIX_ENFORCE_NO_NATIVE=0
-    export USE_SYSTEM_GETOPT=1
     export MAKEFLAGS="-j$NIX_BUILD_CORES"
 
     figlet "Welcome to Nimbus-eth2"

--- a/scripts/getopt-wrapper.sh
+++ b/scripts/getopt-wrapper.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# scripts/getopt-wrapper.sh - exec GNU getopt on any platform.
+set -eu
+
+if [ "$(uname)" != "Darwin" ]; then
+    exec getopt "$@"
+fi
+
+# macOS: prefer getopt in PATH if it's GNU (exit 4 from --test), else Homebrew.
+getopt --test > /dev/null 2>&1 && rc=0 || rc=$?
+if [ "$rc" -eq 4 ]; then
+    exec getopt "$@"
+fi
+
+for c in /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt; do
+    [ -x "$c" ] && exec "$c" "$@"
+done
+
+echo "GNU getopt not installed. Install via 'brew install gnu-getopt'." >&2
+exit 1

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -30,13 +30,7 @@ PIDS_TO_WAIT=""
 # argument parsing #
 ####################
 
-USE_SYSTEM_GETOPT="${USE_SYSTEM_GETOPT:-0}"
-GETOPT_BINARY="getopt"
-if [[ "${OS}" == "macos" && "$USE_SYSTEM_GETOPT" != "1" ]]; then
-  # Without the head -n1 constraint, it gets confused by multiple matches
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
-  [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
-fi
+GETOPT_BINARY="${SCRIPTS_DIR}/getopt-wrapper.sh"
 
 ! ${GETOPT_BINARY} --test > /dev/null
 if [[ ${PIPESTATUS[0]} != 4 ]]; then

--- a/scripts/make_packages.sh
+++ b/scripts/make_packages.sh
@@ -9,16 +9,13 @@
 
 set -e
 
+SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
 ####################
 # argument parsing #
 ####################
 
-GETOPT_BINARY="getopt"
-if uname | grep -qi darwin; then
-  # macOS
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null || true)
-  [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
-fi
+GETOPT_BINARY="${SCRIPTS_DIR}/getopt-wrapper.sh"
 
 ! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then

--- a/scripts/make_prometheus_config.sh
+++ b/scripts/make_prometheus_config.sh
@@ -9,22 +9,18 @@
 
 set -e
 
+SCRIPTS_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
 ####################
 # argument parsing #
 ####################
 
-GETOPT_BINARY="getopt"
-if uname | grep -qi darwin; then
-  # macOS
-  # Without the head -n1 constraint, it gets confused by multiple matches
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
-	[[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
-fi
+GETOPT_BINARY="${SCRIPTS_DIR}/getopt-wrapper.sh"
 
 ! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then
-	echo '`getopt --test` failed in this environment.'
-	exit 1
+  echo '`getopt --test` failed in this environment.'
+  exit 1
 fi
 
 OPTS="h"

--- a/scripts/start_nimbus_el_nodes.sh
+++ b/scripts/start_nimbus_el_nodes.sh
@@ -25,15 +25,16 @@ wait_for_port() {
   done
 }
 
-if [ -d /opt/homebrew/lib ]; then
-  # BEWARE
-  # The recent versions of homebrew/macOS can't add the libraries
-  # installed by Homebrew in the system's library search path, so
-  # Nimbus will fail to load RocksDB on start-up. THe new rules in
-  # macOS make it very difficult for the user to solve the problem
-  # in their profile, so we add an override here as the lessed evil:
-  export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:-}:/opt/homebrew/lib"
-  # See https://github.com/Homebrew/brew/issues/13481 for more details
+if uname | grep -qi darwin; then
+  # Ensure dynamically linked libraries (e.g. RocksDB) can be found at runtime.
+  # Check Nix paths first, then fall back to Homebrew.
+  # See https://github.com/Homebrew/brew/issues/13481 for more details.
+  for libdir in /run/current-system/sw/lib /opt/homebrew/lib /usr/local/lib; do
+    if [ -d "$libdir" ]; then
+      DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH:+$DYLD_LIBRARY_PATH:}$libdir"
+    fi
+  done
+  export DYLD_LIBRARY_PATH
 fi
 
 for NIMBUS_ETH1_NODE_IDX in $(seq 0 $NIMBUS_ETH1_LAST_NODE_IDX); do

--- a/tests/simulation/restapi.sh
+++ b/tests/simulation/restapi.sh
@@ -17,17 +17,14 @@ RESTTEST_DELAY="30"
 TEST_DIRNAME="resttest0_data"
 KILL_OLD_PROCESSES="0"
 
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
 ####################
 # argument parsing #
 ####################
 
-GETOPT_BINARY="getopt"
-if uname | grep -qi darwin; then
-  # macOS
-  # Without the head -n1 constraint, it gets confused by multiple matches
-  GETOPT_BINARY=$(find /opt/homebrew/opt/gnu-getopt/bin/getopt /usr/local/opt/gnu-getopt/bin/getopt 2> /dev/null | head -n1 || true)
-  [[ -f "$GETOPT_BINARY" ]] || { echo "GNU getopt not installed. Please run 'brew install gnu-getopt'. Aborting."; exit 1; }
-fi
+GETOPT_BINARY="${SCRIPTS_DIR}/getopt-wrapper.sh"
 
 ! ${GETOPT_BINARY} --test > /dev/null
 if [ ${PIPESTATUS[0]} != 4 ]; then


### PR DESCRIPTION
Adjustments to the scripts to also work on the MacOS hosts where we configure them using nix-darwin.

Reason for this change is that we are in the process of removing homebrew from our MacOS CI hosts and replacing it with nix-darwin.
