### PR TITLE
Accessors for EL block header data in light client library

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -1054,6 +1054,173 @@ ETHExecutionBlockHeader *_Nullable ETHExecutionBlockHeaderCreateFromJson(
 void ETHExecutionBlockHeaderDestroy(ETHExecutionBlockHeader *executionBlockHeader);
 
 /**
+ * Obtains the parent execution block hash of a given
+ * execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Parent execution block hash.
+ */
+ETH_RESULT_USE_CHECK
+const ETHRoot *ETHExecutionBlockHeaderGetParentHash(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the fee recipient address of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Fee recipient execution address.
+ */
+ETH_RESULT_USE_CHECK
+const ETHExecutionAddress *ETHExecutionBlockHeaderGetFeeRecipient(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the state MPT root of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Execution state root.
+ */
+ETH_RESULT_USE_CHECK
+const ETHRoot *ETHExecutionBlockHeaderGetStateRoot(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the receipts MPT root of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Execution receipts root.
+ */
+ETH_RESULT_USE_CHECK
+const ETHRoot *ETHExecutionBlockHeaderGetReceiptsRoot(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the logs Bloom of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Execution logs Bloom.
+ */
+ETH_RESULT_USE_CHECK
+const ETHLogsBloom *ETHExecutionBlockHeaderGetLogsBloom(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the previous randao mix of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Previous randao mix.
+ */
+ETH_RESULT_USE_CHECK
+const ETHRoot *ETHExecutionBlockHeaderGetPrevRandao(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the execution block number of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Execution block number.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetBlockNumber(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the gas limit of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Gas limit.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetGasLimit(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the gas used of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Gas used.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetGasUsed(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the timestamp of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Execution block timestamp.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetTimestamp(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the extra data buffer of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ * @param[out] numBytes             Length of buffer.
+ *
+ * @return Buffer with execution block extra data.
+ */
+ETH_RESULT_USE_CHECK
+const void *ETHExecutionBlockHeaderGetExtraDataBytes(
+    const ETHExecutionBlockHeader *executionBlockHeader,
+    int *numBytes);
+
+/**
+ * Obtains the base fee per gas of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Base fee per gas.
+ */
+ETH_RESULT_USE_CHECK
+const ETHUInt256 *ETHExecutionBlockHeaderGetBaseFeePerGas(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
  * Obtains the transactions MPT root of a given execution block header.
  *
  * - The returned value is allocated in the given execution block header.
@@ -1101,6 +1268,28 @@ typedef struct ETHWithdrawals ETHWithdrawals;
  */
 ETH_RESULT_USE_CHECK
 const ETHWithdrawals *ETHExecutionBlockHeaderGetWithdrawals(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the blob gas used of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Blob gas used.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetBlobGasUsed(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
+ * Obtains the excess blob gas of a given execution block header.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Excess blob gas.
+ */
+ETH_RESULT_USE_CHECK
+int ETHExecutionBlockHeaderGetExcessBlobGas(
     const ETHExecutionBlockHeader *executionBlockHeader);
 
 /**

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -1293,6 +1293,21 @@ int ETHExecutionBlockHeaderGetExcessBlobGas(
     const ETHExecutionBlockHeader *executionBlockHeader);
 
 /**
+ * Obtains the parent beacon block root of a given execution block header.
+ *
+ * - The returned value is allocated in the given execution block header.
+ *   It must neither be released nor written to, and the execution block
+ *   header must not be released while the returned value is in use.
+ *
+ * @param      executionBlockHeader Execution block header.
+ *
+ * @return Parent beacon block root.
+ */
+ETH_RESULT_USE_CHECK
+const ETHRoot *ETHExecutionBlockHeaderGetParentBeaconBlockRoot(
+    const ETHExecutionBlockHeader *executionBlockHeader);
+
+/**
  * Obtains the requests hash of a given execution block header.
  *
  * - The returned value is allocated in the given execution block header.

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1198,6 +1198,7 @@ type
     withdrawals: seq[ETHWithdrawal]
     blobGasUsed: uint64
     excessBlobGas: uint64
+    parentBeaconBlockRoot: Eth2Digest
     requestsHash: Eth2Digest
 
 template append*(
@@ -1361,6 +1362,8 @@ proc ETHExecutionBlockHeaderCreateFromJson(
     withdrawals: wds,
     blobGasUsed: blockHeader.blobGasUsed.get(0),
     excessBlobGas: blockHeader.excessBlobGas.get(0),
+    parentBeaconBlockRoot:
+      blockHeader.parentBeaconBlockRoot.get(zeroHash32).asEth2Digest(),
     requestsHash: blockHeader.requestsHash.get(zeroHash32).asEth2Digest())
   executionBlockHeader.toUnmanagedPtr()
 
@@ -1622,6 +1625,22 @@ func ETHExecutionBlockHeaderGetExcessBlobGas(
   ## Returns:
   ## * Excess blob gas.
   executionBlockHeader[].excessBlobGas.cint
+
+func ETHExecutionBlockHeaderGetParentBeaconBlockRoot(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr Eth2Digest {.exported.} =
+  ## Obtains the parent beacon block root of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Parent beacon block root.
+  addr executionBlockHeader[].parentBeaconBlockRoot
 
 func ETHExecutionBlockHeaderGetRequestsHash(
     executionBlockHeader: ptr ETHExecutionBlockHeader

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1181,9 +1181,23 @@ type
     bytes: seq[byte]
 
   ETHExecutionBlockHeader = object
+    parentHash: Eth2Digest
+    feeRecipient: ExecutionAddress
+    stateRoot: Eth2Digest
+    receiptsRoot: Eth2Digest
+    logsBloom: BloomLogs
+    prevRandao: Eth2Digest
+    blockNumber: uint64
+    gasLimit: uint64
+    gasUsed: uint64
+    timestamp: uint64
+    extraData: seq[byte]
+    baseFeePerGas: UInt256
     transactionsRoot: Eth2Digest
     withdrawalsRoot: Eth2Digest
     withdrawals: seq[ETHWithdrawal]
+    blobGasUsed: uint64
+    excessBlobGas: uint64
     requestsHash: Eth2Digest
 
 template append*(
@@ -1330,9 +1344,23 @@ proc ETHExecutionBlockHeaderCreateFromJson(
 
   let executionBlockHeader = ETHExecutionBlockHeader.new()
   executionBlockHeader[] = ETHExecutionBlockHeader(
+    parentHash: blockHeader.parentHash.asEth2Digest(),
+    feeRecipient: blockHeader.coinbase,
+    stateRoot: blockHeader.stateRoot.asEth2Digest(),
+    receiptsRoot: blockHeader.receiptsRoot.asEth2Digest(),
+    logsBloom: BloomLogs(data: blockHeader.logsBloom.data),
+    prevRandao: Eth2Digest(data: blockHeader.mixHash.data),
+    blockNumber: blockHeader.number,
+    gasLimit: blockHeader.gasLimit,
+    gasUsed: blockHeader.gasUsed,
+    timestamp: distinctBase(blockHeader.timestamp),
+    extraData: blockHeader.extraData,
+    baseFeePerGas: blockHeader.baseFeePerGas.get(0.u256),
     transactionsRoot: blockHeader.txRoot.asEth2Digest(),
     withdrawalsRoot: blockHeader.withdrawalsRoot.get(zeroHash32).asEth2Digest(),
     withdrawals: wds,
+    blobGasUsed: blockHeader.blobGasUsed.get(0),
+    excessBlobGas: blockHeader.excessBlobGas.get(0),
     requestsHash: blockHeader.requestsHash.get(zeroHash32).asEth2Digest())
   executionBlockHeader.toUnmanagedPtr()
 
@@ -1345,6 +1373,185 @@ proc ETHExecutionBlockHeaderDestroy(
   ## Parameters:
   ## * `executionBlockHeader` - Execution block header.
   executionBlockHeader.destroy()
+
+func ETHExecutionBlockHeaderGetParentHash(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr Eth2Digest {.exported.} =
+  ## Obtains the parent execution block hash of a given
+  ## execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Parent execution block hash.
+  addr executionBlockHeader[].parentHash
+
+func ETHExecutionBlockHeaderGetFeeRecipient(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr ExecutionAddress {.exported.} =
+  ## Obtains the fee recipient address of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Fee recipient execution address.
+  addr executionBlockHeader[].feeRecipient
+
+func ETHExecutionBlockHeaderGetStateRoot(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr Eth2Digest {.exported.} =
+  ## Obtains the state MPT root of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Execution state root.
+  addr executionBlockHeader[].stateRoot
+
+func ETHExecutionBlockHeaderGetReceiptsRoot(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr Eth2Digest {.exported.} =
+  ## Obtains the receipts MPT root of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Execution receipts root.
+  addr executionBlockHeader[].receiptsRoot
+
+func ETHExecutionBlockHeaderGetLogsBloom(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr BloomLogs {.exported.} =
+  ## Obtains the logs Bloom of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Execution logs Bloom.
+  addr executionBlockHeader[].logsBloom
+
+func ETHExecutionBlockHeaderGetPrevRandao(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr Eth2Digest {.exported.} =
+  ## Obtains the previous randao mix of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Previous randao mix.
+  addr executionBlockHeader[].prevRandao
+
+func ETHExecutionBlockHeaderGetBlockNumber(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the execution block number of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Execution block number.
+  executionBlockHeader[].blockNumber.cint
+
+func ETHExecutionBlockHeaderGetGasLimit(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the gas limit of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Gas limit.
+  executionBlockHeader[].gasLimit.cint
+
+func ETHExecutionBlockHeaderGetGasUsed(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the gas used of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Gas used.
+  executionBlockHeader[].gasUsed.cint
+
+func ETHExecutionBlockHeaderGetTimestamp(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the timestamp of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Execution block timestamp.
+  executionBlockHeader[].timestamp.cint
+
+func ETHExecutionBlockHeaderGetExtraDataBytes(
+    executionBlockHeader: ptr ETHExecutionBlockHeader,
+    numBytes #[out]#: ptr cint): ptr UncheckedArray[byte] {.exported.} =
+  ## Obtains the extra data buffer of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ## * `numBytes` [out] - Length of buffer.
+  ##
+  ## Returns:
+  ## * Buffer with execution block extra data.
+  numBytes[] = executionBlockHeader[].extraData.len.cint
+  if executionBlockHeader[].extraData.len == 0:
+    # https://github.com/nim-lang/Nim/issues/22389
+    const defaultExtraData: cstring = ""
+    return cast[ptr UncheckedArray[byte]](defaultExtraData)
+  cast[ptr UncheckedArray[byte]](addr executionBlockHeader[].extraData[0])
+
+func ETHExecutionBlockHeaderGetBaseFeePerGas(
+    executionBlockHeader: ptr ETHExecutionBlockHeader
+): ptr UInt256 {.exported.} =
+  ## Obtains the base fee per gas of a given execution block header.
+  ##
+  ## * The returned value is allocated in the given execution block header.
+  ##   It must neither be released nor written to, and the execution block
+  ##   header must not be released while the returned value is in use.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Base fee per gas.
+  addr executionBlockHeader[].baseFeePerGas
 
 func ETHExecutionBlockHeaderGetTransactionsRoot(
     executionBlockHeader: ptr ETHExecutionBlockHeader
@@ -1393,6 +1600,28 @@ func ETHExecutionBlockHeaderGetWithdrawals(
   ## Returns:
   ## * Withdrawal sequence.
   addr executionBlockHeader[].withdrawals
+
+func ETHExecutionBlockHeaderGetBlobGasUsed(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the blob gas used of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Blob gas used.
+  executionBlockHeader[].blobGasUsed.cint
+
+func ETHExecutionBlockHeaderGetExcessBlobGas(
+    executionBlockHeader: ptr ETHExecutionBlockHeader): cint {.exported.} =
+  ## Obtains the excess blob gas of a given execution block header.
+  ##
+  ## Parameters:
+  ## * `executionBlockHeader` - Execution block header.
+  ##
+  ## Returns:
+  ## * Excess blob gas.
+  executionBlockHeader[].excessBlobGas.cint
 
 func ETHExecutionBlockHeaderGetRequestsHash(
     executionBlockHeader: ptr ETHExecutionBlockHeader

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -484,6 +484,12 @@ int main(void)
     int executionExcessBlobGas = ETHExecutionBlockHeaderGetExcessBlobGas(executionBlockHeader);
     printf("    - excess_blob_gas: %d\n", executionExcessBlobGas);
 
+    const ETHRoot *executionParentBeaconBlockRoot =
+        ETHExecutionBlockHeaderGetParentBeaconBlockRoot(executionBlockHeader);
+    printf("    - parent_beacon_block_root: ");
+    printHexString(executionParentBeaconBlockRoot, sizeof *executionParentBeaconBlockRoot);
+    printf("\n");
+
     const ETHRoot *executionRequestsHash =
         ETHExecutionBlockHeaderGetRequestsHash(executionBlockHeader);
     printf("    - requests_hash: ");

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -377,6 +377,67 @@ int main(void)
 
     printf("\nFinalized_header (execution block header):\n");
 
+    const ETHRoot *executionParentHash =
+        ETHExecutionBlockHeaderGetParentHash(executionBlockHeader);
+    printf("    - parent_hash: ");
+    printHexString(executionParentHash, sizeof *executionParentHash);
+    printf("\n");
+
+    const ETHExecutionAddress *executionFeeRecipient =
+        ETHExecutionBlockHeaderGetFeeRecipient(executionBlockHeader);
+    printf("    - fee_recipient: ");
+    printHexString(executionFeeRecipient, sizeof *executionFeeRecipient);
+    printf("\n");
+
+    const ETHRoot *executionStateRoot =
+        ETHExecutionBlockHeaderGetStateRoot(executionBlockHeader);
+    printf("    - state_root: ");
+    printHexString(executionStateRoot, sizeof *executionStateRoot);
+    printf("\n");
+
+    const ETHRoot *executionReceiptsRoot =
+        ETHExecutionBlockHeaderGetReceiptsRoot(executionBlockHeader);
+    printf("    - receipts_root: ");
+    printHexString(executionReceiptsRoot, sizeof *executionReceiptsRoot);
+    printf("\n");
+
+    const ETHLogsBloom *executionLogsBloom =
+        ETHExecutionBlockHeaderGetLogsBloom(executionBlockHeader);
+    printf("    - logs_bloom: ");
+    printHexString(executionLogsBloom, sizeof *executionLogsBloom);
+    printf("\n");
+
+    const ETHRoot *executionPrevRandao =
+        ETHExecutionBlockHeaderGetPrevRandao(executionBlockHeader);
+    printf("    - prev_randao: ");
+    printHexString(executionPrevRandao, sizeof *executionPrevRandao);
+    printf("\n");
+
+    int executionBlockNumber = ETHExecutionBlockHeaderGetBlockNumber(executionBlockHeader);
+    printf("    - block_number: %d\n", executionBlockNumber);
+
+    int executionGasLimit = ETHExecutionBlockHeaderGetGasLimit(executionBlockHeader);
+    printf("    - gas_limit: %d\n", executionGasLimit);
+
+    int executionGasUsed = ETHExecutionBlockHeaderGetGasUsed(executionBlockHeader);
+    printf("    - gas_used: %d\n", executionGasUsed);
+
+    int executionTimestamp = ETHExecutionBlockHeaderGetTimestamp(executionBlockHeader);
+    printf("    - timestamp: %d\n", executionTimestamp);
+
+    int numExecutionExtraDataBytes;
+    const void *executionExtraDataBytes =
+        ETHExecutionBlockHeaderGetExtraDataBytes(executionBlockHeader, &numExecutionExtraDataBytes);
+    printf("    - extra_data: ");
+    printHexString(executionExtraDataBytes, numExecutionExtraDataBytes);
+    printf("\n");
+
+    const ETHUInt256 *executionBaseFeePerGas =
+        ETHExecutionBlockHeaderGetBaseFeePerGas(executionBlockHeader);
+    printf("    - base_fee_per_gas: ");
+    printGweiString(executionBaseFeePerGas);
+    printf(" Gwei\n");
+
     const ETHRoot *executionTransactionsRoot =
         ETHExecutionBlockHeaderGetTransactionsRoot(executionBlockHeader);
     printf("    - transactions_root: ");
@@ -416,6 +477,12 @@ int main(void)
         printHexString(bytes, numBytes);
         printf("\n");
     }
+
+    int executionBlobGasUsed = ETHExecutionBlockHeaderGetBlobGasUsed(executionBlockHeader);
+    printf("    - blob_gas_used: %d\n", executionBlobGasUsed);
+
+    int executionExcessBlobGas = ETHExecutionBlockHeaderGetExcessBlobGas(executionBlockHeader);
+    printf("    - excess_blob_gas: %d\n", executionExcessBlobGas);
 
     const ETHRoot *executionRequestsHash =
         ETHExecutionBlockHeaderGetRequestsHash(executionBlockHeader);


### PR DESCRIPTION
When starting from JSON-RPC instead of beacon-API (e.g., because only EL block has is known), the existing ETHExecutionPayloadHeaderXyz API cannot be used. Add accessors for JSON-RPC originated headers.