### PR TITLE
switch block_sim to iterate through fulu/gloas/heze forks

### DIFF
--- a/beacon_chain/el/merkle_minimal.nim
+++ b/beacon_chain/el/merkle_minimal.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/tests/core/pyspec/eth2spec/utils/merkle_minimal.py
 
@@ -35,7 +35,7 @@ func attachMerkleProofs*(deposits: var openArray[Deposit]): Eth2Digest =
   let proofs = merkleizer.addChunksAndGenMerkleProofs(depositsRoots)
   for i in 0 ..< depositsRoots.len:
     deposits[i].proof[0 ..< DEPOSIT_CONTRACT_TREE_DEPTH] = getProof(proofs, i)
-    deposits[i].proof[DEPOSIT_CONTRACT_TREE_DEPTH] = default(Eth2Digest)
+    deposits[i].proof[DEPOSIT_CONTRACT_TREE_DEPTH] = ZERO_HASH
     deposits[i].proof[DEPOSIT_CONTRACT_TREE_DEPTH].data[0..7] =
       toBytesLE deposits.lenu64
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -609,7 +609,7 @@ func compute_deltas(
   ## Error:
   ## - If a value in indices is greater than `indices.len`
   ## - If a `Eth2Digest` in `votes` does not exist in `indices`
-  ##   except for the `default(Eth2Digest)` (i.e. zero hash)
+  ##   except for the `ZERO_HASH`
 
   for val_index, vote in votes.mpairs():
     # No need to create a score change if the validator has never voted
@@ -728,7 +728,7 @@ when isMainModule:
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
-        current_root: default(Eth2Digest),
+        current_root: ZERO_HASH,
         next_root: fakeHash(0), # Get a non-zero hash
         slot: Slot(0))
       old_balances.add Balance
@@ -768,7 +768,7 @@ when isMainModule:
     for i in 0 ..< validator_count:
       indices[fakeHash(i)] = i
       votes.add VoteTracker(
-        current_root: default(Eth2Digest),
+        current_root: ZERO_HASH,
         next_root: fakeHash(i), # Each vote for a different root
         slot: Slot(0))
       old_balances.add Balance
@@ -851,7 +851,7 @@ when isMainModule:
     # One validator moves their vote from the block to the zero hash
     votes.add VoteTracker(
       current_root: fakeHash(1),
-      next_root: default(Eth2Digest),
+      next_root: ZERO_HASH,
       slot: Slot(0))
 
     # One validator moves their vote from the block to

