### PR TITLE
nix: use github URL for NBS to fix caching

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,14 +7,20 @@
         ]
       },
       "locked": {
-        "path": "vendor/nimbus-build-system",
-        "type": "path"
+        "lastModified": 1774606021,
+        "narHash": "sha256-XHIThT9Df7djv+8xZiEdZ4sGHVDV8IEeY/UHfH5f3ns=",
+        "ref": "refs/heads/master",
+        "rev": "67f395831f94ba4ac5fb4c511beb99bc6ec63e22",
+        "revCount": 247,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/status-im/nimbus-build-system"
       },
       "original": {
-        "path": "vendor/nimbus-build-system",
-        "type": "path"
-      },
-      "parent": []
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/status-im/nimbus-build-system"
+      }
     },
     "nixpkgs": {
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
+    # WARNING: Do not use relative path, it breaks caching of NBS.
+    # Remember to call 'nix flake update' when NBS is updated.
     nimbusBuildSystem = {
-      url = ./vendor/nimbus-build-system;
+      url = "git+https://github.com/status-im/nimbus-build-system?submodules=1#";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     self = {


### PR DESCRIPTION
When relative path is used it causes unnecessary NBS rebuild when local files are modified which is a waste of time.

The issue with this approach is that calling nix flake update will not cause the `flake.lock` to reflect the state of `vendor/nimbus-build-system`.