### PR TITLE
add validator_client_node_status_counts metrics

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -8,7 +8,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  std/[macros, tables, os, sets, sequtils, strutils, uri, algorithm],
+  std/[macros, tables, os, sets, sequtils, strutils, uri, algorithm, locks],
   results,
   stew/[base10, byteutils],
   bearssl/rand, chronos, presto, presto/client as presto_client,
@@ -45,6 +45,10 @@ const
   EPOCHS_BETWEEN_VALIDATOR_REGISTRATION* = 1
 
   ZeroTimeDiff* = TimeDiff(nanoseconds: 0'i64)
+
+declareGauge validator_client_node_status_counts,
+  "Counts of connected beacon nodes and their statuses",
+  labels = ["url", "status"]
 
 static: doAssert(high(ConsensusFork) == ConsensusFork.Heze,
           "Update OptionalForks constant!")
@@ -145,6 +149,7 @@ type
     logIdent*: string
     index*: int
     timeOffset*: Opt[TimeOffset]
+    statusGaugeLock*: Lock
 
   EpochSelectionProof* = object
     signatures*: array[SLOTS_PER_EPOCH.int, Opt[ValidatorSig]]
@@ -704,6 +709,11 @@ proc updateStatus*(node: BeaconNodeServerRef,
   logScope:
     node = node
 
+  # Reset other to indicate only current state, lock to avoid race conditions.
+  withLock(node.statusGaugeLock):
+    validator_client_node_status_counts.set(0, [$node.uri, $node.status], doUpdateSystemMetrics = false)
+    validator_client_node_status_counts.set(1, [$node.uri, $status])
+
   case status
   of RestBeaconNodeStatus.Invalid:
     if node.status != status:
@@ -922,6 +932,8 @@ proc init*(t: typedesc[BeaconNodeServerRef], remote: Uri,
             client: nil, endpoint: $remoteUri, index: index,
             roles: roles, logIdent: $remoteUri, uri: remoteUri,
             status: RestBeaconNodeStatus.Noname)
+
+  server.statusGaugeLock.initLock()
   ok(server)
 
 proc getMissingRoles*(n: openArray[BeaconNodeServerRef]): set[BeaconNodeRole] =

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -750,8 +750,7 @@ proc updateStatus*(node: BeaconNodeServerRef,
       notice "Beacon node is compatible"
       node.status = status
   of RestBeaconNodeStatus.NotSynced:
-    if node.status notin {RestBeaconNodeStatus.NotSynced,
-                          RestBeaconNodeStatus.OptSynced}:
+    if node.status != status:
       doAssert(node.syncInfo.isSome())
       let si = node.syncInfo.get()
       warn "Beacon node not in sync", reason = failure.getFailureReason(),

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -708,6 +708,12 @@ proc updateStatus*(node: BeaconNodeServerRef,
                    failure: ApiNodeFailure) =
   logScope:
     node = node
+  notice "updateStatus():START",
+    node_status = $node.status,
+    status = $status,
+    node = $node,
+    failure = $failure,
+    chroniclesThreadIds = true
 
   # Reset other to indicate only current state, lock to avoid race conditions.
   withLock(node.statusGaugeLock):
@@ -794,6 +800,13 @@ proc updateStatus*(node: BeaconNodeServerRef,
     if node.status != status:
       warn "Beacon node's clock is out of order, (beacon node is unusable)"
       node.status = status
+
+  notice "updateStatus():END",
+    status = $status,
+    node_status = $node.status,
+    node = $node,
+    failure = $failure,
+    chroniclesThreadIds = true
 
 proc stop*(csr: ClientServiceRef) {.async: (raises: []).} =
   debug "Stopping service", service = csr.name

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -149,7 +149,6 @@ type
     logIdent*: string
     index*: int
     timeOffset*: Opt[TimeOffset]
-    statusGaugeLock*: Lock
 
   EpochSelectionProof* = object
     signatures*: array[SLOTS_PER_EPOCH.int, Opt[ValidatorSig]]
@@ -716,9 +715,7 @@ proc updateStatus*(node: BeaconNodeServerRef,
     chroniclesThreadIds = true
 
   # Reset other to indicate only current state, lock to avoid race conditions.
-  withLock(node.statusGaugeLock):
-    validator_client_node_status_counts.set(0, [$node.uri, $node.status], doUpdateSystemMetrics = false)
-    validator_client_node_status_counts.set(1, [$node.uri, $status])
+  validator_client_node_status_counts.set(0, [$node.uri, $node.status], doUpdateSystemMetrics = false)
 
   case status
   of RestBeaconNodeStatus.Invalid:
@@ -800,6 +797,8 @@ proc updateStatus*(node: BeaconNodeServerRef,
     if node.status != status:
       warn "Beacon node's clock is out of order, (beacon node is unusable)"
       node.status = status
+
+  validator_client_node_status_counts.set(1, [$node.uri, $status])
 
   notice "updateStatus():END",
     status = $status,
@@ -946,7 +945,6 @@ proc init*(t: typedesc[BeaconNodeServerRef], remote: Uri,
             roles: roles, logIdent: $remoteUri, uri: remoteUri,
             status: RestBeaconNodeStatus.Noname)
 
-  server.statusGaugeLock.initLock()
   ok(server)
 
 proc getMissingRoles*(n: openArray[BeaconNodeServerRef]): set[BeaconNodeRole] =


### PR DESCRIPTION
The purpose of this metric is to detect issues with downstream beacon nodes that could cause failures to post or publish attestations.

I'm using a per-node lock to reset the previous metric value because multiple threads are using the `updateStatus` method which would result in multiple statuses being set to 1 for one node a the same time.

Example metrics:
```
validator_client_node_status_counts{url="http://localhost:5052/",status="bn-unsynced"} 0.0
validator_client_node_status_counts{url="http://localhost:5052/",status="compatible"} 0.0
validator_client_node_status_counts{url="http://localhost:5052/",status="el-unsynced"} 0.0
validator_client_node_status_counts{url="http://localhost:5052/",status="offline"} 0.0
validator_client_node_status_counts{url="http://localhost:5052/",status="online"} 0.0
validator_client_node_status_counts{url="http://localhost:5052/",status="synced"} 1.0
```