### PR TITLE
optimize data column pruning and prune payload envelopes along blocks

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2105,8 +2105,10 @@ proc pruneBlockSlot(dag: ChainDAGRef, bs: BlockSlot) =
     dag.deleteLightClientData(bs.blck.bid)
 
     dag.forkBlocks.excl(KeyedBlockRef.init(bs.blck))
-    discard dag.db.delBlock(
-      dag.cfg.consensusForkAtEpoch(bs.blck.slot.epoch), bs.blck.root)
+    let fork = dag.cfg.consensusForkAtEpoch(bs.blck.slot.epoch)
+    discard dag.db.delBlock(fork, bs.blck.root)
+    if fork >= ConsensusFork.Gloas:
+      discard dag.db.delExecutionPayloadEnvelope(bs.blck.root)
 
 proc pruneBlocksDAG(dag: ChainDAGRef) =
   ## This prunes the block DAG
@@ -2413,6 +2415,8 @@ proc pruneHistory*(dag: ChainDAGRef, startup = false) =
           # blocks beyond that point but we have no efficient way of detecting
           # that.
           break
+        if fork >= ConsensusFork.Gloas:
+          discard dag.db.delExecutionPayloadEnvelope(bid.root)
 
         # eaSlot would be the earliest slot for which we can reliably
         # serve a block (and sidecars if it's within the DA retention window)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1766,20 +1766,17 @@ proc pruneDataColumns(node: BeaconNode, slot: Slot) =
   let dataColumnPruneEpoch = (slot.epoch -
                               node.dag.cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS - 1)
   if slot.is_epoch() and dataColumnPruneEpoch >= node.dag.cfg.FULU_FORK_EPOCH:
+    let consensusFork = node.dag.cfg.consensusForkAtEpoch(dataColumnPruneEpoch)
+    if consensusFork < ConsensusFork.Fulu:
+      return
+
     var blocks: array[SLOTS_PER_EPOCH.int, BlockId]
     var count = 0
     let startIndex = node.dag.getBlockRange(
       dataColumnPruneEpoch.start_slot, blocks.toOpenArray(0, SLOTS_PER_EPOCH - 1))
     for i in startIndex..<SLOTS_PER_EPOCH:
-      let blck = node.dag.getForkedBlock(blocks[int(i)]).valueOr: continue
-      withBlck(blck):
-        when consensusFork < ConsensusFork.Fulu: continue
-        else:
-          # Iterate the full column space rather than just the local custody
-          # set so late-arriving or reconstructed columns outside of this
-          # node's custody groups are also cleaned up.
-          count += node.db.delDataColumnSidecars(
-            consensusFork, blocks[int(i)].root)
+      count += node.db.delDataColumnSidecars(
+        consensusFork, blocks[int(i)].root)
     debug "pruned data columns", count, dataColumnPruneEpoch
 
 proc reconstructDataColumns(node: BeaconNode, slot: Slot) =

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1767,9 +1767,6 @@ proc pruneDataColumns(node: BeaconNode, slot: Slot) =
                               node.dag.cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS - 1)
   if slot.is_epoch() and dataColumnPruneEpoch >= node.dag.cfg.FULU_FORK_EPOCH:
     let consensusFork = node.dag.cfg.consensusForkAtEpoch(dataColumnPruneEpoch)
-    if consensusFork < ConsensusFork.Fulu:
-      return
-
     var blocks: array[SLOTS_PER_EPOCH.int, BlockId]
     var count = 0
     let startIndex = node.dag.getBlockRange(

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1769,8 +1769,7 @@ proc pruneDataColumns(node: BeaconNode, slot: Slot) =
     let consensusFork = node.dag.cfg.consensusForkAtEpoch(dataColumnPruneEpoch)
     var blocks: array[SLOTS_PER_EPOCH.int, BlockId]
     var count = 0
-    let startIndex = node.dag.getBlockRange(
-      dataColumnPruneEpoch.start_slot, blocks.toOpenArray(0, SLOTS_PER_EPOCH - 1))
+    let startIndex = node.dag.getBlockRange(dataColumnPruneEpoch.start_slot, blocks)
     for i in startIndex..<SLOTS_PER_EPOCH:
       # Iterate the full column space rather than just the local custody
       # set so late-arriving or reconstructed columns outside of this

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1775,6 +1775,9 @@ proc pruneDataColumns(node: BeaconNode, slot: Slot) =
     let startIndex = node.dag.getBlockRange(
       dataColumnPruneEpoch.start_slot, blocks.toOpenArray(0, SLOTS_PER_EPOCH - 1))
     for i in startIndex..<SLOTS_PER_EPOCH:
+      # Iterate the full column space rather than just the local custody
+      # set so late-arriving or reconstructed columns outside of this
+      # node's custody groups are also cleaned up.
       count += node.db.delDataColumnSidecars(
         consensusFork, blocks[int(i)].root)
     debug "pruned data columns", count, dataColumnPruneEpoch


### PR DESCRIPTION
Instead of loading every block from disk in a loop just to get the consensus fork using `getForkedBlock`,  compute it once with consensusForkAtEpoch and pass it directly to `delDataColumnSidecars`.
 
When pruning post Gloas blocks also delete its executionpayload envelope if present 