### PR TITLE
Remove unused current_slot param in fork_choice

### DIFF
--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -122,7 +122,7 @@ proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
 
 proc update_justified(
     self: var Checkpoints, dag: ChainDAGRef,
-    epoch: Epoch, blck: BlockRef, current_slot: Slot) =
+    epoch: Epoch, blck: BlockRef) =
   let epochRef = dag.getEpochRef(blck, epoch, preFinalized = false).valueOr:
     # Shouldn't happen for justified data unless out of sync with ChainDAG
     warn "Skipping justified checkpoint update, no EpochRef - report bug",
@@ -149,7 +149,7 @@ proc update_justified(
     return err ForkChoiceError(
       kind: fcJustifiedNodeUnknown,
       blockRoot: justified.root)
-  self.checkpoints.update_justified(dag, justified.epoch, blck, current_slot)
+  self.checkpoints.update_justified(dag, justified.epoch, blck)
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/fork-choice.md#update_checkpoints


### PR DESCRIPTION
The inner `update_justified` doesn't need the `current_slot`.