### PR TITLE
Replace Fulu data column GINDEX constants with get_generalized_index

### DIFF
--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -46,8 +46,6 @@ const
   BYTES_PER_CELL* = kzg_abi.FIELD_ELEMENTS_PER_CELL * kzg_abi.BYTES_PER_FIELD_ELEMENT
   # The number of cells in an extended blob |
 
-  KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX* = 27
-
   # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/p2p-interface.md#configuration
   DATA_COLUMN_SIDECAR_SUBNET_COUNT* = 128
 
@@ -634,3 +632,9 @@ template asTrusted*(
     x: SignedBeaconBlock |
        SigVerifiedSignedBeaconBlock): TrustedSignedBeaconBlock =
   isomorphicCast[TrustedSignedBeaconBlock](x)
+
+const
+  KZG_COMMITMENTS_GINDEX* = get_generalized_index(
+    BeaconBlockBody, "blob_kzg_commitments")
+static:
+  doAssert KZG_COMMITMENTS_GINDEX == 27.GeneralizedIndex

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -304,6 +304,8 @@ proc assemble_data_column_sidecars*(
     staticFor j, 0 ..< CELLS_PER_EXT_BLOB:
       assign(proofElem[][j], cell_proofs[i * CELLS_PER_EXT_BLOB + j])
 
+  let inclusion_proof =
+    blck.body.build_proof(KZG_COMMITMENTS_GINDEX).expect("Valid gindex")
   for columnIndex in 0..<CELLS_PER_EXT_BLOB:
     var
       column = newSeqOfCap[KzgCell](blobs.len)
@@ -312,16 +314,13 @@ proc assemble_data_column_sidecars*(
       column.add(cells[rowIndex][columnIndex])
       kzgProofOfColumn.add(proofs[rowIndex][columnIndex])
 
-    var sidecar = fulu.DataColumnSidecar(
+    sidecars.add fulu.DataColumnSidecar(
       index: ColumnIndex(columnIndex),
       column: DataColumn.init(column),
       kzg_commitments: blck.body.blob_kzg_commitments,
       kzg_proofs: deneb.KzgProofs.init(kzgProofOfColumn),
-      signed_block_header: signed_beacon_block_header)
-    blck.body.build_proof(
-      KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX.GeneralizedIndex,
-      sidecar.kzg_commitments_inclusion_proof).expect("Valid gindex")
-    sidecars.add(sidecar)
+      signed_block_header: signed_beacon_block_header,
+      kzg_commitments_inclusion_proof: inclusion_proof)
 
   sidecars
 
@@ -493,18 +492,16 @@ func verify_data_column_sidecar*(cfg: RuntimeConfig, sidecar: gloas.DataColumnSi
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/p2p-interface.md#verify_data_column_sidecar_inclusion_proof
-func verify_data_column_sidecar_inclusion_proof*(sidecar: fulu.DataColumnSidecar):
-                                                 Result[void, cstring] =
+func verify_data_column_sidecar_inclusion_proof*(
+    sidecar: fulu.DataColumnSidecar): Result[void, cstring] =
   ## Verify if the given KZG commitments included in the given beacon block.
-  let gindex =
-    KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX.GeneralizedIndex
+  const gindex = KZG_COMMITMENTS_GINDEX
   if not is_valid_merkle_branch(
       hash_tree_root(sidecar.kzg_commitments),
       sidecar.kzg_commitments_inclusion_proof,
       KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH.int,
       get_subtree_index(gindex),
       sidecar.signed_block_header.message.body_root):
-
     return err("DataColumnSidecar: Inclusion proof is invalid")
 
   ok()
@@ -513,15 +510,13 @@ func verify_data_column_sidecar_inclusion_proof*(sidecar: fulu.DataColumnSidecar
 func verify_partial_data_column_header_inclusion_proof*(
     header: fulu.PartialDataColumnHeader): Result[void, cstring] =
   ## Verify if the given KZG commitments are included in the given beacon block.
-  let gindex =
-    KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH_GINDEX.GeneralizedIndex
+  const gindex = KZG_COMMITMENTS_GINDEX
   if not is_valid_merkle_branch(
       hash_tree_root(header.kzg_commitments),
       header.kzg_commitments_inclusion_proof,
       KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH.int,
       get_subtree_index(gindex),
       header.signed_block_header.message.body_root):
-
     return err("PartialDataColumnHeader: Inclusion proof is invalid")
 
   ok()


### PR DESCRIPTION
Instead of doing the computation of gindex manually (which is sometimes preset dependent), use the new `get_generalized_index` API from nim-ssz and statically assert that the computed value matches the spec values.

Also avoid repeated inclusion proof computation for each data column.