### PR TITLE
Pass RuntimeConfig to light client fork migration helpers

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -578,7 +578,7 @@ proc assignLightClientData(
     let att_header = dag.getExistingLightClientHeader(attested_bid)
     withForkyHeader(att_header):
       when lcDataFork > LightClientDataFork.None:
-        obj.migrateToDataFork(lcDataFork)
+        obj.migrateToDataFork(lcDataFork, dag.cfg)
         obj.forky(lcDataFork).attested_header = forkyHeader
       else:
         dag.handleUnexpectedLightClientError(attested_bid.slot)
@@ -627,7 +627,7 @@ proc assignLightClientData(
                 forkyObject.finalized_header.reset()
                 forkyObject.finality_branch.reset()
               else:
-                fin_header.migrateToDataFork(lcDataFork)
+                fin_header.migrateToDataFork(lcDataFork, dag.cfg)
                 forkyObject.finalized_header = fin_header.forky(lcDataFork)
                 forkyObject.finality_branch = attested_data.finality_branch
   withForkyObject(obj):

--- a/beacon_chain/gossip_processing/light_client_processor.nim
+++ b/beacon_chain/gossip_processing/light_client_processor.nim
@@ -248,12 +248,12 @@ proc doProcessObject(
         if lcDataFork > self.store[].kind:
           info "Upgrading light client",
             oldFork = self.store[].kind, newFork = lcDataFork
-          self.store[].migrateToDataFork(lcDataFork)
+          self.store[].migrateToDataFork(lcDataFork, self.cfg)
     withForkyStore(self.store[]):
       when lcDataFork > LightClientDataFork.None:
         let
           wallSlot = wallTime.slotOrZero(self.cfg.timeParams)
-          upgradedUpdate = update.migratingToDataFork(lcDataFork)
+          upgradedUpdate = update.migratingToDataFork(lcDataFork, self.cfg)
         process_light_client_update(
           forkyStore, upgradedUpdate.forky(lcDataFork), wallSlot,
           self.cfg, self.genesis_validators_root)
@@ -285,8 +285,8 @@ proc processObject(
               of LightClientVerifierError.Duplicate:
                 if wallTime >= self.lastDuplicateTick + duplicateRateLimit:
                   if self.numDupsSinceProgress < minForceUpdateDuplicates:
-                    let upgradedObj = obj.migratingToDataFork(lcDataFork)
-                    if upgradedObj.forky(lcDataFork).matches(
+                    let upgraded = obj.migratingToDataFork(lcDataFork, self.cfg)
+                    if upgraded.forky(lcDataFork).matches(
                         forkyStore.best_valid_update.get):
                       self.lastDuplicateTick = wallTime
                       inc self.numDupsSinceProgress
@@ -347,7 +347,7 @@ template withReportedProgress(
     withForkyStore(self.store[]):
       when lcDataFork > LightClientDataFork.None:
         if oldOptimistic.kind <= lcDataFork:
-          oldOptimistic.migrateToDataFork(lcDataFork)
+          oldOptimistic.migrateToDataFork(lcDataFork, self.cfg)
           if forkyStore.optimistic_header != oldOptimistic.forky(lcDataFork):
             didProgress = true
             when obj isnot SomeForkedLightClientUpdateWithFinality:
@@ -356,7 +356,7 @@ template withReportedProgress(
               self.onOptimisticHeader()
 
         if oldFinalized.kind <= lcDataFork:
-          oldFinalized.migrateToDataFork(lcDataFork)
+          oldFinalized.migrateToDataFork(lcDataFork, self.cfg)
           if forkyStore.finalized_header != oldFinalized.forky(lcDataFork):
             didProgress = true
             didSignificantProgress = true

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -344,7 +344,7 @@ proc ETHLightClientStoreCreateFromBootstrap(
     except RestError:
       return nil
   doAssert bootstrap.kind > LightClientDataFork.None
-  bootstrap.migrateToDataFork(lcDataFork)
+  bootstrap.migrateToDataFork(lcDataFork, cfg[])
 
   let store = lcDataFork.LightClientStore.new()
   store[] = initialize_light_client_store(
@@ -531,7 +531,7 @@ proc ETHLightClientStoreProcessUpdatesByRange(
   var didProgress = false
   for i in 0 ..< updates.len:
     doAssert updates[i].kind > LightClientDataFork.None
-    updates[i].migrateToDataFork(lcDataFork)
+    updates[i].migrateToDataFork(lcDataFork, cfg[])
     let res = process_light_client_update(
       store[], updates[i].forky(lcDataFork),
       currentSlot, cfg[], genesisValRoot[])
@@ -617,7 +617,7 @@ proc ETHLightClientStoreProcessFinalityUpdate(
     except RestError:
       return 1
   doAssert finalityUpdate.kind > LightClientDataFork.None
-  finalityUpdate.migrateToDataFork(lcDataFork)
+  finalityUpdate.migrateToDataFork(lcDataFork, cfg[])
   let res = process_light_client_update(
     store[], finalityUpdate.forky(lcDataFork),
     currentSlot, cfg[], genesisValRoot[])
@@ -701,7 +701,7 @@ proc ETHLightClientStoreProcessOptimisticUpdate(
     except RestError:
       return 1
   doAssert optimisticUpdate.kind > LightClientDataFork.None
-  optimisticUpdate.migrateToDataFork(lcDataFork)
+  optimisticUpdate.migrateToDataFork(lcDataFork, cfg[])
   let res = process_light_client_update(
     store[], optimisticUpdate.forky(lcDataFork),
     currentSlot, cfg[], genesisValRoot[])

--- a/beacon_chain/light_client.nim
+++ b/beacon_chain/light_client.nim
@@ -235,7 +235,6 @@ proc resetToFinalizedHeader*(
     current_sync_committee: altair.SyncCommittee) =
   lightClient.processor[].resetToFinalizedHeader(header, current_sync_committee)
 
-
 declareCounter beacon_light_client_finality_updates_received,
   "Number of valid LC finality updates processed by this node"
 declareCounter beacon_light_client_finality_updates_dropped,

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -741,7 +741,8 @@ func matches*[A, B: SomeForkedLightClientUpdate](a: A, b: B): bool =
 
 func migrateToDataFork*(
     x: var ForkedLightClientHeader,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -784,7 +785,8 @@ func migrateToDataFork*(
 
 func migrateToDataFork*(
     x: var ForkedLightClientBootstrap,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -827,7 +829,8 @@ func migrateToDataFork*(
 
 func migrateToDataFork*(
     x: var ForkedLightClientUpdate,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -870,7 +873,8 @@ func migrateToDataFork*(
 
 func migrateToDataFork*(
     x: var ForkedLightClientFinalityUpdate,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -913,7 +917,8 @@ func migrateToDataFork*(
 
 func migrateToDataFork*(
     x: var ForkedLightClientOptimisticUpdate,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -956,7 +961,8 @@ func migrateToDataFork*(
 
 func migrateToDataFork*(
     x: var ForkedLightClientStore,
-    newKind: static LightClientDataFork) =
+    newKind: static LightClientDataFork,
+    cfg: RuntimeConfig) =
   if newKind == x.kind:
     # Already at correct kind
     discard
@@ -1002,9 +1008,9 @@ func migratingToDataFork*[
       ForkedLightClientHeader |
       SomeForkedLightClientObject |
       ForkedLightClientStore](
-    x: T, newKind: static LightClientDataFork): T =
+    x: T, newKind: static LightClientDataFork, cfg: RuntimeConfig): T =
   var upgradedObject = x
-  upgradedObject.migrateToDataFork(newKind)
+  upgradedObject.migrateToDataFork(newKind, cfg)
   upgradedObject
 
 # Convenience-based location for toExecutionPayloadHeader because this is the

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -112,7 +112,7 @@ proc fetchCheckpointState(
       if bootstrap.kind == LightClientDataFork.None:
         error "LC bootstrap unavailable on server"
         return nil
-      bootstrap.migrateToDataFork(lcDataFork)
+      bootstrap.migrateToDataFork(lcDataFork, cfg)
 
       var store = initialize_light_client_store(
         trustedBlockRoot, bootstrap.forky(lcDataFork), cfg
@@ -161,7 +161,7 @@ proc fetchCheckpointState(
 
         for i in 0 ..< updates.len:
           doAssert updates[i].kind > LightClientDataFork.None
-          updates[i].migrateToDataFork(lcDataFork)
+          updates[i].migrateToDataFork(lcDataFork, cfg)
           store.process_light_client_update(
             updates[i].forky(lcDataFork),
             beaconClock.currentSlot,
@@ -176,8 +176,8 @@ proc fetchCheckpointState(
         try:
           info "Downloading LC finality update"
           awaitWithTimeout(
-            client.getLightClientFinalityUpdate(cfg, forkDigests), smallRequestsTimeout
-          ):
+              client.getLightClientFinalityUpdate(cfg, forkDigests),
+              smallRequestsTimeout):
             error "Attempt to download LC finality update timed out"
             return nil
         except CatchableError as exc:
@@ -187,7 +187,7 @@ proc fetchCheckpointState(
         error "LC finality update unavailable on server"
         return nil
 
-      finalityUpdate.migrateToDataFork(lcDataFork)
+      finalityUpdate.migrateToDataFork(lcDataFork, cfg)
 
       store.process_light_client_update(
         finalityUpdate.forky(lcDataFork),

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2022-2025 Status Research & Development GmbH
+# Copyright (c) 2022-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/tests/consensus_spec/test_fixture_light_client_sync.nim
+++ b/tests/consensus_spec/test_fixture_light_client_sync.nim
@@ -195,7 +195,7 @@ proc runTest(suiteName, path: string) =
       var store: ForkedLightClientStore
       withLcDataFork(lcDataForkAtConsensusFork(store_consensus_fork)):
         when lcDataFork > LightClientDataFork.None:
-          bootstrap[].migrateToDataFork(lcDataFork)
+          bootstrap[].migrateToDataFork(lcDataFork, cfg)
           store = ForkedLightClientStore.init(initialize_light_client_store(
             meta.trusted_block_root, bootstrap[].forky(lcDataFork), cfg).get)
         else: raiseAssert "Unreachable store fork " & $meta.store_fork_digest
@@ -215,7 +215,7 @@ proc runTest(suiteName, path: string) =
           of TestStepKind.ProcessUpdate:
             check step.update.kind <= lcDataFork
             let
-              upgradedUpdate = step.update.migratingToDataFork(lcDataFork)
+              upgradedUpdate = step.update.migratingToDataFork(lcDataFork, cfg)
               res = process_light_client_update(
                 forkyStore, upgradedUpdate.forky(lcDataFork), step.current_slot,
                 cfg, meta.genesis_validators_root)
@@ -224,7 +224,7 @@ proc runTest(suiteName, path: string) =
             check step.store_data_fork >= lcDataFork
             withLcDataFork(step.store_data_fork):
               when lcDataFork > LightClientDataFork.None:
-                store.migrateToDataFork(lcDataFork)
+                store.migrateToDataFork(lcDataFork, cfg)
         else: raiseAssert "Unreachable"
 
       withForkyStore(store):

--- a/tests/test_light_client.nim
+++ b/tests/test_light_client.nim
@@ -181,14 +181,14 @@ suite "Light client" & preset():
       if update.kind > store.kind:
         withForkyUpdate(update):
           when lcDataFork > LightClientDataFork.None:
-            store.migrateToDataFork(lcDataFork)
+            store.migrateToDataFork(lcDataFork, cfg)
       withForkyStore(store):
         when lcDataFork > LightClientDataFork.None:
           # Reduce stack size by making this a `proc`
           proc syncToPeriod() =
-            bootstrap.migrateToDataFork(lcDataFork)
+            bootstrap.migrateToDataFork(lcDataFork, cfg)
             template forkyBootstrap: untyped = bootstrap.forky(lcDataFork)
-            let upgradedUpdate = update.migratingToDataFork(lcDataFork)
+            let upgradedUpdate = update.migratingToDataFork(lcDataFork, cfg)
             template forkyUpdate: untyped = upgradedUpdate.forky(lcDataFork)
             let res = process_light_client_update(
               forkyStore, forkyUpdate, currentSlot, cfg,
@@ -212,10 +212,10 @@ suite "Light client" & preset():
     if finalityUpdate.kind > store.kind:
       withForkyFinalityUpdate(finalityUpdate):
         when lcDataFork > LightClientDataFork.None:
-          store.migrateToDataFork(lcDataFork)
+          store.migrateToDataFork(lcDataFork, cfg)
     withForkyStore(store):
       when lcDataFork > LightClientDataFork.None:
-        let upgradedUpdate = finalityUpdate.migratingToDataFork(lcDataFork)
+        let upgradedUpdate = finalityUpdate.migratingToDataFork(lcDataFork, cfg)
         template forkyUpdate: untyped = upgradedUpdate.forky(lcDataFork)
         let res = process_light_client_update(
           forkyStore, forkyUpdate, currentSlot, cfg, genesis_validators_root)

--- a/tests/test_light_client_processor.nim
+++ b/tests/test_light_client_processor.nim
@@ -128,9 +128,9 @@ suite "Light client processor" & preset():
         check update.kind <= store[].kind
         withForkyStore(store[]):
           when lcDataFork > LightClientDataFork.None:
-            bootstrap.migrateToDataFork(lcDataFork)
+            bootstrap.migrateToDataFork(lcDataFork, cfg)
             template forkyBootstrap: untyped = bootstrap.forky(lcDataFork)
-            let upgraded = update.migratingToDataFork(lcDataFork)
+            let upgraded = update.migratingToDataFork(lcDataFork, cfg)
             template forkyUpdate: untyped = upgraded.forky(lcDataFork)
             check:
               res.isOk
@@ -160,7 +160,7 @@ suite "Light client processor" & preset():
                 withForkyStore(store[]):
                   when lcDataFork > LightClientDataFork.None:
                     let upgraded = newClone(
-                      update[].migratingToDataFork(lcDataFork))
+                      update[].migratingToDataFork(lcDataFork, cfg))
                     template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                     check:
                       res.isOk
@@ -170,7 +170,7 @@ suite "Light client processor" & preset():
                 withForkyStore(store[]):
                   when lcDataFork > LightClientDataFork.None:
                     let upgraded = newClone(
-                      update[].migratingToDataFork(lcDataFork))
+                      update[].migratingToDataFork(lcDataFork, cfg))
                     template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                     check:
                       res.isErr
@@ -181,7 +181,7 @@ suite "Light client processor" & preset():
               withForkyStore(store[]):
                 when lcDataFork > LightClientDataFork.None:
                   let upgraded = newClone(
-                    update[].migratingToDataFork(lcDataFork))
+                    update[].migratingToDataFork(lcDataFork, cfg))
                   template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                   check:
                     res.isErr
@@ -201,7 +201,7 @@ suite "Light client processor" & preset():
               withForkyStore(store[]):
                 when lcDataFork > LightClientDataFork.None:
                   let upgraded = newClone(
-                    update[].migratingToDataFork(lcDataFork))
+                    update[].migratingToDataFork(lcDataFork, cfg))
                   template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                   check:
                     res.isErr
@@ -212,7 +212,7 @@ suite "Light client processor" & preset():
               withForkyStore(store[]):
                 when lcDataFork > LightClientDataFork.None:
                   let upgraded = newClone(
-                    update[].migratingToDataFork(lcDataFork))
+                    update[].migratingToDataFork(lcDataFork, cfg))
                   template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                   check:
                     res.isErr
@@ -234,7 +234,7 @@ suite "Light client processor" & preset():
             withForkyStore(store[]):
               when lcDataFork > LightClientDataFork.None:
                 let upgraded = newClone(
-                  update[].migratingToDataFork(lcDataFork))
+                  update[].migratingToDataFork(lcDataFork, cfg))
                 template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                 check:
                   res.isErr
@@ -248,7 +248,7 @@ suite "Light client processor" & preset():
             withForkyStore(store[]):
               when lcDataFork > LightClientDataFork.None:
                 let upgraded = newClone(
-                  update[].migratingToDataFork(lcDataFork))
+                  update[].migratingToDataFork(lcDataFork, cfg))
                 template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                 check:
                   res.isErr
@@ -259,7 +259,7 @@ suite "Light client processor" & preset():
             withForkyStore(store[]):
               when lcDataFork > LightClientDataFork.None:
                 let upgraded = newClone(
-                  update[].migratingToDataFork(lcDataFork))
+                  update[].migratingToDataFork(lcDataFork, cfg))
                 template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
                 check:
                   res.isErr
@@ -280,14 +280,14 @@ suite "Light client processor" & preset():
           withForkyStore(store[]):
             when lcDataFork > LightClientDataFork.None:
               let upgraded = newClone(
-                update[].migratingToDataFork(lcDataFork))
+                update[].migratingToDataFork(lcDataFork, cfg))
               template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
               check forkyStore.finalized_header == forkyUpdate.attested_header
         else:
           withForkyStore(store[]):
             when lcDataFork > LightClientDataFork.None:
               let upgraded = newClone(
-                update[].migratingToDataFork(lcDataFork))
+                update[].migratingToDataFork(lcDataFork, cfg))
               template forkyUpdate: untyped = upgraded[].forky(lcDataFork)
               check forkyStore.finalized_header != forkyUpdate.attested_header
 
@@ -308,9 +308,9 @@ suite "Light client processor" & preset():
       if res.isOk:
         withForkyStore(store[]):
           when lcDataFork > LightClientDataFork.None:
-            oldFinalized.migrateToDataFork(lcDataFork)
+            oldFinalized.migrateToDataFork(lcDataFork, cfg)
             template forkyOldFinalized: untyped = oldFinalized.forky(lcDataFork)
-            let upgraded = finalityUpdate.migratingToDataFork(lcDataFork)
+            let upgraded = finalityUpdate.migratingToDataFork(lcDataFork, cfg)
             template forkyUpdate: untyped = upgraded.forky(lcDataFork)
             check:
               finalizationMode == LightClientFinalizationMode.Optimistic


### PR DESCRIPTION
Will need cfg to determine shape of historical execution payload header when migrating a header proof to a Gloas style block hash proof.