### PR TITLE
Fix Gloas data column quarantine crash on non-custody columns

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -14,7 +14,7 @@ import
   kzg4844/kzg,
   ssz_serialization/types,
   ../el/el_manager,
-  ../spec/[helpers, forks],
+  ../spec/[column_map, helpers, forks],
   ../consensus_object_pools/[
     attestation_pool, blob_quarantine, block_clearance, block_quarantine,
     blockchain_dag, envelope_quarantine, execution_payload_pool,
@@ -500,9 +500,10 @@ proc processDataColumnSidecar*(
     return v
 
   debug "Data column validated"
-  self.gloasColumnQuarantine[].put(
-    dataColumnSidecar.beacon_block_root, newClone(dataColumnSidecar))
-  self.blockProcessor.enqueuePayload(dataColumnSidecar.beacon_block_root)
+  if dataColumnSidecar.index in self.gloasColumnQuarantine[].custodyMap:
+    self.gloasColumnQuarantine[].put(
+      dataColumnSidecar.beacon_block_root, newClone(dataColumnSidecar))
+    self.blockProcessor.enqueuePayload(dataColumnSidecar.beacon_block_root)
 
   data_column_sidecars_received.inc()
   v

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -454,6 +454,11 @@ proc processDataColumnSidecar*(
   let block_root = hash_tree_root(block_header)
 
   debug "Data column validated, putting data column in quarantine"
+  if dataColumnSidecar.index notin self.dataColumnQuarantine[].custodyMap:
+    data_column_sidecars_received.inc()
+    data_column_sidecar_delay.observe(delay.toFloatSeconds())
+    return v
+
   self.dataColumnQuarantine[].put(block_root, newClone(dataColumnSidecar))
 
   if block_root in self.quarantine[].sidecarless:
@@ -500,10 +505,13 @@ proc processDataColumnSidecar*(
     return v
 
   debug "Data column validated"
-  if dataColumnSidecar.index in self.gloasColumnQuarantine[].custodyMap:
-    self.gloasColumnQuarantine[].put(
-      dataColumnSidecar.beacon_block_root, newClone(dataColumnSidecar))
-    self.blockProcessor.enqueuePayload(dataColumnSidecar.beacon_block_root)
+  if dataColumnSidecar.index notin self.gloasColumnQuarantine[].custodyMap:
+    data_column_sidecars_received.inc()
+    return v
+
+  self.gloasColumnQuarantine[].put(
+    dataColumnSidecar.beacon_block_root, newClone(dataColumnSidecar))
+  self.blockProcessor.enqueuePayload(dataColumnSidecar.beacon_block_root)
 
   data_column_sidecars_received.inc()
   v

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1358,8 +1358,12 @@ proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
     node.network.subscribe(topic, basicParams())
     custody.add(i)
 
-  # Due to dynamic column changes, we need to maintain the set of columns we
-  # subscribe to, as the column set may change.
+  # Unsubscribe from custody groups we no longer have custody of.
+  for i in node.lastColumnCustodyIndices:
+    if i notin custody:
+      let topic = getDataColumnSidecarTopic(forkDigest, i)
+      node.network.unsubscribe(topic)
+
   node.lastColumnCustodyIndices = custody
 
 proc addAltairMessageHandlers(
@@ -1729,11 +1733,9 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   node.gossipState = targetGossipState
 
   # Validator custody can change in the middle of a fork/BPO interval; need to
-  # subscribe to potentially new column topics. Do this after node.gossipState
-  # is updated to avoid adding immediately unsubscribed subscriptions. Custody
-  # can only grow in a node's lifetime, so only address additive case. It can,
-  # therefore, overlap existing subscriptions, rather than separately tracking
-  # them.
+  # subscribe to potentially new column topics and unsubscribe from stale ones.
+  # Do this after node.gossipState is updated to avoid adding immediately
+  # unsubscribed subscriptions.
   for gossipEpoch in node.gossipState:
     if node.dag.cfg.consensusForkAtEpoch(gossipEpoch) >= ConsensusFork.Fulu:
       node.updateDataColumnSidecarHandlers(gossipEpoch)


### PR DESCRIPTION
Adds a custody check before putting a data column sidecar into the quarantine. When a node receives an already gossip-validated data column for a column index it doesn't have custody of  `getIndex()` returns -1, and put() hits `doAssert(index >= 0)`. This skips non-custody columns so they are never inserted into the quarantine