### PR TITLE
Cache participating balances from unrealized finality computation

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -178,7 +178,11 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
               if blckRef == dag.head:
                 withState(dag.headState):
                   when consensusFork >= ConsensusFork.Altair:
-                    forkyState.data.compute_unrealized_finality()
+                    let (checkpoints, balances) =
+                      forkyState.data.compute_unrealized_finality()
+                    dag.putParticipatingBalances CachedParticipatingBalances(
+                      bid: blckRef.bid, balances: balances)
+                    checkpoints
                   else:
                     var cache: StateCache
                     forkyState.data.compute_unrealized_finality(cache)

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -139,14 +139,14 @@ proc addResolvedHeadBlock(
   # Notify others of the new block before processing the quarantine, such that
   # notifications for parents happens before those of the children
   if onBlockAdded != nil:
-    let unrealized =
-      when consensusFork >= ConsensusFork.Altair:
-        state.forky(consensusFork).data.compute_unrealized_finality()
-      else:
-        state.forky(consensusFork).data.compute_unrealized_finality(cache)
-    onBlockAdded(
-      blockRef, trustedBlock, state.forky(consensusFork).data, epochRef, unrealized
-    )
+    template forkyState: auto = state.forky(consensusFork)
+    when consensusFork >= ConsensusFork.Altair:
+      let (unrealized, balances) = forkyState.data.compute_unrealized_finality()
+      dag.putParticipatingBalances CachedParticipatingBalances(
+        bid: blockRef.bid, balances: balances)
+    else:
+      let unrealized = forkyState.data.compute_unrealized_finality(cache)
+    onBlockAdded(blockRef, trustedBlock, forkyState.data, epochRef, unrealized)
 
   if not(isNil(dag.onBlockAdded)):
     dag.onBlockAdded(ForkedTrustedSignedBeaconBlock.init(trustedBlock))

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -67,6 +67,10 @@ type
     entries*: array[I, tuple[value: T, lastUsed: uint32]]
     timestamp*: uint32
 
+  CachedParticipatingBalances* = object
+    bid*: BlockId
+    balances*: ParticipatingBalances
+
   ChainDAGRef* = ref object
     ## ChainDAG validates, stores and serves chain history of valid blocks
     ## according to the beacon chain state transition. From genesis to the
@@ -208,6 +212,8 @@ type
     updateFlags*: UpdateFlags
 
     cfg*: RuntimeConfig
+
+    participatingBalances*: LRUCache[8, CachedParticipatingBalances]
 
     shufflingRefs*: LRUCache[16, ShufflingRef]
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -764,7 +764,7 @@ func loadStateCache*(
 
   let balances = dag.findParticipatingBalances(bid)
   if balances.isSome:
-    cache.participating.ok (epoch: bid.slot.epoch, balances: balances.unsafeGet)
+    cache.participating.ok (slot: bid.slot, balances: balances.unsafeGet)
 
 func containsForkBlock*(dag: ChainDAGRef, root: Eth2Digest): bool =
   ## Checks for blocks at the finalized checkpoint or newer

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -603,6 +603,10 @@ func putParticipatingBalances*(
     dag: ChainDAGRef, value: CachedParticipatingBalances) =
   dag.participatingBalances.put value
 
+func findParticipatingBalances*(
+    dag: ChainDAGRef, bid: BlockId): Opt[ParticipatingBalances] =
+  ok (? dag.participatingBalances.findIt(it.bid == bid)).balances
+
 func putShufflingRef*(dag: ChainDAGRef, shufflingRef: ShufflingRef) =
   ## Store shuffling in the cache
   if shufflingRef.epoch < dag.finalizedHead.slot.epoch():
@@ -758,11 +762,9 @@ func loadStateCache*(
         # validation / head updates
         cache.sync_committees[period] = dag.headSyncCommittees
 
-  let balances = dag.participatingBalances.findIt(it.bid.root == bid.root)
+  let balances = dag.findParticipatingBalances(bid)
   if balances.isSome:
-    cache.participating.ok (
-      epoch: balances.unsafeGet.bid.slot.epoch,
-      balances: balances.unsafeGet.balances)
+    cache.participating.ok (epoch: bid.slot.epoch, balances: balances.unsafeGet)
 
 func containsForkBlock*(dag: ChainDAGRef, root: Eth2Digest): bool =
   ## Checks for blocks at the finalized checkpoint or newer

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -599,6 +599,10 @@ func epochKey(dag: ChainDAGRef, bid: BlockId, epoch: Epoch): Opt[EpochKey] =
 
   Opt.some(EpochKey(bid: bsi.bid, epoch: epoch))
 
+func putParticipatingBalances*(
+    dag: ChainDAGRef, value: CachedParticipatingBalances) =
+  dag.participatingBalances.put value
+
 func putShufflingRef*(dag: ChainDAGRef, shufflingRef: ShufflingRef) =
   ## Store shuffling in the cache
   if shufflingRef.epoch < dag.finalizedHead.slot.epoch():
@@ -753,6 +757,12 @@ func loadStateCache*(
         # We often end up sharing sync committees with head during sync / gossip
         # validation / head updates
         cache.sync_committees[period] = dag.headSyncCommittees
+
+  let balances = dag.participatingBalances.findIt(it.bid.root == bid.root)
+  if balances.isSome:
+    cache.participating.ok (
+      epoch: balances.unsafeGet.bid.slot.epoch,
+      balances: balances.unsafeGet.balances)
 
 func containsForkBlock*(dag: ChainDAGRef, root: Eth2Digest): bool =
   ## Checks for blocks at the finalized checkpoint or newer

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -7,6 +7,8 @@
 
 {.push raises: [].}
 
+import metrics
+
 # Temporary dumping ground for extra types and helpers that could make it into
 # the spec potentially
 #
@@ -42,3 +44,12 @@ type
     ## strict state transition of the last envelope in updateState().
 
   UpdateFlags* = set[UpdateFlag]
+
+# Single metric used for internal inconsistencies that should not happen.
+# If it ever becomes non-0, check the logs for warnings and report a bug.
+
+declareCounter beacon_errors_internal_total,
+  "Total occurrences of internal errors - check logs"
+
+proc incInternalErrors*() =
+  beacon_errors_internal_total.inc()

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -27,12 +27,6 @@ export base, sets
 from ssz_serialization/proofs import GeneralizedIndex, get_generalized_index
 export proofs.GeneralizedIndex
 
-type
-  TimelyFlag* {.pure.} = enum
-    TIMELY_SOURCE_FLAG_INDEX
-    TIMELY_TARGET_FLAG_INDEX
-    TIMELY_HEAD_FLAG_INDEX
-
 static:
   # Verify that ordinals follow spec values (the spec uses these as shifts for bit flags)
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/altair/beacon-chain.md#participation-flag-indices
@@ -192,11 +186,6 @@ type
     current_sync_committee*: SyncCommittee     # [New in Altair]
     next_sync_committee*: SyncCommittee        # [New in Altair]
 
-  UnslashedParticipatingBalances* = object
-    previous_epoch*: array[TimelyFlag, Gwei]
-    current_epoch_TIMELY_TARGET*: Gwei
-    current_epoch*: Gwei # aka total_active_balance
-
   ParticipationFlag* {.pure.} = enum
     timelySourceAttester
     timelyTargetAttester
@@ -210,7 +199,7 @@ type
   EpochInfo* = object
     ## Information about the outcome of epoch processing
     validators*: seq[ParticipationInfo]
-    balances*: UnslashedParticipatingBalances
+    balances*: ParticipatingBalances
 
   # TODO Careful, not nil analysis is broken / incomplete and the semantics will
   #      likely change in future versions of the language:
@@ -657,7 +646,7 @@ chronicles.formatIt LightClientOptimisticUpdate: shortLog(it)
 
 func clear*(info: var EpochInfo) =
   info.validators.setLen(0)
-  info.balances = UnslashedParticipatingBalances()
+  info.balances.reset()
 
 template asSigned*(
     x: SigVerifiedSignedBeaconBlock |

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -426,7 +426,7 @@ type
     shuffled_active_validator_indices*: Table[Epoch, seq[ValidatorIndex]]
     beacon_proposer_indices*: Table[Slot, Opt[ValidatorIndex]]
     sync_committees*: Table[SyncCommitteePeriod, SyncCommitteeCache]
-    participating*: Opt[tuple[epoch: Epoch, balances: ParticipatingBalances]]
+    participating*: Opt[tuple[slot: Slot, balances: ParticipatingBalances]]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/beacon-chain.md#validator
   ValidatorStatus* = object
@@ -1006,7 +1006,7 @@ func prune*(cache: var StateCache, epoch: Epoch) =
     drops.setLen(0)
 
   if cache.participating.isSome and
-      cache.participating.unsafeGet.epoch < pruneEpoch:
+      cache.participating.unsafeGet.slot.epoch < pruneEpoch:
     cache.participating.reset()
 
 func clear*(cache: var StateCache) =

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -408,6 +408,17 @@ type
     current_sync_committee*: array[SYNC_COMMITTEE_SIZE, ValidatorIndex]
     next_sync_committee*: array[SYNC_COMMITTEE_SIZE, ValidatorIndex]
 
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/altair/beacon-chain.md#participation-flag-indices
+  TimelyFlag* {.pure.} = enum
+    TIMELY_SOURCE_FLAG_INDEX = 0
+    TIMELY_TARGET_FLAG_INDEX = 1
+    TIMELY_HEAD_FLAG_INDEX = 2
+
+  ParticipatingBalances* = object
+    previous_epoch*: array[TimelyFlag, Gwei]
+    current_epoch_TIMELY_TARGET*: Gwei
+    current_epoch*: Gwei  # aka total_active_balance
+
   # This doesn't know about forks or branches in the DAG. It's for straight,
   # linear chunks of the chain.
   StateCache* = object
@@ -415,6 +426,7 @@ type
     shuffled_active_validator_indices*: Table[Epoch, seq[ValidatorIndex]]
     beacon_proposer_indices*: Table[Slot, Opt[ValidatorIndex]]
     sync_committees*: Table[SyncCommitteePeriod, SyncCommitteeCache]
+    participating*: Opt[tuple[epoch: Epoch, balances: ParticipatingBalances]]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/phase0/beacon-chain.md#validator
   ValidatorStatus* = object
@@ -993,11 +1005,16 @@ func prune*(cache: var StateCache, epoch: Epoch) =
       cache.sync_committees.del drop.sync_committee_period
     drops.setLen(0)
 
+  if cache.participating.isSome and
+      cache.participating.unsafeGet.epoch < pruneEpoch:
+    cache.participating.reset()
+
 func clear*(cache: var StateCache) =
   cache.total_active_balance.clear
   cache.shuffled_active_validator_indices.clear
   cache.beacon_proposer_indices.clear
   cache.sync_committees.clear
+  cache.participating.reset()
 
 func checkForkConsistency*(cfg: RuntimeConfig) =
   let forkVersions =

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -25,7 +25,7 @@
 #   motivated by security or performance considerations
 
 import
-  chronicles, metrics,
+  chronicles,
   ../extras,
   ./[beaconstate, eth2_merkleization, forks, helpers, validator, signatures],
   kzg4844/kzg_abi, kzg4844/kzg

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -176,11 +176,11 @@ func get_unslashed_participating_balances*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
            gloas.BeaconState):
-    UnslashedParticipatingBalances =
+    ParticipatingBalances =
   let
     previous_epoch = get_previous_epoch(state)
     current_epoch = get_current_epoch(state)
-  var res: UnslashedParticipatingBalances
+  var res: ParticipatingBalances
 
   for validator_index in 0'u64 ..< state.validators.lenu64:
     let
@@ -423,7 +423,7 @@ proc process_justification_and_finalization*(
     state: var (altair.BeaconState | bellatrix.BeaconState |
                 capella.BeaconState | deneb.BeaconState | electra.BeaconState |
                 fulu.BeaconState | gloas.BeaconState),
-    balances: UnslashedParticipatingBalances,
+    balances: ParticipatingBalances,
     flags: UpdateFlags = {}) =
   # Initial FFG checkpoint values have a `0x00` stub for `root`.
   # Skip FFG updates in the first two epochs to avoid corner cases that might
@@ -445,22 +445,22 @@ proc process_justification_and_finalization*(
 proc compute_unrealized_finality*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
-           gloas.BeaconState): FinalityCheckpoints =
-  if get_current_epoch(state) <= GENESIS_EPOCH + 1:
-    return FinalityCheckpoints(
-      justified: state.current_justified_checkpoint,
-      finalized: state.finalized_checkpoint)
-
+           gloas.BeaconState): (FinalityCheckpoints, ParticipatingBalances) =
   let balances = get_unslashed_participating_balances(state)
+
+  if get_current_epoch(state) <= GENESIS_EPOCH + 1:
+    return (FinalityCheckpoints(
+      justified: state.current_justified_checkpoint,
+      finalized: state.finalized_checkpoint), balances)
 
   var finalityState = state.toFinalityState()
   let jfRes = weigh_justification_and_finalization(
     finalityState, balances.current_epoch,
     balances.previous_epoch[TIMELY_TARGET_FLAG_INDEX],
     balances.current_epoch_TIMELY_TARGET)
-  FinalityCheckpoints(
+  (FinalityCheckpoints(
     justified: jfRes.current_justified_checkpoint,
-    finalized: jfRes.finalized_checkpoint)
+    finalized: jfRes.finalized_checkpoint), balances)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/beacon-chain.md#helpers
 func get_base_reward_sqrt*(state: phase0.BeaconState, index: ValidatorIndex,
@@ -1425,9 +1425,14 @@ func init*(
     info: var altair.EpochInfo,
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
-           gloas.BeaconState) =
-  # init participation, overwriting the full structure
-  info.balances = get_unslashed_participating_balances(state)
+           gloas.BeaconState,
+    cache = default(StateCache)) =
+  # init participation, reusing cached balances when available
+  if cache.participating.isSome and
+      cache.participating.unsafeGet.epoch == get_current_epoch(state):
+    info.balances = cache.participating.unsafeGet.balances
+  else:
+    info.balances = get_unslashed_participating_balances(state)
   info.validators.setLen(state.validators.len())
 
   let previous_epoch = get_previous_epoch(state)
@@ -1436,9 +1441,7 @@ func init*(
     if is_eligible_validator(state.validators[index], previous_epoch):
       flags.incl ParticipationFlag.eligible
 
-    info.validators[index] = ParticipationInfo(
-      flags: flags
-    )
+    info.validators[index] = ParticipationInfo(flags: flags)
 
 func init*(
     T: type altair.EpochInfo,
@@ -1454,7 +1457,7 @@ proc process_epoch*(
     flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
     Result[void, cstring] =
   let epoch = get_current_epoch(state)
-  info.init(state)
+  info.init(state, cache)
 
   process_justification_and_finalization(state, info.balances, flags)
 
@@ -1489,7 +1492,7 @@ proc process_epoch*(
     flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
     Result[void, cstring] =
   let epoch = get_current_epoch(state)
-  info.init(state)
+  info.init(state, cache)
 
   process_justification_and_finalization(state, info.balances, flags)
 
@@ -1524,7 +1527,7 @@ proc process_epoch*(
     flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
     Result[void, cstring] =
   let epoch = get_current_epoch(state)
-  info.init(state)
+  info.init(state, cache)
 
   process_justification_and_finalization(state, info.balances, flags)
 
@@ -1561,7 +1564,7 @@ proc process_epoch*(
     flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
     Result[void, cstring] =
   let epoch = get_current_epoch(state)
-  info.init(state)
+  info.init(state, cache)
 
   process_justification_and_finalization(state, info.balances, flags)
 
@@ -1599,7 +1602,7 @@ proc process_epoch*(
     flags: UpdateFlags, cache: var StateCache, info: var altair.EpochInfo):
     Result[void, cstring] =
   let epoch = get_current_epoch(state)
-  info.init(state)
+  info.init(state, cache)
 
   process_justification_and_finalization(state, info.balances, flags)
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1458,19 +1458,23 @@ proc init*(
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
            gloas.BeaconState | heze.BeaconState,
     cache = default(StateCache)) =
-  # init participation, reusing cached balances when available
-  if cache.participating.isSome and
-      cache.participating.unsafeGet.epoch == get_current_epoch(state):
-    info.balances = cache.participating.unsafeGet.balances
-    debugGloasComment "remove + proc -> func once this got enough maturity"
-    let expected = get_unslashed_participating_balances(state)
-    if info.balances != expected:
-      warn "Participating balances cache mismatch - report bug",
-        slot = state.slot, actual = info.balances, expected
-      incInternalErrors()
-      info.balances = expected
-  else:
-    info.balances = get_unslashed_participating_balances(state)
+  # init participation, overwriting the full structure
+  info.balances =
+    if cache.participating.isSome:
+      let participating = cache.participating.unsafeGet
+      if participating.slot == state.latest_block_header.slot and
+          participating.slot.epoch == get_current_epoch(state):
+        debugGloasComment "remove + proc -> func once this got enough maturity"
+        let expected_balances = get_unslashed_participating_balances(state)
+        if participating.balances != expected_balances:
+          warn "Participating balances cache mismatch - report bug",
+            slot = state.slot, participating, expected_balances
+          incInternalErrors()
+        expected_balances  # participating.balances
+      else:
+        get_unslashed_participating_balances(state)
+    else:
+      get_unslashed_participating_balances(state)
   info.validators.setLen(state.validators.len())
 
   let previous_epoch = get_previous_epoch(state)

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1421,7 +1421,7 @@ proc process_epoch*(
 
   ok()
 
-func init*(
+proc init*(
     info: var altair.EpochInfo,
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
@@ -1431,6 +1431,12 @@ func init*(
   if cache.participating.isSome and
       cache.participating.unsafeGet.epoch == get_current_epoch(state):
     info.balances = cache.participating.unsafeGet.balances
+    let expected = get_unslashed_participating_balances(state)
+    if info.balances != expected:
+      warn "Participating balances cache mismatch - report bug",
+        slot = state.slot, actual = info.balances, expected
+      incInternalErrors()
+      info.balances = expected
   else:
     info.balances = get_unslashed_participating_balances(state)
   info.validators.setLen(state.validators.len())
@@ -1443,7 +1449,7 @@ func init*(
 
     info.validators[index] = ParticipationInfo(flags: flags)
 
-func init*(
+proc init*(
     T: type altair.EpochInfo,
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -1431,6 +1431,7 @@ proc init*(
   if cache.participating.isSome and
       cache.participating.unsafeGet.epoch == get_current_epoch(state):
     info.balances = cache.participating.unsafeGet.balances
+    debugGloasComment "remove + proc -> func once this got enough maturity"
     let expected = get_unslashed_participating_balances(state)
     if info.balances != expected:
       warn "Participating balances cache mismatch - report bug",


### PR DESCRIPTION
When block is received, we have to run a partial epoch transition to obtain unrealized finality checkpoints. As part of this, participating balances info is computed. Later, when the epoch transition triggers, we compute the participating balances a second time, on the same data. Add a small cache for that to save ~10ms of epoch processing time.