### PR TITLE
Replace verifying signer GINDEX constants with get_generalized_index

### DIFF
--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -250,18 +250,15 @@ proc installApiHandlers*(node: SigningNodeRef) =
           return signatureResponse(Http200, signature)
 
         let (feeRecipientIndex, blockHeader) =
-          case request.beaconBlockHeader.kind
-          of ConsensusFork.Phase0 .. ConsensusFork.Capella:
-            return errorResponse(Http400, BlockIncorrectFork)
-          of ConsensusFork.Deneb:
-            (GeneralizedIndex(801), request.beaconBlockHeader.data)
-          of ConsensusFork.Electra:
-            (GeneralizedIndex(801), request.beaconBlockHeader.data)
-          of ConsensusFork.Fulu:
-            (GeneralizedIndex(801), request.beaconBlockHeader.data)
-          of ConsensusFork.Gloas:
-            debugGloasComment "do not this"
-            return errorResponse(Http400, BlockIncorrectFork)
+          withConsensusFork(request.beaconBlockHeader.kind):
+            when consensusFork in ConsensusFork.Deneb ..< ConsensusFork.Gloas:
+              const gindex = get_generalized_index(
+                consensusFork.BeaconBlockBody,
+                "execution_payload", "fee_recipient")
+              (gindex, request.beaconBlockHeader.data)
+            else:
+              debugGloasComment "do not this"
+              return errorResponse(Http400, BlockIncorrectFork)
 
         if request.proofs.isNone() or len(request.proofs.get()) == 0:
           return errorResponse(Http400, MissingMerkleProofError)

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -21,7 +21,12 @@ import
   nimcrypto/[sha2, rijndael, pbkdf2, bcmode, hash, scrypt],
   # Local modules
   libp2p/crypto/crypto as lcrypto,
-  ./datatypes/base, ./signatures
+  ./datatypes/base, ./[ssz_codec, signatures]
+
+from ssz_serialization/proofs import get_generalized_index
+from ./datatypes/electra import BeaconBlockBody
+from ./datatypes/fulu import BeaconBlockBody
+from ./datatypes/gloas import BeaconBlockBody
 
 from std/algorithm import binarySearch
 from std/math import `^`
@@ -719,25 +724,48 @@ template writeValue*(w: var JsonWriter,
                      value: Pbkdf2Salt|SimpleHexEncodedTypes|Aes128CtrIv) =
   writeJsonHexString(w.stream, distinctBase value)
 
-func parseProvenBlockProperty*(propertyPath: string): Result[ProvenProperty, string] =
-  if propertyPath == ".execution_payload.fee_recipient":
-    debugGloasComment "almost certainly not correct anymore, execution payload position changes substantially"
-    ok ProvenProperty(
+func parseProvenBlockProperty*(
+    propertyPath: string): Result[ProvenProperty, string] =
+  template gindexOrZero(path: varargs[untyped]): GeneralizedIndex =
+    when compiles(get_generalized_index(path)):
+      get_generalized_index(path)
+    else:
+      0.GeneralizedIndex
+
+  template initProvenProperty(
+      pathArgs: varargs[untyped]): ProvenProperty =
+    ProvenProperty(
       path: propertyPath,
-      electraIndex: GeneralizedIndex(801),
-      fuluIndex: GeneralizedIndex(801),
-      gloasIndex: GeneralizedIndex(801))
-  elif propertyPath == ".graffiti":
-    debugGloasComment "check if graffiti is still generalizedindex 18"
-    ok ProvenProperty(
-      path: propertyPath,
-      electraIndex: GeneralizedIndex(18),
-      fuluIndex: GeneralizedIndex(18),
-      gloasIndex: GeneralizedIndex(18))
+      electraIndex: electra.BeaconBlockBody.gindexOrZero(pathArgs),
+      fuluIndex: fulu.BeaconBlockBody.gindexOrZero(pathArgs),
+      gloasIndex: gloas.BeaconBlockBody.gindexOrZero(pathArgs))
+
+  case propertyPath
+  of ".execution_payload.fee_recipient":
+    let res = initProvenProperty("execution_payload", "fee_recipient")
+    ok res
+  of ".graffiti":
+    let res = initProvenProperty("graffiti")
+    ok res
   else:
     err("Keystores with proven properties different than " &
         "`.execution_payload.fee_recipient` and `.graffiti` " &
         "require a more recent version of Nimbus")
+
+static:
+  debugGloasComment "How to do fee recipient on Gloas?"
+  doAssert parseProvenBlockProperty(".execution_payload.fee_recipient").get ==
+    ProvenProperty(
+      path: ".execution_payload.fee_recipient",
+      electraIndex: 801.GeneralizedIndex,
+      fuluIndex: 801.GeneralizedIndex,
+      gloasIndex: 0.GeneralizedIndex)
+  doAssert parseProvenBlockProperty(".graffiti").get ==
+    ProvenProperty(
+      path: ".graffiti",
+      electraIndex: 18.GeneralizedIndex,
+      fuluIndex: 18.GeneralizedIndex,
+      gloasIndex: 18.GeneralizedIndex)
 
 proc readValue*(reader: var JsonReader, value: var RemoteKeystore)
                {.raises: [SerializationError, IOError].} =
@@ -839,20 +867,8 @@ proc readValue*(reader: var JsonReader, value: var RemoteKeystore)
           "RemoteKeystore")
       var provenProperties = reader.readValue(seq[ProvenProperty])
       for prop in provenProperties.mitems:
