### PR TITLE
gloas: reduce envelope root request size

### DIFF
--- a/beacon_chain/spec/datatypes/constants.nim
+++ b/beacon_chain/spec/datatypes/constants.nim
@@ -80,7 +80,7 @@ const
   MAX_PAYLOAD_SIZE* = 10'u64 * 1024 * 1024 # bytes
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/deneb/p2p-interface.md#configuration
-  MAX_REQUEST_BLOCKS_DENEB*: uint64 = 128 # TODO Make use of in request code
+  MAX_REQUEST_BLOCKS_DENEB*: uint64 = 128
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#misc
   UNSET_DEPOSIT_REQUESTS_START_INDEX*: uint64 = not 0'u64
@@ -104,3 +104,6 @@ const
 
   # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#index-flags
   BUILDER_INDEX_FLAG* = 1'u64 shl 40
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.6/specs/gloas/p2p-interface.md#configuration
+  MAX_REQUEST_PAYLOADS* = 128

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -27,9 +27,12 @@ logScope:
   topics = "requman"
 
 const
-  SYNC_MAX_REQUESTED_BLOCKS = 32 # Spec allows up to MAX_REQUEST_BLOCKS.
+  SYNC_MAX_REQUESTED_BLOCKS = 32 # Spec allows up to MAX_REQUEST_BLOCKS_DENEB.
     ## Maximum number of blocks which will be requested in each
     ## `beaconBlocksByRoot` invocation.
+  SYNC_MAX_REQUESTED_PAYLOADS = 32 # Spec allows up to MAX_REQUEST_PAYLOADS.
+    ## Maximum number of payloads which will be requested in each
+    ## `executionPayloadEnvelopesByRoot` invocation.
   PARALLEL_REQUESTS = 2
     ## Number of peers we're using to resolve our request.
 
@@ -292,7 +295,7 @@ proc fetchEnvelopesFromNetwork(self: RequestManager, roots: seq[Eth2Digest])
 
   try:
     let envelopes = await executionPayloadEnvelopesByRoot(
-      peer, BlockRootsList roots)
+      peer, BlockRootsList roots, maxResponseItems = roots.len)
 
     if envelopes.isOk:
       let uenvelopes = envelopes.get().asSeq()
@@ -613,13 +616,18 @@ proc requestManagerEnvelopeLoop(self: RequestManager)
 
     var blockRoots: seq[Eth2Digest]
     if self.envelopeLoader == nil:
-      assign(blockRoots, missingBlockRoots)
+      assign(
+        blockRoots,
+        missingBlockRoots[0 ..< min(missingBlockRoots.len, SYNC_MAX_REQUESTED_PAYLOADS)],
+      )
     else:
       var verifiers:
         seq[Future[Result[void, VerifierError]].Raising([CancelledError])]
       for blockRoot in missingBlockRoots:
         let envelope = self.envelopeLoader(blockRoot).valueOr:
           blockRoots.add blockRoot
+          if blockRoots.len >= SYNC_MAX_REQUESTED_PAYLOADS:
+            break
           continue
         debug "Loaded orphaned envelope from storage", blockRoot
         verifiers.add self.envelopeVerifier(envelope.asSigned())

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -92,7 +92,7 @@ type
     slots*: uint64
 
   BeaconBlocksRes =
-    NetRes[List[ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS]]
+    NetRes[List[ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS_DENEB]]
   BlobSidecarsRes =
     NetRes[List[ref BlobSidecar, Limit(MAX_SUPPORTED_REQUEST_BLOB_SIDECARS)]]
 

--- a/beacon_chain/sync/sync_protocol.nim
+++ b/beacon_chain/sync/sync_protocol.nim
@@ -38,7 +38,7 @@ type
     blockRoot: Eth2Digest
     slot: Slot
 
-  BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS]
+  BlockRootsList* = List[Eth2Digest, Limit MAX_REQUEST_BLOCKS_DENEB]
   BlobIdentifierList* = List[
     BlobIdentifier, Limit MAX_SUPPORTED_REQUEST_BLOB_SIDECARS]
   DataColumnIdentifierList* = List[
@@ -252,7 +252,7 @@ p2pProtocol BeaconSync(version = 1,
       reqCount: uint64,
       reqStep: uint64,
       response: MultipleChunksResponse[
-        ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS])
+        ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS_DENEB])
       {.async, libp2pProtocol("beacon_blocks_by_range", 2).} =
     # TODO Semantically, this request should return a non-ref, but doing so
     #      runs into extreme inefficiency due to the compiler introducing
@@ -273,7 +273,7 @@ p2pProtocol BeaconSync(version = 1,
     if reqCount == 0:
       raise newException(InvalidInputsError, "Empty range requested")
 
-    var blocks: array[MAX_REQUEST_BLOCKS.int, BlockId]
+    var blocks: array[MAX_REQUEST_BLOCKS_DENEB.int, BlockId]
     let dag = peer.networkState.dag
     if startSlot < dag.backfill.slot:
       # Peers that are unable to reply to block requests within the
@@ -321,10 +321,10 @@ p2pProtocol BeaconSync(version = 1,
   proc beaconBlocksByRoot_v2(
       peer: Peer,
       # Please note that the SSZ list here ensures that the
-      # spec constant MAX_REQUEST_BLOCKS is enforced:
+      # spec constant MAX_REQUEST_BLOCKS_DENEB is enforced:
       blockRoots: BlockRootsList,
       response: MultipleChunksResponse[
-        ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS])
+        ref ForkedSignedBeaconBlock, Limit MAX_REQUEST_BLOCKS_DENEB])
       {.async, libp2pProtocol("beacon_blocks_by_root", 2).} =
     # TODO Semantically, this request should return a non-ref, but doing so
     #      runs into extreme inefficiency due to the compiler introducing
@@ -379,13 +379,13 @@ p2pProtocol BeaconSync(version = 1,
       startSlot: Slot,
       reqCount: uint64,
       response: MultipleChunksResponse[
-        ref gloas.SignedExecutionPayloadEnvelope, Limit MAX_REQUEST_BLOCKS])
+        ref gloas.SignedExecutionPayloadEnvelope, Limit MAX_REQUEST_BLOCKS_DENEB])
       {.async, libp2pProtocol("execution_payload_envelopes_by_range", 1).} =
 
     if reqCount == 0:
       raise newException(InvalidInputsError, "Empty range requested")
 
-    var blocks: array[MAX_REQUEST_BLOCKS.int, BlockId]
+    var blocks: array[MAX_REQUEST_BLOCKS_DENEB.int, BlockId]
     let dag = peer.networkState.dag
     if startSlot < dag.backfill.slot:
       # Peers that are unable to reply to block requests within the
@@ -435,7 +435,7 @@ p2pProtocol BeaconSync(version = 1,
       peer: Peer,
       blockRoots: BlockRootsList,
       response: MultipleChunksResponse[
-        ref gloas.SignedExecutionPayloadEnvelope, Limit MAX_REQUEST_BLOCKS])
+        ref gloas.SignedExecutionPayloadEnvelope, Limit MAX_REQUEST_PAYLOADS])
       {.async, libp2pProtocol("execution_payload_envelopes_by_root", 1).} =
 
     if blockRoots.len == 0:


### PR DESCRIPTION
Also fixes the limit for the regular requests to
MAX_REQUEST_BLOCKS_DENEB (we were overly liberal in accepting large requests)