### PR TITLE
Add gindex constants for Gloas light client

### DIFF
--- a/beacon_chain/spec/datatypes/gloas.nim
+++ b/beacon_chain/spec/datatypes/gloas.nim
@@ -22,15 +22,16 @@ import
   json_serialization,
   ssz_serialization/[merkleization, proofs],
   ssz_serialization/types as sszTypes,
-  ../digest,
+  ../[digest, ssz_codec],
   kzg4844/[kzg, kzg_abi]
 
 from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
   TrustedSyncAggregate, SyncnetBits, num_active_participants
 from ./capella import
-  ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
-  SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX
+  BeaconBlockBody, ExecutionBranch, HistoricalSummary,
+  SignedBLSToExecutionChange, SignedBLSToExecutionChangeList,
+  Withdrawal, EXECUTION_PAYLOAD_GINDEX
 from ./deneb import
   Blobs, KzgCommitments, KzgProofs
 
@@ -687,3 +688,15 @@ template builder_index*(v: BeaconBlock | TrustedBeaconBlock): uint64 =
 template builder_index*(
     v: SignedBeaconBlock | TrustedSignedBeaconBlock): uint64 =
   v.message.builder_index
+
+const
+  LATEST_BLOCK_HASH_GINDEX* = get_generalized_index(
+    capella.BeaconBlockBody, "execution_payload", "block_hash")
+  LATEST_BLOCK_HASH_GINDEX_DENEB* = get_generalized_index(
+    deneb.BeaconBlockBody, "execution_payload", "block_hash")
+  LATEST_BLOCK_HASH_GINDEX_GLOAS* = get_generalized_index(
+    BeaconState, "latest_block_hash")
+static:
+  doAssert LATEST_BLOCK_HASH_GINDEX == 412.GeneralizedIndex
+  doAssert LATEST_BLOCK_HASH_GINDEX_DENEB == 812.GeneralizedIndex
+  doAssert LATEST_BLOCK_HASH_GINDEX_GLOAS == 88.GeneralizedIndex

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1711,11 +1711,22 @@ static:
         check lcDataFork.next_sync_committee_gindex,
           BeaconState, "next_sync_committee"
 
-        when lcDataFork >= LightClientDataFork.Capella and
-            consensusFork < ConsensusFork.Gloas:
-          debugGloasComment "[PH] LC specs"
-          check EXECUTION_PAYLOAD_GINDEX,
-            BeaconBlockBody, "execution_payload"
+        when lcDataFork >= LightClientDataFork.Capella:
+          when consensusFork >= ConsensusFork.Gloas:
+            check LATEST_BLOCK_HASH_GINDEX_GLOAS,
+              BeaconState, "latest_block_hash"
+          else:
+            check EXECUTION_PAYLOAD_GINDEX,
+              BeaconBlockBody, "execution_payload"
+            const latest_block_hash_gindex =
+              when consensusFork >= ConsensusFork.Deneb:
+                LATEST_BLOCK_HASH_GINDEX_DENEB
+              else:
+                LATEST_BLOCK_HASH_GINDEX
+            check latest_block_hash_gindex,
+              BeaconBlockBody, "execution_payload", "block_hash"
+        else:
+          discard  # Light client data does not track execution data
 
 func getForkSchedule*(cfg: RuntimeConfig): array[8, Fork] =
   ## This procedure returns list of known and/or scheduled forks.


### PR DESCRIPTION
Two changes:

(1) ePBS made the execution data in the BeaconBlock optimistic, it is
    not canonical until later in the slot when confirmed by the PTC.
    Sync committee signs earlier though, so light client data can no
    longer rely on BeaconBlock data for execution headers.

(2) Submarine where they replaced ExecutionPayload with just the block
    hash, meaning even for basics like block number or gas usage, one
    has to pay for another API call (either $ with provider, or latency
    with portal). Not a complicated change, but we have to re-root the
    Capella and Deneb execution proofs when migrating to Gloas.

Define the constants for now, this doesn't break anything and ensures that we know when something becomes inconsistent in Heze etc.