-        if prop.path == ".execution_payload.fee_recipient":
-          debugGloasComment "nearly certainly incorrect fee recipient generalizedindex"
-          prop.electraIndex = GeneralizedIndex(801)
-          prop.fuluIndex = GeneralizedIndex(801)
-          prop.gloasIndex = GeneralizedIndex(801)
-        elif prop.path == ".graffiti":
-          debugGloasComment "check if graffiti is still generalizedindex 18"
-          prop.electraIndex = GeneralizedIndex(18)
-          prop.fuluIndex = GeneralizedIndex(18)
-          prop.gloasIndex = GeneralizedIndex(18)
-        else:
-          reader.raiseUnexpectedValue("Keystores with proven properties different than " &
-                                      "`.execution_payload.fee_recipient` and `.graffiti` " &
-                                      "require a more recent version of Nimbus")
+        prop = parseProvenBlockProperty(prop.path).valueOr:
+          reader.raiseUnexpectedValue(error)
       provenBlockProperties = some provenProperties
     of "threshold":
       if threshold.isSome:

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -536,7 +536,8 @@ proc signData(v: AttachedValidator,
 proc init(T: type Web3SignerForkedBeaconBlock, blck: ForkyBeaconBlock | ForkyBlindedBeaconBlock): Web3SignerForkedBeaconBlock =
   Web3SignerForkedBeaconBlock(kind: typeof(blck).kind, data: blck.toBeaconBlockHeader())
 
-proc forkIndex(prop: ProvenProperty, fork: static ConsensusFork): GeneralizedIndex =
+proc forkIndex(
+    prop: ProvenProperty, fork: static ConsensusFork): GeneralizedIndex =
   when fork < ConsensusFork.Electra:
     static: raiseAssert "Unsupported fork " & $fork
   elif fork == ConsensusFork.Electra:
@@ -571,16 +572,19 @@ proc getBlockSignature*(v: AttachedValidator, fork: Fork,
           of RemoteSignerType.Web3Signer:
             Web3SignerRequest.init(fork, genesis_validators_root, fbb)
           of RemoteSignerType.VerifyingWeb3Signer:
-            when typeof(blck).kind >= ConsensusFork.Electra:
+            when consensusFork >= ConsensusFork.Electra:
               template blockPropertiesProofs(): seq[Web3SignerMerkleProof] =
                 var proofs: seq[Web3SignerMerkleProof]
 
                 for prop in v.data.provenBlockProperties:
-                  let idx = prop.forkIndex(typeof(blck).kind)
-                  proofs.add Web3SignerMerkleProof(
-                    index: idx,
-                    proof: ?build_proof(blck.body, idx)
-                  )
+                  let idx = prop.forkIndex(consensusFork)
+                  if idx > 0.GeneralizedIndex:
+                    proofs.add Web3SignerMerkleProof(
+                      index: idx,
+                      proof: ?build_proof(blck.body, idx))
+                  else:
+                    warn "Skipping proof of unsupported property",
+                      consensusFork, prop = prop.path
 
                 proofs
 

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2025 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/test_remote_keystore.nim
+++ b/tests/test_remote_keystore.nim
@@ -137,7 +137,7 @@ suite "Remove keystore testing suite":
       check keystore.provenBlockProperties.len == 1
       check keystore.provenBlockProperties[0].electraIndex == GeneralizedIndex(801)
       check keystore.provenBlockProperties[0].fuluIndex == GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].gloasIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].gloasIndex == GeneralizedIndex(0)
 
   test "Verifying Signer / Many remotes":
     for version in [3]:
@@ -186,4 +186,4 @@ suite "Remove keystore testing suite":
       check keystore.provenBlockProperties.len == 1
       check keystore.provenBlockProperties[0].electraIndex == GeneralizedIndex(801)
       check keystore.provenBlockProperties[0].fuluIndex == GeneralizedIndex(801)
-      check keystore.provenBlockProperties[0].gloasIndex == GeneralizedIndex(801)
+      check keystore.provenBlockProperties[0].gloasIndex == GeneralizedIndex(0)

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -240,7 +240,6 @@ func getRemoteKeystoreData(data: string, basePort: int,
       pubkey: publicKey
     )
 
-  debugGloasComment "presumably gloasIndex shouldn't be 801"
   ok case rt
     of RemoteSignerType.Web3Signer:
       KeystoreData(
@@ -254,12 +253,7 @@ func getRemoteKeystoreData(data: string, basePort: int,
         kind: KeystoreKind.Remote,
         remoteType: RemoteSignerType.VerifyingWeb3Signer,
         provenBlockProperties: @[
-          ProvenProperty(
-            path: ".execution_payload.fee_recipient",
-            gloasIndex: GeneralizedIndex(801),
-            fuluIndex: GeneralizedIndex(801),
-            electraIndex: GeneralizedIndex(801),
-          )
+          parseProvenBlockProperty(".execution_payload.fee_recipient").get,
         ],
         version: uint64(4),
         pubkey: publicKey,


### PR DESCRIPTION
Instead of doing the computation of gindex manually (which is sometimes preset dependent), use the new `get_generalized_index` API from nim-ssz and statically assert that the computed value matches the spec values.

Gloas flow for fee recipient was broken before and still is.