### PR TITLE
Light client execution_block_hash helper

### DIFF
--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -82,7 +82,7 @@ proc initLightClient*(
           when lcDataFork >= LightClientDataFork.Capella:
             let
               consensusFork = node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch)
-              blockHash = forkyHeader.execution.block_hash
+              blockHash = forkyHeader.execution_block_hash
 
             # Retain light client head for other `forkchoiceUpdated` callers.
             # May temporarily block `forkchoiceUpdated` calls, e.g., Geth:

--- a/beacon_chain/libnimbus_lc/libnimbus_lc.nim
+++ b/beacon_chain/libnimbus_lc/libnimbus_lc.nim
@@ -1027,7 +1027,7 @@ proc ETHLightClientHeaderCopyExecutionHash(
   ## * https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.4/specs/deneb/beacon-chain.md#executionpayloadheader
   discard cfg  # Future-proof against SSZ execution block header, EIP-6404ff.
   let root = Eth2Digest.new()
-  root[] = header[].execution.block_hash
+  root[] = header[].execution_block_hash
   root.toUnmanagedPtr()
 
 type ExecutionPayloadHeader =

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -165,7 +165,7 @@ proc main() {.noinline, raises: [CatchableError].} =
           let
             bid = forkyHeader.beacon.toBlockId()
             consensusFork = cfg.consensusForkAtEpoch(bid.slot.epoch)
-            blockHash = forkyHeader.execution.block_hash
+            blockHash = forkyHeader.execution_block_hash
 
           info "New LC optimistic header"
           if elManager == nil or blockHash.isZero or
@@ -177,7 +177,7 @@ proc main() {.noinline, raises: [CatchableError].} =
               let finalizedHeader = lightClient.finalizedHeader
               withForkyHeader(finalizedHeader):
                 when lcDataFork >= LightClientDataFork.Capella:
-                  forkyHeader.execution.block_hash
+                  forkyHeader.execution_block_hash
                 else:
                   ZERO_HASH
             else:

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -214,6 +214,13 @@ template kind*(
       electra.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Electra
 
+template execution_block_hash*(
+    forkyHeader:
+      capella.LightClientHeader |
+      deneb.LightClientHeader |
+      electra.LightClientHeader): Eth2Digest =
+  forkyHeader.execution.block_hash
+
 template finalized_root_gindex*(
     kind: static LightClientDataFork): GeneralizedIndex =
   when kind >= LightClientDataFork.Electra:


### PR DESCRIPTION
Accessor to directly provide EL block hash, without requiring explicit "execution" at various call sites, which may go away with Gloas.