### PR TITLE
initial Heze consensus fork infrastructure

### DIFF
--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[typetraits, tables],
@@ -538,12 +538,13 @@ proc new*(T: type BeaconChainDB,
       kvStore db.openKvStore("capella_blocks").expectDb(),
       kvStore db.openKvStore("deneb_blocks").expectDb(),
       kvStore db.openKvStore("electra_blocks").expectDb(),
-      if cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
-        kvStore db.openKvStore("fulu_blocks").expectDb()
-      else:
-        nil,
+      kvStore db.openKvStore("fulu_blocks").expectDb(),
       if cfg.GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH:
         kvStore db.openKvStore("gloas_blocks").expectDb()
+      else:
+        nil,
+      if cfg.HEZE_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        kvStore db.openKvStore("321cd149fc98434fa315ce9afd563ad1").expectDb()
       else:
         nil
     ]
@@ -557,12 +558,13 @@ proc new*(T: type BeaconChainDB,
       kvStore db.openKvStore("capella_state_no_validator_pubkeys").expectDb(),
       kvStore db.openKvStore("deneb_state_no_validator_pubkeys").expectDb(),
       kvStore db.openKvStore("electra_state_no_validator_pubkeys").expectDb(),
-      if cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
-        kvStore db.openKvStore("fulu_state_no_validator_pubkeys").expectDb()
-      else:
-        nil,
+      kvStore db.openKvStore("fulu_state_no_validator_pubkeys").expectDb(),
       if cfg.GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH:
         kvStore db.openKvStore("gloas_state_no_validator_pubkeys").expectDb()
+      else:
+        nil,
+      if cfg.HEZE_FORK_EPOCH != FAR_FUTURE_EPOCH:
+        kvStore db.openKvStore("92859b2e460944169bcca68d8a620069").expectDb()
       else:
         nil
     ]
@@ -609,12 +611,11 @@ proc new*(T: type BeaconChainDB,
     nil, # Capella
     nil, # Deneb
     nil, # Electra
-    if cfg.FULU_FORK_EPOCH != FAR_FUTURE_EPOCH:
-      kvStore db.openKvStore("fulu_columns").expectDb()
-    else: nil,
+    kvStore db.openKvStore("fulu_columns").expectDb(),
     if cfg.GLOAS_FORK_EPOCH != FAR_FUTURE_EPOCH:
       kvStore db.openKvStore("gloas_columns").expectDb()
-    else: nil
+    else: nil,
+    nil  # Heze
   ]
 
   var envelopes: KvStoreRef
