### PR TITLE
nix: use Nix Flake from NBS repo to provide Nim

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -6,7 +6,7 @@
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
-library 'status-jenkins-lib@v1.9.2'
+library 'status-jenkins-lib@v1.9.41'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */

--- a/ci/Jenkinsfile.linux
+++ b/ci/Jenkinsfile.linux
@@ -1,12 +1,12 @@
 #!/usr/bin/env groovy
 /* beacon_chain
- * Copyright (c) 2025 Status Research & Development GmbH
+ * Copyright (c) 2026 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
-library 'status-jenkins-lib@v1.9.2'
+library 'status-jenkins-lib@v1.9.41'
 
 pipeline {
   agent {
@@ -64,7 +64,7 @@ pipeline {
 
   stages {
     stage('Deps') {
-      steps { 
+      steps {
         timeout(20) {
           script {
             /* To allow the following parallel stages. */
@@ -74,17 +74,17 @@ pipeline {
             /* Download test vectors. */
             sh './scripts/setup_scenarios.sh'
           }
-        } 
+        }
       }
     }
 
     stage('Build') {
-      steps { 
+      steps {
         timeout(50) {
           script {
             sh 'make LOG_LEVEL=TRACE'
           }
-        } 
+        }
       }
     }
 
@@ -99,23 +99,23 @@ pipeline {
     stage('Tests') {
       parallel {
         stage('General') {
-          steps { 
+          steps {
             timeout(60) {
               script {
                 sh 'make DISABLE_TEST_FIXTURES_SCRIPT=1 NIMFLAGS="--passC:\"-fno-lto\" --passL:\"-fno-lto\"" test'
                 sh 'git diff --exit-code --ignore-submodules=all'
               }
-            } 
+            }
           }
         }
 
         stage('REST') {
-          steps { 
+          steps {
             timeout(5) {
               script {
                 sh 'make restapi-test'
               }
-            } 
+            }
           }
           post { always {
             sh 'tar cjf restapi-test.tar.gz resttest0_data/*.txt'
@@ -130,12 +130,12 @@ pipeline {
     stage('Finalizations') {
       stages {  /* parallel builds of minimal / mainnet not yet supported */
         stage('minimal') {
-          steps { 
+          steps {
             timeout(26) {
               script {
                 sh 'make local-testnet-minimal'
               }
-            } 
+            }
           }
           post { always {
             sh 'tar cjf local-testnet-minimal.tar.gz local-testnet-minimal/logs/*'
@@ -143,12 +143,12 @@ pipeline {
         }
 
         stage('mainnet') {
-          steps { 
+          steps {
             timeout(62) {
               script {
                 sh 'make local-testnet-mainnet'
               }
-            } 
+            }
           }
           post { always {
             sh 'tar cjf local-testnet-mainnet.tar.gz local-testnet-mainnet/logs/*'

--- a/ci/Jenkinsfile.macos
+++ b/ci/Jenkinsfile.macos
@@ -6,7 +6,7 @@
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
-library 'status-jenkins-lib@v1.9.2'
+library 'status-jenkins-lib@v1.9.41'
 
 pipeline {
   /* This way we run the same Jenkinsfile on different platforms. */

--- a/ci/nix.Jenkinsfile
+++ b/ci/nix.Jenkinsfile
@@ -1,23 +1,24 @@
 #!/usr/bin/env groovy
 /* beacon_chain
- * Copyright (c) 2019-2025 Status Research & Development GmbH
+ * Copyright (c) 2019-2026 Status Research & Development GmbH
  * Licensed and distributed under either of
  *   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
-library 'status-jenkins-lib@v1.9.2'
+library 'status-jenkins-lib@v1.9.41'
 
 pipeline {
-  /* This way we run the same Jenkinsfile on different platforms. */
-  agent { label params.AGENT_LABEL }
+  agent {
+    docker {
+      label 'linuxcontainer'
+      image 'harbor.status.im/infra/ci-build-containers:linux-base-1.0.0'
+      args '--volume=/nix:/nix ' +
+           '--volume=/etc/nix:/etc/nix '
+    }
+  }
 
   parameters {
-    string(
-      name: 'AGENT_LABEL',
-      description: 'Label for targetted CI slave host: linux/macos',
-      defaultValue: params.AGENT_LABEL ?: getAgentLabel(),
-    )
     choice(
       name: 'VERBOSITY',
       description: 'Value for the V make flag to increase log verbosity',
@@ -68,19 +69,4 @@ pipeline {
 
 def isMainBranch() {
   return ['stable', 'testing', 'unstable'].contains(env.BRANCH_NAME)
-}
-
-/* This allows us to use one Jenkinsfile and run
- * jobs on different platforms based on job name. */
-def getAgentLabel() {
-    if (params.AGENT_LABEL) { return params.AGENT_LABEL }
-    /* We extract the name of the job from currentThread because
-     * before an agent is picket env is not available. */
-    def tokens = Thread.currentThread().getName().split('/')
-    def labels = []
-    /* Check if the job path contains any of the valid labels. */
-    ['linux', 'macos', 'x86_64', 'aarch64', 'arm64'].each {
-        if (tokens.contains(it)) { labels.add(it) }
-    }
-    return labels.join(' && ')
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,27 @@
 {
   "nodes": {
+    "nimbusBuildSystem": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774606021,
+        "narHash": "sha256-XHIThT9Df7djv+8xZiEdZ4sGHVDV8IEeY/UHfH5f3ns=",
+        "ref": "refs/heads/master",
+        "rev": "67f395831f94ba4ac5fb4c511beb99bc6ec63e22",
+        "revCount": 247,
+        "submodules": true,
+        "type": "git",
+        "url": "file:./vendor/nimbus-build-system"
+      },
+      "original": {
+        "submodules": true,
+        "type": "git",
+        "url": "file:./vendor/nimbus-build-system"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1768818593,
@@ -18,6 +40,7 @@
     },
     "root": {
       "inputs": {
+        "nimbusBuildSystem": "nimbusBuildSystem",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
+    nimbusBuildSystem = {
+      url = "git+file:./vendor/nimbus-build-system?submodules=1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     self = {
       # WARNING: Does not work with 'github:' schema URLs.
       # https://github.com/NixOS/nix/issues/14982
@@ -12,7 +16,7 @@
     };
   };
 
-  outputs = { self, nixpkgs }:
+  outputs = { self, nixpkgs, nimbusBuildSystem }:
     assert (builtins.compareVersions builtins.nixVersion "2.27") <= 0
       -> throw "Nix 2.27 or newer needed for proper submodules support!";
 
@@ -32,7 +36,8 @@
         buildTarget = pkgsFor.${system}.callPackage ./nix/default.nix {
           inherit stableSystems; src = self;
         };
-        build = targets: buildTarget.override { inherit targets; };
+        nim = nimbusBuildSystem.packages.${system}.nim;
+        build = targets: buildTarget.override { inherit targets nim; };
       in rec {
         beacon_node      = build ["nimbus_beacon_node"];
         signing_node     = build ["nimbus_signing_node"];

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -2,12 +2,12 @@
   pkgs ? import <nixpkgs> { },
   # Source code of this repo.
   src ? ../.,
+  # Nimbus-build-system package.
+  nim ? null,
   # Options: nimbus_light_client, nimbus_validator_client, nimbus_signing_node, all
   targets ? ["nimbus_beacon_node"],
   # Options: 0,1,2
   verbosity ? 1,
-  # Perform 2-stage bootstrap instead of 3-stage to save time.
-  quickAndDirty ? true,
   # These are the only platforms tested in CI and considered stable.
   stableSystems ? [
     "x86_64-linux" "aarch64-linux" "armv7a-linux"
@@ -23,56 +23,47 @@ assert pkgs.lib.assertMsg ((src.submodules or true) == true)
 let
   inherit (pkgs) stdenv lib writeScriptBin callPackage;
 
-  revision = lib.substring 0 8 (src.rev or "00000000");
+  revision = lib.substring 0 8 (src.rev or src.dirtyRev or "00000000");
 in stdenv.mkDerivation rec {
   pname = "nimbus-eth2";
   version = "${callPackage ./version.nix {}}-${revision}";
 
   inherit src;
 
-  # Fix for Nim compiler calling 'git rev-parse' and 'lsb_release'.
   nativeBuildInputs = let
     fakeGit = writeScriptBin "git" "echo ${version}";
-    fakeLsbRelease = writeScriptBin "lsb_release" "echo nix";
   in
-    with pkgs; [ fakeGit fakeLsbRelease which ]
+    with pkgs; [ nim which fakeGit ]
     ++ lib.optionals stdenv.isDarwin [ pkgs.darwin.cctools ];
 
   enableParallelBuilding = true;
 
   # Disable CPU optmizations that make binary not portable.
   NIMFLAGS = "-d:disableMarchNative -d:git_revision_override=${revision}";
+  # Avoid errors about missing user home.
+  NIMBLE_DIR = "/tmp";
   # Avoid Nim cache permission errors.
   XDG_CACHE_HOME = "/tmp";
 
   makeFlags = targets ++ [
     "V=${toString verbosity}"
-    # TODO: Compile Nim in a separate derivation to save time.
-    "QUICK_AND_DIRTY_COMPILER=${if quickAndDirty then "1" else "0"}"
-    "QUICK_AND_DIRTY_NIMBLE=${if quickAndDirty then "1" else "0"}"
+    # Built from nimbus-build-system via flake.
+    "USE_SYSTEM_NIM=1"
   ];
 
-  # Generate the nimbus-build-system.paths file.
-  configurePhase = ''
-    patchShebangs scripts vendor/nimbus-build-system > /dev/null
-    make nimbus-build-system-paths
-  '';
-
-  # Avoid nimbus-build-system invoking `git clone` to build Nim.
-  preBuild = ''
-    pushd vendor/nimbus-build-system/vendor/Nim
-    mkdir dist
-    cp -r ${callPackage ./nimble.nix {}}    dist/nimble
-    cp -r ${callPackage ./checksums.nix {}} dist/checksums
-    cp -r ${callPackage ./csources.nix {}}  csources_v2
-    chmod 777 -R dist/nimble csources_v2
-    popd
+  patchPhase = ''
+    patchShebangs scripts vendor/nimbus-build-system/scripts
   '';
 
   installPhase = ''
     mkdir -p $out/bin
     rm -f build/generate_makefile
     cp build/* $out/bin
+  '';
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    for BINARY in $out/bin/*; do $BINARY --version; done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
This way we can avoid rebuilding Nim every time we build packages.

* Compilation with Nim: `12 minutes`
* Compilation without Nim: `8.5 minutes`

Depends on:
- https://github.com/status-im/nimbus-build-system/pull/112
- https://github.com/status-im/nimbus-build-system/pull/117
- https://github.com/status-im/nimbus-build-system/pull/120
- https://github.com/status-im/nimbus-eth2/pull/8186

This was already merged in the past and then reverted due to Nim `2.2.8` bug:
- https://github.com/status-im/nimbus-eth2/pull/7870
- https://github.com/status-im/nimbus-eth2/pull/8035