### PR TITLE
ensure newPayload/fcU enforce timeouts regardless of responses

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -662,6 +662,7 @@ AllTests-mainnet
 ```diff
 + forkchoiceUpdated basic call                                                               OK
 + forkchoiceUpdated multiple sequential calls                                                OK
++ forkchoiceUpdated times out without selected response                                      OK
 + forkchoiceUpdated with payload attributes                                                  OK
 + forkchoiceUpdated with response delay                                                      OK
 ```
@@ -671,6 +672,7 @@ AllTests-mainnet
 ```
 ## EL Manager - newPayload
 ```diff
++ newPayload times out without selected response                                             OK
 + success without retry                                                                      OK
 ```
 ## Engine API conversions

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -855,7 +855,7 @@ proc newPayload*(
       if responseProcessor.selectedResponse.isSome():
         discard await race(race(pending), earlyDeadline)
       else:
-        discard await race(pending)
+        discard await race(race(pending), deadline)
     except ValueError:
       raiseAssert "race error cannot happen"
 
@@ -946,7 +946,7 @@ proc forkchoiceUpdated*(
       if responseProcessor.selectedResponse.isSome():
         discard await race(race(pending), earlyDeadline)
       else:
-        discard await race(pending)
+        discard await race(race(pending), deadline)
     except ValueError:
       raiseAssert "race error cannot happen"
 

--- a/tests/test_el_manager.nim
+++ b/tests/test_el_manager.nim
@@ -90,6 +90,24 @@ proc setupMockEngineAPI*(server: RpcHttpServer, state: MockEngineState) =
       status: PayloadExecutionStatus.valid, latestValidHash: Opt.some(payload.blockHash)
     )
 
+  server.rpc("engine_newPayloadV5") do(
+    payload: ExecutionPayloadV4,
+    expectedBlobVersionedHashes: Opt[seq[Hash32]],
+    parentBeaconBlockRoot: Opt[Hash32],
+    executionRequests: Opt[seq[seq[byte]]]
+  ) -> PayloadStatusV1:
+    inc state.newPayloadCallCount
+    if state.responseDelay > 0.milliseconds:
+      await sleepAsync(state.responseDelay)
+
+    if state.shouldFailNewPayload:
+      raise
+        (ref ApplicationError)(code: -32603, msg: "Internal error: execution failed")
+
+    return PayloadStatusV1(
+      status: PayloadExecutionStatus.valid, latestValidHash: Opt.some(payload.blockHash)
+    )
+
   server.rpc("engine_forkchoiceUpdatedV3") do(
     fcState: ForkchoiceStateV1, payloadAttributes: Opt[PayloadAttributesV3]
   ) -> ForkchoiceUpdatedResponse:
@@ -309,6 +327,34 @@ suite "EL Manager - forkchoiceUpdated":
         status3 == PayloadExecutionStatus.valid
         setup.state.forkchoiceCallCount == i
 
+  test "forkchoiceUpdated times out without selected response":
+    setup.state.shouldFailForkchoice = true
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    const
+      deadline = 2.seconds
+      overhead = 2.seconds
+      testTimeout = 30.seconds
+    static: doAssert deadline + overhead < testTimeout
+    let
+      state = ForkchoiceStateV1.init(ZERO_HASH, ZERO_HASH, ZERO_HASH)
+      startTime = Moment.now()
+      fut = manager.forkchoiceUpdated(
+        state, Opt.none(PayloadAttributesV3), sleepAsync(deadline), true)
+      completed = waitFor fut.withTimeout(testTimeout)
+      elapsed = Moment.now() - startTime
+
+    if not completed:
+      waitFor fut.cancelAndWait()
+    check completed
+
+    let (status, _) = fut.read()
+    check:
+      setup.state.forkchoiceCallCount > 1
+      elapsed < deadline + overhead
+      status == PayloadExecutionStatus.syncing
+
 suite "EL Manager - getPayload":
   setup:
     var setup = mockSetup()
@@ -348,6 +394,33 @@ suite "EL Manager - newPayload":
     check:
       setup.state.newPayloadCallCount == 1
       resp.isOk()
+
+  test "newPayload times out without selected response":
+    setup.state.shouldFailNewPayload = true
+    let manager = createELManager(@[setup.url])
+    manager.start()
+
+    const
+      deadline = 2.seconds
+      overhead = 2.seconds
+      testTimeout = 30.seconds
+    static: doAssert deadline + overhead < testTimeout
+    let
+      startTime = Moment.now()
+      fut = manager.newPayload(
+        fulu.BeaconBlock(), noEnvelope, sleepAsync(deadline), true)
+      completed = waitFor fut.withTimeout(testTimeout)
+      elapsed = Moment.now() - startTime
+
+    if not completed:
+      waitFor fut.cancelAndWait()
+    check completed
+
+    let resp = fut.read()
+    check:
+      setup.state.newPayloadCallCount > 1
+      elapsed < deadline + overhead
+      resp.isNone
 
 suite "EL Manager - Payload Request Caching":
   setup:


### PR DESCRIPTION
Otherwise, the individual per-EL `retryUntilCancelled` indefinitely, with no overarching timeout/cancellation in place.