### PR TITLE
Pass slot number to Gloas data column sidecar REST objects

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -838,6 +838,7 @@ proc validateDataColumnSidecar*(
     onDataColumnSidecarCallback DataColumnSidecarInfoObject(
       block_root: block_root,
       index: data_column_sidecar.index,
+      slot: data_column_sidecar.slot,
       kzg_commitments: bid.blob_kzg_commitments)
 
   ok()


### PR DESCRIPTION
For Gloas, data column sidecars forgot to pass the slot as the version back then in the spec didn't have a slot. However, the slot is meanwhile available, so we can also forward it via REST.