--- a/beacon_chain/spec/state_transition.nim
+++ b/beacon_chain/spec/state_transition.nim
@@ -347,7 +347,8 @@ proc makeBeaconBlockWithRewards*(
     verificationFlags: UpdateFlags,
     kzg_commitments: KzgCommitments,
     execution_requests: ExecutionRequests,
-    signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
+    signed_execution_payload_bid:
+        gloas.SignedExecutionPayloadBid | heze.SignedExecutionPayloadBid,
     payload_attestations: seq[PayloadAttestation]
 ): Result[
     tuple[
@@ -405,8 +406,7 @@ proc makeBeaconBlockWithRewards*(
       consensusFork < ConsensusFork.Gloas:
     blck.body.execution_requests = execution_requests
 
-  debugHezeComment "..."
-  when consensusFork == ConsensusFork.Gloas:
+  when consensusFork >= ConsensusFork.Gloas:
     blck.body.signed_execution_payload_bid =
       signed_execution_payload_bid
 
@@ -440,7 +440,8 @@ proc makeBeaconBlock*[EP: ForkyExecutionPayload | ForkyExecutionPayloadHeader](
     verificationFlags: UpdateFlags,
     kzg_commitments: KzgCommitments,
     execution_requests: ExecutionRequests,
-    signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
+    signed_execution_payload_bid:
+        gloas.SignedExecutionPayloadBid | heze.SignedExecutionPayloadBid,
     payload_attestations: seq[PayloadAttestation]
 ): Result[consensusFork.BeaconBlock, cstring] =
   ok (
@@ -468,7 +469,8 @@ proc makeBeaconBlock*(
     eps: ForkyExecutionPayloadForSigning,
     verificationFlags: UpdateFlags,
     execution_requests: ExecutionRequests = default(ExecutionRequests),
-    signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
+    signed_execution_payload_bid:
+        gloas.SignedExecutionPayloadBid | heze.SignedExecutionPayloadBid,
     payload_attestations: seq[PayloadAttestation]
 ): Result[consensusFork.BeaconBlock, cstring] =
   makeBeaconBlock(

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -245,7 +245,23 @@ proc makeEngineBlock*(
     )
     sync_aggregate = node.syncCommitteeMsgPool[].produceSyncAggregate(head.bid, slot)
     signed_execution_payload_bid =
-      when consensusFork >= ConsensusFork.Gloas:
+      when consensusFork >= ConsensusFork.Heze:
+        debugHezeComment "set inclusion_list_bits with FOCIL information"
+        heze.SignedExecutionPayloadBid(
+          message: heze.ExecutionPayloadBid(
+            parent_block_hash: eps.executionPayload.parent_hash,
+            parent_block_root: state.latest_block_root,
+            block_hash: eps.executionPayload.block_hash,
+            prev_randao: eps.executionPayload.prev_randao,
+            fee_recipient: eps.executionPayload.fee_recipient,
+            gas_limit: eps.executionPayload.gas_limit,
+            builder_index: BUILDER_INDEX_SELF_BUILD,
+            slot: slot,
+            value: 0.Gwei,
+            execution_payment: 0.Gwei,
+            blob_kzg_commitments: eps.kzg_commitments),
+          signature: ValidatorSig.infinity())
+      elif consensusFork == ConsensusFork.Gloas:
         makeSignedExecutionPayloadBid(
           eps.executionPayload, eps.kzg_commitments, state.latest_block_root, slot
         )

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -202,10 +202,12 @@ func makeExecutionPayloadEnvelope*(
   )
 
 func makeSignedExecutionPayloadBid(
+    T: type gloas.SignedExecutionPayloadBid,
     executionPayload: deneb.ExecutionPayload,
     blob_kzg_commitments: KzgCommitments,
     parentBlockRoot: Eth2Digest,
     slot: Slot,
+    _: BitArray[int INCLUSION_LIST_COMMITTEE_SIZE],
 ): gloas.SignedExecutionPayloadBid =
   let bid = gloas.ExecutionPayloadBid(
     parent_block_hash: executionPayload.parent_hash,
@@ -224,6 +226,31 @@ func makeSignedExecutionPayloadBid(
     message: bid,
     signature: ValidatorSig.infinity()
   )
+
+func makeSignedExecutionPayloadBid(
+    T: type heze.SignedExecutionPayloadBid,
+    executionPayload: deneb.ExecutionPayload,
+    blob_kzg_commitments: KzgCommitments,
+    parentBlockRoot: Eth2Digest,
+    slot: Slot,
+    inclusion_list_bits: BitArray[int INCLUSION_LIST_COMMITTEE_SIZE],
+): heze.SignedExecutionPayloadBid =
+  let bid = heze.ExecutionPayloadBid(
+    parent_block_hash: executionPayload.parent_hash,
+    parent_block_root: parentBlockRoot,
+    block_hash: executionPayload.block_hash,
+    prev_randao: executionPayload.prev_randao,
+    fee_recipient: executionPayload.fee_recipient,
+    gas_limit: executionPayload.gas_limit,
+    builder_index: BUILDER_INDEX_SELF_BUILD,
+    slot: slot,
+    value: 0.Gwei,
+    execution_payment: 0.Gwei,
+    blob_kzg_commitments: blob_kzg_commitments,
+    inclusion_list_bits: inclusion_list_bits)
+  heze.SignedExecutionPayloadBid(
+    message: bid,
+    signature: ValidatorSig.infinity())
 
 proc makeEngineBlock*(
     node: BeaconNode,
@@ -247,24 +274,15 @@ proc makeEngineBlock*(
     signed_execution_payload_bid =
       when consensusFork >= ConsensusFork.Heze:
         debugHezeComment "set inclusion_list_bits with FOCIL information"
-        heze.SignedExecutionPayloadBid(
-          message: heze.ExecutionPayloadBid(
-            parent_block_hash: eps.executionPayload.parent_hash,
-            parent_block_root: state.latest_block_root,
-            block_hash: eps.executionPayload.block_hash,
-            prev_randao: eps.executionPayload.prev_randao,
-            fee_recipient: eps.executionPayload.fee_recipient,
-            gas_limit: eps.executionPayload.gas_limit,
-            builder_index: BUILDER_INDEX_SELF_BUILD,
-            slot: slot,
-            value: 0.Gwei,
-            execution_payment: 0.Gwei,
-            blob_kzg_commitments: eps.kzg_commitments),
-          signature: ValidatorSig.infinity())
+        makeSignedExecutionPayloadBid(
+          heze.SignedExecutionPayloadBid,
+          eps.executionPayload, eps.kzg_commitments, state.latest_block_root,
+          slot, static(default(BitArray[int INCLUSION_LIST_COMMITTEE_SIZE])))
       elif consensusFork == ConsensusFork.Gloas:
         makeSignedExecutionPayloadBid(
-          eps.executionPayload, eps.kzg_commitments, state.latest_block_root, slot
-        )
+          gloas.SignedExecutionPayloadBid,
+          eps.executionPayload, eps.kzg_commitments, state.latest_block_root,
+          slot, static(default(BitArray[int INCLUSION_LIST_COMMITTEE_SIZE])))
       else:
         default(gloas.SignedExecutionPayloadBid)
     payload_attestations =

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -318,7 +318,7 @@ proc getExecutionPayload*(
       elif consensusFork >= ConsensusFork.Bellatrix:
         forkyState.data.latest_execution_payload_header.block_hash
       else:
-        (static(default(Eth2Digest)))
+        ZERO_HASH
     latestSafe = beaconHead.safeExecutionBlockHash
     latestFinalized = beaconHead.finalizedExecutionBlockHash
     timestamp = node.dag.timeParams.compute_timestamp_at_slot(forkyState.data, slot)

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1506,7 +1506,7 @@ proc inclSPDIR*(db: SlashingProtectionDB_v2, spdir: SPDIR):
 
     selectRootStmt.dispose()
 
-    if dbGenValRoot != default(Eth2Digest) and
+    if dbGenValRoot != ZERO_HASH and
          dbGenValRoot != spdir.metadata.genesis_validators_root.Eth2Digest:
       error "The slashing protection database and imported file refer to different blockchains.",
         DB_genesis_validators_root = dbGenValRoot,
@@ -1519,7 +1519,7 @@ proc inclSPDIR*(db: SlashingProtectionDB_v2, spdir: SPDIR):
       # is in an earlier version that used the kvstore table
       db.setupDB(spdir.metadata.genesis_validators_root.Eth2Digest)
 
-    # TODO: dbGenValRoot == default(Eth2Digest)
+    # TODO: dbGenValRoot == ZERO_HASH
 
   db.setupCachedQueries()
 

--- a/research/block_sim.nim
+++ b/research/block_sim.nim
@@ -290,20 +290,33 @@ cli do(
       )
       sync_aggregate = syncCommitteePool[].produceSyncAggregate(dag.head.bid, slot)
 
-    let
       epb =
         when consensusFork >= ConsensusFork.Heze:
-          debugHezeComment "..."
-          default(gloas.SignedExecutionPayloadBid)
+          let bid =
+            heze.ExecutionPayloadBid(
+              parent_block_hash: state.data.latest_block_hash,
+              parent_block_root: hash_tree_root(state.data.latest_block_header),
+              block_hash: ZERO_HASH,
+              prev_randao:
+                get_randao_mix(state.data, get_current_epoch(state.data)),
+              fee_recipient: static(default(ExecutionAddress)),
+              gas_limit: 30000000'u64,
+              builder_index: BUILDER_INDEX_SELF_BUILD,
+              slot: slot,
+              value: 0.Gwei,
+              execution_payment: 0.Gwei,
+              blob_kzg_commitments: default(KzgCommitments))
+          heze.SignedExecutionPayloadBid(
+            message: bid, signature: ValidatorSig.infinity())
         elif consensusFork == ConsensusFork.Gloas:
           let bid =
             gloas.ExecutionPayloadBid(
               parent_block_hash: state.data.latest_block_hash,
               parent_block_root: hash_tree_root(state.data.latest_block_header),
-              block_hash: default(Eth2Digest),
+              block_hash: ZERO_HASH,
               prev_randao:
                 get_randao_mix(state.data, get_current_epoch(state.data)),
-              fee_recipient: default(ExecutionAddress),
+              fee_recipient: static(default(ExecutionAddress)),
               gas_limit: 30000000'u64,
               builder_index: BUILDER_INDEX_SELF_BUILD,
               slot: slot,

--- a/research/simutils.nim
+++ b/research/simutils.nim
@@ -59,8 +59,9 @@ func getSimulationConfig*(): RuntimeConfig {.compileTime.} =
   cfg.CAPELLA_FORK_EPOCH = 0.Epoch
   cfg.DENEB_FORK_EPOCH = 0.Epoch
   cfg.ELECTRA_FORK_EPOCH = 0.Epoch
-  cfg.FULU_FORK_EPOCH = 3.Epoch
-  cfg.GLOAS_FORK_EPOCH = 5.Epoch
+  cfg.FULU_FORK_EPOCH = 0.Epoch
+  cfg.GLOAS_FORK_EPOCH = 3.Epoch
+  cfg.HEZE_FORK_EPOCH = 5.Epoch
   cfg
 
 proc loadGenesis*(
@@ -125,7 +126,7 @@ proc loadGenesis*(
 
     info "Saving genesis file", fileName = genesisFn
     try:
-      SSZ.saveFile(genesisFn, res.electraData.data)
+      SSZ.saveFile(genesisFn, res.fuluData.data)
     except IOError as exc:
       fatal "Genesis file failed to save",
         fileName = genesisFn, exc = exc.msg

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -278,8 +278,7 @@ proc stepOnBlock(
       # before the block itself, while Nimbus fork choice treats invalidating
       # a non-existent block root as a no-op and does not remember it for the
       # future.
-      let lvh = invalidatedHashes.getOrDefault(
-        executionBlockHash, static(default(Eth2Digest)))
+      let lvh = invalidatedHashes.getOrDefault(executionBlockHash, ZERO_HASH)
       fkChoice[].mark_root_invalid(dag.getEarliestInvalidBlockRoot(
         signedBlock.message.parent_root, lvh, executionBlockHash))
 

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -319,17 +319,10 @@ suite "EL Manager - getPayload":
   test "success without retry":
     let
       manager = createELManager(@[setup.url])
-      state = ForkchoiceStateV1.init(
-        default(Eth2Digest), default(Eth2Digest), default(Eth2Digest)
-      )
+      state = ForkchoiceStateV1.init(ZERO_HASH, ZERO_HASH, ZERO_HASH)
       attrs = PayloadAttributesV3.init(
-        default(uint64),
-        default(Eth2Digest),
-        default(Eth1Address),
-        default(seq[capella.Withdrawal]),
-        default(Eth2Digest),
-      )
-
+        0'u64, ZERO_HASH, default(Eth1Address),
+        default(seq[capella.Withdrawal]), ZERO_HASH)
       resp =
         waitFor manager.getPayload(electra.ExecutionPayloadForSigning, state, attrs)
 

--- a/tests/test_spec_signatures.nim
+++ b/tests/test_spec_signatures.nim
@@ -44,7 +44,7 @@ suite "Message signatures":
 
   test "Slot signatures":
     let
-      root0 = default(Eth2Digest)
+      root0 = ZERO_HASH
       root1 = gvr1
       sig = get_block_signature(fork0, gvr0, slot0, root0, privkey0).toValidatorSig
 
@@ -122,7 +122,7 @@ suite "Message signatures":
 
   test "Sync committee message signatures":
     let
-      root0 = default(Eth2Digest)
+      root0 = ZERO_HASH
       root1 = gvr1
       sig = get_sync_committee_message_signature(fork0, gvr0, slot0, root0, privkey0)
         .toValidatorSig()
@@ -293,7 +293,7 @@ suite "Message signatures":
       not verify_builder_signature(version1, reg0, pubkey0, sig)
       not verify_builder_signature(version0, reg1, pubkey0, sig)
       not verify_builder_signature(version0, reg0, pubkey1, sig)
-  
+
     test "proposer preferences message signatures":
       let
         data0 = default(ProposerPreferences)

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -171,7 +171,7 @@ func makeExecutionPayloadForSigning*(
     payload.withdrawals =
       List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](get_expected_withdrawals(state))
 
-  let parent_root = state.latest_block_root(default(Eth2Digest))
+  let parent_root = state.latest_block_root(ZERO_HASH)
   payload.block_hash =
     when consensusFork >= ConsensusFork.Electra:
       let emptyRequestsHash = computeRequestsHash(default(electra.ExecutionRequests))
@@ -260,7 +260,7 @@ func makeExecutionPayloadWithNonEmptyBlobsForSigning*(
     payload.withdrawals =
       List[capella.Withdrawal, MAX_WITHDRAWALS_PER_PAYLOAD](get_expected_withdrawals(state))
 
-  let parent_root = state.latest_block_root(default(Eth2Digest))
+  let parent_root = state.latest_block_root(ZERO_HASH)
   payload.block_hash =
     when consensusFork >= ConsensusFork.Electra:
       # Use correct empty requests hash
@@ -346,9 +346,17 @@ proc addTestEngineBlock*(
       when consensusFork >= ConsensusFork.Electra: electraAttestations else: attestations
 
     signed_execution_payload_bid =
-      when consensusFork == ConsensusFork.Heze:
-        debugHezeComment "..."
-        default(gloas.SignedExecutionPayloadBid)
+      when consensusFork >= ConsensusFork.Heze:
+        heze.SignedExecutionPayloadBid(
+          message: heze.ExecutionPayloadBid(
+            builder_index: BUILDER_INDEX_SELF_BUILD,
+            slot: state.data.slot,
+            block_hash: eps.executionPayload.block_hash,
+            parent_block_hash: state.data.latest_block_hash,
+            parent_block_root: state.latest_block_root,
+            prev_randao: get_randao_mix(state.data, get_current_epoch(state.data)),
+            value: 0.Gwei),
+          signature: ValidatorSig.infinity())
       elif consensusFork == ConsensusFork.Gloas:
         gloas.SignedExecutionPayloadBid(
           message: gloas.ExecutionPayloadBid(
@@ -447,9 +455,17 @@ proc addTestEngineBlockWithBlobs*(
         default(bellatrix.ExecutionPayloadForSigning)
 
     signed_execution_payload_bid =
-      when consensusFork >= ConsensusFork.Gloas:
-        debugHezeComment "..."
-        default(gloas.SignedExecutionPayloadBid)
+      when consensusFork >= ConsensusFork.Heze:
+        heze.SignedExecutionPayloadBid(
+          message: heze.ExecutionPayloadBid(
+            builder_index: BUILDER_INDEX_SELF_BUILD,
+            slot: state.data.slot,
+            block_hash: eps.executionPayload.block_hash,
+            parent_block_hash: state.data.latest_block_hash,
+            parent_block_root: state.latest_block_root,
+            prev_randao: get_randao_mix(state.data, get_current_epoch(state.data)),
+            value: 0.Gwei),
+          signature: ValidatorSig.infinity())
       elif consensusFork == ConsensusFork.Gloas:
         gloas.SignedExecutionPayloadBid(
           message: gloas.ExecutionPayloadBid(

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2025 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronicles,
@@ -34,6 +34,7 @@ proc makeTestDB*(
     cfg.FULU_FORK_EPOCH = 120000.Epoch
   if cfg.GLOAS_FORK_EPOCH == FAR_FUTURE_EPOCH:
     cfg.GLOAS_FORK_EPOCH = 130000.Epoch
+  debugHezeComment "..."
 
   let genState = initGenesisState(cfg, validators.uint64)
 
@@ -62,7 +63,7 @@ proc getEarliestInvalidBlockRoot*(
   var curBlck = dag.getBlockRef(initialSearchRoot).valueOr:
     # Being asked to traverse a chain which the DAG doesn't know about -- but
     # that'd imply the block's otherwise invalid for CL as well as EL.
-    return static(default(Eth2Digest))
+    return ZERO_HASH
 
   # Only allow this special case outside loop; it's when the LVH is the direct
   # parent of the reported invalid block


### PR DESCRIPTION
Consistent `ZERO_HASH` is a side change which avoids pointlessly expensive runtime construction of a constant already present at compile-time.