### PR TITLE
Set --sync-light-client-finality=true by default in standalone LC

### DIFF
--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -113,6 +113,7 @@ type LightClientConf* = object
 
   syncLightClientFinality* {.
     desc: "Whether the light client should including finality information when syncing execution layers"
+    defaultValue: true
     name: "sync-light-client-finality" .}: bool
 
   # Execution layer


### PR DESCRIPTION
When using `nimbus_light_client`, we don't have a meaningful finalized block hash to send to the EL. Because the light client 'finalized' has lower security than the regular 'finalized' from a full node, so far we opted to send `ZERO_HASH` on `engine_forkChoiceUpdated` in this mode, with an opt-in flag to choose the finalized head from the LC data.

Change to opt-out, as sending an actual finalized head is very useful for common EL sync scenarios. Users can pick the previous behaviour by explicitly setting the flag to false.