### PR TITLE
Allow bumps to tagged libp2p versions to be proposed by Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
   - package-ecosystem: gitsubmodule
     directory: /
     ignore:
-      # nim-libp2p releases are not always on master, avoid daily spam
       - dependency-name: vendor/nim-libp2p
+        versions: ["<= 0.0.0"]
     schedule:
       interval: daily
     target-branch: unstable


### PR DESCRIPTION
Less restrictive filter that allows bumps to tagged versions, while still blocking "daily spam" with proposals for untagged commits, even when we are currently locked to an untagged commit ourselves.

- https://github.com/dependabot/dependabot-core/pull/14352