### PR TITLE
Adopt FCR function renames

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -881,8 +881,8 @@ proc getBeaconHead*(
       pool.dag.loadExecutionBlockHash(pool.dag.finalizedHead.blck)
         .get(ZERO_HASH)
 
-    # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/fork_choice/safe-block.md#get_safe_execution_payload_hash
-    safeBlockRoot = pool.forkChoice.get_safe_beacon_block_root()
+    # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/fork_choice/safe-block.md#get_safe_execution_block_hash
+    safeBlockRoot = pool.forkChoice.retrieve_fast_confirmed_root()
     safeBlock = pool.dag.getBlockRef(safeBlockRoot)
     safeExecutionBlockHash =
       if safeBlock.isErr:
@@ -904,7 +904,7 @@ proc willSelectNewHead*(
     pool: var AttestationPool,
     headBlock: BlockRef, wallTime: BeaconTime): Opt[void] =
   ## Informs fork choice that a new head will be selected.
-  ## This may affect `get_safe_beacon_block_root` so must be called before that.
+  ## This may affect `retrieve_fast_confirmed_root`; must call this before that.
   pool.forkChoice.will_select_head(pool.dag, headBlock, wallTime).isOkOr:
     error "Couldn't store head to fork choice", err = error
     return err()

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -201,7 +201,7 @@ proc updateHead(self: var ConsensusManager, newHead: BlockRef) =
     newHead, self.quarantine[],
     self.getKnownValidatorsForBlsChangeTracking(newHead))
   updateSafeBlockMetrics(
-    self.attestationPool[].forkChoice.get_safe_beacon_block_id)
+    self.attestationPool[].forkChoice.retrieve_fast_confirmed_bid)
   self.checkExpectedBlock()
 
 proc updateHead*(self: var ConsensusManager, wallSlot: Slot) =

--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -326,7 +326,7 @@ func is_full_validator_set_covered(slots: Slice[Slot]): bool =
 
 func adjust_committee_weight_estimate_to_ensure_safety(estimate: Gwei): Gwei =
   ## Return adjusted ``estimate`` of the weight of a committee for a sequence
-  ## of slots not covering a full epoch.
+  ## of slots spanning an epoch boundary that does not cover any full epoch.
   # Per mille value to add to the estimation of the committee weight across a
   # range of slots not covering a full epoch in order to ensure the safety of
   # the confirmation rule with high probability.

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -556,12 +556,12 @@ proc will_select_head*(
   self.backend.update_confirmed(dag, confirmed, reason)
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/fork_choice/safe-block.md#get_safe_beacon_block_root
-func get_safe_beacon_block_id*(self: ForkChoice): lent BlockId =
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-beta.4/fork_choice/safe-block.md#get_safe_beacon_block_root
+func retrieve_fast_confirmed_bid*(self: ForkChoice): lent BlockId =
   self.backend.confirmed
 
-func get_safe_beacon_block_root*(self: ForkChoice): lent Eth2Digest =
-  self.get_safe_beacon_block_id.root
+func retrieve_fast_confirmed_root*(self: ForkChoice): lent Eth2Digest =
+  self.retrieve_fast_confirmed_bid.root
 
 proc prune(
     self: var ForkChoiceBackend, dag: ChainDAGRef,

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2615,7 +2615,7 @@ when not defined(windows):
       error "Couldn't enable colors", err = exc.msg
 
     template safe: lent BlockId =
-      node.attestationPool[].forkChoice.get_safe_beacon_block_id()
+      node.attestationPool[].forkChoice.retrieve_fast_confirmed_bid()
 
     var stored_justified: Opt[BlockSlot]
     template justified: lent BlockSlot =

--- a/beacon_chain/rpc/rest_debug_api.nim
+++ b/beacon_chain/rpc/rest_debug_api.nim
@@ -104,7 +104,7 @@ proc installDebugApiHandlers*(router: var RestRouter, node: BeaconNode) =
       justified_checkpoint: forkChoice.checkpoints.justified.checkpoint,
       finalized_checkpoint: forkChoice.checkpoints.finalized,
       extra_data: RestExtraData(
-        confirmed_root: forkChoice.get_safe_beacon_block_root,
+        confirmed_root: forkChoice.retrieve_fast_confirmed_root(),
         current_epoch_observed_justified_checkpoint:
           forkChoice.backend.current_epoch_observed_justified.checkpoint,
         previous_epoch_greatest_unrealized_checkpoint:


### PR DESCRIPTION
get_safe_beacon_block_root was renamed to retrieve_fast_confirmed_root in the specs:

- https://github.com/ethereum/consensus-specs/pull/4747