### PR TITLE
fix(nix): for ncli,ncli_db target, do install check with help flag

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -69,7 +69,17 @@ in stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckPhase = ''
-    for BINARY in $out/bin/*; do $BINARY --version; done
+    for BINARY in $out/bin/*; do
+      case "$(basename "$BINARY")" in
+        ncli|ncli_db)
+          # These don't support --version, just verify they execute.
+          $BINARY --help > /dev/null 2>&1
+          ;;
+        *)
+          $BINARY --version
+          ;;
+      esac
+    done
   '';
 
   meta = with lib; {


### PR DESCRIPTION
Fix when building with nix `ncli` or `ncli_db`:
```
       > Running phase: installCheckPhase
       > Unrecognized option 'version'
       > Try ncli --help for more information.
       For full logs, run:
```