### PR TITLE
Use proof unions for collecting the various light client data branches

### DIFF
--- a/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types_light_client.nim
@@ -36,16 +36,10 @@ type
   CachedLightClientData* = object
     ## Cached data from historical non-finalized states to improve speed when
     ## creating future `LightClientUpdate` and `LightClientBootstrap` instances.
-    current_sync_committee_branch*:
-      LightClientDataFork.high.CurrentSyncCommitteeBranch
-    next_sync_committee_branch*:
-      LightClientDataFork.high.NextSyncCommitteeBranch
-
     finalized_slot*: Slot
-    finality_branch*: LightClientDataFork.high.FinalityBranch
-
     current_period_best_update*: ref ForkedLightClientUpdate
     latest_signature_slot*: Slot
+    union_roots*: seq[Eth2Digest]
 
   LightClientDataCache* = object
     data*: Table[BlockId, CachedLightClientData]

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -419,9 +419,9 @@ proc initLightClientUpdateForPeriod(
             union_roots.extract_branch(
               union_indices, lcDataFork.finalized_root_gindex).get
         else:
-          forkyState.data.build_proof(
-            lcDataFork.next_sync_committee_gindex,
-            update.forky(lcDataFork).next_sync_committee_branch).expect("OK")
+          update.forky(lcDataFork).next_sync_committee_branch =
+            forkyState.data.build_proof(
+              lcDataFork.next_sync_committee_gindex).get
       else: raiseAssert "Unreachable"
   do:
     dag.handleUnexpectedLightClientError(attestedBid.slot)

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -8,9 +8,6 @@
 {.push raises: [], gcsafe.}
 
 import
-  # Status libraries
-  stew/bitops2,
-  # Beacon chain internals
   ../spec/forks,
   ../beacon_chain_db_light_client,
   "."/[block_pools_types, blockchain_dag]
@@ -407,16 +404,24 @@ proc initLightClientUpdateForPeriod(
         debugGloasComment ""
       elif consensusFork >= ConsensusFork.Altair:
         const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
-        update = ForkedLightClientUpdate.init(lcDataFork.LightClientUpdate(
+        update = ForkedLightClientUpdate.init lcDataFork.LightClientUpdate(
           attested_header: forkyBlck.toLightClientHeader(lcDataFork),
-          next_sync_committee: forkyState.data.next_sync_committee,
-          next_sync_committee_branch: forkyState.data.build_proof(
-            lcDataFork.next_sync_committee_gindex).get,
-          finality_branch:
-            if finalizedBid.slot != FAR_FUTURE_SLOT:
-              forkyState.data.build_proof(lcDataFork.finalized_root_gindex).get
-            else:
-              default(lcDataFork.FinalityBranch)))
+          next_sync_committee: forkyState.data.next_sync_committee)
+        if finalizedBid.slot != FAR_FUTURE_SLOT:
+          const union_indices = get_union_indices(
+            lcDataFork.next_sync_committee_gindex,
+            lcDataFork.finalized_root_gindex)
+          let union_roots = forkyState.data.hash_tree_root(union_indices).get
+          update.forky(lcDataFork).next_sync_committee_branch =
+            union_roots.extract_branch(
+              union_indices, lcDataFork.next_sync_committee_gindex).get
+          update.forky(lcDataFork).finality_branch =
+            union_roots.extract_branch(
+              union_indices, lcDataFork.finalized_root_gindex).get
+        else:
+          forkyState.data.build_proof(
+            lcDataFork.next_sync_committee_gindex,
+            update.forky(lcDataFork).next_sync_committee_branch).expect("OK")
       else: raiseAssert "Unreachable"
   do:
     dag.handleUnexpectedLightClientError(attestedBid.slot)
@@ -474,6 +479,34 @@ func getLightClientData(
   try: dag.lcDataStore.cache.data[bid]
   except KeyError: raiseAssert "Unreachable"
 
+func union_indices(
+    lcDataFork: static LightClientDataFork): auto {.compileTime.} =
+  get_union_indices(
+    lcDataFork.current_sync_committee_gindex,
+    lcDataFork.next_sync_committee_gindex,
+    lcDataFork.finalized_root_gindex)
+
+template current_sync_committee_branch(
+    cachedData: CachedLightClientData): auto =
+  const
+    union_indices = lcDataFork.union_indices
+    index = lcDataFork.current_sync_committee_gindex
+  cachedData.union_roots.extract_branch(union_indices, index).get
+
+template next_sync_committee_branch(
+    cachedData: CachedLightClientData): auto =
+  const
+    union_indices = lcDataFork.union_indices
+    index = lcDataFork.next_sync_committee_gindex
+  cachedData.union_roots.extract_branch(union_indices, index).get
+
+template finality_branch(
+    cachedData: CachedLightClientData): auto =
+  const
+    union_indices = lcDataFork.union_indices
+    index = lcDataFork.finalized_root_gindex
+  cachedData.union_roots.extract_branch(union_indices, index).get
+
 func cacheLightClientData(
     dag: ChainDAGRef,
     state: ForkyHashedBeaconState,
@@ -483,27 +516,18 @@ func cacheLightClientData(
   ## Cache data for a given block and its post-state to speed up creating future
   ## `LightClientUpdate` and `LightClientBootstrap` instances that refer to this
   ## block and state.
-  const lcDataFork = lcDataForkAtConsensusFork(typeof(state).kind)
-  let
-    bid = blck.toBlockId()
-    cachedData = CachedLightClientData(
-      current_sync_committee_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.current_sync_committee_gindex).get,
-        LightClientDataFork.high.current_sync_committee_gindex),
-      next_sync_committee_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.next_sync_committee_gindex).get,
-        LightClientDataFork.high.next_sync_committee_gindex),
-      finalized_slot:
-        state.data.finalized_checkpoint.epoch.start_slot,
-      finality_branch: normalize_merkle_branch(
-        state.data.build_proof(lcDataFork.finalized_root_gindex).get,
-        LightClientDataFork.high.finalized_root_gindex),
-      current_period_best_update:
-        current_period_best_update,
-      latest_signature_slot:
-        latest_signature_slot)
+  const
+    lcDataFork = lcDataForkAtConsensusFork(typeof(state).kind)
+    union_indices = lcDataFork.union_indices
+  var cachedData = CachedLightClientData(
+    finalized_slot: state.data.finalized_checkpoint.epoch.start_slot,
+    current_period_best_update: current_period_best_update,
+    latest_signature_slot: latest_signature_slot,
+    union_roots: newSeqUninit[Eth2Digest](union_indices.len))
+  state.data.hash_tree_root(union_indices, cachedData.union_roots).expect("OK")
+  let bid = blck.toBlockId()
   if dag.lcDataStore.cache.data.hasKeyOrPut(bid, cachedData):
-    doAssert false, "Redundant `cacheLightClientData` call"
+    raiseAssert "Redundant `cacheLightClientData` call"
   dag.cacheRecentLightClientHeader(bid, blck.lightClientHeader())
   dag.cacheRecentSyncAggregate(bid, blck.sync_aggregate())
 
@@ -561,18 +585,15 @@ proc assignLightClientData(
         when lcDataFork > LightClientDataFork.None:
           forkyObject.next_sync_committee =
             next_sync_committee.get
-          forkyObject.next_sync_committee_branch = normalize_merkle_branch(
-            attested_data.next_sync_committee_branch,
-            lcDataFork.next_sync_committee_gindex)
+          forkyObject.next_sync_committee_branch =
+            attested_data.next_sync_committee_branch
     else:
       doAssert next_sync_committee.isNone
     var finalized_slot = attested_data.finalized_slot
     withForkyObject(obj):
       when lcDataFork > LightClientDataFork.None:
         if finalized_slot == forkyObject.finalized_header.beacon.slot:
-          forkyObject.finality_branch = normalize_merkle_branch(
-            attested_data.finality_branch,
-            lcDataFork.finalized_root_gindex)
+          forkyObject.finality_branch = attested_data.finality_branch
         elif finalized_slot < max(dag.tail.slot, dag.backfill.slot):
           forkyObject.finalized_header.reset()
           forkyObject.finality_branch.reset()
@@ -590,14 +611,10 @@ proc assignLightClientData(
               attested_data.finalized_slot = finalized_slot
               dag.lcDataStore.cache.data[attested_bid] = attested_data
             if finalized_slot == forkyObject.finalized_header.beacon.slot:
-              forkyObject.finality_branch = normalize_merkle_branch(
-                attested_data.finality_branch,
-                lcDataFork.finalized_root_gindex)
+              forkyObject.finality_branch = attested_data.finality_branch
             elif finalized_slot == GENESIS_SLOT:
               forkyObject.finalized_header.reset()
-              forkyObject.finality_branch = normalize_merkle_branch(
-                attested_data.finality_branch,
-                lcDataFork.finalized_root_gindex)
+              forkyObject.finality_branch = attested_data.finality_branch
             else:
               var fin_header = dag.getExistingLightClientHeader(finalized_bid)
               if fin_header.kind == LightClientDataFork.None:
@@ -607,9 +624,7 @@ proc assignLightClientData(
               else:
                 fin_header.migrateToDataFork(lcDataFork)
                 forkyObject.finalized_header = fin_header.forky(lcDataFork)
-                forkyObject.finality_branch = normalize_merkle_branch(
-                  attested_data.finality_branch,
-                  lcDataFork.finalized_root_gindex)
+                forkyObject.finality_branch = attested_data.finality_branch
   withForkyObject(obj):
     when lcDataFork > LightClientDataFork.None:
       forkyObject.sync_aggregate = sync_aggregate
@@ -735,9 +750,7 @@ proc createLightClientBootstrap(
       dag.lcDataStore.db.putHeader(
         forkyBlck.toLightClientHeader(lcDataFork))
       dag.lcDataStore.db.putCurrentSyncCommitteeBranch(
-        bid.slot, normalize_merkle_branch(
-          dag.getLightClientData(bid).current_sync_committee_branch,
-          lcDataFork.current_sync_committee_gindex))
+        bid.slot, dag.getLightClientData(bid).current_sync_committee_branch)
     else: raiseAssert "Unreachable"
   ok()
 


### PR DESCRIPTION
Consolidate 3x build_proof to a single proof union with the new SSZ API. Saves ~10ms / block. Could consider grabbing the union as a side effect of the primary hash_tree_root to save another ~5ms.