### PR TITLE
fix proposal execution head at genesis; rm non-spec SSE; ensure envelopse SSE has envelope in database

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -66,7 +66,6 @@ type
     optUpdateQueue*: AsyncEventQueue[
       RestVersioned[ForkedLightClientOptimisticUpdate]]
     optFinHeaderUpdateQueue*: AsyncEventQueue[ForkedLightClientHeader]
-    execPayloadAddedQueue*: AsyncEventQueue[EventExecutionPayloadObject]
     execPayloadGossipAddedQueue*: AsyncEventQueue[EventExecutionPayloadGossipObject]
     execPayloadAvlQueue*: AsyncEventQueue[EventExecutionPayloadAvailableObject]
     execPayloadBidQueue*: AsyncEventQueue[gloas.SignedExecutionPayloadBid]
@@ -221,8 +220,6 @@ func init*(T: type EventBus): T =
       newAsyncEventQueue[RestVersioned[ForkedLightClientOptimisticUpdate]](),
     optFinHeaderUpdateQueue:
       newAsyncEventQueue[ForkedLightClientHeader](),
-    execPayloadAddedQueue:
-      newAsyncEventQueue[EventExecutionPayloadObject](),
     execPayloadGossipAddedQueue:
       newAsyncEventQueue[EventExecutionPayloadGossipObject](),
     execPayloadAvlQueue:

