### PR TITLE
BN: Dynamic number of columns count which depends on current sync status.

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -125,6 +125,7 @@ type
       ## Number of validators that we've checked for activation
     processingDelay*: Opt[Duration]
     lastValidAttestedBlock*: Opt[BlockSlot]
+    lastColumnCustodyIndices*: seq[CustodyIndex]
     shutdownEvent*: AsyncEvent
 
 # TODO https://github.com/status-im/nim-stew/pull/258

--- a/beacon_chain/consensus_object_pools/blob_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/blob_quarantine.nim
@@ -901,10 +901,21 @@ proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     onDataColumnSidecarCallback: OnDataColumnSidecarCallback
 ): SidecarQuarantine[A, B] =
   doAssert(len(custodyColumns) <= NUMBER_OF_COLUMNS)
-
   let custodyMap = ColumnMap.init(custodyColumns)
+  T.init(
+    cfg, custodyMap, database, maxDiskSizeMultipler,
+    onDataColumnSidecarCallback)
+
+proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
+    T: typedesc[SidecarQuarantine[A, B]],
+    cfg: RuntimeConfig,
+    custodyMap: ColumnMap,
+    database: QuarantineDB,
+    maxDiskSizeMultipler: int,
+    onDataColumnSidecarCallback: OnDataColumnSidecarCallback
+): SidecarQuarantine[A, B] =
   var indexMap = newSeqUninit[int](NUMBER_OF_COLUMNS)
-  if len(custodyColumns) < NUMBER_OF_COLUMNS:
+  if len(custodyMap) < NUMBER_OF_COLUMNS:
     for i in 0 ..< len(indexMap):
       indexMap[i] = -1
   for index, item in custodyMap.pairs():
@@ -921,7 +932,7 @@ proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
   SidecarQuarantine[A, B](
     minEpochsForSidecarsRequests:
       cfg.MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS,
-    maxSidecarsPerBlockCount: len(custodyColumns),
+    maxSidecarsPerBlockCount: len(custodyMap),
     maxMemSidecarsCount: size,
     maxDiskSidecarsCount: size * maxDiskSizeMultipler,
     memSidecarsCount: 0,
@@ -937,15 +948,12 @@ proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
 proc update*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     quarantine: var SidecarQuarantine[A, B],
     cfg: RuntimeConfig,
-    custodyColumns: openArray[ColumnIndex]
+    custodyMap: ColumnMap
 ) =
-  doAssert(len(custodyColumns) <= NUMBER_OF_COLUMNS)
-  let
-    custodyMap = ColumnMap.init(custodyColumns)
-    maxSidecarsPerBlockCount = len(custodyMap)
+  let maxSidecarsPerBlockCount = len(custodyMap)
 
   var indexMap = newSeqUninit[int](NUMBER_OF_COLUMNS)
-  if len(custodyColumns) < NUMBER_OF_COLUMNS:
+  if len(custodyMap) < NUMBER_OF_COLUMNS:
     for i in 0 ..< len(indexMap):
       indexMap[i] = -1
   for index, item in custodyMap.pairs():
@@ -1008,3 +1016,12 @@ proc update*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
   quarantine.indexMap = indexMap
   quarantine.custodyColumns = toSeq(custodyMap.items)
   quarantine.custodyMap = custodyMap
+
+proc update*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
+    quarantine: var SidecarQuarantine[A, B],
+    cfg: RuntimeConfig,
+    custodyColumns: openArray[ColumnIndex]
+) =
+  doAssert(len(custodyColumns) <= NUMBER_OF_COLUMNS)
+  let custodyMap = ColumnMap.init(custodyColumns)
+  quarantine.update(cfg, custodyMap)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -24,14 +24,13 @@ import
   ./rpc/[rest_api, state_ttl_cache],
   ./el/el_getblobs_service,
   ./spec/[
-    engine_authentication, weak_subjectivity, peerdas_helpers],
+    engine_authentication, weak_subjectivity, peerdas_helpers, column_map],
   ./sync/[sync_protocol, light_client_protocol, sync_overseer, validator_custody],
   ./validators/[keystore_management, beacon_validators],
   ./[
     beacon_node, beacon_node_light_client, buildinfo, deposits, era_db,
     nimbus_binary_common, process_state, statusbar, trusted_node_sync, wallets]
 
-from std/algorithm import sort
 from std/sequtils import filterIt, mapIt, toSeq
 from libp2p/protocols/pubsub/gossipsub import
   TopicParams, validateParameters, init
