### PR TITLE
Add ca-certificates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ FROM debian:testing-slim AS build
 SHELL ["/bin/bash", "-c"]
 
 RUN apt-get clean && apt update \
- && apt -y install build-essential git-lfs
+ && apt -y install build-essential git-lfs ca-certificates
 
 RUN ldd --version ldd
 


### PR DESCRIPTION
## Summary
- `debian:testing-slim` was recently updated and no longer includes `ca-certificates` in the base image
- This causes all git submodule clones over HTTPS to fail during Docker builds with:
  ```
  fatal: unable to access '...': Problem with the SSL CA cert (path? access rights?)
  ```
- Fix: explicitly install `ca-certificates` in the build stage

## Context
We noticed this in our downstream image builder ([ethpandaops/eth-client-docker-image-builder](https://github.com/ethpandaops/eth-client-docker-image-builder)) where all nimbus-eth2 builds started failing: https://github.com/ethpandaops/eth-client-docker-image-builder/actions/runs/23539794734/job/68524197866

🤖 Generated with [Claude Code](https://claude.com/claude-code)