--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -563,8 +563,12 @@ proc addHeadExecutionPayload*(
   # Put the envelope into db and update optimistic status for the block.
   dag.db.putExecutionPayloadEnvelope(signedEnvelope)
 
-  if not isNil(dag.onEnvelopeAdded):
-    dag.onEnvelopeAdded(signedEnvelope)
+  # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.1/apis/eventstream/index.yaml
+  # `execution_payload_available`: "The node has verified that the execution
+  # payload and blobs for a block are available and ready for payload
+  # attestation"; emit after envelope in database and REST-queryable.
+  if not isNil(dag.onEnvelopeAvailable):
+    dag.onEnvelopeAvailable(signedEnvelope)
 
   ok(blck)
 

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -252,8 +252,6 @@ type
       ## On beacon chain reorganization
     onFinHappened*: OnFinalizedCallback
       ## On finalization callback
-    onEnvelopeAdded*: OnExecutionPayloadCallback
-      ## On envelope added callback
     onEnvelopeGossipAdded*: OnExecutionPayloadCallback
       ## On envelope gossip added callback
     onEnvelopeAvailable*: OnExecutionPayloadCallback
@@ -353,14 +351,6 @@ type
     blck*: ForkedSignedBeaconBlock
     src*: PeerId
 
-  EventExecutionPayloadObject* = object
-    slot*: Slot
-    builder_index*: uint64
-    block_hash*: Eth2Digest
-    block_root*: Eth2Digest
-    state_root*: Eth2Digest
-    execution_optimistic*: bool
-
   EventExecutionPayloadGossipObject* = object
     slot*: Slot
     builder_index*: uint64
@@ -426,9 +416,6 @@ template setHeadCb*(dag: ChainDAGRef, cb: OnHeadCallback) =
 
 template setReorgCb*(dag: ChainDAGRef, cb: OnReorgCallback) =
   dag.onReorgHappened = cb
-
-template setEnvelopeCb*(dag: ChainDAGRef, cb: OnExecutionPayloadCallback) =
-  dag.onEnvelopeAdded = cb
 
 template setEnvelopeGossipCb*(dag: ChainDAGRef, cb: OnExecutionPayloadCallback) =
   dag.onEnvelopeGossipAdded = cb
@@ -522,19 +509,6 @@ func init*(
   EventBeaconBlockGossipPeerObject(
     blck: ForkedSignedBeaconBlock.init(v),
     src: s
-  )
-
-func init*(
-    T: typedesc[EventExecutionPayloadObject],
-    v: SignedExecutionPayloadEnvelope,
-    optimistic: bool,
-): EventExecutionPayloadObject =
-  EventExecutionPayloadObject(
-    slot: v.message.slot,
-    builder_index: v.message.builder_index,
-    block_hash: v.message.payload.block_hash,
-    block_root: v.message.beacon_block_root,
-    execution_optimistic: optimistic,
   )
 
 func init*(

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -330,11 +330,7 @@ proc prepareNextSlot*(
   # Approximately lines up with validator_duties version. Used optimistically/
   # opportunistically, so mismatches are fine if not too frequent.
   withState(dag.clearanceState):
-    when consensusFork == ConsensusFork.Heze:
-      debugHezeComment "well, likely can't keep reusing V3 much longer"
-    elif consensusFork == ConsensusFork.Gloas:
-      debugGloasComment "well, likely can't keep reusing V3 much longer"
-    elif consensusFork in ConsensusFork.Electra .. ConsensusFork.Fulu:
+    when consensusFork >= ConsensusFork.Electra:
       debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer
       let
         timestamp = dag.timeParams
@@ -347,30 +343,36 @@ proc prepareNextSlot*(
           nextProposer, Opt.some(validatorIndex), proposalSlot.epoch
         )
         beaconHead = self.attestationPool[].getBeaconHead(head)
-        headBlockHash = dag.loadExecutionBlockHash(beaconHead.blck).valueOr:
-          return
+        executionHead =
+          when consensusFork >= ConsensusFork.Gloas:
+            proposalExecutionHead(forkyState.data)
+          else:
+            dag.loadExecutionBlockHash(beaconHead.blck).valueOr:
+              return
 
-      if headBlockHash.isZero:
+      if executionHead.isZero:
         return
 
-      # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/cancun.md#payloadattributesv3
       let
         state = ForkchoiceStateV1.init(
-          headBlockHash, beaconHead.safeExecutionBlockHash,
+          executionHead, beaconHead.safeExecutionBlockHash,
           beaconHead.finalizedExecutionBlockHash,
         )
-        attributes = PayloadAttributesV3.init(
-          timestamp,
-          prevRandao,
-          feeRecipient,
-          get_expected_withdrawals(forkyState.data),
-          beaconHead.blck.bid.root,
-        )
+        attributes =
+          when consensusFork >= ConsensusFork.Gloas:
+            PayloadAttributesV4.init(timestamp, prevRandao, feeRecipient,
+              get_expected_withdrawals(forkyState.data).withdrawals,
+              beaconHead.blck.bid.root, proposalSlot)
+          else:
+            # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/cancun.md#payloadattributesv3
+            PayloadAttributesV3.init(timestamp, prevRandao, feeRecipient,
+              get_expected_withdrawals(forkyState.data),
+              beaconHead.blck.bid.root)
 
         (status, _) = await self.elManager.forkchoiceUpdated(
           state, Opt.some(attributes), deadline, false
         )
-      debug "Fork-choice updated for proposal", status, headBlockHash, attributes
+      debug "Fork-choice updated for proposal", status, executionHead, attributes
     elif consensusFork in ConsensusFork.Phase0 .. ConsensusFork.Deneb:
       debug "Not producing blocks in pre-Electra fork"
     else:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -960,9 +960,6 @@ proc storePayload(
           chronos.nanoseconds((slotTime - wallTime).nanoseconds)
     deadline = sleepAsync(deadlineTime)
 
-  if not isNil(dag.onEnvelopeAvailable):
-    dag.onEnvelopeAvailable(signedEnvelope)
-
   let
     optimisticStatusRes =
       block:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -498,12 +498,6 @@ proc initFullNode(
       else:
         data
     node.eventBus.reorgQueue.emit(eventData)
-  proc onEnvelopeAdded(data: SignedExecutionPayloadEnvelope) =
-    let optimistic = node.dag.is_optimistic(BlockId(
-      root: data.message.beacon_block_root,
-      slot: data.message.slot))
-    node.eventBus.execPayloadAddedQueue.emit(
-      EventExecutionPayloadObject.init(data, optimistic))
   proc onEnvelopeGossipAdded(data: SignedExecutionPayloadEnvelope) =
     node.eventBus.execPayloadGossipAddedQueue.emit(
       EventExecutionPayloadGossipObject.init(data))
@@ -858,7 +852,6 @@ proc initFullNode(
   dag.setBlockGossipCb(onBlockGossipAdded)
   dag.setHeadCb(onHeadChanged)
   dag.setReorgCb(onChainReorg)
-  dag.setEnvelopeCb(onEnvelopeAdded)
   dag.setEnvelopeGossipCb(onEnvelopeGossipAdded)
   dag.setEnvelopeAvailableCb(onEnvelopeAvailable)
 

--- a/beacon_chain/rpc/rest_event_api.nim
+++ b/beacon_chain/rpc/rest_event_api.nim
@@ -179,10 +179,6 @@ proc installEventApiHandlers*(router: var RestRouter, node: BeaconNode) =
           let handler = response.eventHandler(node.eventBus.optUpdateQueue,
                                               "light_client_optimistic_update")
           res.add(handler)
-        if EventTopic.ExecutionPayloadAdded in eventTopics:
-          let handler = response.eventHandler(node.eventBus.execPayloadAddedQueue,
-                                              "execution_payload")
-          res.add(handler)
         if EventTopic.ExecutionPayloadGossipAdded in eventTopics:
           let handler = response.eventHandler(node.eventBus.execPayloadGossipAddedQueue,
                                               "execution_payload_gossip")

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -3317,3 +3317,14 @@ func can_builder_cover_bid*(
   if builder_balance < min_balance:
     return false
   builder_balance - min_balance >= bid_amount
+
+func proposalExecutionHead*(
+    state: gloas.BeaconState | heze.BeaconState): Eth2Digest =
+  debugGloasComment "this empirically matches a current testnet gloas provider behavior"
+  # `latest_execution_payload_bid` is empty until the first Gloas block's
+  # processed; for a Gloas genesis chain, a genesis state generator seeds
+  # `latest_block_hash` with the EL genesis block hash.
+  if state.latest_execution_payload_bid.block_hash.isZero():
+    state.latest_block_hash
+  else:
+    state.latest_execution_payload_bid.block_hash

--- a/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_json_serialization.nim
@@ -89,7 +89,6 @@ RestJson.useDefaultSerializationFor(
   EventBeaconBlockGossipObject,
   EventBeaconBlockGossipPeerObject,
   ExecutionPayloadEnvelope,
-  EventExecutionPayloadObject,
   EventExecutionPayloadGossipObject,
   EventExecutionPayloadAvailableObject,
   ExecutionRequests,

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -1070,8 +1070,6 @@ func decodeString*(t: typedesc[EventTopic],
     ok(EventTopic.LightClientFinalityUpdate)
   of "light_client_optimistic_update":
     ok(EventTopic.LightClientOptimisticUpdate)
-  of "execution_payload":
-    ok(EventTopic.ExecutionPayloadAdded)
   of "execution_payload_gossip":
     ok(EventTopic.ExecutionPayloadGossipAdded)
   of "execution_payload_available":
@@ -1115,8 +1113,6 @@ func encodeString*(value: set[EventTopic]): Result[string, cstring] =
     res.add("light_client_finality_update,")
   if EventTopic.LightClientOptimisticUpdate in value:
     res.add("light_client_optimistic_update,")
-  if EventTopic.ExecutionPayloadAdded in value:
-    res.add("execution_payload,")
   if EventTopic.ExecutionPayloadGossipAdded in value:
     res.add("execution_payload_gossip,")
   if EventTopic.ExecutionPayloadAvailable in value:

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -60,7 +60,7 @@ type
     ProposerSlashing, AttesterSlashing, BlobSidecar, DataColumnSidecar,
     SingleAttestation, FinalizedCheckpoint, ChainReorg, ContributionAndProof,
     LightClientFinalityUpdate, LightClientOptimisticUpdate,
-    ExecutionPayloadAdded, ExecutionPayloadGossipAdded,
+    ExecutionPayloadGossipAdded,
     ExecutionPayloadAvailable, ExecutionPayloadBid, PayloadAttestationMessage
 
 

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -611,6 +611,10 @@ proc proposeBlockAux(
 
   when consensusFork >= ConsensusFork.Gloas:
     debugGloasComment("check if slot/slot_number is set properly in eps")
+    # The envelope is published immediately after the block. Peers may receive
+    # this envelope before they have validated the block. Per the p2p-interface
+    # spec the block_root-not-seen case is `[IGNORE]` and client MAY queue, but
+    # is not required to.
     let envelope = makeExecutionPayloadEnvelope(
       engineBid[].eps,
       engineBid[].execution_requests,
@@ -1010,7 +1014,7 @@ proc sendProposerPreferences(
 
           let signed = SignedProposerPreferences(
             message: data, signature: signatureRes.get)
-          
+
           await node.router.routeProposerPreferences(signed)
 
 proc handleProposal(node: BeaconNode, head: BlockRef, slot: Slot):

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -362,14 +362,7 @@ proc getExecutionPayload*(
     beaconHead = node.attestationPool[].getBeaconHead(head)
     executionHead =
       when consensusFork >= ConsensusFork.Gloas:
-        debugGloasComment "this empirically matches a current testnet gloas provider behavior"
-        # `latest_execution_payload_bid` is empty until the first Gloas block's
-        # processed; for a Gloas genesis chain, a genesis state generator seeds
-        # `latest_block_hash` with the EL genesis block hash.
-        if forkyState.data.latest_execution_payload_bid.block_hash.isZero():
-          forkyState.data.latest_block_hash
-        else:
-          forkyState.data.latest_execution_payload_bid.block_hash
+        proposalExecutionHead(forkyState.data)
       elif consensusFork >= ConsensusFork.Bellatrix:
         forkyState.data.latest_execution_payload_header.block_hash
       else:


### PR DESCRIPTION
For the proposal head at genesis, even though
- https://github.com/ethereum/consensus-specs/pull/5067

states
```python
        state.latest_block_hash = spec.Hash32()
        empty_requests_root = spec.hash_tree_root(spec.ExecutionRequests())
        state.latest_execution_payload_bid = spec.ExecutionPayloadBid(
            block_hash=spec.Hash32(eth1_block_hash),
```
the current generator does the opposite of this. So, work around this mismatch.

Should be removed when the generator is fixed.

According to https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.1/apis/eventstream/index.yaml `execution_payload_available` and `execution_payload_bid` exist but plain `execution_payload` does not.