### PR TITLE
use --num-threads=1 on mainnet, not minimal local testnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,8 +246,7 @@ local-testnet-minimal:
 		--run-spamoor \
 		-- \
 		--verify-finalization \
-		--discv5:no \
-		--num-threads:1
+		--discv5:no
 
 local-testnet-mainnet:
 	./scripts/launch_local_testnet.sh \
@@ -274,7 +273,8 @@ local-testnet-mainnet:
 		--run-spamoor \
 		-- \
 		--verify-finalization \
-		--discv5:no
+		--discv5:no \
+		--num-threads:1
 
 # test binaries that can output an XML report
 XML_TEST_BINARIES_CORE := \


### PR DESCRIPTION
Context:
- https://github.com/status-im/nimbus-eth2/pull/5303
- https://github.com/status-im/nimbus-eth2/pull/5315
- https://github.com/status-im/nimbus-eth2/pull/8253

Seeing various `Low sync committee participation` in minimal testnets since re-enabling fulu in minimal due to the 2s time window of receiving and validating all data columns being overrun in mainly the macOS Jenkins machines:
```
{"lvl":"INF","ts":"2026-04-13 23:48:33.001+03:00","msg":"Slot start","topics":"beacnde","nextFork":"gloas:100000","slot":19,"epoch":2,"sync":"synced","peers":1,"head":"b6943592:18","finalized":"0:00000000","delay":"1ms883us"}
...
{"lvl":"DBG","ts":"2026-04-13 23:48:33.687+03:00","msg":"Block received","topics":"beacnde","delay":"687ms991us"}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.690+03:00","msg":"Block without sidecars has been added to the quarantine","topics":"gossip_blocks","block_root":"fd698a62"}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.690+03:00","msg":"Block received","topics":"beacnde","delay":"690ms416us"}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.690+03:00","msg":"Block without sidecars has been added to the quarantine","topics":"gossip_blocks","block_root":"fd698a62"}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.690+03:00","msg":"Sending JSON-RPC request","topics":"jsonrpc client","name":"engine_getBlobsV2","len":412,"id":62,"remote":"127.0.0.1:25709"}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.691+03:00","msg":"Data column received","topics":"gossip_eth2","delay":"691ms497us","dcs":{"index":0,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":19,"proposer_index":149,"parent_root":"b6943592","state_root":"06a89eed"}},"
wallSlot":19}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.699+03:00","msg":"Data column validated, putting data column in quarantine","topics":"gossip_eth2","dcs":{"index":0,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":19,"proposer_index":149,"parent_root":"b6943592","state_root"
:"06a89eed"}},"wallSlot":19}
{"lvl":"DBG","ts":"2026-04-13 23:48:33.699+03:00","msg":"Data column received","topics":"gossip_eth2","delay":"699ms383us","dcs":{"index":0,"kzg_commitments":5,"kzg_proofs":5,"block_header":{"slot":19,"proposer_index":149,"parent_root":"b6943592","state_root":"06a89eed"}},"
wallSlot":19}
```
The block in this case was delayed 500ms, which didn't help. But doing the non-batched verification of column proofs in for a supernode takes 900ms or so on its own, which continuously pushes `minimal` to near its limits.

It is, yes, necessary to test `--num-threads=1` because of the #3503 failure mode, but that test can/should live on `mainnet` at least for now.

If we, separately, want to add an additional timing stress test back, specifically to `minimal`, once the known issues are mitigated, we can revert this change.