@@ -570,35 +569,21 @@ proc initFullNode(
     blobQuarantine = newClone(BlobQuarantine.init(
       dag.cfg, dag.db.getQuarantineDB(), 10, onBlobSidecarAdded))
     supernode = node.config.peerdasSupernode
-    lightSupernode = node.config.lightSupernode
-    localCustodyGroups =
-      if supernode:
-        dag.cfg.NUMBER_OF_CUSTODY_GROUPS
-      elif lightSupernode:
-        (dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
-      else:
-        dag.cfg.CUSTODY_REQUIREMENT
-    custodyColumns =
-      if node.config.lightSupernode:
-        # Just the first half of custody columns
-        var res: HashSet[ColumnIndex]
-        for i in 0..<(dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1:
-          res.incl ColumnIndex(i)
-        res
-      else:
-        dag.cfg.resolve_columns_from_custody_groups(
-          node.network.nodeId, localCustodyGroups)
-
-  var sortedColumns = custodyColumns.toSeq()
-  sort(sortedColumns)
+    validatorCustody = ValidatorCustodyRef.init(
+      node.config, node.network, dag)
 
   let
     dataColumnQuarantine = newClone(ColumnQuarantine.init(
-      dag.cfg, sortedColumns, dag.db.getQuarantineDB(), 10,
+      dag.cfg, validatorCustody.getMap(), dag.db.getQuarantineDB(), 10,
       onColumnSidecarAdded))
     gloasColumnQuarantine = newClone(GloasColumnQuarantine.init(
-      dag.cfg, sortedColumns, dag.db.getQuarantineDB(), 10,
+      dag.cfg, validatorCustody.getMap(), dag.db.getQuarantineDB(), 10,
       onColumnSidecarAdded))
+
+  validatorCustody.setQuarantine(dataColumnQuarantine)
+  validatorCustody.setQuarantine(gloasColumnQuarantine)
+
+  let
     consensusManager = ConsensusManager.new(
       dag, attestationPool, quarantine, node.elManager,
       ActionTracker.init(node.network.nodeId, config.subscribeAllSubnets),
@@ -806,14 +791,12 @@ proc initFullNode(
       processor: processor,
       network: node.network)
     requestManager = RequestManager.init(
-      node.network, supernode, custodyColumns,
+      node.network, validatorCustody,
       dag.cfg.DENEB_FORK_EPOCH, getBeaconTime, (proc(): bool = syncManager.inProgress),
       quarantine, envelopeQuarantine, blobQuarantine,
       dataColumnQuarantine, rmanBlockVerifier, rmanBlockLoader,
       rmanEnvelopeVerifier, rmanEnvelopeLoader,
       rmanBlobLoader, rmanDataColumnLoader)
-    validatorCustody = ValidatorCustodyRef.init(node.network, dag, custodyColumns,
-      dataColumnQuarantine)
 
   # As per EIP 7594, the BN is now categorised into a
   # `Fullnode` and a `Supernode`, the fullnodes custodies a
@@ -833,11 +816,6 @@ proc initFullNode(
   # but there are multiple instances of computing custody columns, especially
   # during peer selection, sync with columns, and so on. That is why,
   # the rationale of populating it at boot and using it gloabally.
-
-  if supernode:
-    node.network.loadCgcnetMetadataAndEnr(dag.cfg.NUMBER_OF_CUSTODY_GROUPS.uint8)
-  else:
-    node.network.loadCgcnetMetadataAndEnr(dag.cfg.CUSTODY_REQUIREMENT.uint8)
 
   if node.config.lightClientDataServe:
     proc scheduleSendingLightClientUpdates(slot: Slot) =
@@ -1350,34 +1328,11 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
 
   subnets + node.getNextSyncCommitteeSubnets(epoch)
 
-func readCustodyGroupSubnets(node: BeaconNode): uint64 =
-  let
-    custodyGroups = node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
-    vcus_count = node.dataColumnQuarantine.custodyColumns.lenu64
-  if node.config.peerdasSupernode:
-    custodyGroups
-  elif node.config.lightSupernode:
-    (custodyGroups div 2) + 1
-  elif vcus_count > node.dag.cfg.CUSTODY_REQUIREMENT:
-    vcus_count
-  else:
-    node.dag.cfg.CUSTODY_REQUIREMENT
-
 proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
   let
     custody_groups = node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
     forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
-    targetSubnets = node.readCustodyGroupSubnets()
-    custody =
-      if node.config.lightSupernode:
-        # Light supernode serves only half of the custody groups
-        var res = newSeqOfCap[CustodyIndex]((custody_groups div 2) + 1)
-        for i in 0..<(custody_groups div 2) + 1:
-          res.add CustodyIndex(i)
-        res
-      else:
-        node.dag.cfg.get_custody_groups(
-        node.network.nodeId, targetSubnets.uint64)
+    custody = node.validatorCustody.getCustodyGroups()
 
   for i in custody:
     let topic = getDataColumnSidecarTopic(forkDigest, i)
@@ -1475,9 +1430,7 @@ proc removeFuluMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removeCapellaMessageHandlers(forkDigest)
 
   let
-    targetSubnets = node.readCustodyGroupSubnets()
-    custody = node.dag.cfg.get_custody_groups(
-      node.network.nodeId, targetSubnets.uint64)
+    custody = node.validatorCustody.getCustodyGroups()
 
   for i in custody:
     let topic = getDataColumnSidecarTopic(forkDigest, i)
@@ -2087,33 +2040,9 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # above, this will be done just before the next slot starts
   node.updateSyncCommitteeTopics(slot + 1)
 
-  if (not node.config.peerdasSupernode) and
-     (not node.config.lightSupernode) and
-     node.attachedValidatorBalanceTotal > 0.Gwei:
-    # Detect new validator custody at the last slot of every epoch
-    node.validatorCustody.detectNewValidatorCustody(slot,
-      node.attachedValidatorBalanceTotal)
-
-    if node.validatorCustody.diff_set.len > 0:
-      var custodyColumns =
-        node.validatorCustody.newer_column_set.toSeq()
-      sort(custodyColumns)
-      # update custody columns
-      node.dataColumnQuarantine[].update(node.dag.cfg, custodyColumns)
-      # update custody columns into request manager
-      node.requestManager.custody_columns_set =
-        node.validatorCustody.newer_column_set
-
-      # Update CGC and metadata with respect to the new detected validator custody
-      let new_vcus = CgcCount node.validatorCustody.newer_column_set.lenu64
-
-      if new_vcus > node.dag.cfg.CUSTODY_REQUIREMENT.uint8:
-        node.network.loadCgcnetMetadataAndEnr(new_vcus)
-      else:
-        node.network.loadCgcnetMetadataAndEnr(node.dag.cfg.CUSTODY_REQUIREMENT.uint8)
-
-      info "New validator custody count detected",
-        custody_columns = node.dataColumnQuarantine.custodyColumns.len
+  # TODO (cheatfate): This does not include VC provided validators balances.
+  node.validatorCustody.updateValidatorCustody(
+    slot, node.attachedValidatorBalanceTotal)
 
   # Update nfd field for BPOs
   let

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -569,7 +569,7 @@ proc initFullNode(
     blobQuarantine = newClone(BlobQuarantine.init(
       dag.cfg, dag.db.getQuarantineDB(), 10, onBlobSidecarAdded))
     validatorCustody = ValidatorCustodyRef.init(
-      node.config, node.network, dag)
+      node.config, node.network, dag, node.attachedValidatorBalanceTotal)
 
   let
     dataColumnQuarantine = newClone(ColumnQuarantine.init(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1336,6 +1336,10 @@ proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
     let topic = getDataColumnSidecarTopic(forkDigest, i)
     node.network.subscribe(topic, basicParams())
 
+  # Due to dynamic column changes, we need to maintain the set of columns we
+  # subscribe to, as the column set may change.
+  node.lastColumnCustodyIndices = custody
+
 proc addAltairMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
   node.addPhase0MessageHandlers(forkDigest, slot)
@@ -1427,10 +1431,10 @@ proc removeFuluMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   # of columns. Last common ancestor fork for gossip environment is Capellla.
   node.removeCapellaMessageHandlers(forkDigest)
 
-  let
-    custody = node.validatorCustody.getCustodyGroups()
-
-  for i in custody:
+  # Due to the dynamic column change, we need to unsubscribe from all the
+  # subnets we subscribed to. Because getCustodyGroups() may return a different
+  # set than the one we subscribed to previously.
+  for i in node.lastColumnCustodyIndices:
     let topic = getDataColumnSidecarTopic(forkDigest, i)
     node.network.unsubscribe(topic)
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -568,7 +568,6 @@ proc initFullNode(
     payloadAttestationPool = newClone(PayloadAttestationPool.init(dag))
     blobQuarantine = newClone(BlobQuarantine.init(
       dag.cfg, dag.db.getQuarantineDB(), 10, onBlobSidecarAdded))
-    supernode = node.config.peerdasSupernode
     validatorCustody = ValidatorCustodyRef.init(
       node.config, node.network, dag)
 
@@ -1330,7 +1329,6 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
 
 proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
   let
-    custody_groups = node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
     forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
     custody = node.validatorCustody.getCustodyGroups()
 
@@ -2244,9 +2242,6 @@ proc runOnSecondLoop(node: BeaconNode) {.async.} =
     ticks_delay.set(sleepTime.nanoseconds.float / nanosecondsIn1s)
     trace "onSecond task completed",
       sleepTime, processingTime = chronos.now(chronos.Moment) - afterSleep
-
-func connectedPeersCount(node: BeaconNode): int =
-  len(node.network.peerPool)
 
 proc installRestHandlers(restServer: RestServerRef, node: BeaconNode) =
   restServer.router.installBeaconApiHandlers(node)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2243,6 +2243,9 @@ proc runOnSecondLoop(node: BeaconNode) {.async.} =
     trace "onSecond task completed",
       sleepTime, processingTime = chronos.now(chronos.Moment) - afterSleep
 
+func connectedPeersCount(node: BeaconNode): int =
+  len(node.network.peerPool)
+
 proc installRestHandlers(restServer: RestServerRef, node: BeaconNode) =
   restServer.router.installBeaconApiHandlers(node)
   restServer.router.installBuilderApiHandlers()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1328,13 +1328,13 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   subnets + node.getNextSyncCommitteeSubnets(epoch)
 
 proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
-  let
-    forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
-    custody = node.validatorCustody.getCustodyGroups()
+  let forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
+  var custody: seq[CustodyIndex]
 
-  for i in custody:
+  for i in node.validatorCustody.custodyGroups():
     let topic = getDataColumnSidecarTopic(forkDigest, i)
     node.network.subscribe(topic, basicParams())
+    custody.add(i)
 
   # Due to dynamic column changes, we need to maintain the set of columns we
   # subscribe to, as the column set may change.

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -17,7 +17,7 @@ import
     types],
   stew/assign2,
   ./crypto,
-  ./[helpers, digest],
+  ./[helpers, digest, column_map],
   ./datatypes/[fulu, deneb]
 
 from std/algorithm import sort
@@ -85,6 +85,18 @@ func resolve_columns_from_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
   for group in custody_groups:
     for index in compute_columns_for_custody_group(cfg, group):
       columns.incl index
+  columns
+
+func resolve_column_map_from_custody_groups*(
+    cfg: RuntimeConfig,
+    node_id: NodeId,
+    custody_group_count: CustodyIndex
+): ColumnMap =
+  let custody_groups = cfg.get_custody_groups(node_id, custody_group_count)
+  var columns: ColumnMap
+  for group in custody_groups:
+    for index in compute_columns_for_custody_group(cfg, group):
+      columns.incl(index)
   columns
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/fulu/das-core.md#compute_matrix

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -80,7 +80,7 @@ func resolve_columns_from_custody_groups*(cfg: RuntimeConfig, node_id: NodeId,
                                           custody_group_count: CustodyIndex):
                                           HashSet[ColumnIndex] =
   ## Returns a set of unique columns for the custody groups of a node.
-  let custody_groups = cfg.get_custody_groups(node_id, custody_group_count)
+  let custody_groups = cfg.handle_custody_groups(node_id, custody_group_count)
   var columns: HashSet[ColumnIndex]
   for group in custody_groups:
     for index in compute_columns_for_custody_group(cfg, group):
@@ -92,7 +92,7 @@ func resolve_column_map_from_custody_groups*(
     node_id: NodeId,
     custody_group_count: CustodyIndex
 ): ColumnMap =
-  let custody_groups = cfg.get_custody_groups(node_id, custody_group_count)
+  let custody_groups = cfg.handle_custody_groups(node_id, custody_group_count)
   var columns: ColumnMap
   for group in custody_groups:
     for index in compute_columns_for_custody_group(cfg, group):

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -10,11 +10,11 @@
 import std/[sets, sequtils], chronos, chronicles
 import ssz_serialization/types
 import
-  ../spec/[forks, network, peerdas_helpers],
+  ../spec/[forks, network, peerdas_helpers, column_map],
   ../networking/eth2_network,
   ../consensus_object_pools/[
     blob_quarantine, block_quarantine, envelope_quarantine],
-  "."/sync_protocol, "."/sync_manager,
+  "."/sync_protocol, "."/sync_manager, "."/validator_custody,
   ../gossip_processing/block_processor
 
 from std/algorithm import binarySearch, sort
@@ -84,8 +84,7 @@ type
 
   RequestManager* = object
     network*: Eth2Node
-    supernode*: bool
-    custody_columns_set*: HashSet[ColumnIndex]
+    vcus*: ValidatorCustodyRef
     getBeaconTime: GetBeaconTimeFn
     inhibit: InhibitFn
     quarantine: ref Quarantine
@@ -110,8 +109,7 @@ func shortLog*(x: seq[FetchRecord]): string =
   "[" & x.mapIt(shortLog(it.root)).join(", ") & "]"
 
 func init*(T: type RequestManager, network: Eth2Node,
-              supernode: bool,
-              custody_columns_set: HashSet[ColumnIndex],
+              vcus: ValidatorCustodyRef,
               denebEpoch: Epoch,
               getBeaconTime: GetBeaconTimeFn,
               inhibit: InhibitFn,
@@ -127,8 +125,7 @@ func init*(T: type RequestManager, network: Eth2Node,
               dataColumnLoader: DataColumnLoaderFn = nil): RequestManager =
   RequestManager(
     network: network,
-    supernode: supernode,
-    custody_columns_set: custody_columns_set,
+    vcus: vcus,
     getBeaconTime: getBeaconTime,
     inhibit: inhibit,
     quarantine: quarantine,
@@ -401,7 +398,7 @@ proc checkPeerCustody(rman: RequestManager,
   var intersection: DataColumnIndices
   let remoteCustodyGroupCount = peer.lookupCgcFromPeer()
 
-  if rman.supernode:
+  if rman.vcus.isSupernode():
     if remoteCustodyGroupCount == rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS:
       for col in 0 ..< rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS:
         discard intersection.add(ColumnIndex col)
@@ -428,7 +425,7 @@ proc checkPeerCustody(rman: RequestManager,
             max(rman.network.cfg.SAMPLES_PER_SLOT,
                 remoteCustodyGroupCount))
 
-      for local_column in rman.custody_columns_set:
+      for local_column in rman.vcus.getSet():
         if local_column in remoteCustodyColumns:
           discard intersection.add(local_column)
       # Apply scoring logic + logs
@@ -437,18 +434,18 @@ proc checkPeerCustody(rman: RequestManager,
         debug "Peer has no custody overlap",
           peer = peer, score = peer.getScore(),
           remote_custody = remoteCustodyGroupCount
-      elif intersection.len < (rman.custody_columns_set.len div 2):
+      elif intersection.len < (len(rman.vcus.getMap()) div 2):
         peer.updateScore(PeerScoreScantyColumnIntersection)
         debug "Peer has scanty custody overlap",
           peer = peer, score = peer.getScore(),
           remote_custody = remoteCustodyGroupCount,
-          overlap = intersection.len, local = rman.custody_columns_set.len
+          overlap = intersection.len, local = len(rman.vcus.getMap())
       else:
         peer.updateScore(PeerScoreDecentColumnIntersection)
         debug "Peer has decent custody overlap",
           peer = peer, score = peer.getScore(),
           remote_custody = remoteCustodyGroupCount,
-          overlap = intersection.len, local = rman.custody_columns_set.len
+          overlap = intersection.len, local = len(rman.vcus.getMap())
 
   intersection
 
@@ -461,8 +458,8 @@ func matchIntersection(rman: RequestManager): PeerCustomFilterCallback[Peer] =
         rman.network.cfg.resolve_columns_from_custody_groups(
           remoteNodeId,
           max(rman.network.cfg.SAMPLES_PER_SLOT, remoteCustodyGroupCount))
-      overlap = rman.custody_columns_set.countIt(it in remoteCustodyColumns)
-    overlap > (rman.custody_columns_set.len div 2)
+      overlap = rman.vcus.getMap().countIt(it in remoteCustodyColumns)
+    overlap > (len(rman.vcus.getMap()) div 2)
 
 proc fetchDataColumnsFromNetwork(rman: RequestManager,
                                  colIdList: seq[DataColumnsByRootIdentifier])
@@ -478,7 +475,7 @@ proc fetchDataColumnsFromNetwork(rman: RequestManager,
       peer = peer,
       peer_score = peer.getScore(),
       overlap = intersection.len,
-      local = rman.custody_columns_set.len
+      local = len(rman.vcus.getMap())
     if intersection.len == 0:
       debug "Peer has no usable custody overlap",
         peer = peer
@@ -859,7 +856,7 @@ proc requestManagerDataColumnLoop(
       debug "Requesting detected missing data columns", columns = shortLog(columnIds)
       let start = SyncMoment.now(0)
       let workerCount =
-        if rman.custody_columns_set.lenu64 >=
+        if lenu64(rman.vcus.getMap()) >=
             rman.network.cfg.NUMBER_OF_CUSTODY_GROUPS:
           PARALLEL_DATA_COLUMNS_SUPER
         else:

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -12,60 +12,257 @@ import chronicles
 import ssz_serialization/[proofs, types]
 import
   ../validators/action_tracker,
-  ../spec/[beaconstate, forks, network, helpers, peerdas_helpers],
+  ../spec/[beaconstate, forks, network, helpers, peerdas_helpers, column_map],
   ../networking/eth2_network,
-  ../consensus_object_pools/blockchain_dag,
-  ../consensus_object_pools/block_dag,
-  ../consensus_object_pools/blob_quarantine
+  ../conf,
+  ../consensus_object_pools/[blockchain_dag, block_dag, blob_quarantine]
 
-from std/sequtils import toSeq
 from ../beacon_clock import GetBeaconTimeFn
 
 logScope: topics = "validator_custody"
 
+const
+  MaxSyncDistanceDeviationSlots = 5'u64
+    ## Distance from wall slot after which Validator Custody will think that
+    ## node is out of sync.
+  StabilityDistanceSlots = 32'u64
+    ## Distance which Validator Custody will wait until it switches back to
+    ## full custody.
 
 type
+  ValidatorCustodyState* {.pure.} = enum
+    Init,
+      ## Period when node has been started, but validators balance is not yet
+      ## known.
+    FullCustody,
+      ## When node is in sync it uses full validator custody columns set.
+    LimitedCustody,
+      ## When node is out of sync it uses `CUSTODY_REQUIREMENT` validator
+      ## custody columns set
+    StabilityPeriod
+      ## When node recently become synced it should stay synced for some period
+      ## of time before switch from `LimitedCustody` to `FullCustody`.
+
+  ## Init -> FullCustody -> LimitedCustody -> StablePeriod -> FullCustody
+  ## Init -> LimitedCustody -> StablePeriod -> FullCustody
+
   ValidatorCustody* = object
     network: Eth2Node
-    dag*: ChainDAGRef
-    older_column_set: HashSet[ColumnIndex]
-    newer_column_set*: HashSet[ColumnIndex]
-    diff_set*: seq[ColumnIndex]
-    dataColumnQuarantine: ref ColumnQuarantine
+    dag: ChainDAGRef
+    config: BeaconNodeConf
+    curGroupsCount: CgcCount
+    curColumnMap: ColumnMap
+    fuluColumnQuarantine: ref ColumnQuarantine
+    gloasColumnQuarantine: ref GloasColumnQuarantine
+    state: ValidatorCustodyState
+    stabilitySlot: Opt[Slot]
 
   ValidatorCustodyRef* = ref ValidatorCustody
 
-func init*(T: type ValidatorCustodyRef, network: Eth2Node,
-           dag: ChainDAGRef,
-           older_column_set: HashSet[ColumnIndex],
-           dataColumnQuarantine: ref ColumnQuarantine): ValidatorCustodyRef =
-  (ValidatorCustodyRef)(
-    network: network,
-    dag: dag,
-    older_column_set: older_column_set,
-    dataColumnQuarantine: dataColumnQuarantine)
+  ColumnQuarantines* = ref ColumnQuarantine | ref GloasColumnQuarantine
 
-proc detectNewValidatorCustody*(vcus: ValidatorCustodyRef,
-                                current_slot: Slot,
-                                total_node_balance: Gwei) =
-  debug "Total node balance before applying validator custody",
-    total_node_balance = total_node_balance
-  let
-    vcustody =
-      vcus.dag.cfg.get_validators_custody_requirement(total_node_balance)
-    newer_columns =
-      vcus.dag.cfg.resolve_columns_from_custody_groups(
-        vcus.network.nodeId,
-        max(vcus.dag.cfg.CUSTODY_REQUIREMENT.uint64,
-        vcustody))
+func getGroupsCount(
+  state: ValidatorCustodyState,
+  config: BeaconNodeConf,
+  network: Eth2Node,
+  dag: ChainDAGRef,
+  nodeBalance: Opt[Gwei]
+): CgcCount =
+  case state
+  of ValidatorCustodyState.Init:
+    if config.peerdasSupernode:
+      CgcCount(dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
+    elif config.lightSupernode:
+      CgcCount((dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1)
+    else:
+      CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
+  of ValidatorCustodyState.FullCustody:
+    if config.peerdasSupernode:
+      CgcCount(dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
+    elif config.lightSupernode:
+      CgcCount((dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1)
+    else:
+      if nodeBalance.isSome():
+        CgcCount(
+          dag.cfg.get_validators_custody_requirement(nodeBalance.get()))
+      else:
+        CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
+  of ValidatorCustodyState.LimitedCustody:
+    CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
+  of ValidatorCustodyState.StabilityPeriod:
+    CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
 
-  # check which custody set is larger
-  if newer_columns.len >= vcus.older_column_set.len:
-    vcus.diff_set = toSeq(newer_columns.difference(vcus.older_column_set))
-  # else declare the difference to be 0
+func getColumnMap(
+    config: BeaconNodeConf,
+    network: Eth2Node,
+    dag: ChainDagRef,
+    groupsCount: CgcCount
+): ColumnMap =
+  if uint64(groupsCount) == dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
+    var res: ColumnMap
+    for i in 0 ..< dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
+      res.incl(ColumnIndex(i))
+    res
+  elif uint64(groupsCount) == (dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1:
+    var res: ColumnMap
+    for i in 0 ..< (dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1:
+      res.incl(ColumnIndex(i))
+    res
   else:
-    vcus.diff_set = @[]
+    dag.cfg.resolve_column_map_from_custody_groups(
+      network.nodeId, CustodyIndex(groupsCount))
 
-  vcus.older_column_set = vcus.newer_column_set
-  vcus.newer_column_set = newer_columns
-  vcus.dag.eaSlot = max(vcus.dag.eaSlot, current_slot)
+func getGroupsCount(
+    vcus: ValidatorCustodyRef,
+    nodeBalance: Opt[Gwei]
+): CgcCount =
+  getGroupsCount(vcus.state, vcus.config, vcus.network, vcus.dag, nodeBalance)
+
+func getColumnMap(
+    vcus: ValidatorCustodyRef,
+    groupsCount: CgcCount
+): ColumnMap =
+  getColumnMap(vcus.config, vcus.network, vcus.dag, groupsCount)
+
+func syncDistance(
+  vcus: ValidatorCustodyRef,
+  currentSlot: Slot
+): uint64 =
+  let headSlot = vcus.dag.head.slot
+  if currentSlot <= headSlot:
+    0'u64
+  else:
+    currentSlot - headSlot
+
+func updateState(vcus: ValidatorCustodyRef, currentSlot: Slot) =
+  let distance = vcus.syncDistance(currentSlot)
+  case vcus.state
+  of ValidatorCustodyState.Init:
+    if distance <= MaxSyncDistanceDeviationSlots:
+      vcus.state = ValidatorCustodyState.FullCustody
+    else:
+      vcus.state = ValidatorCustodyState.LimitedCustody
+  of ValidatorCustodyState.FullCustody:
+    if distance > MaxSyncDistanceDeviationSlots:
+      vcus.state = ValidatorCustodyState.LimitedCustody
+  of ValidatorCustodyState.LimitedCustody:
+    if distance > MaxSyncDistanceDeviationSlots:
+      vcus.state = ValidatorCustodyState.StabilityPeriod
+      vcus.stabilitySlot = Opt.some(currentSlot)
+  of ValidatorCustodyState.StabilityPeriod:
+    if distance > MaxSyncDistanceDeviationSlots:
+      vcus.state = ValidatorCustodyState.LimitedCustody
+      vcus.stabilitySlot = Opt.none(Slot)
+    else:
+      doAssert(vcus.stabilitySlot.isSome(),
+        "Stability start slot should be set at this moment")
+      doAssert(vcus.stabilitySlot.get() <= currentSlot,
+        "Invalid time? Current slot is less than stability start slot")
+      if currentSlot - vcus.stabilitySlot.get() >= StabilityDistanceSlots:
+        vcus.state = ValidatorCustodyState.FullCustody
+        vcus.stabilitySlot = Opt.none(Slot)
+
+proc init*(
+    T: type ValidatorCustodyRef,
+    config: BeaconNodeConf,
+    network: Eth2Node,
+    dag: ChainDAGRef
+): ValidatorCustodyRef =
+  let
+    localGroupsCount = getGroupsCount(
+      ValidatorCustodyState.Init, config, network, dag, Opt.none(Gwei))
+    columnMap = getColumnMap(config, network, dag, localGroupsCount)
+
+  network.loadCgcnetMetadataAndEnr(localGroupsCount.uint8)
+
+  ValidatorCustodyRef(
+    network: network,
+    config: config,
+    dag: dag,
+    curColumnMap: columnMap,
+    state: ValidatorCustodyState.Init
+  )
+
+proc setQuarantine*[T: ColumnQuarantines](
+    vcus: ValidatorCustodyRef,
+    q: T
+) =
+  when T is ColumnQuarantine:
+    vcus.fuluColumnQuarantine = q
+  elif T is GloasColumnQuarantine:
+    vcus.gloasColumnQuarantine = q
+
+proc setValidatorCustody*(
+  vcus: ValidatorCustodyRef,
+  currentSlot: Slot,
+  newGroupsCount: CgcCount,
+  newMap: ColumnMap
+) =
+  if len(newMap) != len(vcus.curColumnMap):
+    if not(isNil(vcus.fuluColumnQuarantine)):
+      vcus.fuluColumnQuarantine[].update(vcus.dag.cfg, newMap)
+    if not(isNil(vcus.gloasColumnQuarantine)):
+      vcus.gloasColumnQuarantine[].update(vcus.dag.cfg, newMap)
+    vcus.network.loadCgcnetMetadataAndEnr(newGroupsCount)
+    vcus.curColumnMap = newMap
+    vcus.curGroupsCount = newGroupsCount
+
+    # We only update the `ea_slot` when the new validator custody set is larger
+    # than the old one.
+    if len(newMap) > len(vcus.curColumnMap):
+      vcus.dag.eaSlot = currentSlot
+
+    info "New validator custody set", custody_columns = len(newMap)
+
+proc updateValidatorCustody*(
+    vcus: ValidatorCustodyRef,
+    currentSlot: Slot,
+    totalNodeBalance: Gwei
+) =
+  if totalNodeBalance == Gwei(0):
+    return
+
+  logScope:
+    total_node_balance = totalNodeBalance
+    current_state = vcus.state
+
+  debug "Total node balance before applying validator custody"
+
+  vcus.updateState(currentSlot)
+
+  let
+    newGroupsCount = vcus.getGroupsCount(Opt.some(totalNodeBalance))
+    newMap = vcus.getColumnMap(newGroupsCount)
+
+  if len(vcus.curColumnMap) != len(newMap):
+    info "New validator custody count detected"
+    vcus.setValidatorCustody(currentSlot, newGroupsCount, newMap)
+
+func getMap*(vcus: ValidatorCustodyRef): ColumnMap =
+  vcus.curColumnMap
+
+func getSet*(vcus: ValidatorCustodyRef): HashSet[ColumnIndex] =
+  var res: HashSet[ColumnIndex]
+  for index in vcus.curColumnMap:
+    res.incl(index)
+  res
+
+func getCustodyGroupSubnets*(vcus: ValidatorCustodyRef): uint64 =
+  uint64(vcus.curGroupsCount)
+
+func isSupernode*(vcus: ValidatorCustodyRef): bool =
+  uint64(vcus.curGroupsCount) == vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
+
+func isLightSupernode*(vcus: ValidatorCustodyRef): bool =
+  uint64(vcus.curGroupsCount) ==
+    (vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
+
+func getCustodyGroups*(vcus: ValidatorCustodyRef): seq[CustodyIndex] =
+  if vcus.isLightSupernode():
+    let custodyGroups = (vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
+    var res = newSeqOfCap[CustodyIndex](custodyGroups)
+    for i in 0 ..< custodyGroups:
+      res.add CustodyIndex(i)
+    res
+  else:
+    vcus.dag.cfg.get_custody_groups(vcus.network.nodeId, vcus.curGroupsCount)

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -59,6 +59,26 @@ type
 
   ValidatorCustodyRef* = ref ValidatorCustody
 
+func supernodeGroupsCount*(cfg: RuntimeConfig): CgcCount =
+  CgcCount(cfg.NUMBER_OF_CUSTODY_GROUPS)
+
+func lightSupernodeGroupsCount*(cfg: RuntimeConfig): CgcCount =
+  let columnsPerGroup =
+    NUMBER_OF_COLUMNS div cfg.NUMBER_OF_CUSTODY_GROUPS
+  CgcCount((NUMBER_OF_COLUMNS div 2) div columnsPerGroup)
+
+func supernodeGroupsCount*(vcus: ValidatorCustodyRef): CgcCount =
+  supernodeGroupsCount(vcus.dag.cfg)
+
+func lightSupernodeGroupsCount*(vcus: ValidatorCustodyRef): CgcCount =
+  lightSupernodeGroupsCount(vcus.dag.cfg)
+
+func supernodeColumnsCount*(): int =
+  NUMBER_OF_COLUMNS
+
+func lightSupernodeColumnsCount*(): int =
+  NUMBER_OF_COLUMNS div 2
+
 func getGroupsCount(
   state: ValidatorCustodyState,
   config: BeaconNodeConf,
@@ -67,18 +87,11 @@ func getGroupsCount(
   nodeBalance: Gwei
 ): CgcCount =
   case state
-  of ValidatorCustodyState.Init:
+  of ValidatorCustodyState.Init, ValidatorCustodyState.FullCustody:
     if config.peerdasSupernode:
-      CgcCount(dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
+      supernodeGroupsCount(dag.cfg)
     elif config.lightSupernode:
-      CgcCount((dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1)
-    else:
-      CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
-  of ValidatorCustodyState.FullCustody:
-    if config.peerdasSupernode:
-      CgcCount(dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
-    elif config.lightSupernode:
-      CgcCount((dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1)
+      lightSupernodeGroupsCount(dag.cfg)
     else:
       if nodeBalance == Gwei(0):
         # While there no active validators attached.
@@ -96,14 +109,16 @@ func getColumnMap(
     dag: ChainDAGRef,
     groupsCount: CgcCount
 ): ColumnMap =
-  if uint64(groupsCount) == dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
+  if config.peerdasSupernode:
+    # Supernode
     var res: ColumnMap
-    for i in 0 ..< dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
+    for i in 0 ..< supernodeColumnsCount():
       res.incl(ColumnIndex(i))
     res
-  elif uint64(groupsCount) == (dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1:
+  elif config.lightSupernode:
+    # Light supernode
     var res: ColumnMap
-    for i in 0 ..< (dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1:
+    for i in 0 ..< lightSupernodeColumnsCount():
       res.incl(ColumnIndex(i))
     res
   else:
@@ -245,17 +260,23 @@ func getSet*(vcus: ValidatorCustodyRef): HashSet[ColumnIndex] =
   res
 
 func isSupernode*(vcus: ValidatorCustodyRef): bool =
-  vcus.curGroupsCount == CgcCount(vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
+  ## This function returns current value, based on current state, so if we are
+  ## not in `LimitedCustody` state it will returns ``true``.
+  vcus.config.peerdasSupernode and
+    vcus.curGroupsCount == vcus.supernodeGroupsCount()
 
 func isLightSupernode*(vcus: ValidatorCustodyRef): bool =
-  vcus.curGroupsCount ==
-    CgcCount(vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
+  ## This function returns current value, based on current state, so if we are
+  ## not in `LimitedCustody` state it will returns ``true``.
+  vcus.config.lightSupernode and
+    vcus.curGroupsCount == vcus.lightSupernodeGroupsCount()
 
 func getCustodyGroups*(vcus: ValidatorCustodyRef): seq[CustodyIndex] =
+  ## Returns current dynamic state of custody groups.
   if vcus.isLightSupernode():
-    let custodyGroups = (vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
-    var res = newSeqOfCap[CustodyIndex](custodyGroups)
-    for i in 0 ..< custodyGroups:
+    let custodyGroups = vcus.lightSupernodeGroupsCount()
+    var res = newSeqOfCap[CustodyIndex](distinctBase(custodyGroups))
+    for i in CgcCount(0) ..< custodyGroups:
       res.add CustodyIndex(i)
     res
   else:

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -43,8 +43,8 @@ type
       ## When node recently become synced it should stay synced for some period
       ## of time before switch from `LimitedCustody` to `FullCustody`.
 
-  ## Init -> FullCustody -> LimitedCustody -> StablePeriod -> FullCustody
-  ## Init -> LimitedCustody -> StablePeriod -> FullCustody
+  ## Init -> FullCustody -> LimitedCustody -> StabilityPeriod -> FullCustody
+  ## Init -> LimitedCustody -> StabilityPeriod -> FullCustody
 
   ValidatorCustody* = object
     network: Eth2Node
@@ -58,8 +58,6 @@ type
     stabilitySlot: Opt[Slot]
 
   ValidatorCustodyRef* = ref ValidatorCustody
-
-  ColumnQuarantines* = ref ColumnQuarantine | ref GloasColumnQuarantine
 
 func getGroupsCount(
   state: ValidatorCustodyState,
@@ -95,7 +93,7 @@ func getGroupsCount(
 func getColumnMap(
     config: BeaconNodeConf,
     network: Eth2Node,
-    dag: ChainDagRef,
+    dag: ChainDAGRef,
     groupsCount: CgcCount
 ): ColumnMap =
   if uint64(groupsCount) == dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
@@ -156,8 +154,9 @@ func updateState(vcus: ValidatorCustodyRef, currentSlot: Slot) =
     else:
       doAssert(vcus.stabilitySlot.isSome(),
         "Stability start slot should be set at this moment")
-      doAssert(vcus.stabilitySlot.get() <= currentSlot,
-        "Invalid time? Current slot is less than stability start slot")
+      if vcus.stabilitySlot.get() <= currentSlot:
+        # Invalid time, or time shift, so we just update stability slot.
+        vcus.stabilitySlot = Opt.some(currentSlot)
       if currentSlot - vcus.stabilitySlot.get() >= StabilityDistanceSlots:
         vcus.state = ValidatorCustodyState.FullCustody
         vcus.stabilitySlot = Opt.none(Slot)
@@ -183,14 +182,11 @@ proc init*(
     state: ValidatorCustodyState.Init
   )
 
-proc setQuarantine*[T: ColumnQuarantines](
-    vcus: ValidatorCustodyRef,
-    q: T
-) =
-  when T is ColumnQuarantine:
-    vcus.fuluColumnQuarantine = q
-  elif T is GloasColumnQuarantine:
-    vcus.gloasColumnQuarantine = q
+func setQuarantine*(vcus: ValidatorCustodyRef, q: ref ColumnQuarantine) =
+  vcus.fuluColumnQuarantine = q
+
+func setQuarantine*(vcus: ValidatorCustodyRef, q: ref GloasColumnQuarantine) =
+  vcus.gloasColumnQuarantine = q
 
 proc setValidatorCustody*(
   vcus: ValidatorCustodyRef,
@@ -246,9 +242,6 @@ func getSet*(vcus: ValidatorCustodyRef): HashSet[ColumnIndex] =
   for index in vcus.curColumnMap:
     res.incl(index)
   res
-
-func getCustodyGroupSubnets*(vcus: ValidatorCustodyRef): uint64 =
-  uint64(vcus.curGroupsCount)
 
 func isSupernode*(vcus: ValidatorCustodyRef): bool =
   uint64(vcus.curGroupsCount) == vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -268,12 +268,12 @@ func isLightSupernode*(vcus: ValidatorCustodyRef): bool =
   vcus.config.lightSupernode and
     vcus.curGroupsCount == vcus.lightSupernodeGroupsCount()
 
-iterator getCustodyGroups*(vcus: ValidatorCustodyRef): CustodyIndex =
+iterator custodyGroups*(vcus: ValidatorCustodyRef): CustodyIndex =
   ## Returns current dynamic state of custody groups.
   if vcus.isLightSupernode():
-    let custodyGroups = vcus.lightSupernodeGroupsCount()
-    var res = newSeqOfCap[CustodyIndex](distinctBase(custodyGroups))
-    for i in CgcCount(0) ..< custodyGroups:
+    let groups = vcus.lightSupernodeGroupsCount()
+    var res = newSeqOfCap[CustodyIndex](distinctBase(groups))
+    for i in CgcCount(0) ..< groups:
       yield CustodyIndex(i)
   else:
     for i in vcus.dag.cfg.get_custody_groups(

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -7,7 +7,6 @@
 
 {.push raises: [].}
 
-import std/[sets]
 import chronicles
 import ssz_serialization/[proofs, types]
 import
@@ -253,11 +252,9 @@ proc updateValidatorCustody*(
 func getMap*(vcus: ValidatorCustodyRef): ColumnMap =
   vcus.curColumnMap
 
-func getSet*(vcus: ValidatorCustodyRef): HashSet[ColumnIndex] =
-  var res: HashSet[ColumnIndex]
+iterator getSet*(vcus: ValidatorCustodyRef): ColumnIndex =
   for index in vcus.curColumnMap:
-    res.incl(index)
-  res
+    yield index
 
 func isSupernode*(vcus: ValidatorCustodyRef): bool =
   ## This function returns current value, based on current state, so if we are
@@ -271,13 +268,14 @@ func isLightSupernode*(vcus: ValidatorCustodyRef): bool =
   vcus.config.lightSupernode and
     vcus.curGroupsCount == vcus.lightSupernodeGroupsCount()
 
-func getCustodyGroups*(vcus: ValidatorCustodyRef): seq[CustodyIndex] =
+iterator getCustodyGroups*(vcus: ValidatorCustodyRef): CustodyIndex =
   ## Returns current dynamic state of custody groups.
   if vcus.isLightSupernode():
     let custodyGroups = vcus.lightSupernodeGroupsCount()
     var res = newSeqOfCap[CustodyIndex](distinctBase(custodyGroups))
     for i in CgcCount(0) ..< custodyGroups:
-      res.add CustodyIndex(i)
-    res
+      yield CustodyIndex(i)
   else:
-    vcus.dag.cfg.get_custody_groups(vcus.network.nodeId, vcus.curGroupsCount)
+    for i in vcus.dag.cfg.get_custody_groups(
+      vcus.network.nodeId, vcus.curGroupsCount):
+      yield CustodyIndex(i)

--- a/beacon_chain/sync/validator_custody.nim
+++ b/beacon_chain/sync/validator_custody.nim
@@ -64,7 +64,7 @@ func getGroupsCount(
   config: BeaconNodeConf,
   network: Eth2Node,
   dag: ChainDAGRef,
-  nodeBalance: Opt[Gwei]
+  nodeBalance: Gwei
 ): CgcCount =
   case state
   of ValidatorCustodyState.Init:
@@ -80,11 +80,11 @@ func getGroupsCount(
     elif config.lightSupernode:
       CgcCount((dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1)
     else:
-      if nodeBalance.isSome():
-        CgcCount(
-          dag.cfg.get_validators_custody_requirement(nodeBalance.get()))
-      else:
+      if nodeBalance == Gwei(0):
+        # While there no active validators attached.
         CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
+      else:
+        CgcCount(dag.cfg.get_validators_custody_requirement(nodeBalance))
   of ValidatorCustodyState.LimitedCustody:
     CgcCount(dag.cfg.CUSTODY_REQUIREMENT)
   of ValidatorCustodyState.StabilityPeriod:
@@ -112,7 +112,7 @@ func getColumnMap(
 
 func getGroupsCount(
     vcus: ValidatorCustodyRef,
-    nodeBalance: Opt[Gwei]
+    nodeBalance: Gwei
 ): CgcCount =
   getGroupsCount(vcus.state, vcus.config, vcus.network, vcus.dag, nodeBalance)
 
@@ -165,11 +165,12 @@ proc init*(
     T: type ValidatorCustodyRef,
     config: BeaconNodeConf,
     network: Eth2Node,
-    dag: ChainDAGRef
+    dag: ChainDAGRef,
+    totalNodeBalance: Gwei
 ): ValidatorCustodyRef =
   let
     localGroupsCount = getGroupsCount(
-      ValidatorCustodyState.Init, config, network, dag, Opt.none(Gwei))
+      ValidatorCustodyState.Init, config, network, dag, totalNodeBalance)
     columnMap = getColumnMap(config, network, dag, localGroupsCount)
 
   network.loadCgcnetMetadataAndEnr(localGroupsCount.uint8)
@@ -227,7 +228,7 @@ proc updateValidatorCustody*(
   vcus.updateState(currentSlot)
 
   let
-    newGroupsCount = vcus.getGroupsCount(Opt.some(totalNodeBalance))
+    newGroupsCount = vcus.getGroupsCount(totalNodeBalance)
     newMap = vcus.getColumnMap(newGroupsCount)
 
   if len(vcus.curColumnMap) != len(newMap):
@@ -244,11 +245,11 @@ func getSet*(vcus: ValidatorCustodyRef): HashSet[ColumnIndex] =
   res
 
 func isSupernode*(vcus: ValidatorCustodyRef): bool =
-  uint64(vcus.curGroupsCount) == vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS
+  vcus.curGroupsCount == CgcCount(vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS)
 
 func isLightSupernode*(vcus: ValidatorCustodyRef): bool =
-  uint64(vcus.curGroupsCount) ==
-    (vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
+  vcus.curGroupsCount ==
+    CgcCount(vcus.dag.cfg.NUMBER_OF_CUSTODY_GROUPS div 2) + 1
 
 func getCustodyGroups*(vcus: ValidatorCustodyRef): seq[CustodyIndex] =
   if vcus.isLightSupernode():


### PR DESCRIPTION
With this change i have also made `ValidatorCustodyRef` as main source for number of custody groups and columns.

Algorithm:

1. Node starts with minimal amount of columns  `CUSTODY_REQUIREMENT` (state: `Init`).
2. When node is not in sync it will going to use minimal amount of columns `CUSTODY_REQUIREMENT` (state: `LimitedSet`).
3. When node become optimistically synced it will enter period of time where we monitor node sync status stability, so if node kept synced it will be switched to number of columns based on validators total balance (state: `StabilityPeriod`).
4. When node is in sync it will use number of columns based on validators total balance (**NOTE**: current version does not fix bug that we did not count validators managed by VC).

`syncDistance()` is main sync check function. As soon as result of function is bigger than `MaxSyncDistanceDeviationSlots = 5` node considered as not in sync.