### PR TITLE
Update light client Gloas proof constants

### DIFF
--- a/beacon_chain/spec/datatypes/gloas.nim
+++ b/beacon_chain/spec/datatypes/gloas.nim
@@ -690,13 +690,13 @@ template builder_index*(
   v.message.builder_index
 
 const
-  LATEST_BLOCK_HASH_GINDEX* = get_generalized_index(
+  EXECUTION_BLOCK_HASH_GINDEX* = get_generalized_index(
     capella.BeaconBlockBody, "execution_payload", "block_hash")
-  LATEST_BLOCK_HASH_GINDEX_DENEB* = get_generalized_index(
+  EXECUTION_BLOCK_HASH_GINDEX_DENEB* = get_generalized_index(
     deneb.BeaconBlockBody, "execution_payload", "block_hash")
-  LATEST_BLOCK_HASH_GINDEX_GLOAS* = get_generalized_index(
-    BeaconState, "latest_block_hash")
+  EXECUTION_BLOCK_HASH_GINDEX_GLOAS* = get_generalized_index(BeaconBlockBody,
+    "signed_execution_payload_bid", "message", "parent_block_hash")
 static:
-  doAssert LATEST_BLOCK_HASH_GINDEX == 412.GeneralizedIndex
-  doAssert LATEST_BLOCK_HASH_GINDEX_DENEB == 812.GeneralizedIndex
-  doAssert LATEST_BLOCK_HASH_GINDEX_GLOAS == 88.GeneralizedIndex
+  doAssert EXECUTION_BLOCK_HASH_GINDEX == 412.GeneralizedIndex
+  doAssert EXECUTION_BLOCK_HASH_GINDEX_DENEB == 812.GeneralizedIndex
+  doAssert EXECUTION_BLOCK_HASH_GINDEX_GLOAS == 832.GeneralizedIndex

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -1715,16 +1715,16 @@ static:
 
         when lcDataFork >= LightClientDataFork.Capella:
           when consensusFork >= ConsensusFork.Gloas:
-            check LATEST_BLOCK_HASH_GINDEX_GLOAS,
-              BeaconState, "latest_block_hash"
+            check EXECUTION_BLOCK_HASH_GINDEX_GLOAS, BeaconBlockBody,
+              "signed_execution_payload_bid", "message", "parent_block_hash"
           else:
             check EXECUTION_PAYLOAD_GINDEX,
               BeaconBlockBody, "execution_payload"
             const latest_block_hash_gindex =
               when consensusFork >= ConsensusFork.Deneb:
-                LATEST_BLOCK_HASH_GINDEX_DENEB
+                EXECUTION_BLOCK_HASH_GINDEX_DENEB
               else:
-                LATEST_BLOCK_HASH_GINDEX
+                EXECUTION_BLOCK_HASH_GINDEX
             check latest_block_hash_gindex,
               BeaconBlockBody, "execution_payload", "block_hash"
         else:


### PR DESCRIPTION
Instead of proving `BeaconState.latest_block_hash` in Gloas, switch to `BeaconBlockBody.signed_execution_payload_bid.message.parent_block_hash.