### PR TITLE
don't require safe/finalized block hashes to match when checking cached payload requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ local-testnet-minimal:
 		--signer-nodes 1 \
 		--remote-validators-count 512 \
 		--signer-type $(SIGNER_TYPE) \
-		--fulu-fork-epoch 1 \
+		--fulu-fork-epoch 100000 \
 		--stop-at-epoch 6 \
 		--disable-htop \
 		--base-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \

--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ local-testnet-minimal:
 		--signer-nodes 1 \
 		--remote-validators-count 512 \
 		--signer-type $(SIGNER_TYPE) \
-		--fulu-fork-epoch 100000 \
+		--fulu-fork-epoch 10000 \
 		--stop-at-epoch 6 \
 		--disable-htop \
 		--base-port $$(( $(MINIMAL_TESTNET_BASE_PORT) + EXECUTOR_NUMBER * 400 + 0 )) \

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -334,10 +334,15 @@ proc getPayload(
   retryUntilCancelled:
     let
       rpcClient = await connection.connectedRpcClient()
-      # Use prepared payload if it was given or still pending, otherwise make a
-      # new request
+      # Use prepared payload if it was given or still pending; otherwise make a
+      # new request. `safeBlockHash` and `finalizedBlockHash` are intentionally
+      # excluded, because the payload depends on neither and the FCR safe block
+      # typically change between when the payload preparation was requested and
+      # getPayload is sent.
       useLastPayload =
-        payloadReq.resp != nil and payloadReq.params == params and
+        payloadReq.resp != nil and
+        payloadReq.params.state.headBlockHash == params.state.headBlockHash and
+        payloadReq.params.attributes == params.attributes and
         (not payloadReq.resp.completed or payloadReq.resp.value().payloadId.isSome())
 
       forkchoiceUpdated = await(


### PR DESCRIPTION
This was causing consistent misses, and additional 500ms delays when proposing.

This also disables fulu in minimal local testnets for now because it needs further fixes to be fast enough.