### PR TITLE
Deprecate access to ExecutionPayloadHeader from light client data

### DIFF
--- a/beacon_chain/libnimbus_lc/libnimbus_lc.h
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.h
@@ -25,6 +25,12 @@ extern "C" {
 #define __has_feature(x) 0
 #endif
 
+#if __has_attribute(deprecated)
+#define ETH_DEPRECATED __attribute__((deprecated))
+#else
+#define ETH_DEPRECATED
+#endif
+
 #if __has_attribute(warn_unused_result)
 #define ETH_RESULT_USE_CHECK __attribute__((warn_unused_result))
 #else
@@ -848,6 +854,7 @@ typedef struct ETHExecutionPayloadHeader ETHExecutionPayloadHeader;
  *
  * @see https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/deneb/beacon-chain.md#executionpayloadheader
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHExecutionPayloadHeader *ETHLightClientHeaderGetExecution(
     const ETHLightClientHeader *header);
@@ -864,6 +871,7 @@ const ETHExecutionPayloadHeader *ETHLightClientHeaderGetExecution(
  *
  * @return Parent execution block hash.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHRoot *ETHExecutionPayloadHeaderGetParentHash(
     const ETHExecutionPayloadHeader *execution);
@@ -886,6 +894,7 @@ typedef struct {
  *
  * @return Fee recipient execution address.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHExecutionAddress *ETHExecutionPayloadHeaderGetFeeRecipient(
     const ETHExecutionPayloadHeader *execution);
@@ -901,6 +910,7 @@ const ETHExecutionAddress *ETHExecutionPayloadHeaderGetFeeRecipient(
  *
  * @return Execution state root.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHRoot *ETHExecutionPayloadHeaderGetStateRoot(
     const ETHExecutionPayloadHeader *execution);
@@ -916,6 +926,7 @@ const ETHRoot *ETHExecutionPayloadHeaderGetStateRoot(
  *
  * @return Execution receipts root.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHRoot *ETHExecutionPayloadHeaderGetReceiptsRoot(
     const ETHExecutionPayloadHeader *execution);
@@ -938,6 +949,7 @@ typedef struct {
  *
  * @return Execution logs Bloom.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHLogsBloom *ETHExecutionPayloadHeaderGetLogsBloom(
     const ETHExecutionPayloadHeader *execution);
@@ -953,6 +965,7 @@ const ETHLogsBloom *ETHExecutionPayloadHeaderGetLogsBloom(
  *
  * @return Previous randao mix.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHRoot *ETHExecutionPayloadHeaderGetPrevRandao(
     const ETHExecutionPayloadHeader *execution);
@@ -964,6 +977,7 @@ const ETHRoot *ETHExecutionPayloadHeaderGetPrevRandao(
  *
  * @return Execution block number.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetBlockNumber(
     const ETHExecutionPayloadHeader *execution);
@@ -975,6 +989,7 @@ int ETHExecutionPayloadHeaderGetBlockNumber(
  *
  * @return Gas limit.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetGasLimit(
     const ETHExecutionPayloadHeader *execution);
@@ -986,6 +1001,7 @@ int ETHExecutionPayloadHeaderGetGasLimit(
  *
  * @return Gas used.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetGasUsed(
     const ETHExecutionPayloadHeader *execution);
@@ -997,6 +1013,7 @@ int ETHExecutionPayloadHeaderGetGasUsed(
  *
  * @return Execution block timestamp.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetTimestamp(
     const ETHExecutionPayloadHeader *execution);
@@ -1013,6 +1030,7 @@ int ETHExecutionPayloadHeaderGetTimestamp(
  *
  * @return Buffer with execution block extra data.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const void *ETHExecutionPayloadHeaderGetExtraDataBytes(
     const ETHExecutionPayloadHeader *execution,
@@ -1036,6 +1054,7 @@ typedef struct {
  *
  * @return Base fee per gas.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 const ETHUInt256 *ETHExecutionPayloadHeaderGetBaseFeePerGas(
     const ETHExecutionPayloadHeader *execution);
@@ -1047,6 +1066,7 @@ const ETHUInt256 *ETHExecutionPayloadHeaderGetBaseFeePerGas(
  *
  * @return Blob gas used.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetBlobGasUsed(
     const ETHExecutionPayloadHeader *execution);
@@ -1058,6 +1078,7 @@ int ETHExecutionPayloadHeaderGetBlobGasUsed(
  *
  * @return Excess blob gas.
  */
+ETH_DEPRECATED
 ETH_RESULT_USE_CHECK
 int ETHExecutionPayloadHeaderGetExcessBlobGas(
     const ETHExecutionPayloadHeader *execution);

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1035,7 +1035,7 @@ type ExecutionPayloadHeader =
 
 func ETHLightClientHeaderGetExecution(
     header: ptr lcDataFork.LightClientHeader
-): ptr ExecutionPayloadHeader {.exported.} =
+): ptr ExecutionPayloadHeader {.deprecated, exported.} =
   ## Obtains the execution payload header of a given light client header.
   ##
   ## * The returned value is allocated in the given light client header.
@@ -1053,7 +1053,8 @@ func ETHLightClientHeaderGetExecution(
   addr header[].execution
 
 func ETHExecutionPayloadHeaderGetParentHash(
-    execution: ptr ExecutionPayloadHeader): ptr Eth2Digest {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr Eth2Digest {.deprecated, exported.} =
   ## Obtains the parent execution block hash of a given
   ## execution payload header.
   ##
@@ -1069,7 +1070,8 @@ func ETHExecutionPayloadHeaderGetParentHash(
   addr execution[].parent_hash
 
 func ETHExecutionPayloadHeaderGetFeeRecipient(
-    execution: ptr ExecutionPayloadHeader): ptr ExecutionAddress {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr ExecutionAddress {.deprecated, exported.} =
   ## Obtains the fee recipient address of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1084,7 +1086,8 @@ func ETHExecutionPayloadHeaderGetFeeRecipient(
   addr execution[].fee_recipient
 
 func ETHExecutionPayloadHeaderGetStateRoot(
-    execution: ptr ExecutionPayloadHeader): ptr Eth2Digest {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr Eth2Digest {.deprecated, exported.} =
   ## Obtains the state MPT root of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1099,7 +1102,8 @@ func ETHExecutionPayloadHeaderGetStateRoot(
   addr execution[].state_root
 
 func ETHExecutionPayloadHeaderGetReceiptsRoot(
-    execution: ptr ExecutionPayloadHeader): ptr Eth2Digest {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr Eth2Digest {.deprecated, exported.} =
   ## Obtains the receipts MPT root of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1114,7 +1118,8 @@ func ETHExecutionPayloadHeaderGetReceiptsRoot(
   addr execution[].receipts_root
 
 func ETHExecutionPayloadHeaderGetLogsBloom(
-    execution: ptr ExecutionPayloadHeader): ptr BloomLogs {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr BloomLogs {.deprecated, exported.} =
   ## Obtains the logs Bloom of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1129,7 +1134,8 @@ func ETHExecutionPayloadHeaderGetLogsBloom(
   addr execution[].logs_bloom
 
 func ETHExecutionPayloadHeaderGetPrevRandao(
-    execution: ptr ExecutionPayloadHeader): ptr Eth2Digest {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr Eth2Digest {.deprecated, exported.} =
   ## Obtains the previous randao mix of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1144,7 +1150,8 @@ func ETHExecutionPayloadHeaderGetPrevRandao(
   addr execution[].prev_randao
 
 func ETHExecutionPayloadHeaderGetBlockNumber(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the execution block number of a given execution payload header.
   ##
   ## Parameters:
@@ -1155,7 +1162,8 @@ func ETHExecutionPayloadHeaderGetBlockNumber(
   execution[].block_number.cint
 
 func ETHExecutionPayloadHeaderGetGasLimit(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the gas limit of a given execution payload header.
   ##
   ## Parameters:
@@ -1166,7 +1174,8 @@ func ETHExecutionPayloadHeaderGetGasLimit(
   execution[].gas_limit.cint
 
 func ETHExecutionPayloadHeaderGetGasUsed(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the gas used of a given execution payload header.
   ##
   ## Parameters:
@@ -1177,7 +1186,8 @@ func ETHExecutionPayloadHeaderGetGasUsed(
   execution[].gas_used.cint
 
 func ETHExecutionPayloadHeaderGetTimestamp(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the timestamp of a given execution payload header.
   ##
   ## Parameters:
@@ -1189,7 +1199,8 @@ func ETHExecutionPayloadHeaderGetTimestamp(
 
 func ETHExecutionPayloadHeaderGetExtraDataBytes(
     execution: ptr ExecutionPayloadHeader,
-    numBytes #[out]#: ptr cint): ptr UncheckedArray[byte] {.exported.} =
+    numBytes #[out]#: ptr cint
+): ptr UncheckedArray[byte] {.deprecated, exported.} =
   ## Obtains the extra data buffer of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1210,7 +1221,8 @@ func ETHExecutionPayloadHeaderGetExtraDataBytes(
   cast[ptr UncheckedArray[byte]](addr execution[].extra_data[0])
 
 func ETHExecutionPayloadHeaderGetBaseFeePerGas(
-    execution: ptr ExecutionPayloadHeader): ptr UInt256 {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): ptr UInt256 {.deprecated, exported.} =
   ## Obtains the base fee per gas of a given execution payload header.
   ##
   ## * The returned value is allocated in the given execution payload header.
@@ -1225,7 +1237,8 @@ func ETHExecutionPayloadHeaderGetBaseFeePerGas(
   addr execution[].base_fee_per_gas
 
 func ETHExecutionPayloadHeaderGetBlobGasUsed(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the blob gas used of a given execution payload header.
   ##
   ## Parameters:
@@ -1236,7 +1249,8 @@ func ETHExecutionPayloadHeaderGetBlobGasUsed(
   execution[].blob_gas_used.cint
 
 func ETHExecutionPayloadHeaderGetExcessBlobGas(
-    execution: ptr ExecutionPayloadHeader): cint {.exported.} =
+    execution: ptr ExecutionPayloadHeader
+): cint {.deprecated, exported.} =
   ## Obtains the excess blob gas of a given execution payload header.
   ##
   ## Parameters:

--- a/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
+++ b/beacon_chain/libnimbus_lc/test_libnimbus_lc.c
@@ -188,73 +188,10 @@ static void visualizeHeader(const ETHLightClientHeader *header, const ETHConsens
     printf("\n");
 
     ETHRoot *executionHash = ETHLightClientHeaderCopyExecutionHash(header, cfg);
-    printf("  - execution: ");
+    printf("  - execution_block_hash: ");
     printHexString(executionHash, sizeof *executionHash);
     printf("\n");
     ETHRootDestroy(executionHash);
-
-    const ETHExecutionPayloadHeader *execution = ETHLightClientHeaderGetExecution(header);
-
-    const ETHRoot *executionParentHash = ETHExecutionPayloadHeaderGetParentHash(execution);
-    printf("    - parent_hash: ");
-    printHexString(executionParentHash, sizeof *executionParentHash);
-    printf("\n");
-
-    const ETHExecutionAddress *executionFeeRecipient =
-        ETHExecutionPayloadHeaderGetFeeRecipient(execution);
-    printf("    - fee_recipient: ");
-    printHexString(executionFeeRecipient, sizeof *executionFeeRecipient);
-    printf("\n");
-
-    const ETHRoot *executionStateRoot = ETHExecutionPayloadHeaderGetStateRoot(execution);
-    printf("    - state_root: ");
-    printHexString(executionStateRoot, sizeof *executionStateRoot);
-    printf("\n");
-
-    const ETHRoot *executionReceiptsRoot = ETHExecutionPayloadHeaderGetReceiptsRoot(execution);
-    printf("    - receipts_root: ");
-    printHexString(executionReceiptsRoot, sizeof *executionReceiptsRoot);
-    printf("\n");
-
-    const ETHLogsBloom *executionLogsBloom = ETHExecutionPayloadHeaderGetLogsBloom(execution);
-    printf("    - logs_bloom: ");
-    printHexString(executionLogsBloom, sizeof *executionLogsBloom);
-    printf("\n");
-
-    const ETHRoot *executionPrevRandao = ETHExecutionPayloadHeaderGetPrevRandao(execution);
-    printf("    - prev_randao: ");
-    printHexString(executionPrevRandao, sizeof *executionPrevRandao);
-    printf("\n");
-
-    int executionBlockNumber = ETHExecutionPayloadHeaderGetBlockNumber(execution);
-    printf("    - block_number: %d\n", executionBlockNumber);
-
-    int executionGasLimit = ETHExecutionPayloadHeaderGetGasLimit(execution);
-    printf("    - gas_limit: %d\n", executionGasLimit);
-
-    int executionGasUsed = ETHExecutionPayloadHeaderGetGasUsed(execution);
-    printf("    - gas_used: %d\n", executionGasUsed);
-
-    int executionTimestamp = ETHExecutionPayloadHeaderGetTimestamp(execution);
-    printf("    - timestamp: %d\n", executionTimestamp);
-
-    int numExecutionExtraDataBytes;
-    const void *executionExtraDataBytes =
-        ETHExecutionPayloadHeaderGetExtraDataBytes(execution, &numExecutionExtraDataBytes);
-    printf("    - extra_data: ");
-    printHexString(executionExtraDataBytes, numExecutionExtraDataBytes);
-    printf("\n");
-
-    const ETHUInt256 *executionBaseFeePerGas = ETHExecutionPayloadHeaderGetBaseFeePerGas(execution);
-    printf("    - base_fee_per_gas: ");
-    printGweiString(executionBaseFeePerGas);
-    printf(" Gwei\n");
-
-    int executionBlobGasUsed = ETHExecutionPayloadHeaderGetBlobGasUsed(execution);
-    printf("    - blob_gas_used: %d\n", executionBlobGasUsed);
-
-    int executionExcessBlobGas = ETHExecutionPayloadHeaderGetExcessBlobGas(execution);
-    printf("    - excess_blob_gas: %d\n", executionExcessBlobGas);
 }
 
 ETH_RESULT_USE_CHECK

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -663,7 +663,7 @@ func shortLog*(v: LightClientOptimisticUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
-    signature_slot: v.signature_slot,
+    signature_slot: v.signature_slot
   )
 
 chronicles.formatIt LightClientBootstrap: shortLog(it)

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -747,9 +747,7 @@ func upgrade_lc_optimistic_update_to_capella*(
 func shortLog*(v: LightClientHeader): auto =
   (
     beacon: shortLog(v.beacon),
-    execution: (
-      block_hash: v.execution.block_hash,
-      block_number: v.execution.block_number)
+    execution_block_hash: v.execution.block_hash
   )
 
 func shortLog*(v: LightClientBootstrap): auto =
@@ -779,7 +777,7 @@ func shortLog*(v: LightClientOptimisticUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
-    signature_slot: v.signature_slot,
+    signature_slot: v.signature_slot
   )
 
 chronicles.formatIt LightClientBootstrap: shortLog(it)
@@ -803,4 +801,3 @@ func upgrade_lc_store_to_capella*(
     optimistic_header: upgrade_lc_header_to_capella(pre.optimistic_header),
     previous_max_active_participants: pre.previous_max_active_participants,
     current_max_active_participants: pre.current_max_active_participants)
-

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -768,9 +768,7 @@ func upgrade_lc_optimistic_update_to_deneb*(
 func shortLog*(v: LightClientHeader): auto =
   (
     beacon: shortLog(v.beacon),
-    execution: (
-      block_hash: v.execution.block_hash,
-      block_number: v.execution.block_number)
+    execution_block_hash: v.execution.block_hash
   )
 
 func shortLog*(v: LightClientBootstrap): auto =
@@ -800,7 +798,7 @@ func shortLog*(v: LightClientOptimisticUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
-    signature_slot: v.signature_slot,
+    signature_slot: v.signature_slot
   )
 
 chronicles.formatIt LightClientBootstrap: shortLog(it)

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -825,9 +825,7 @@ func upgrade_lc_optimistic_update_to_electra*(
 func shortLog*(v: LightClientHeader): auto =
   (
     beacon: shortLog(v.beacon),
-    execution: (
-      block_hash: v.execution.block_hash,
-      block_number: v.execution.block_number)
+    execution_block_hash: v.execution.block_hash
   )
 
 func shortLog*(v: LightClientBootstrap): auto =
@@ -857,7 +855,7 @@ func shortLog*(v: LightClientOptimisticUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
-    signature_slot: v.signature_slot,
+    signature_slot: v.signature_slot
   )
 
 chronicles.formatIt LightClientBootstrap: shortLog(it)

--- a/beacon_chain/spec/datatypes/fulu.nim
+++ b/beacon_chain/spec/datatypes/fulu.nim
@@ -32,8 +32,8 @@ from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
   TrustedSyncAggregate, SyncnetBits, num_active_participants
 from ./capella import
-  ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
-  SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX
+  HistoricalSummary, SignedBLSToExecutionChange,
+  SignedBLSToExecutionChangeList, Withdrawal
 from ./deneb import
   Blobs, ExecutionPayload, ExecutionPayloadHeader, KzgCommitments, KzgProofs
 

--- a/beacon_chain/spec/datatypes/heze.nim
+++ b/beacon_chain/spec/datatypes/heze.nim
@@ -29,10 +29,10 @@ from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
   TrustedSyncAggregate, SyncnetBits, num_active_participants
 from ./capella import
-  ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
-  SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX
+  HistoricalSummary, SignedBLSToExecutionChange,
+  SignedBLSToExecutionChangeList, Withdrawal
 from ./deneb import
-  Blobs, ExecutionPayload, ExecutionPayloadHeader, KzgCommitments, KzgProofs
+  Blobs, KzgCommitments, KzgProofs
 from ./gloas import
   Builder, BuilderPendingPayment, BuilderPendingWithdrawal, PayloadAttestation
 


### PR DESCRIPTION
With Gloas, they replaced `latest_execution_payload_header` with `latest_block_hash`, meaning all light client flows have to obtain the execution block header via EL JSON-RPC. Stop relying on the payload header being available, mark corresponding APIs that stop working with Gloas as deprecated.