@@ -916,7 +917,9 @@ proc updateImmutableValidators*(
     db.immutableValidators.add immutableValidator
 
 template BeaconStateNoImmutableValidators(kind: static ConsensusFork): auto =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    typedesc[HezeBeaconStateNoImmutableValidators]
+  elif kind == ConsensusFork.Gloas:
     typedesc[GloasBeaconStateNoImmutableValidators]
   elif kind == ConsensusFork.Fulu:
     typedesc[FuluBeaconStateNoImmutableValidators]

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles, web3/engine_api_types,
@@ -42,7 +42,9 @@ proc initLightClient*(
         signedBlock: ForkedSignedBeaconBlock
     ): Future[void] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
-        when consensusFork == ConsensusFork.Gloas:
+        when consensusFork == ConsensusFork.Heze:
+          debugHezeComment ""
+        elif consensusFork == ConsensusFork.Gloas:
           debugGloasComment ""
         elif consensusFork >= ConsensusFork.Bellatrix:
           if forkyBlck.message.is_execution_block:
@@ -186,7 +188,7 @@ proc updateLightClientFromDag*(node: BeaconNode) =
   var header: ForkedLightClientHeader
   withBlck(bdata):
     debugGloasComment ""
-    when consensusFork != ConsensusFork.Gloas:
+    when consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
       const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
       when lcDataFork > LightClientDataFork.None:
         header = ForkedLightClientHeader.init(

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -585,7 +585,7 @@ func add(
 func init(
     T: type AttestationCache,
     state: electra.HashedBeaconState | fulu.HashedBeaconState |
-           gloas.HashedBeaconState,
+           gloas.HashedBeaconState | heze.HashedBeaconState,
     cache: var StateCache): T =
   # Load attestations that are scheduled for being given rewards for
   let
@@ -657,7 +657,7 @@ func check_attestation_compatible*(
 proc getAttestationsForBlock*(
     pool: var AttestationPool,
     state: electra.HashedBeaconState | fulu.HashedBeaconState |
-           gloas.HashedBeaconState,
+           gloas.HashedBeaconState | heze.HashedBeaconState,
     cache: var StateCache,
 ): seq[electra.Attestation] =
   let newBlockSlot = state.data.slot.uint64

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -99,7 +99,8 @@ func init*(
 
 func init*(
     T: type BlockRef, root: Eth2Digest, optimisticStatus: OptimisticStatus,
-    blck: gloas.SomeBeaconBlock | gloas.TrustedBeaconBlock): BlockRef =
+    blck: gloas.SomeBeaconBlock | gloas.TrustedBeaconBlock |
+          heze.SomeBeaconBlock | heze.TrustedBeaconBlock): BlockRef =
   template bid(): auto = blck.body.signed_execution_payload_bid
   BlockRef.init(
     root,

--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -361,7 +361,8 @@ iterator pop*(quarantine: var Quarantine, root: Eth2Digest): ForkedSignedBeaconB
 proc addSidecarless(
     quarantine: var Quarantine, finalizedSlot: Opt[Slot],
     signedBlock: deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
-                 fulu.SignedBeaconBlock | gloas.SignedBeaconBlock
+                 fulu.SignedBeaconBlock | gloas.SignedBeaconBlock |
+                 heze.SignedBeaconBlock
 ): bool =
   if finalizedSlot.isSome():
     if signedBlock.message.isUnviableFork(finalizedSlot.get()):
@@ -379,14 +380,16 @@ proc addSidecarless(
 proc addSidecarless*(
   quarantine: var Quarantine, finalizedSlot: Slot,
   signedBlock: deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
-               fulu.SignedBeaconBlock | gloas.SignedBeaconBlock
+               fulu.SignedBeaconBlock | gloas.SignedBeaconBlock |
+               heze.SignedBeaconBlock
 ): bool =
   quarantine.addSidecarless(Opt.some(finalizedSlot), signedBlock)
 
 proc addSidecarless*(
   quarantine: var Quarantine,
   signedBlock: deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
-               fulu.SignedBeaconBlock | gloas.SignedBeaconBlock
+               fulu.SignedBeaconBlock | gloas.SignedBeaconBlock |
+               heze.SignedBeaconBlock
 ) =
   discard quarantine.addSidecarless(Opt.none(Slot), signedBlock)
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -312,7 +312,8 @@ proc getForkedBlock*(db: BeaconChainDB, root: Eth2Digest):
     Opt[ForkedTrustedSignedBeaconBlock] =
   # When we only have a digest, we don't know which fork it's from so we try
   # them one by one - this should be used sparingly
-  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  static: doAssert high(ConsensusFork) == ConsensusFork.Heze
+  debugHezeComment "use Heze getBlock"
   if   (let blck = db.getBlock(root, gloas.TrustedSignedBeaconBlock);
       blck.isSome()):
     ok(ForkedTrustedSignedBeaconBlock.init(blck.get()))
@@ -1345,6 +1346,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       of ConsensusFork.Electra:   electraFork(cfg)
       of ConsensusFork.Fulu:      fuluFork(cfg)
       of ConsensusFork.Gloas:     gloasFork(cfg)
+      of ConsensusFork.Heze:      hezeFork(cfg)
     stateFork = dag.headState.fork
 
   # Here, we check only the `current_version` field because the spec
@@ -1633,7 +1635,9 @@ proc computeRandaoMix(
   ## Compute the requested RANDAO mix for `bdata` without `state`, if possible.
   withBlck(bdata):
     debugGloasComment ""
-    when consensusFork == ConsensusFork.Gloas:
+    when consensusFork == ConsensusFork.Heze:
+      return Opt.none(Eth2Digest)
+    elif consensusFork == ConsensusFork.Gloas:
       return Opt.none(Eth2Digest)
     elif consensusFork >= ConsensusFork.Bellatrix:
       if forkyBlck.message.is_execution_block:

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -113,7 +113,10 @@ func cacheRecentSyncAggregate(
 
 func lightClientHeader(
     blck: ForkyTrustedSignedBeaconBlock): ForkedLightClientHeader =
-  when kind(typeof(blck)) == ConsensusFork.Gloas:
+  when kind(typeof(blck)) == ConsensusFork.Heze:
+    debugHezeComment "..."
+    default(ForkedLightClientHeader)
+  elif kind(typeof(blck)) == ConsensusFork.Gloas:
     debugGloasComment "..."
     default(ForkedLightClientHeader)
   else:
@@ -249,6 +252,8 @@ proc initLightClientBootstrapForPeriod(
       withStateAndBlck(tmpState[], bdata):
         when consensusFork == ConsensusFork.Gloas:
           debugGloasComment "..."
+        elif consensusFork == ConsensusFork.Heze:
+          debugHezeComment "..."
         elif consensusFork >= ConsensusFork.Altair:
           const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
           if not dag.lcDataStore.db.hasSyncCommittee(period):
@@ -432,7 +437,7 @@ proc initLightClientUpdateForPeriod(
       return err()
     withBlck(bdata):
       debugGloasComment ""
-      when consensusFork != ConsensusFork.Gloas:
+      when consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
         withForkyUpdate(update):
           when lcDataFork > LightClientDataFork.None:
             when lcDataFork >= lcDataForkAtConsensusFork(consensusFork):
@@ -745,7 +750,8 @@ proc createLightClientBootstrap(
       dag.lcDataStore.db.putSyncCommittee(period, syncCommittee)
   withBlck(bdata):
     debugGloasComment ""
-    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
+    when consensusFork >= ConsensusFork.Altair and
+         consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
       const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
       dag.lcDataStore.db.putHeader(
         forkyBlck.toLightClientHeader(lcDataFork))
@@ -1124,7 +1130,8 @@ proc getLightClientBootstrap*(
     return default(ForkedLightClientBootstrap)
   withBlck(bdata):
     debugGloasComment ""
-    when consensusFork >= ConsensusFork.Altair and consensusFork != ConsensusFork.Gloas:
+    when consensusFork >= ConsensusFork.Altair and
+         consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
       const lcDataFork = lcDataForkAtConsensusFork(consensusFork)
       let
         header = forkyBlck.toLightClientHeader(lcDataFork)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -329,7 +329,9 @@ proc prepareNextSlot*(
   # Approximately lines up with validator_duties version. Used optimistically/
   # opportunistically, so mismatches are fine if not too frequent.
   withState(dag.clearanceState):
-    when consensusFork == ConsensusFork.Gloas:
+    when consensusFork == ConsensusFork.Heze:
+      debugHezeComment "well, likely can't keep reusing V3 much longer"
+    elif consensusFork == ConsensusFork.Gloas:
       debugGloasComment "well, likely can't keep reusing V3 much longer"
     elif consensusFork in ConsensusFork.Electra .. ConsensusFork.Fulu:
       debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer

--- a/beacon_chain/consensus_object_pools/envelope_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/envelope_quarantine.nim
@@ -56,7 +56,7 @@ func addOrphan*(
 
 func popOrphan*(
     self: var EnvelopeQuarantine,
-    blck: gloas.SignedBeaconBlock,
+    blck: gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
 ): Opt[SignedExecutionPayloadEnvelope] =
   if blck.root notin self.orphans:
     return Opt.none(SignedExecutionPayloadEnvelope)

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   results,
@@ -230,7 +230,8 @@ func is_aggregator*(shufflingRef: ShufflingRef, slot: Slot,
   return is_aggregator(committee_len, slot_signature)
 
 iterator get_ptc*(
-  state: gloas.BeaconState, shufflingRef: ShufflingRef, slot: Slot):
+  state: gloas.BeaconState | heze.BeaconState,
+  shufflingRef: ShufflingRef, slot: Slot):
     ValidatorIndex {.closure.} =
   let epoch = slot.epoch()
   var buffer {.noinit.}: array[40, byte]

--- a/beacon_chain/consensus_object_pools/validator_change_pool.nim
+++ b/beacon_chain/consensus_object_pools/validator_change_pool.nim
@@ -251,7 +251,8 @@ proc getValidatorChangeMessagesForBlock(
 
 proc getBeaconBlockValidatorChanges*(
     pool: var ValidatorChangePool, cfg: RuntimeConfig,
-    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState):
+    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState |
+           heze.BeaconState):
     BeaconBlockValidatorChanges =
   var res: BeaconBlockValidatorChanges
 

--- a/beacon_chain/deposits.nim
+++ b/beacon_chain/deposits.nim
@@ -27,10 +27,10 @@ type
     of ValidatorStorageKind.Identifier:
       ident: ValidatorIdent
 
-static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
+static: doAssert(high(ConsensusFork) == ConsensusFork.Heze,
           "Update OptionalForks constant!")
 const
-  OptionalForks* = {ConsensusFork.Gloas}
+  OptionalForks* = {ConsensusFork.Gloas, ConsensusFork.Heze}
     ## When a new ConsensusFork is added and before this fork is activated on
     ## `mainnet`, it should be part of `OptionalForks`.
     ## In this case, the client will ignore missing <FORKNAME>_VERSION

--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -471,8 +471,9 @@ iterator getBlockIds*(
   while true:
     # `case` ensures we're on a fork for which the `PartialBeaconState`
     # definition is consistent
+    debugHezeComment "actually do this"
     case db.cfg.consensusForkAtEpoch(slot.epoch)
-    of ConsensusFork.Phase0 .. ConsensusFork.Gloas:
+    of ConsensusFork.Phase0 .. ConsensusFork.Heze:
       let stateSlot = (slot.era() + 1).start_slot()
       if not getPartialState(
           db, historical_roots, historical_summaries, stateSlot, state[]):

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -274,6 +274,7 @@ proc storeSidecars(self: BlockProcessor, sidecarsOpt: NoSidecars) =
   discard
 
 proc enqueuePayload*(self: ref BlockProcessor, blck: gloas.SignedBeaconBlock)
+proc enqueuePayload*(self: ref BlockProcessor, blck: heze.SignedBeaconBlock)
 
 proc storeBackfillBlock(
     self: ref BlockProcessor,
@@ -1004,6 +1005,15 @@ proc addPayload*(
 
   ok()
 
+proc addPayload*(
+    self: ref BlockProcessor,
+    signedBlock: heze.SignedBeaconBlock,
+    signedEnvelope: gloas.SignedExecutionPayloadEnvelope,
+    sidecarsOpt: Opt[gloas.DataColumnSidecars],
+): Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
+  debugHezeComment "stub: heze addPayload not yet implemented"
+  ok()
+
 proc enqueuePayload*(self: ref BlockProcessor, blck: gloas.SignedBeaconBlock) =
   ## Enqueue payload processing by block that is a valid block.
 
@@ -1030,6 +1040,9 @@ proc enqueuePayload*(self: ref BlockProcessor, blck: gloas.SignedBeaconBlock) =
 
   discard self.addPayload(blck, envelope, sidecarsOpt)
 
+proc enqueuePayload*(self: ref BlockProcessor, blck: heze.SignedBeaconBlock) =
+  debugHezeComment "stub: heze enqueuePayload not yet implemented"
+
 proc enqueuePayload*(self: ref BlockProcessor, blockRoot: Eth2Digest) =
   ## Enqueue payload processing by block root. If it is not a valid block, the
   ## enqueue request will be discarded silently.
@@ -1048,7 +1061,8 @@ proc enqueuePayload*(self: ref BlockProcessor, blockRoot: Eth2Digest) =
             bid = shortLog(blockRef.bid)
           return
         withBlck(forkedBlock):
-          when consensusFork >= ConsensusFork.Gloas:
+          debugHezeComment "..."
+          when consensusFork == ConsensusFork.Gloas:
             forkyBlck.asSigned()
           else:
             # Incorrect fork which shouldn't be happening.

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -315,7 +315,8 @@ func getMaxBlobsPerBlock(cfg: RuntimeConfig, slot: Slot): uint64 =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.1/specs/gloas/p2p-interface.md#beacon_block
 template validateBeaconBlockBellatrix(
-    _: phase0.SignedBeaconBlock | altair.SignedBeaconBlock | gloas.SignedBeaconBlock,
+    _: phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
+       gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
     _: BlockRef): untyped =
   discard
 
@@ -378,7 +379,8 @@ template validateBeaconBlockDeneb(
     _: ChainDAGRef,
     _:
       phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
-      bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock | gloas.SignedBeaconBlock,
+      bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
+      gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
     _: BeaconTime): untyped =
   discard
 
@@ -405,7 +407,8 @@ template validateBeaconBlockGloas(
       phase0.SignedBeaconBlock | altair.SignedBeaconBlock |
       bellatrix.SignedBeaconBlock | capella.SignedBeaconBlock |
       deneb.SignedBeaconBlock | electra.SignedBeaconBlock |
-      fulu.SignedBeaconBlock): untyped =
+      fulu.SignedBeaconBlock | heze.SignedBeaconBlock): untyped =
+  debugHezeComment "this effectively disables gossip validation for Heze blocks currently"
   discard
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.1/specs/gloas/p2p-interface.md#beacon_block
@@ -791,8 +794,11 @@ proc validateDataColumnSidecar*(
             root = shortLog(blockRoot)
           return errIgnore("DataColumnSidecar: block not yet seen")
       withBlck(forkedBlock):
-        when consensusFork >= ConsensusFork.Gloas:
+        when consensusFork == ConsensusFork.Gloas:
           forkyBlck
+        elif consensusFork == ConsensusFork.Heze:
+          debugHezeComment "..."
+          return errIgnore("DataColumnSidecar: block in incorrect fork")
         else:
           return errIgnore("DataColumnSidecar: block in incorrect fork")
 
@@ -1076,7 +1082,10 @@ proc validateExecutionPayload*(
           root: envelope.beacon_block_root, slot: envelope.slot)).valueOr:
         return dag.checkedReject("ExecutionPayload: invalid block")
       withBlck(forkedBlock):
-        when consensusFork >= ConsensusFork.Gloas:
+        when consensusFork == ConsensusFork.Heze:
+          debugHezeComment "..."
+          return dag.checkedReject("ExecutionPayload: invalid fork")
+        elif consensusFork == ConsensusFork.Gloas:
           forkyBlck.asSigned().message
         else:
           return dag.checkedReject("ExecutionPayload: invalid fork")

--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -857,7 +857,8 @@ template gossipMaxSize(T: untyped): uint32 =
          T is fulu.SignedBeaconBlock or T is fulu.DataColumnSidecar or
          T is gloas.SignedBeaconBlock or T is gloas.DataColumnSidecar or
          T is gloas.SignedExecutionPayloadEnvelope or
-         T is gloas.SignedExecutionPayloadBid:
+         T is gloas.SignedExecutionPayloadBid or
+         T is heze.SignedBeaconBlock:
       MAX_PAYLOAD_SIZE
     # TODO https://github.com/status-im/nim-ssz-serialization/issues/20 for
     # Attestation, AttesterSlashing, and SignedAggregateAndProof, which all

--- a/beacon_chain/networking/network_metadata.nim
+++ b/beacon_chain/networking/network_metadata.nim
@@ -245,7 +245,7 @@ when IsGnosisSupported:
       checkForkConsistency(network.cfg)
       doAssert network.cfg.FULU_FORK_EPOCH < FAR_FUTURE_EPOCH
       doAssert network.cfg.GLOAS_FORK_EPOCH == FAR_FUTURE_EPOCH
-      doAssert ConsensusFork.high == ConsensusFork.Gloas
+      doAssert ConsensusFork.high == ConsensusFork.Heze
       doAssert network.cfg.BLOB_SCHEDULE.len == 0
 
 elif IsMainnetSupported:
@@ -318,7 +318,7 @@ elif IsMainnetSupported:
         digest: Eth2Digest.fromHex "0x2683ebc120f91f740c7bed4c866672d01e1ba51b4cc360297138465ee5df40f0"))
 
   static:
-    doAssert ConsensusFork.high == ConsensusFork.Gloas
+    doAssert ConsensusFork.high == ConsensusFork.Heze
     for network in [mainnetMetadata, sepoliaMetadata, hoodiMetadata]:
       checkForkConsistency(network.cfg)
       doAssert network.cfg.FULU_FORK_EPOCH < FAR_FUTURE_EPOCH

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -327,6 +327,8 @@ func getVanityLogs(stdoutKind: StdoutLogKind): VanityLogs =
 func getVanityMascot(consensusFork: ConsensusFork): string =
   debugGloasComment "don't know vanity mascot yet"
   case consensusFork
+  of ConsensusFork.Heze:
+    "?"
   of ConsensusFork.Gloas:
     "?"
   of ConsensusFork.Fulu:
@@ -614,9 +616,12 @@ proc initFullNode(
                          blobs: Opt[BlobSidecars], maybeFinalized: bool):
         Future[Result[void, VerifierError]] {.async: (raises: [CancelledError], raw: true).} =
       withBlck(signedBlock):
-        when consensusFork in ConsensusFork.Fulu .. ConsensusFork.Gloas:
+        when consensusFork in ConsensusFork.Fulu .. ConsensusFork.Heze:
           # TODO document why there are no columns here
-          when consensusFork == ConsensusFork.Gloas:
+          when consensusFork == ConsensusFork.Heze:
+            # Disable sidecars processing at block time.
+            const sidecarsOpt = noSidecars
+          elif consensusFork == ConsensusFork.Gloas:
             # Disable sidecars processing at block time.
             const sidecarsOpt = noSidecars
           else:
@@ -701,7 +706,10 @@ proc initFullNode(
                 bid = shortLog(blockRef.bid)
               return err(VerifierError.Invalid)
             withBlck(forkedBlock):
-              when consensusFork >= ConsensusFork.Gloas:
+              when consensusFork == ConsensusFork.Heze:
+                debugHezeComment "..."
+                return err(VerifierError.Duplicate)
+              elif consensusFork == ConsensusFork.Gloas:
                 forkyBlck.asSigned()
               else:
                 # Incorrect fork which shouldn't be happening.
@@ -1647,7 +1655,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     TOPIC_SUBSCRIBE_THRESHOLD_SLOTS = 64
     HYSTERESIS_BUFFER = 16
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  static: doAssert high(ConsensusFork) == ConsensusFork.Heze
 
   let
     head = node.dag.head
@@ -1720,7 +1728,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     removeDenebMessageHandlers,
     removeElectraMessageHandlers,
     removeFuluMessageHandlers,
-    removeGloasMessageHandlers
+    removeGloasMessageHandlers,
+    removeGloasMessageHandlers  # heze (gloas handlers)
   ]
 
   for gossipEpoch in oldGossipEpochs:
@@ -1736,7 +1745,8 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     addDenebMessageHandlers,
     addElectraMessageHandlers,
     addCapellaMessageHandlers, # no blobs; updateDataColumnSidecarHandlers for rest
-    addGloasMessageHandlers
+    addGloasMessageHandlers,
+    addGloasMessageHandlers  # heze (gloas handlers)
   ]
 
   for gossipEpoch in newGossipEpochs:
@@ -1773,7 +1783,7 @@ proc pruneBlobs(node: BeaconNode, slot: Slot) =
       let blck = node.dag.getForkedBlock(blocks[int(i)]).valueOr: continue
       withBlck(blck):
         debugGloasComment " "
-        when typeof(forkyBlck).kind < ConsensusFork.Deneb or typeof(forkyBlck).kind == ConsensusFork.Gloas: continue
+        when typeof(forkyBlck).kind < ConsensusFork.Deneb or typeof(forkyBlck).kind in [ConsensusFork.Gloas, ConsensusFork.Heze]: continue
         else:
           for j in 0..len(forkyBlck.message.body.blob_kzg_commitments) - 1:
             if node.db.delBlobSidecar(blocks[int(i)].root, BlobIndex(j)):

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/os,
@@ -96,7 +96,8 @@ proc main() {.noinline, raises: [CatchableError].} =
     ): Future[void] {.async: (raises: [CancelledError]).} =
       withBlck(signedBlock):
         debugGloasComment ""
-        when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
+        when consensusFork >= ConsensusFork.Bellatrix and
+             consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
           if forkyBlck.message.is_execution_block:
             template payload(): auto = forkyBlck.message.body.execution_payload
             if elManager != nil and not payload.block_hash.isZero:

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import std/[tables, os, strutils]
 import serialization, json_serialization,

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -1047,8 +1047,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             doAssert strictVerification notin node.dag.updateFlags
             return RestApiResponse.jsonError(Http400, InvalidBlockObjectError)
 
-          static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
-          when consensusFork == ConsensusFork.Gloas:
+          static: doAssert high(ConsensusFork) == ConsensusFork.Heze
+          when consensusFork == ConsensusFork.Heze:
+            debugHezeComment "stub: heze block routing"
+            await node.router.routeSignedBeaconBlock(
+              forkyBlck, Opt.none(seq[gloas.DataColumnSidecar]),
+              checkValidator = true)
+          elif consensusFork == ConsensusFork.Gloas:
             await node.router.routeSignedBeaconBlock(
               forkyBlck, Opt.none(seq[gloas.DataColumnSidecar]),
               checkValidator = true)
@@ -1111,7 +1116,10 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         RestApiResponse.jsonError(Http500, InvalidAcceptError)
 
     withBlck(bdata.asSigned()):
-      when consensusFork == ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Heze:
+        debugHezeComment ""
+        return RestApiResponse.jsonError(Http404, BlockNotFoundError)
+      elif consensusFork == ConsensusFork.Gloas:
         debugGloasComment ""
         return RestApiResponse.jsonError(Http404, BlockNotFoundError)
       elif consensusFork <= ConsensusFork.Altair:
@@ -1348,7 +1356,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400,
                                          UnsupportedForkError,
                                          $UnsupportedForkError)
-      of ConsensusFork.Electra .. ConsensusFork.Gloas:
+      of ConsensusFork.Electra .. ConsensusFork.Heze:
         decodeAttestations(electra.SingleAttestation)
 
     let failures =
@@ -1431,7 +1439,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       of ConsensusFork.Phase0 .. ConsensusFork.Deneb:
         RestApiResponse.jsonError(Http400, SlotFromTheIncorrectForkError,
                                   $error)
-      of ConsensusFork.Electra .. ConsensusFork.Gloas:
+      of ConsensusFork.Electra .. ConsensusFork.Heze:
         decodeAttesterSlashing(electra.AttesterSlashing)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getPoolProposerSlashings

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -613,7 +613,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400,
                                          UnsupportedForkError,
                                          $UnsupportedForkError)
-      of ConsensusFork.Electra .. ConsensusFork.Gloas:
+      of ConsensusFork.Electra .. ConsensusFork.Heze:
         addDecodedProofs(electra.SignedAggregateAndProof)
 
     await allFutures(proofs)

--- a/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
@@ -680,6 +680,8 @@ proc readValue*(r: var RestJsonReader, value: var ForkedHashedBeaconState) {.rea
       toValue(fuluData)
     of ConsensusFork.Gloas:
       toValue(gloasData)
+    of ConsensusFork.Heze:
+      toValue(hezeData)
   except SerializationError:
     r.raiseUnexpectedValue(&"Incorrect {v.version} beacon state format")
 

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -864,7 +864,9 @@ proc decodeBytes*[T: ProduceBlockResponseV3](
     withConsensusFork(fork):
       debugGloasComment ""
       when consensusFork == ConsensusFork.Gloas:
-        return err("gloas produceblockv3 not available yet")
+        return err("gloas produceblock not available yet")
+      elif consensusFork == ConsensusFork.Heze:
+        return err("heze produceblock not available yet")
       elif consensusFork >= ConsensusFork.Electra:
         if blinded:
           let contents =

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -216,6 +216,8 @@ proc publishBlockV2*(
       ConsensusFork.Fulu.toString()
     elif blck is GloasSignedBlockContents:
       ConsensusFork.Gloas.toString()
+    elif blck is HezeSignedBlockContents:
+      ConsensusFork.Heze.toString()
     else:
       typeof(blck).kind.toString()
   client.publishBlockV2(

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -340,6 +340,7 @@ type
     of ConsensusFork.Electra:   electraData*:   ElectraSignedBlockContents
     of ConsensusFork.Fulu:      fuluData*:      FuluSignedBlockContents
     of ConsensusFork.Gloas:     gloasData*:     GloasSignedBlockContents
+    of ConsensusFork.Heze:      hezeData*:      HezeSignedBlockContents
 
   ProduceBlockResponseV3* = ForkedMaybeBlindedBeaconBlock
 
@@ -626,6 +627,13 @@ func `==`*(a, b: RestValidatorIndex): bool {.borrow.}
 template withForkyBlck*(
     x: RestPublishedSignedBlockContents, body: untyped): untyped =
   case x.kind
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyData: untyped {.inject, used.} = x.hezeData
+    template forkyBlck: untyped {.inject, used.} = x.hezeData.signed_block
+    template kzg_proofs: untyped {.inject, used.} = x.hezeData.kzg_proofs
+    template blobs: untyped {.inject, used.} = x.hezeData.blobs
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyData: untyped {.inject, used.} = x.gloasData
@@ -695,6 +703,8 @@ func init*(T: type ForkedSignedBeaconBlock,
       ForkedSignedBeaconBlock.init(contents.fuluData.signed_block)
     of ConsensusFork.Gloas:
       ForkedSignedBeaconBlock.init(contents.gloasData.signed_block)
+    of ConsensusFork.Heze:
+      ForkedSignedBeaconBlock.init(contents.hezeData.signed_block)
 
 func init*(t: typedesc[RestPublishedSignedBlockContents],
            blck: phase0.BeaconBlock, root: Eth2Digest,
@@ -791,6 +801,22 @@ func init*(t: typedesc[RestPublishedSignedBlockContents],
     kind: ConsensusFork.Gloas,
     gloasData: GloasSignedBlockContents(
       signed_block: gloas.SignedBeaconBlock(
+        message: contents.`block`,
+        root: root,
+        signature: signature
+      ),
+      kzg_proofs: contents.kzg_proofs,
+      blobs: contents.blobs
+    )
+  )
+
+func init*(t: typedesc[RestPublishedSignedBlockContents],
+           contents: heze.BlockContents, root: Eth2Digest,
+           signature: ValidatorSig): RestPublishedSignedBlockContents =
+  RestPublishedSignedBlockContents(
+    kind: ConsensusFork.Heze,
+    hezeData: HezeSignedBlockContents(
+      signed_block: heze.SignedBeaconBlock(
         message: contents.`block`,
         root: root,
         signature: signature

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -57,6 +57,7 @@ type
     Electra = "electra"
     Fulu = "fulu"
     Gloas = "gloas"
+    Heze = "heze"
 
   ForkyBeaconState* =
     phase0.BeaconState |
@@ -90,6 +91,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.HashedBeaconState
     of ConsensusFork.Fulu:      fuluData*:      fulu.HashedBeaconState
     of ConsensusFork.Gloas:     gloasData*:     gloas.HashedBeaconState
+    of ConsensusFork.Heze:      hezeData*:      heze.HashedBeaconState
 
   ForkyExecutionPayload* =
     bellatrix.ExecutionPayload |
@@ -244,6 +246,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.Attestation
     of ConsensusFork.Fulu:      fuluData*:      electra.Attestation
     of ConsensusFork.Gloas:     gloasData*:     electra.Attestation
+    of ConsensusFork.Heze:      hezeData*:      electra.Attestation
 
   ForkedAggregateAndProof* = object
     case kind*: ConsensusFork
@@ -255,6 +258,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.AggregateAndProof
     of ConsensusFork.Fulu:      fuluData*:      electra.AggregateAndProof
     of ConsensusFork.Gloas:     gloasData*:     electra.AggregateAndProof
+    of ConsensusFork.Heze:      hezeData*:      electra.AggregateAndProof
 
   ForkedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -266,6 +270,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.BeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.BeaconBlock
     of ConsensusFork.Gloas:     gloasData*:     gloas.BeaconBlock
+    of ConsensusFork.Heze:      hezeData*:      heze.BeaconBlock
 
   ForkedMaybeBlindedBeaconBlock* = object
     case kind*: ConsensusFork
@@ -285,6 +290,8 @@ type
       fuluData*: fulu_mev.MaybeBlindedBeaconBlock
     of ConsensusFork.Gloas:
       gloasData*: gloas.BlockContents
+    of ConsensusFork.Heze:
+      hezeData*: heze.BlockContents
     consensusValue*: Opt[UInt256]
     executionValue*: Opt[UInt256]
 
@@ -314,6 +321,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.SignedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.SignedBeaconBlock
     of ConsensusFork.Gloas:     gloasData*:     gloas.SignedBeaconBlock
+    of ConsensusFork.Heze:      hezeData*:      heze.SignedBeaconBlock
 
   ForkySignedBlindedBeaconBlock* =
     phase0.SignedBeaconBlock |
@@ -334,6 +342,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra_mev.SignedBlindedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu_mev.SignedBlindedBeaconBlock
     of ConsensusFork.Gloas:     gloasData*:     fulu_mev.SignedBlindedBeaconBlock
+    of ConsensusFork.Heze:      hezeData*:      fulu_mev.SignedBlindedBeaconBlock
 
   ForkySigVerifiedSignedBeaconBlock* =
     phase0.SigVerifiedSignedBeaconBlock |
@@ -343,7 +352,8 @@ type
     deneb.SigVerifiedSignedBeaconBlock |
     electra.SigVerifiedSignedBeaconBlock |
     fulu.SigVerifiedSignedBeaconBlock |
-    gloas.SigVerifiedSignedBeaconBlock
+    gloas.SigVerifiedSignedBeaconBlock |
+    heze.SigVerifiedSignedBeaconBlock
 
   ForkyTrustedSignedBeaconBlock* =
     phase0.TrustedSignedBeaconBlock |
@@ -366,6 +376,7 @@ type
     of ConsensusFork.Electra:   electraData*:   electra.TrustedSignedBeaconBlock
     of ConsensusFork.Fulu:      fuluData*:      fulu.TrustedSignedBeaconBlock
     of ConsensusFork.Gloas:     gloasData*:     gloas.TrustedSignedBeaconBlock
+    of ConsensusFork.Heze:      hezeData*:      heze.TrustedSignedBeaconBlock
 
   SomeForkySignedBeaconBlock* =
     ForkySignedBeaconBlock |
@@ -533,8 +544,25 @@ template kind*(
       gloas.TrustedSignedBeaconBlock]): ConsensusFork =
   ConsensusFork.Gloas
 
+template kind*(
+    x: typedesc[
+      heze.BeaconState |
+      heze.HashedBeaconState |
+      heze.BeaconBlock |
+      heze.SignedBeaconBlock |
+      heze.SigVerifiedBeaconBlock |
+      heze.TrustedBeaconBlock |
+      heze.BeaconBlockBody |
+      heze.SigVerifiedBeaconBlockBody |
+      heze.TrustedBeaconBlockBody |
+      heze.SigVerifiedSignedBeaconBlock |
+      heze.TrustedSignedBeaconBlock]): ConsensusFork =
+  ConsensusFork.Heze
+
 template BeaconState*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.BeaconState
+  elif kind == ConsensusFork.Gloas:
     gloas.BeaconState
   elif kind == ConsensusFork.Fulu:
     fulu.BeaconState
@@ -554,7 +582,9 @@ template BeaconState*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconState unsupported in " & $kind.}
 
 template BeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.BeaconBlock
+  elif kind == ConsensusFork.Gloas:
     gloas.BeaconBlock
   elif kind == ConsensusFork.Fulu:
     fulu.BeaconBlock
@@ -574,7 +604,9 @@ template BeaconBlock*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconBlock unsupported in " & $kind.}
 
 template BeaconBlockBody*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.BeaconBlockBody
+  elif kind == ConsensusFork.Gloas:
     gloas.BeaconBlockBody
   elif kind == ConsensusFork.Fulu:
     fulu.BeaconBlockBody
@@ -594,7 +626,9 @@ template BeaconBlockBody*(kind: static ConsensusFork): typedesc =
     {.error: "BeaconBlockBody unsupported in " & $kind.}
 
 template SignedBeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.SignedBeaconBlock
+  elif kind == ConsensusFork.Gloas:
     gloas.SignedBeaconBlock
   elif kind == ConsensusFork.Fulu:
     fulu.SignedBeaconBlock
@@ -614,7 +648,9 @@ template SignedBeaconBlock*(kind: static ConsensusFork): typedesc =
     {.error: "SignedBeaconBlock unsupported in " & $kind.}
 
 template TrustedSignedBeaconBlock*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.TrustedSignedBeaconBlock
+  elif kind == ConsensusFork.Gloas:
     gloas.TrustedSignedBeaconBlock
   elif kind == ConsensusFork.Fulu:
     fulu.TrustedSignedBeaconBlock
@@ -644,7 +680,9 @@ template ExecutionPayloadHeader*(kind: static ConsensusFork): typedesc =
     {.error: "ExecutionPayloadHeader unsupported in " & $kind.}
 
 template ExecutionPayloadForSigning*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    gloas.ExecutionPayloadForSigning
+  elif kind == ConsensusFork.Gloas:
     gloas.ExecutionPayloadForSigning
   elif kind == ConsensusFork.Fulu:
     fulu.ExecutionPayloadForSigning
@@ -700,7 +738,7 @@ template SignedBuilderBid*(kind: static ConsensusFork): typedesc =
     {.error: "SignedBuilderBid unsupported in " & $kind.}
 
 template BlobsBundle*(kind: static ConsensusFork): typedesc =
-  when kind in ConsensusFork.Fulu .. ConsensusFork.Gloas:
+  when kind in ConsensusFork.Fulu .. ConsensusFork.Heze:
     fulu.BlobsBundle
   elif kind in ConsensusFork.Deneb .. ConsensusFork.Electra:
     deneb.BlobsBundle
@@ -714,7 +752,8 @@ template Forky*(
 
 template withAll*(
     x: typedesc[ConsensusFork], body: untyped): untyped =
-  static: doAssert ConsensusFork.high == ConsensusFork.Gloas
+  debugHezeComment "actually iterate Heze"
+  static: doAssert ConsensusFork.high == ConsensusFork.Heze
   block:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     body
@@ -743,6 +782,9 @@ template withAll*(
 template withConsensusFork*(
     x: ConsensusFork, body: untyped): untyped =
   case x
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     body
@@ -769,7 +811,9 @@ template withConsensusFork*(
     body
 
 template BlockContents*(kind: static ConsensusFork): typedesc =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    heze.BlockContents
+  elif kind == ConsensusFork.Gloas:
     gloas.BlockContents
   elif kind == ConsensusFork.Fulu:
     fulu.BlockContents
@@ -815,8 +859,8 @@ template PayloadAttributes*(
     {.error: "PayloadAttributes unsupported in " & $kind.}
 
 # `eth2_merkleization` cannot import `forks` (circular), so the check is here
-debugGloasComment "actually verify this"
-static: doAssert ConsensusFork.high == ConsensusFork.Gloas,
+debugHezeComment "actually verify this"
+static: doAssert ConsensusFork.high == ConsensusFork.Heze,
   "eth2_merkleization has been checked and `hash_tree_root` is up to date"
 
 # TODO when https://github.com/nim-lang/Nim/issues/21086 fixed, use return type
@@ -853,6 +897,10 @@ func new*(T: type ForkedHashedBeaconState, data: gloas.BeaconState):
     ref ForkedHashedBeaconState =
   (ref T)(kind: ConsensusFork.Gloas, gloasData: gloas.HashedBeaconState(
     data: data, root: hash_tree_root(data)))
+func new*(T: type ForkedHashedBeaconState, data: heze.BeaconState):
+    ref ForkedHashedBeaconState =
+  (ref T)(kind: ConsensusFork.Heze, hezeData: heze.HashedBeaconState(
+    data: data, root: hash_tree_root(data)))
 
 template init*(T: type ForkedBeaconBlock, blck: electra.BeaconBlock): T =
   T(kind: ConsensusFork.Electra, electraData: blck)
@@ -860,6 +908,8 @@ template init*(T: type ForkedBeaconBlock, blck: fulu.BeaconBlock): T =
   T(kind: ConsensusFork.Fulu, fuluData: blck)
 template init*(T: type ForkedBeaconBlock, blck: gloas.BeaconBlock): T =
   T(kind: ConsensusFork.Gloas, gloasData: blck)
+template init*(T: type ForkedBeaconBlock, blck: heze.BeaconBlock): T =
+  T(kind: ConsensusFork.Heze, hezeData: blck)
 
 template init*(T: type ForkedSignedBeaconBlock, blck: phase0.SignedBeaconBlock): T =
   T(kind: ConsensusFork.Phase0, phase0Data: blck)
@@ -877,6 +927,8 @@ template init*(T: type ForkedSignedBeaconBlock, blck: fulu.SignedBeaconBlock): T
   T(kind: ConsensusFork.Fulu, fuluData: blck)
 template init*(T: type ForkedSignedBeaconBlock, blck: gloas.SignedBeaconBlock): T =
   T(kind: ConsensusFork.Gloas, gloasData: blck)
+template init*(T: type ForkedSignedBeaconBlock, blck: heze.SignedBeaconBlock): T =
+  T(kind: ConsensusFork.Heze, hezeData: blck)
 
 template init*(T: type ForkedSignedBlindedBeaconBlock,
                blck: electra_mev.BlindedBeaconBlock, blockRoot: Eth2Digest,
@@ -908,12 +960,16 @@ template init*(T: type ForkedTrustedSignedBeaconBlock, blck: fulu.TrustedSignedB
   T(kind: ConsensusFork.Fulu, fuluData: blck)
 template init*(T: type ForkedTrustedSignedBeaconBlock, blck: gloas.TrustedSignedBeaconBlock): T =
   T(kind: ConsensusFork.Gloas, gloasData: blck)
+template init*(T: type ForkedTrustedSignedBeaconBlock, blck: heze.TrustedSignedBeaconBlock): T =
+  T(kind: ConsensusFork.Heze, hezeData: blck)
 
 template toString*(kind: ConsensusFork): string =
   $kind
 
 template init*(T: typedesc[ConsensusFork], value: string): Opt[ConsensusFork] =
   case value
+  of "heze":
+    Opt.some ConsensusFork.Heze
   of "gloas":
     Opt.some ConsensusFork.Gloas
   of "fulu":
@@ -939,6 +995,10 @@ static:
 
 template withState*(x: ForkedHashedBeaconState, body: untyped): untyped =
   case x.kind
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyState: untyped {.inject, used.} = x.hezeData
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyState: untyped {.inject, used.} = x.gloasData
@@ -978,7 +1038,9 @@ template forky*(
       ForkedSignedBeaconBlock |
       ForkedHashedBeaconState,
     kind: static ConsensusFork): untyped =
-  when kind == ConsensusFork.Gloas:
+  when kind == ConsensusFork.Heze:
+    x.hezeData
+  elif kind == ConsensusFork.Gloas:
     x.gloasData
   elif kind == ConsensusFork.Fulu:
     x.fuluData
@@ -1098,6 +1160,8 @@ func get_blob_parameters*(cfg: RuntimeConfig, epoch: Epoch): BlobParameters =
 func consensusForkEpoch*(
     cfg: RuntimeConfig, consensusFork: ConsensusFork): Epoch =
   case consensusFork
+  of ConsensusFork.Heze:
+    cfg.HEZE_FORK_EPOCH
   of ConsensusFork.Gloas:
     cfg.GLOAS_FORK_EPOCH
   of ConsensusFork.Fulu:
@@ -1118,7 +1182,8 @@ func consensusForkEpoch*(
 func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
   ## Return the current fork for the given epoch.
   static:
-    doAssert high(ConsensusFork) == ConsensusFork.Gloas
+    doAssert high(ConsensusFork) == ConsensusFork.Heze
+    doAssert ConsensusFork.Heze      > ConsensusFork.Gloas
     doAssert ConsensusFork.Gloas     > ConsensusFork.Fulu
     doAssert ConsensusFork.Fulu      > ConsensusFork.Electra
     doAssert ConsensusFork.Electra   > ConsensusFork.Deneb
@@ -1128,7 +1193,8 @@ func consensusForkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): ConsensusFork =
     doAssert ConsensusFork.Altair    > ConsensusFork.Phase0
     doAssert GENESIS_EPOCH == 0
 
-  if   epoch >= cfg.GLOAS_FORK_EPOCH:     ConsensusFork.Gloas
+  if   epoch >= cfg.HEZE_FORK_EPOCH:      ConsensusFork.Heze
+  elif epoch >= cfg.GLOAS_FORK_EPOCH:     ConsensusFork.Gloas
   elif epoch >= cfg.FULU_FORK_EPOCH:      ConsensusFork.Fulu
   elif epoch >= cfg.ELECTRA_FORK_EPOCH:   ConsensusFork.Electra
   elif epoch >= cfg.DENEB_FORK_EPOCH:     ConsensusFork.Deneb
@@ -1253,6 +1319,10 @@ template withBlck*(
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyBlck: untyped {.inject, used.} = x.gloasData
     body
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyBlck: untyped {.inject, used.} = x.hezeData
+    body
 
 func hash_tree_root*(x: ForkedBeaconBlock): Eth2Digest =
   withBlck(x): hash_tree_root(forkyBlck)
@@ -1298,6 +1368,12 @@ template withForkyMaybeBlindedBlck*(
     body: untyped): untyped =
   debugGloasComment "re-add mev to gloas"
   case b.kind
+  of ConsensusFork.Heze:
+    const
+      consensusFork {.inject, used.} = ConsensusFork.Heze
+      isBlinded {.inject, used.} = false
+    template forkyMaybeBlindedBlck: untyped {.inject, used.} = b.hezeData
+    body
   of ConsensusFork.Gloas:
     const
       consensusFork {.inject, used.} = ConsensusFork.Gloas
@@ -1375,6 +1451,11 @@ template withStateAndBlck*(
        ForkedTrustedSignedBeaconBlock,
     body: untyped): untyped =
   case s.kind
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyState: untyped {.inject.} = s.hezeData
+    template forkyBlck: untyped {.inject.} = b.hezeData
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyState: untyped {.inject.} = s.gloasData
@@ -1418,6 +1499,10 @@ template withStateAndBlck*(
 
 template withAttestation*(a: ForkedAttestation, body: untyped): untyped =
   case a.kind
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyAttestation: untyped {.inject.} = a.hezeData
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyAttestation: untyped {.inject.} = a.gloasData
@@ -1454,6 +1539,10 @@ template withAttestation*(a: ForkedAttestation, body: untyped): untyped =
 template withAggregateAndProof*(a: ForkedAggregateAndProof,
                                 body: untyped): untyped =
   case a.kind
+  of ConsensusFork.Heze:
+    const consensusFork {.inject, used.} = ConsensusFork.Heze
+    template forkyProof: untyped {.inject.} = a.hezeData
+    body
   of ConsensusFork.Gloas:
     const consensusFork {.inject, used.} = ConsensusFork.Gloas
     template forkyProof: untyped {.inject.} = a.gloasData
@@ -1567,6 +1656,7 @@ func hezeFork*(cfg: RuntimeConfig): Fork =
 
 func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
   case cfg.consensusForkAtEpoch(epoch)
+  of ConsensusFork.Heze:      cfg.hezeFork
   of ConsensusFork.Gloas:     cfg.gloasFork
   of ConsensusFork.Fulu:      cfg.fuluFork
   of ConsensusFork.Electra:   cfg.electraFork
@@ -1578,6 +1668,7 @@ func forkAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Fork =
 
 func forkVersionAtEpoch*(cfg: RuntimeConfig, epoch: Epoch): Version =
   case cfg.consensusForkAtEpoch(epoch)
+  of ConsensusFork.Heze:      cfg.HEZE_FORK_VERSION
   of ConsensusFork.Gloas:     cfg.GLOAS_FORK_VERSION
   of ConsensusFork.Fulu:      cfg.FULU_FORK_VERSION
   of ConsensusFork.Electra:   cfg.ELECTRA_FORK_VERSION
@@ -1650,7 +1741,8 @@ func getForkSchedule*(cfg: RuntimeConfig): array[8, Fork] =
   ## This procedure is used by HTTP REST framework and validator client.
   ##
   ## NOTE: Update this procedure when new fork will be scheduled.
-  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  debugHezeComment "add hezeFork to getForkSchedule"
+  static: doAssert high(ConsensusFork) == ConsensusFork.Heze
   [cfg.genesisFork(), cfg.altairFork(), cfg.bellatrixFork(), cfg.capellaFork(),
    cfg.denebFork(), cfg.electraFork(), cfg.fuluFork(), cfg.gloasFork()]
 
@@ -1782,7 +1874,9 @@ func init*(T: type ForkDigests,
           @[(cfg.FULU_FORK_EPOCH, ConsensusFork.Fulu, compute_fork_digest_fulu(
             cfg, genesis_validators_root, cfg.FULU_FORK_EPOCH)),
            (cfg.GLOAS_FORK_EPOCH, ConsensusFork.Gloas, compute_fork_digest_fulu(
-            cfg, genesis_validators_root, cfg.GLOAS_FORK_EPOCH))] &
+            cfg, genesis_validators_root, cfg.GLOAS_FORK_EPOCH)),
+           (cfg.HEZE_FORK_EPOCH, ConsensusFork.Heze, compute_fork_digest_fulu(
+            cfg, genesis_validators_root, cfg.HEZE_FORK_EPOCH))] &
           mapIt(cfg.BLOB_SCHEDULE, (
             it.EPOCH,
             consensusForkAtEpoch(cfg, it.EPOCH),
@@ -1890,6 +1984,12 @@ template init*(T: type ForkedMaybeBlindedBeaconBlock,
     gloasData: blck)
 
 template init*(T: type ForkedMaybeBlindedBeaconBlock,
+               blck: heze.BlockContents): T =
+  ForkedMaybeBlindedBeaconBlock(
+    kind: ConsensusFork.Heze,
+    hezeData: blck)
+
+template init*(T: type ForkedMaybeBlindedBeaconBlock,
                blck: fulu_mev.BlindedBeaconBlock,
                evalue: Opt[UInt256], cvalue: Opt[UInt256]): T =
   ForkedMaybeBlindedBeaconBlock(
@@ -1912,6 +2012,8 @@ template init*(T: type ForkedAttestation,
     ForkedAttestation(kind: ConsensusFork.Fulu, fuluData: attestation)
   of ConsensusFork.Gloas:
     ForkedAttestation(kind: ConsensusFork.Gloas, gloasData: attestation)
+  of ConsensusFork.Heze:
+    ForkedAttestation(kind: ConsensusFork.Heze, hezeData: attestation)
 
 template init*(T: type ForkedAggregateAndProof,
                proof: electra.AggregateAndProof,
@@ -1926,6 +2028,8 @@ template init*(T: type ForkedAggregateAndProof,
     ForkedAggregateAndProof(kind: ConsensusFork.Fulu, fuluData: proof)
   of ConsensusFork.Gloas:
     ForkedAggregateAndProof(kind: ConsensusFork.Gloas, gloasData: proof)
+  of ConsensusFork.Heze:
+    ForkedAggregateAndProof(kind: ConsensusFork.Heze, hezeData: proof)
 
 func kzg_commitments*(eps: ForkyExecutionPayloadForSigning): KzgCommitments =
   when typeof(eps).kind >= ConsensusFork.Deneb:

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -386,7 +386,8 @@ func is_merge_transition_complete*(
   state.latest_execution_payload_header != defaultExecutionPayloadHeader
 
 debugGloasComment ""
-func is_merge_transition_complete*(state: gloas.BeaconState): bool =
+func is_merge_transition_complete*(
+    state: gloas.BeaconState | heze.BeaconState): bool =
   state.latest_block_hash != ZERO_HASH
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.9/sync/optimistic.md#helpers

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -209,7 +209,7 @@ func getTargetGossipState*(epoch: Epoch, cfg: RuntimeConfig, isBehind: bool):
   if isBehind:
     return static(HashSet[Epoch]())
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  static: doAssert high(ConsensusFork) == ConsensusFork.Heze
   var epochs = newSeqOfCap[Epoch](
     int(high(ConsensusFork)) + 1 + len(cfg.BLOB_SCHEDULE))
   for bpo in cfg.BLOB_SCHEDULE:

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -445,7 +445,8 @@ proc process_justification_and_finalization*(
 proc compute_unrealized_finality*(
     state: altair.BeaconState | bellatrix.BeaconState | capella.BeaconState |
            deneb.BeaconState | electra.BeaconState | fulu.BeaconState |
-           gloas.BeaconState): (FinalityCheckpoints, ParticipatingBalances) =
+           gloas.BeaconState | heze.BeaconState):
+    (FinalityCheckpoints, ParticipatingBalances) =
   let balances = get_unslashed_participating_balances(state)
 
   if get_current_epoch(state) <= GENESIS_EPOCH + 1:
@@ -986,7 +987,8 @@ func get_slashing_penalty*(
                             adjusted_total_slashing_balance
     penalty_numerator div total_balance * increment
   elif consensusFork in
-      [ConsensusFork.Electra, ConsensusFork.Fulu, ConsensusFork.Gloas]:
+      [ConsensusFork.Electra, ConsensusFork.Fulu, ConsensusFork.Gloas,
+       ConsensusFork.Heze]:
     let
       effective_balance_increments = validator.effective_balance div increment
       penalty_per_effective_balance_increment =

--- a/beacon_chain/validator_client/api.nim
+++ b/beacon_chain/validator_client/api.nim
@@ -2433,6 +2433,8 @@ proc publishBlockV2*(
           publishBlockV2(it, some(broadcast_validation), data.fuluData)
         of ConsensusFork.Gloas:
           publishBlockV2(it, some(broadcast_validation), data.gloasData)
+        of ConsensusFork.Heze:
+          publishBlockV2(it, some(broadcast_validation), data.hezeData)
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2488,6 +2490,8 @@ proc publishBlockV2*(
         publishBlockV2(it, some(broadcast_validation), data.fuluData)
       of ConsensusFork.Gloas:
         publishBlockV2(it, some(broadcast_validation), data.gloasData)
+      of ConsensusFork.Heze:
+        publishBlockV2(it, some(broadcast_validation), data.hezeData)
 
     do:
       if apiResponse.isErr():
@@ -2553,6 +2557,9 @@ proc publishBlindedBlockV2*(
         of ConsensusFork.Gloas:
           debugGloasComment ""
           return false
+        of ConsensusFork.Heze:
+          debugHezeComment ""
+          return false
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2601,6 +2608,9 @@ proc publishBlindedBlockV2*(
           data.fuluData)
       of ConsensusFork.Gloas:
         debugGloasComment ""
+        return false
+      of ConsensusFork.Heze:
+        debugHezeComment ""
         return false
     do:
       if apiResponse.isErr():
@@ -2669,6 +2679,8 @@ proc publishBlindedBlock*(
           publishBlindedBlock(it, data.fuluData)
         of ConsensusFork.Gloas:
           publishBlindedBlock(it, data.gloasData)
+        of ConsensusFork.Heze:
+          publishBlindedBlock(it, data.hezeData)
       do:
         if apiResponse.isErr():
           handleCommunicationError()
@@ -2720,6 +2732,8 @@ proc publishBlindedBlock*(
         publishBlindedBlock(it, data.fuluData)
       of ConsensusFork.Gloas:
         publishBlindedBlock(it, data.gloasData)
+      of ConsensusFork.Heze:
+        publishBlindedBlock(it, data.hezeData)
     do:
       if apiResponse.isErr():
         handleCommunicationError()

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -46,10 +46,10 @@ const
 
   ZeroTimeDiff* = TimeDiff(nanoseconds: 0'i64)
 
-static: doAssert(high(ConsensusFork) == ConsensusFork.Gloas,
+static: doAssert(high(ConsensusFork) == ConsensusFork.Heze,
           "Update OptionalForks constant!")
 const
-  OptionalForks* = {ConsensusFork.Gloas}
+  OptionalForks* = {ConsensusFork.Gloas, ConsensusFork.Heze}
     ## When a new ConsensusFork is added and before this fork is activated on
     ## `mainnet`, it should be part of `OptionalForks`.
     ## In this case, the client will ignore missing <FORKNAME>_VERSION

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -407,7 +407,12 @@ proc proposeBlockAux(
     validator_index = validator.index.expect("index set for proposer")
 
     engineBid =
-      when consensusFork == ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Heze:
+        debugHezeComment "stub: heze block proposals"
+        await node.getExecutionPayload(
+          consensusFork, head, state, validator_index, validator.pubkey
+        )
+      elif consensusFork == ConsensusFork.Gloas:
         # Fetch only engine payload for now
         await node.getExecutionPayload(
           consensusFork, head, state, validator_index, validator.pubkey
@@ -568,11 +573,14 @@ proc proposeBlockAux(
       message: engineBlock.blck, signature: signature, root: blockRoot
     )
 
-  when consensusFork == ConsensusFork.Gloas:
+  when consensusFork == ConsensusFork.Heze:
+    debugHezeComment "stub: heze sidecar assembly"
+    let sidecarsOpt = Opt.none(seq[gloas.DataColumnSidecar])
+  elif consensusFork == ConsensusFork.Gloas:
     let sidecarsOpt =
       Opt.some(signedBlock.assemble_data_column_sidecars(
         engineBid[].eps.blobsBundle.blobs.mapIt(kzg.KzgBlob(bytes: it)),
-        @(engineBid[].eps.blobsBundle.proofs.mapIt(kzg.KzgProof(it)))
+        engineBid[].eps.blobsBundle.proofs.mapIt(kzg.KzgProof(it))
       ))
   elif consensusFork == ConsensusFork.Fulu:
     let sidecarsOpt =

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -143,7 +143,7 @@ proc publishRouteBlock(
 
 proc publishSidecars(
     router: ref MessageRouter,
-    blck: gloas.SignedBeaconBlock,
+    blck: gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
     sidecarsOpt: Opt[seq[gloas.DataColumnSidecar]]
 ): Future[Opt[gloas.DataColumnSidecars]] {.async: (raises: [CancelledError]).} =
   let cols = sidecarsOpt.get()
@@ -287,7 +287,7 @@ proc addRoutedBlock(
 proc routeSignedBeaconBlock*(
     router: ref MessageRouter,
     blck: electra.SignedBeaconBlock | fulu.SignedBeaconBlock |
-          gloas.SignedBeaconBlock,
+          gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
     someSidecarsOpt: SomeSidecarsToRoute,
     checkValidator: bool
 ): Future[RouteBlockResult] {.async: (raises: [CancelledError]).} =

--- a/beacon_chain/validators/validator_pool.nim
+++ b/beacon_chain/validators/validator_pool.nim
@@ -546,6 +546,9 @@ proc forkIndex(
     prop.fuluIndex
   elif fork == ConsensusFork.Gloas:
     prop.gloasIndex
+  elif fork == ConsensusFork.Heze:
+    debugHezeComment "add hezeIndex to ProvenProperty"
+    prop.gloasIndex
   else:
     static: raiseAssert "Unknown fork " & $fork
 

--- a/ncli/ncli.nim
+++ b/ncli/ncli.nim
@@ -101,6 +101,7 @@ template saveSSZFile(filename: string, value: ForkedHashedBeaconState) =
     of ConsensusFork.Electra:   SSZ.saveFile(filename, value.electraData.data)
     of ConsensusFork.Fulu:      SSZ.saveFile(filename, value.fuluData.data)
     of ConsensusFork.Gloas:     SSZ.saveFile(filename, value.gloasData.data)
+    of ConsensusFork.Heze:      SSZ.saveFile(filename, value.hezeData.data)
   except IOError:
     raiseAssert "error saving SSZ file"
 

--- a/ncli/ncli_common.nim
+++ b/ncli/ncli_common.nim
@@ -272,7 +272,7 @@ proc collectEpochRewardsAndPenalties*(
     rewardsAndPenalties: var seq[RewardsAndPenalties],
     state: var (altair.BeaconState | bellatrix.BeaconState |
                 capella.BeaconState | deneb.BeaconState | electra.BeaconState |
-                fulu.BeaconState | gloas.BeaconState),
+                fulu.BeaconState | gloas.BeaconState | heze.BeaconState),
     cache: var StateCache, cfg: RuntimeConfig, flags: UpdateFlags) =
   if get_current_epoch(state) == GENESIS_EPOCH:
     return

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -253,7 +253,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       seq[deneb.TrustedSignedBeaconBlock],
       seq[electra.TrustedSignedBeaconBlock],
       seq[fulu.TrustedSignedBeaconBlock],
-      seq[gloas.TrustedSignedBeaconBlock])
+      seq[gloas.TrustedSignedBeaconBlock],
+      seq[heze.TrustedSignedBeaconBlock])
 
   echo "Loaded head slot ", dag.head.slot,
     " selected ", blockRefs.len, " blocks"
@@ -288,6 +289,9 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       of ConsensusFork.Gloas:
         blocks[7].add dag.db.getBlock(
           blck.root, gloas.TrustedSignedBeaconBlock).get()
+      of ConsensusFork.Heze:
+        blocks[8].add dag.db.getBlock(
+          blck.root, heze.TrustedSignedBeaconBlock).get()
 
   let stateData = newClone(dag.headState)
 
@@ -302,7 +306,8 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
       (ref deneb.HashedBeaconState)(),
       (ref electra.HashedBeaconState)(),
       (ref fulu.HashedBeaconState)(),
-      (ref gloas.HashedBeaconState)())
+      (ref gloas.HashedBeaconState)(),
+      (ref heze.HashedBeaconState)())
 
   withTimer(timers[tLoadState]):
     doAssert dag.updateState(
@@ -372,6 +377,9 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
               of ConsensusFork.Gloas:
                 doAssert dbBenchmark.getState(
                   forkyState.root, loadedState[7][].data, noRollback)
+              of ConsensusFork.Heze:
+                doAssert dbBenchmark.getState(
+                  forkyState.root, loadedState[8][].data, noRollback)
 
             if forkyState.data.slot.epoch mod 16 == 0:
               let loadedRoot = case consensusFork
@@ -383,9 +391,10 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
                 of ConsensusFork.Electra:   hash_tree_root(loadedState[5][].data)
                 of ConsensusFork.Fulu:      hash_tree_root(loadedState[6][].data)
                 of ConsensusFork.Gloas:     hash_tree_root(loadedState[7][].data)
+                of ConsensusFork.Heze:      hash_tree_root(loadedState[8][].data)
               doAssert hash_tree_root(forkyState.data) == loadedRoot
 
-  staticFor i, 0 .. 7:
+  staticFor i, 0 .. 8:
     processBlocks(blocks[i])
   printTimers(false, timers)
 

--- a/research/wss_sim.nim
+++ b/research/wss_sim.nim
@@ -113,7 +113,8 @@ cli do(validatorsDir: string, secretsDir: string,
   elManager.start()
   withBlck(blck[]):
     debugGloasComment ""
-    when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
+    when consensusFork >= ConsensusFork.Bellatrix and
+         consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
       if forkyBlck.message.is_execution_block:
         template payload(): auto = forkyBlck.message.body.execution_payload
         if not payload.block_hash.isZero:

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -267,7 +267,8 @@ proc stepOnBlock(
   # this wouldn't be part of this check, presumably, their FC test vector step
   # would also have `true` validity because it'd not be known they weren't, so
   # adding this mock of the block processor is realistic and sufficient.
-  when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
+  when consensusFork >= ConsensusFork.Bellatrix and
+       consensusFork notin [ConsensusFork.Gloas, ConsensusFork.Heze]:
     debugGloasComment "skip execution payload for Gloas?"
     let executionBlockHash =
       signedBlock.message.body.execution_payload.block_hash

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -131,7 +131,8 @@ let
     for consensusFork in ConsensusFork:
       res[consensusFork] = cfg.getTestStates(consensusFork)
     res
-doAssert testStates.allIt(it.len > 8)
+debugHezeComment "..."
+doAssert testStates.toOpenArray(0, testStates.len - 2).allIt(it.len > 8)
 
 suite "Beacon chain DB" & preset():
   test "empty database" & preset():
@@ -567,15 +568,15 @@ suite "Beacon chain DB" & preset():
         message: BeaconBlockHeader(slot: Slot(0)))
       blockHeader1 = SignedBeaconBlockHeader(
         message: BeaconBlockHeader(slot: Slot(1)))
-    
-    let 
+
+    let
       blockRoot0 = hash_tree_root(blockHeader0.message)
       blockRoot1 = hash_tree_root(blockHeader1.message)
 
       dataColumnSidecar0 = gloas.DataColumnSidecar(index: 3, beacon_block_root: blockRoot0)
       dataColumnSidecar1 = gloas.DataColumnSidecar(index: 2, beacon_block_root: blockRoot0)
       dataColumnSidecar2 = gloas.DataColumnSidecar(index: 2, beacon_block_root: blockRoot1)
-      
+
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
 
     var
@@ -697,7 +698,7 @@ suite "Beacon chain DB" & preset():
         message: ExecutionPayloadEnvelope(beacon_block_root: blockRoot1))
 
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
-    
+
     var data: seq[byte]
 
     check:
@@ -718,7 +719,7 @@ suite "Beacon chain DB" & preset():
       not db.getExecutionPayloadEnvelope(blockRoot1).isSome()
       db.getExecutionPayloadEnvelopeSZ(blockRoot0, data)
       not db.getExecutionPayloadEnvelopeSZ(blockRoot1, data)
-    
+
     db.putExecutionPayloadEnvelope(envelope1)
 
     check:
@@ -748,7 +749,7 @@ suite "Beacon chain DB" & preset():
       not db.getExecutionPayloadEnvelope(blockRoot1).isSome()
       not db.getExecutionPayloadEnvelopeSZ(blockRoot0, data)
       not db.getExecutionPayloadEnvelopeSZ(blockRoot1, data)
-    
+
     db.close()
 
 suite "Quarantine" & preset():

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -25,7 +25,9 @@ suite "Light client" & preset():
     headPeriod = 4.SyncCommitteePeriod
   let
     cfg = block:  # Fork schedule that covers each `LightClientDataFork`
-      static: doAssert ConsensusFork.high == ConsensusFork.Gloas
+      debugGloasComment "..."
+      debugHezeComment "..."
+      static: doAssert ConsensusFork.high == ConsensusFork.Heze
       var res = defaultRuntimeConfig
       res.ALTAIR_FORK_EPOCH = 1.Epoch
       res.BELLATRIX_FORK_EPOCH = 2.Epoch

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2025 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -27,8 +27,9 @@ suite "Light client processor" & preset():
     lastPeriodWithSupermajority = 4.SyncCommitteePeriod
     highPeriod = 6.SyncCommitteePeriod
   debugGloasComment "add res.GLOAS_FORK_EPOCH = ..."
+  debugHezeComment "add res.HEZE_FORK_EPOCH = ..."
   let cfg = block:  # Fork schedule that covers each `LightClientDataFork`
-    static: doAssert ConsensusFork.high == ConsensusFork.Gloas
+    static: doAssert ConsensusFork.high == ConsensusFork.Heze
     var res = defaultRuntimeConfig
     res.ALTAIR_FORK_EPOCH = 1.Epoch
     res.BELLATRIX_FORK_EPOCH = 2.Epoch

--- a/tests/test_payload_attestation_pool.nim
+++ b/tests/test_payload_attestation_pool.nim
@@ -91,7 +91,8 @@ suite "Payload attestation pool" & preset():
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var ptc_member: ValidatorIndex
         var found = false
         for validator_index in get_ptc(forkyState.data, slot):
@@ -126,7 +127,8 @@ suite "Payload attestation pool" & preset():
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var messages: seq[PayloadAttestationMessage]
         var ptc_members: seq[ValidatorIndex]
 
@@ -158,7 +160,8 @@ suite "Payload attestation pool" & preset():
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var
           validator_positions: Table[ValidatorIndex, seq[int]]
           ptc_index = 0
@@ -208,7 +211,8 @@ suite "Payload attestation pool" & preset():
       target_slot = slot + 1
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var added_count = 0
         for validator_index in get_ptc(forkyState.data, slot):
           if added_count >= 2:
@@ -234,7 +238,8 @@ suite "Payload attestation pool" & preset():
       future_time = (slot + 5).start_beacon_time(dag.cfg.timeParams)
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var ptc_member: ValidatorIndex
         for validator_index in get_ptc(forkyState.data, slot):
           ptc_member = validator_index
@@ -264,7 +269,8 @@ suite "Payload attestation pool" & preset():
       wallTime = slot.start_beacon_time(dag.cfg.timeParams)
 
     withState(state[]):
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork == ConsensusFork.Gloas:
+        debugHezeComment "..."
         var ptc_members: seq[ValidatorIndex]
         for validator_index in get_ptc(forkyState.data, slot):
           if ptc_members.len >= 4:

--- a/tests/test_signing_node.nim
+++ b/tests/test_signing_node.nim
@@ -101,6 +101,9 @@ proc getBlock(
     of ConsensusFork.Gloas:
       debugGloasComment "gloas test signing node getblock"
       raiseAssert "gloas unsupported"
+    of ConsensusFork.Heze:
+      debugGloasComment "heze test signing node getblock"
+      raiseAssert "heze unsupported"
   except ValueError:
     # https://github.com/nim-lang/Nim/pull/23356
     raiseAssert "Arguments match the format string"
@@ -124,6 +127,10 @@ func init(t: typedesc[Web3SignerForkedBeaconBlock],
     Web3SignerForkedBeaconBlock(
       kind: ConsensusFork.Gloas,
       data: forked.gloasData.toBeaconBlockHeader)
+  of ConsensusFork.Heze:
+    Web3SignerForkedBeaconBlock(
+      kind: ConsensusFork.Heze,
+      data: forked.hezeData.toBeaconBlockHeader)
 
 proc createKeystore(dataDir, pubkey,
                     store, password: string): Result[void, string] =

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024-2025 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -146,7 +146,8 @@ template fulu_steps() =
 suite "Blinded block conversions":
   withAll(ConsensusFork):
     debugGloasComment "needs toSignedBlindedBeaconBlock"
-    when consensusFork >= ConsensusFork.Bellatrix and consensusFork != ConsensusFork.Gloas:
+    debugHezeComment "needs toSignedBlindedBeaconBlock"
+    when consensusFork >= ConsensusFork.Bellatrix and consensusFork < ConsensusFork.Gloas:
       test $consensusFork & " toSignedBlindedBeaconBlock":
         var b = default(consensusFork.SignedBeaconBlock)
         do_check
@@ -160,4 +161,5 @@ suite "Blinded block conversions":
         when consensusFork >= ConsensusFork.Fulu:
           fulu_steps
         debugGloasComment ""
-        static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+        debugHezeComment ""
+        static: doAssert high(ConsensusFork) == ConsensusFork.Heze

--- a/tests/teststateutil.nim
+++ b/tests/teststateutil.nim
@@ -136,7 +136,7 @@ proc getTestStates*(
     info = ForkedEpochInfo()
     cfg = defaultRuntimeConfig
 
-  static: doAssert high(ConsensusFork) == ConsensusFork.Gloas
+  static: doAssert high(ConsensusFork) == ConsensusFork.Heze
   if consensusFork >= ConsensusFork.Altair:
     cfg.ALTAIR_FORK_EPOCH = 1.Epoch
   if consensusFork >= ConsensusFork.Bellatrix:
@@ -151,6 +151,8 @@ proc getTestStates*(
     cfg.FULU_FORK_EPOCH = 6.Epoch
   if consensusFork >= ConsensusFork.Gloas:
     cfg.GLOAS_FORK_EPOCH = 7.Epoch
+  if consensusFork >= ConsensusFork.Heze:
+    cfg.HEZE_FORK_EPOCH = 8.Epoch
 
   for i, epoch in stateEpochs:
     let slot = epoch.Epoch.start_slot


### PR DESCRIPTION
Fairly minimal. Disabled in various ways, but sets up the `enum` infrastructure to enable most further changes to be incremental and local.