### PR TITLE
gloas: pool cleanups

### DIFF
--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -51,11 +51,9 @@ proc addBid*(
 
   let slotData = addr pool.slotBids.mgetOrPut(bid.slot, default(SlotBids))
 
-  if bid.builder_index in slotData.seenBuilders:
+  if slotData.seenBuilders.containsOrIncl(bid.builder_index):
     debug "Duplicate bid from builder, ignoring"
     return
-
-  slotData.seenBuilders.incl(bid.builder_index)
 
   let currentBid = slotData.highestBids.getOrDefault(bid.parent_block_hash)
   if currentBid != static(default(gloas.SignedExecutionPayloadBid)):

--- a/beacon_chain/consensus_object_pools/payload_attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/payload_attestation_pool.nim
@@ -50,6 +50,20 @@ func pruneOldEntries(pool: var PayloadAttestationPool, wallTime: BeaconTime) =
   for slot in slotsToRemove:
     pool.attestations.del(slot)
 
+func isSeen*(
+    pool: var PayloadAttestationPool, message: PayloadAttestationMessage
+): bool =
+  pool.attestations.withValue(message.data.slot, slotEntries):
+    let key = (
+      message.data.beacon_block_root, message.data.payload_present,
+      message.data.blob_data_available,
+    )
+
+    slotEntries[].withValue(key, entry):
+      return message.validator_index in entry[].messages
+
+  false
+
 func addPayloadAttestation*(
     pool: var PayloadAttestationPool, message: PayloadAttestationMessage,
     wallTime: BeaconTime): bool =

--- a/beacon_chain/consensus_object_pools/payload_attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/payload_attestation_pool.nim
@@ -20,13 +20,13 @@ from ../spec/beaconstate import get_ptc
 
 logScope: topics = "payattpool"
 
-declareGauge payload_attestation_pool_block_packing_time,
-  "Time it took to create list of payload attestations for block"
+declareCounter payload_attestation_pool_block_packing_secs,
+  "Total amount of time pent packing payload attestations"
 
 type
   PayloadAttestationEntry* = object
     data*: PayloadAttestationData
-    messages*: Table[ValidatorIndex, PayloadAttestationMessage]
+    messages*: Table[uint64, PayloadAttestationMessage]
     aggregated*: Opt[PayloadAttestation]
 
   PayloadAttestationPool* = object
@@ -70,11 +70,8 @@ func addPayloadAttestation*(
       key, PayloadAttestationEntry(data: message.data))
 
   # Check for duplicate
-  let vidx = ValidatorIndex(validator_index)
-  if vidx in entry[].messages:
+  if entry[].messages.hasKeyOrPut(validator_index, message):
     return false
-
-  entry[].messages[vidx] = message
 
   entry[].aggregated = Opt.none(PayloadAttestation)
 
@@ -94,7 +91,7 @@ func aggregateMessages(
         ptc_index = 0
 
       for ptc_validator_index in get_ptc(forkyState.data, slot):
-        entry.messages.withValue(ptc_validator_index, message):
+        entry.messages.withValue(uint64 ptc_validator_index, message):
           let cookedSig = message[].signature.load().valueOr:
             continue
           aggregation_bits[ptc_index] = true
@@ -134,8 +131,6 @@ proc getPayloadAttestationsForBlock*(
     parent_block_root: Eth2Digest
 ): seq[PayloadAttestation] =
   ## Get payload attestations to include in a block for a target slot
-  let startPackingTick = Moment.now()
-
   if target_slot == 0:
     return @[]
 
@@ -143,6 +138,8 @@ proc getPayloadAttestationsForBlock*(
 
   if attestation_slot notin pool.attestations:
     return @[]
+
+  let startPackingTick = Moment.now()
 
   var
     payload_attestations: seq[PayloadAttestation]
@@ -172,6 +169,6 @@ proc getPayloadAttestationsForBlock*(
     packingDur = packingDur, totalCandidates = totalCandidates,
     payload_attestations = payload_attestations.len()
 
-  payload_attestation_pool_block_packing_time.set(packingDur.toFloatSeconds())
+  payload_attestation_pool_block_packing_secs.inc(packingDur.toFloatSeconds())
 
   payload_attestations

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2146,14 +2146,8 @@ proc validatePayloadAttestationMessage*(
 
   # [IGNORE] The `payload_attestaion_message`is the first valid message
   # received from the validator with index `paylod_attestation_message.validator_index`.
-  let entry = payloadAttestationPool[].attestations
-                .getOrDefault(data.slot)
-                .getOrDefault((data.beacon_block_root,
-                  data.payload_present, data.blob_data_available))
-
-  if ValidatorIndex(payload_attestation_message.validator_index) in
-      entry.messages:
-    return errIgnore("PayloadAttestaionMessage: duplicate message from validator")
+  if payloadAttestationPool[].isSeen(payload_attestation_message):
+    return errIgnore("PayloadAttestationMessage: duplicate message from validator")
 
   # [IGNORE] The message's block `data.beacon_block_root` has been seen (via
   # gossip or non-gossip sources)

--- a/tests/test_payload_attestation_pool.nim
+++ b/tests/test_payload_attestation_pool.nim
@@ -107,7 +107,9 @@ suite "Payload attestation pool" & preset():
           message = makePayloadAttestationMessage(
             forkyState, beacon_block_root, ptc_member, privkey, cache)
 
+        check not pool[].isSeen(message)
         check pool[].addPayloadAttestation(message, wallTime)
+        check pool[].isSeen(message)
 
         # Should not be able to add the same attestation twice
         check not pool[].addPayloadAttestation(message, wallTime)


### PR DESCRIPTION
* prefer `uint64` in pool table (converting vidx to `uint64` is safer than the other way around)
* avoid some redundant table lookups
* use a counter for cumulative packing time (else the time keeps getting overwritten)