### PR TITLE
Do not compute shuffling for answering total_active_balance query

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1021,7 +1021,7 @@ func get_total_active_balance*(state: ForkyBeaconState, cache: var StateCache): 
     return tab[]
   do:
     let tab = get_total_balance(
-      state, cache.get_shuffled_active_validator_indices(state, epoch))
+      state, get_active_validator_indices(state, epoch))
     cache.total_active_balance[epoch] = tab
     return tab
 


### PR DESCRIPTION
Saves about 120ms for `process_epoch` on the massive deposit queue. The shuffling isn't needed until later (and then it's in `EpochRef`).