### PR TITLE
Avoid SSZ codec depending on Altair

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -78,15 +78,6 @@ static: doAssert TIMELY_SOURCE_WEIGHT + TIMELY_TARGET_WEIGHT +
 type
   ### New types
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/specs/altair/beacon-chain.md#custom-types
-  ParticipationFlags* = uint8
-
-  EpochParticipationFlags* =
-    distinct List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
-    ## Not a HashList because the list sees significant updates every block
-    ## effectively making the cost of clearing the cache higher than the typical
-    ## gains
-
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#syncaggregate
   SyncAggregate* = object
     sync_committee_bits*: BitArray[SYNC_COMMITTEE_SIZE]
@@ -538,45 +529,6 @@ template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
 
 makeLimitedU8(SyncSubcommitteeIndex, SYNC_COMMITTEE_SUBNET_COUNT)
 makeLimitedU16(IndexInSyncCommittee, SYNC_COMMITTEE_SIZE)
-
-template asList*(epochFlags: EpochParticipationFlags): untyped =
-  List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
-template asList*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr epochFlags)
-  tmp[]
-
-template asSeq*(epochFlags: EpochParticipationFlags): untyped =
-  seq[ParticipationFlags] asList(epochFlags)
-
-template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
-  tmp[]
-
-template item*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex): ParticipationFlags =
-  asList(epochFlags)[idx]
-
-template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
-  asList(epochFlags)[idx]
-
-template `[]=`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex, flags: ParticipationFlags) =
-  asList(epochFlags)[idx] = flags
-
-template add*(epochFlags: var EpochParticipationFlags, flags: ParticipationFlags): bool =
-  asList(epochFlags).add flags
-
-template len*(epochFlags: EpochParticipationFlags): int =
-  asList(epochFlags).len
-
-template low*(epochFlags: EpochParticipationFlags): int =
-  asSeq(epochFlags).low
-template high*(epochFlags: EpochParticipationFlags): int =
-  asSeq(epochFlags).high
-
-template assign*(v: var EpochParticipationFlags, src: EpochParticipationFlags) =
-  # TODO https://github.com/nim-lang/Nim/issues/21123
-  mixin assign
-  var tmp = cast[ptr seq[ParticipationFlags]](addr v)
-  assign(tmp[], distinctBase src)
 
 func shortLog*(v: SomeBeaconBlock): auto =
   (

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -218,6 +218,15 @@ type
   # SSZ / hashing purposes
   JustificationBits* = distinct uint8
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/altair/beacon-chain.md#custom-types
+  ParticipationFlags* = uint8
+
+  EpochParticipationFlags* =
+    distinct List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+    ## Not a HashList because the list sees significant updates every block
+    ## effectively making the cost of clearing the cache higher than the typical
+    ## gains
+
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/beacon-chain.md#proposerslashing
   ProposerSlashing* = object
     signed_header_1*: SignedBeaconBlockHeader
@@ -682,6 +691,45 @@ iterator vindices*(
 
 template `==`*(x, y: JustificationBits): bool =
   distinctBase(x) == distinctBase(y)
+
+template asList*(epochFlags: EpochParticipationFlags): untyped =
+  List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
+template asList*(epochFlags: var EpochParticipationFlags): untyped =
+  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr epochFlags)
+  tmp[]
+
+template asSeq*(epochFlags: EpochParticipationFlags): untyped =
+  seq[ParticipationFlags] asList(epochFlags)
+
+template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
+  let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
+  tmp[]
+
+template item*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex): ParticipationFlags =
+  asList(epochFlags)[idx]
+
+template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
+  asList(epochFlags)[idx]
+
+template `[]=`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex, flags: ParticipationFlags) =
+  asList(epochFlags)[idx] = flags
+
+template add*(epochFlags: var EpochParticipationFlags, flags: ParticipationFlags): bool =
+  asList(epochFlags).add flags
+
+template len*(epochFlags: EpochParticipationFlags): int =
+  asList(epochFlags).len
+
+template low*(epochFlags: EpochParticipationFlags): int =
+  asSeq(epochFlags).low
+template high*(epochFlags: EpochParticipationFlags): int =
+  asSeq(epochFlags).high
+
+template assign*(v: var EpochParticipationFlags, src: EpochParticipationFlags) =
+  # TODO https://github.com/nim-lang/Nim/issues/21123
+  mixin assign
+  var tmp = cast[ptr seq[ParticipationFlags]](addr v)
+  assign(tmp[], distinctBase src)
 
 func `as`*(d: DepositData, T: type DepositMessage): T =
   T(pubkey: d.pubkey,

--- a/beacon_chain/spec/ssz_codec.nim
+++ b/beacon_chain/spec/ssz_codec.nim
@@ -12,10 +12,7 @@ import
   ssz_serialization/codec,
   ./datatypes/base
 
-from ./datatypes/altair import
-  ParticipationFlags, EpochParticipationFlags
-
-export codec, base, typetraits, ParticipationFlags, EpochParticipationFlags
+export codec, base, typetraits
 
 # Coding and decoding of SSZ to spec-specific types
 


### PR DESCRIPTION
To use `get_generalized_index`, altair.nim needs to import SSZ, but SSZ currently depends on the ParticipationFlags types of altair.nim. Moving these types to base cleans up the dependencies.