### PR TITLE
Track current epoch observed justified checkpoint block slot

### DIFF
--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -633,10 +633,7 @@ func should_restart_confirmation_chain*(
     self.current_epoch_observed_justified.checkpoint
   let
     observed_justified_block_slot =
-      self.proto_array.slot(current_epoch_justified.root).valueOr:
-        return err ForkChoiceError(
-          kind: fcJustifiedNodeUnknown,
-          blockRoot: current_epoch_justified.root)
+      self.current_epoch_observed_justified.info.block_slot
     is_observed_justified_block_epoch_ok =
       observed_justified_block_slot.epoch + 1 == current_slot.epoch
   if not is_observed_justified_block_epoch_ok:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -200,6 +200,11 @@ proc to_block_id(self: ForkChoiceBackend, checkpoint: Checkpoint): BlockId =
     checkpoint.epoch.start_slot
   result.root = checkpoint.root
 
+func observed_justified_block_id(self: ForkChoiceBackend): BlockId =
+  BlockId(
+    slot: self.current_epoch_observed_justified.info.block_slot,
+    root: self.current_epoch_observed_justified.checkpoint.root)
+
 proc update_unrealized_justified(self: var ForkChoice, dag: ChainDAGRef) =
   let unrealized = self.backend.previous_epoch_greatest_unrealized_checkpoint
   if unrealized == self.backend.current_epoch_observed_justified.checkpoint:
@@ -243,7 +248,7 @@ proc reconfirm_fcr(
   fcr.current_slot_head = ? fcr.find_head(current_slot, self.checkpoints)
   if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
     reason = "restart/e"
-    confirmed = fcr.to_block_id(current_epoch_justified)
+    confirmed = fcr.observed_justified_block_id
     incSafeRestarts()
   ok()
 
@@ -517,7 +522,7 @@ proc advance_fcr(
 
   if ? fcr.should_restart_confirmation_chain(confirmed, current_slot):
     reason = "restart/h"
-    confirmed = fcr.to_block_id(current_epoch_justified)
+    confirmed = fcr.observed_justified_block_id
     incSafeRestarts()
 
   # Attempt to further advance the latest confirmed block.

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -124,6 +124,7 @@ type
 
   BalanceCheckpoint* = object
     checkpoint*: Checkpoint
+    block_slot*: Slot
     total_active_balance*: Gwei
     balances*: seq[ForkChoiceBalance]
 
@@ -192,6 +193,7 @@ template to_balance_checkpoint*(
     epochRef: EpochRef, blck: BlockRef): BalanceCheckpoint =
   BalanceCheckpoint(
     checkpoint: Checkpoint(root: blck.root, epoch: epochRef.epoch),
+    block_slot: blck.slot,
     total_active_balance: epochRef.total_active_balance,
     balances: epochRef.fork_choice_balances)
 


### PR DESCRIPTION
FCR needs a reliable access to the current epoch observed justified cp block's slot, even when that one gets pruned (only updates every epoch). It's simple to track and ensures computation is accurate in edge case.