### PR TITLE
nix: drop git+file: from NBS vendor input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,20 +7,14 @@
         ]
       },
       "locked": {
-        "lastModified": 1774606021,
-        "narHash": "sha256-XHIThT9Df7djv+8xZiEdZ4sGHVDV8IEeY/UHfH5f3ns=",
-        "ref": "refs/heads/master",
-        "rev": "67f395831f94ba4ac5fb4c511beb99bc6ec63e22",
-        "revCount": 247,
-        "submodules": true,
-        "type": "git",
-        "url": "file:./vendor/nimbus-build-system"
+        "path": "vendor/nimbus-build-system",
+        "type": "path"
       },
       "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "file:./vendor/nimbus-build-system"
-      }
+        "path": "vendor/nimbus-build-system",
+        "type": "path"
+      },
+      "parent": []
     },
     "nixpkgs": {
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
     nimbusBuildSystem = {
-      url = "git+file:./vendor/nimbus-build-system?submodules=1";
+      url = ./vendor/nimbus-build-system;
       inputs.nixpkgs.follows = "nixpkgs";
     };
     self = {


### PR DESCRIPTION
Using the git+file: protocol can in more complex nested NixOS configurations result in errors like this:
```
error: The path './vendor/nimbus-build-system' does not exist.
warning: Fetching Git repository 'file:./vendor/nimbus-build-system',
which uses a path relative to the current directory.
This is not supported and will stop working in a future release.
See https://github.com/NixOS/nix/issues/12281 for details.
```
Issue:
- https://github.com/NixOS/nix/issues/12281