### PR TITLE
Light client C API for creating beacon block header from REST

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -702,6 +702,54 @@ const ETHBeaconBlockHeader *ETHLightClientHeaderGetBeacon(
     const ETHLightClientHeader *header);
 
 /**
+ * Obtains a copy of the beacon block header of a given light client header.
+ *
+ * - The beacon block header must be destroyed with
+ *   `ETHBeaconBlockHeaderDestroy` once no longer needed,
+ *   to release memory.
+ *
+ * @param      header               Light client header.
+ *
+ * @return Beacon block header.
+ *
+ * @see https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/phase0/beacon-chain.md#beaconblockheader
+ */
+ETH_RESULT_USE_CHECK
+ETHBeaconBlockHeader *ETHLightClientHeaderCopyBeacon(
+    const ETHLightClientHeader *header);
+
+/**
+ * Verifies that a JSON beacon block header is valid and that it matches
+ * the given `beaconRoot`.
+ *
+ * - The beacon block header must be destroyed with
+ *   `ETHBeaconBlockHeaderDestroy` once no longer needed,
+ *   to release memory.
+ *
+ * @param      beaconRoot           Beacon block root.
+ * @param      beaconJson           Buffer with JSON encoded header. NULL-terminated.
+ *
+ * @return Pointer to an initialized beacon block header - If successful.
+ * @return `NULL` - If the given `beaconJson` is malformed or incompatible.
+ *
+ * @see https://ethereum.github.io/beacon-APIs/?urls.primaryName=v4.0.0#/Beacon/getBlockHeader
+ * @see https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/phase0/beacon-chain.md#beaconblockheader
+ */
+ETH_RESULT_USE_CHECK
+ETHBeaconBlockHeader *_Nullable ETHBeaconBlockHeaderCreateFromJson(
+    const ETHRoot *beaconRoot,
+    const char *beaconJson);
+
+/**
+ * Destroys a beacon block header.
+ *
+ * - The beacon block header must no longer be used after destruction.
+ *
+ * @param      beacon               Beacon block header.
+ */
+void ETHBeaconBlockHeaderDestroy(ETHBeaconBlockHeader *beacon);
+
+/**
  * Obtains the slot number of a given beacon block header.
  *
  * @param      beacon               Beacon block header.

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -865,6 +865,70 @@ func ETHLightClientHeaderGetBeacon(
   ## * https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/phase0/beacon-chain.md#beaconblockheader
   addr header[].beacon
 
+proc ETHLightClientHeaderCopyBeacon(
+    header: ptr lcDataFork.LightClientHeader
+): ptr BeaconBlockHeader {.exported.} =
+  ## Obtains a copy of the beacon block header of a given light client header.
+  ##
+  ## * The beacon block header must be destroyed with
+  ##   `ETHBeaconBlockHeaderDestroy` once no longer needed,
+  ##   to release memory.
+  ##
+  ## Parameters:
+  ## * `header` - Light client header.
+  ##
+  ## Returns:
+  ## * Beacon block header.
+  ##
+  ## See:
+  ## * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/phase0/beacon-chain.md#beaconblockheader
+  let beacon = BeaconBlockHeader.new()
+  beacon[] = header[].beacon
+  beacon.toUnmanagedPtr()
+
+proc ETHBeaconBlockHeaderCreateFromJson(
+    beaconRoot: ptr Eth2Digest,
+    beaconJson: cstring): ptr BeaconBlockHeader {.exported.} =
+  ## Verifies that a JSON beacon block header is valid and that it matches
+  ## the given `beaconRoot`.
+  ##
+  ## * The beacon block header must be destroyed with
+  ##   `ETHBeaconBlockHeaderDestroy` once no longer needed,
+  ##   to release memory.
+  ##
+  ## Parameters:
+  ## * `beaconRoot` - Beacon block root.
+  ## * `beaconJson` - Buffer with JSON encoded header. NULL-terminated.
+  ##
+  ## Returns:
+  ## * Pointer to an initialized beacon block header - If successful.
+  ## * `NULL` - If the given `beaconJson` is malformed or incompatible.
+  ##
+  ## See:
+  ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v4.0.0#/Beacon/getBlockHeader
+  ## * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/phase0/beacon-chain.md#beaconblockheader
+  let beacon = BeaconBlockHeader.new()
+  try:
+    # a direct parameter like RestJson.decode($beaconJson, BeaconBlockHeader)
+    # will cause premature garbage collector kick in.
+    let jsonBytes = $beaconJson
+    beacon[] = RestJson.decode(jsonBytes, BeaconBlockHeader)
+  except SerializationError:
+    return nil
+  if beacon[].hash_tree_root() != beaconRoot[]:
+    return nil
+  beacon.toUnmanagedPtr()
+
+proc ETHBeaconBlockHeaderDestroy(
+    beacon: ptr BeaconBlockHeader) {.exported.} =
+  ## Destroys a beacon block header.
+  ##
+  ## * The beacon block header must no longer be used after destruction.
+  ##
+  ## Parameters:
+  ## * `beacon` - Beacon block header.
+  beacon.destroy()
+
 func ETHBeaconBlockHeaderGetSlot(
     beacon: ptr BeaconBlockHeader): cint {.exported.} =
   ## Obtains the slot number of a given beacon block header.

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -19,7 +19,8 @@ import
   secp256k1,
   web3/[engine_api_types, eth_api_types, conversions],
   ../el/engine_api_conversions,
-  ../spec/eth2_apis/[eth2_rest_serialization, rest_light_client_calls],
+  ../spec/eth2_apis/[
+    eth2_rest_serialization, rest_light_client_calls, rest_types],
   ../spec/[helpers, light_client_sync],
   ../sync/light_client_sync_helpers,
   ../beacon_clock
@@ -907,14 +908,23 @@ proc ETHBeaconBlockHeaderCreateFromJson(
   ## See:
   ## * https://ethereum.github.io/beacon-APIs/?urls.primaryName=v4.0.0#/Beacon/getBlockHeader
   ## * https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/phase0/beacon-chain.md#beaconblockheader
-  let beacon = BeaconBlockHeader.new()
-  try:
-    # a direct parameter like RestJson.decode($beaconJson, BeaconBlockHeader)
-    # will cause premature garbage collector kick in.
-    let jsonBytes = $beaconJson
-    beacon[] = RestJson.decode(jsonBytes, BeaconBlockHeader)
-  except SerializationError:
-    return nil
+  let
+    data =
+      try:
+        # a direct parameter like
+        # RestJson.decode($beaconJson, GetBlockHeaderResponse)
+        # will cause premature garbage collector kick in.
+        let jsonBytes = $beaconJson
+        RestJson.decode(jsonBytes, GetBlockHeaderResponse).data.header.message
+      except SerializationError:
+        return nil
+    beacon = BeaconBlockHeader.new()
+  beacon[] = BeaconBlockHeader(
+    slot: data.slot,
+    proposer_index: data.proposer_index.uint64,
+    parent_root: data.parent_root,
+    state_root: data.state_root,
+    body_root: data.body_root)
   if beacon[].hash_tree_root() != beaconRoot[]:
     return nil
   beacon.toUnmanagedPtr()


### PR DESCRIPTION
To enable use case of backfilling blocks for which no LightClientHeader is available (e.g., empty sync participation).