### PR TITLE
speedup block processing with batch verification

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -202,17 +202,15 @@ proc verifySidecars(
     template kzgCommits(): auto =
       bid.message.blob_kzg_commitments.asSeq
     if columns.len > 0 and kzgCommits.len > 0:
-      for i in 0 ..< columns.len:
-        let r = verify_data_column_sidecar_kzg_proofs(
-          columns[i][], bid.message.blob_kzg_commitments)
-        if r.isErr():
-          debug "data column validation failed",
-            blockRoot = shortLog(signedBlock.root),
-            column_sidecar = shortLog(columns[i][]),
-            blck = shortLog(signedBlock.message),
-            signature = shortLog(signedBlock.signature),
-            msg = r.error()
-          return err(VerifierError.Invalid)
+      let r = verify_data_column_sidecar_kzg_proofs(
+        columns, bid.message.blob_kzg_commitments)
+      if r.isErr():
+        debug "data column validation failed",
+          blockRoot = shortLog(signedBlock.root),
+          blck = shortLog(signedBlock.message),
+          signature = shortLog(signedBlock.signature),
+          msg = r.error()
+        return err(VerifierError.Invalid)
   ok()
 
 proc verifySidecars(
@@ -224,16 +222,14 @@ proc verifySidecars(
     let columns = sidecarsOpt.get()
     let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
     if columns.len > 0 and kzgCommits.len > 0:
-      for i in 0 ..< columns.len:
-        let r = verify_data_column_sidecar_kzg_proofs(columns[i][])
-        if r.isErr():
-          debug "data column validation failed",
-            blockRoot = shortLog(signedBlock.root),
-            column_sidecar = shortLog(columns[i][]),
-            blck = shortLog(signedBlock.message),
-            signature = shortLog(signedBlock.signature),
-            msg = r.error()
-          return err(VerifierError.Invalid)
+      let r = verify_data_column_sidecar_kzg_proofs(columns)
+      if r.isErr():
+        debug "data column validation failed",
+          blockRoot = shortLog(signedBlock.root),
+          blck = shortLog(signedBlock.message),
+          signature = shortLog(signedBlock.signature),
+          msg = r.error()
+        return err(VerifierError.Invalid)
   ok()
 
 proc verifySidecars(

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -553,21 +553,14 @@ proc verify_data_column_sidecar_kzg_proofs*(sidecar: fulu.DataColumnSidecar):
   ## Verify if the KZG proofs are correct.
   verify_data_column_sidecar_kzg_proofs(sidecar, sidecar.kzg_commitments)
 
-proc verify_data_column_sidecar_kzg_proofs*[
-    T: fulu.DataColumnSidecar | gloas.DataColumnSidecar |
-       ref fulu.DataColumnSidecar | ref gloas.DataColumnSidecar](
-    sidecars: openArray[T],
-    kzg_commitments: KzgCommitments): Result[void, cstring] =
-  ## Batch verify KZG proofs across multiple DataColumnSidecars.
-  ## All cells/commitments/proofs from every sidecar are flattened into a
-  ## single `verifyCellKzgProofBatch` call, which is more efficient than
-  ## verifying each sidecar individually. Accepts either values or refs.
-  if sidecars.len == 0:
+template verifyKzgBatchBody(
+    sidecarsArg, expectedLen, commitmentAt: untyped) =
+  if sidecarsArg.len == 0:
     return ok()
 
   var totalCells = 0
-  for sidecar in sidecars:
-    if sidecar.column.len != kzg_commitments.len or
+  for sidecar {.inject.} in sidecarsArg:
+    if sidecar.column.len != expectedLen or
         sidecar.column.len != sidecar.kzg_proofs.len:
       return err("DataColumnSidecar: length mismatch")
     totalCells += sidecar.column.len
@@ -578,10 +571,10 @@ proc verify_data_column_sidecar_kzg_proofs*[
     cells = newSeqOfCap[KzgCell](totalCells)
     proofs = newSeqOfCap[KzgProof](totalCells)
 
-  for sidecar in sidecars:
+  for sidecar {.inject.} in sidecarsArg:
     let idx = CellIndex(sidecar.index)
-    for i in 0 ..< sidecar.column.len:
-      commitments.add(kzg_commitments[i])
+    for i {.inject.} in 0 ..< sidecar.column.len:
+      commitments.add(commitmentAt)
       cellIndices.add(idx)
       cells.add(sidecar.column[i])
       proofs.add(sidecar.kzg_proofs[i])
@@ -593,21 +586,27 @@ proc verify_data_column_sidecar_kzg_proofs*[
   if not res:
     return err("DataColumnSidecar: validation failed")
 
-  ok()
+  return ok()
 
-proc verify_data_column_sidecar_kzg_proofs*(
-    sidecars: openArray[fulu.DataColumnSidecar]): Result[void, cstring] =
-  ## Batch verify KZG proofs across multiple fulu DataColumnSidecars.
-  if sidecars.len == 0:
-    return ok()
-  verify_data_column_sidecar_kzg_proofs(sidecars, sidecars[0].kzg_commitments)
+proc verify_data_column_sidecar_kzg_proofs*[
+    T: fulu.DataColumnSidecar | gloas.DataColumnSidecar |
+       ref fulu.DataColumnSidecar | ref gloas.DataColumnSidecar](
+    sidecars: openArray[T],
+    kzg_commitments: KzgCommitments): Result[void, cstring] =
+  ## Batch verify KZG proofs across multiple DataColumnSidecars against a
+  ## single shared `kzg_commitments` array (e.g. gloas, where commitments
+  ## come from the bid). Accepts either values or refs.
+  verifyKzgBatchBody(sidecars, kzg_commitments.len, kzg_commitments[i])
 
-proc verify_data_column_sidecar_kzg_proofs*(
-    sidecars: openArray[ref fulu.DataColumnSidecar]): Result[void, cstring] =
-  ## Batch verify KZG proofs across multiple fulu DataColumnSidecars (ref variant).
-  if sidecars.len == 0:
-    return ok()
-  verify_data_column_sidecar_kzg_proofs(sidecars, sidecars[0].kzg_commitments)
+proc verify_data_column_sidecar_kzg_proofs*[
+    T: fulu.DataColumnSidecar | ref fulu.DataColumnSidecar](
+    sidecars: openArray[T]): Result[void, cstring] =
+  ## Batch verify KZG proofs across multiple fulu DataColumnSidecars using
+  ## each sidecar's own `kzg_commitments`. Equivalent to verifying each
+  ## sidecar individually: a sidecar carrying commitments that don't match
+  ## its cells/proofs is rejected regardless of its position in the batch.
+  verifyKzgBatchBody(
+    sidecars, sidecar.kzg_commitments.len, sidecar.kzg_commitments[i])
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/validator.md#validator-custody
 func get_validators_custody_requirement*(cfg: RuntimeConfig,

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -573,11 +573,11 @@ template verifyKzgBatchBody(
 
   for sidecar {.inject.} in sidecarsArg:
     let idx = CellIndex(sidecar.index)
-    for i {.inject.} in 0 ..< sidecar.column.len:
+    for blobIdx {.inject.} in 0 ..< sidecar.column.len:
       commitments.add(commitmentAt)
       cellIndices.add(idx)
-      cells.add(sidecar.column[i])
-      proofs.add(sidecar.kzg_proofs[i])
+      cells.add(sidecar.column[blobIdx])
+      proofs.add(sidecar.kzg_proofs[blobIdx])
 
   let res = verifyCellKzgProofBatch(
       commitments, cellIndices, cells, proofs).valueOr:
@@ -586,7 +586,7 @@ template verifyKzgBatchBody(
   if not res:
     return err("DataColumnSidecar: validation failed")
 
-  return ok()
+  ok()
 
 proc verify_data_column_sidecar_kzg_proofs*[
     T: fulu.DataColumnSidecar | gloas.DataColumnSidecar |
@@ -596,7 +596,7 @@ proc verify_data_column_sidecar_kzg_proofs*[
   ## Batch verify KZG proofs across multiple DataColumnSidecars against a
   ## single shared `kzg_commitments` array (e.g. gloas, where commitments
   ## come from the bid). Accepts either values or refs.
-  verifyKzgBatchBody(sidecars, kzg_commitments.len, kzg_commitments[i])
+  verifyKzgBatchBody(sidecars, kzg_commitments.len, kzg_commitments[blobIdx])
 
 proc verify_data_column_sidecar_kzg_proofs*[
     T: fulu.DataColumnSidecar | ref fulu.DataColumnSidecar](
@@ -606,7 +606,7 @@ proc verify_data_column_sidecar_kzg_proofs*[
   ## sidecar individually: a sidecar carrying commitments that don't match
   ## its cells/proofs is rejected regardless of its position in the batch.
   verifyKzgBatchBody(
-    sidecars, sidecar.kzg_commitments.len, sidecar.kzg_commitments[i])
+    sidecars, sidecar.kzg_commitments.len, sidecar.kzg_commitments[blobIdx])
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.4/specs/fulu/validator.md#validator-custody
 func get_validators_custody_requirement*(cfg: RuntimeConfig,

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -554,13 +554,14 @@ proc verify_data_column_sidecar_kzg_proofs*(sidecar: fulu.DataColumnSidecar):
   verify_data_column_sidecar_kzg_proofs(sidecar, sidecar.kzg_commitments)
 
 proc verify_data_column_sidecar_kzg_proofs*[
-    T: fulu.DataColumnSidecar | gloas.DataColumnSidecar](
+    T: fulu.DataColumnSidecar | gloas.DataColumnSidecar |
+       ref fulu.DataColumnSidecar | ref gloas.DataColumnSidecar](
     sidecars: openArray[T],
     kzg_commitments: KzgCommitments): Result[void, cstring] =
   ## Batch verify KZG proofs across multiple DataColumnSidecars.
   ## All cells/commitments/proofs from every sidecar are flattened into a
   ## single `verifyCellKzgProofBatch` call, which is more efficient than
-  ## verifying each sidecar individually.
+  ## verifying each sidecar individually. Accepts either values or refs.
   if sidecars.len == 0:
     return ok()
 
@@ -597,6 +598,13 @@ proc verify_data_column_sidecar_kzg_proofs*[
 proc verify_data_column_sidecar_kzg_proofs*(
     sidecars: openArray[fulu.DataColumnSidecar]): Result[void, cstring] =
   ## Batch verify KZG proofs across multiple fulu DataColumnSidecars.
+  if sidecars.len == 0:
+    return ok()
+  verify_data_column_sidecar_kzg_proofs(sidecars, sidecars[0].kzg_commitments)
+
+proc verify_data_column_sidecar_kzg_proofs*(
+    sidecars: openArray[ref fulu.DataColumnSidecar]): Result[void, cstring] =
+  ## Batch verify KZG proofs across multiple fulu DataColumnSidecars (ref variant).
   if sidecars.len == 0:
     return ok()
   verify_data_column_sidecar_kzg_proofs(sidecars, sidecars[0].kzg_commitments)


### PR DESCRIPTION
we always get >= 65 columns as a `BlockEntry` in our block processor, the batch kzg verification should significantly speed up block processing