### PR TITLE
Rename ElectraCommitteeValidatorsBits to AggregationBits

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -39,7 +39,7 @@ type
     ## eth2, a single bit is used to keep track of which signatures have been
     ## added to the aggregate meaning that only non-overlapping aggregates may
     ## be further combined.
-    aggregation_bits: ElectraCommitteeValidatorsBits
+    aggregation_bits: AggregationBits
     aggregate_signature: AggregateSignature
 
   AttestationEntry = object
@@ -252,7 +252,7 @@ proc updateCurrent(pool: var AttestationPool, wallSlot: Slot) =
 
   pool.startingSlot = newStartingSlot
 
-func oneIndex(bits: ElectraCommitteeValidatorsBits): Opt[int] =
+func oneIndex(bits: AggregationBits): Opt[int] =
   # Find the index of the set bit, iff one bit is set
   var res = Opt.none(int)
   for idx in 0..<bits.len():
@@ -290,7 +290,7 @@ func updateAggregates(entry: var AttestationEntry) =
       if entry.aggregates.len() == 0:
         # Create aggregate on first iteration..
         entry.aggregates.add Validation(
-          aggregation_bits: ElectraCommitteeValidatorsBits.init(entry.committee_len),
+          aggregation_bits: AggregationBits.init(entry.committee_len),
           aggregate_signature: AggregateSignature.init(signature),
         )
       else:
@@ -343,7 +343,7 @@ func updateAggregates(entry: var AttestationEntry) =
     # committee voted successfully
     entry.singles.reset()
 
-func covers(entry: AttestationEntry, bits: ElectraCommitteeValidatorsBits): bool =
+func covers(entry: AttestationEntry, bits: AggregationBits): bool =
   entry.aggregates.anyIt(bits.isSubsetOf(it.aggregation_bits))
 
 proc addAttestation(
@@ -492,7 +492,7 @@ proc addAttestation*(
 func covers*(
     pool: var AttestationPool,
     data: AttestationData,
-    aggregation_bits: ElectraCommitteeValidatorsBits,
+    aggregation_bits: AggregationBits,
     committee_index: CommitteeIndex,
 ): bool =
   ## Return true iff the given attestation already is fully covered by one of
@@ -550,7 +550,7 @@ iterator electraAttestations*(
         committee_bits[int(entry.index)] = true
 
         var attestation = electra.Attestation(
-          aggregation_bits: ElectraCommitteeValidatorsBits.init(entry.committee_len),
+          aggregation_bits: AggregationBits.init(entry.committee_len),
           committee_bits: committee_bits,
           data: AttestationData.init(entry),
         )
@@ -567,7 +567,7 @@ iterator electraAttestations*(
 type
   AttestationCacheKey = (Slot, uint64)
   AttestationCache =
-    Table[AttestationCacheKey, ElectraCommitteeValidatorsBits]
+    Table[AttestationCacheKey, AggregationBits]
       ## Cache for quick lookup during beacon block construction of attestations
       ## which have already been included, and therefore should be skipped.
 
@@ -578,7 +578,7 @@ func getAttestationCacheKey(entry: AttestationEntry): AttestationCacheKey =
 
 func add(
     attCache: var AttestationCache, key: AttestationCacheKey,
-    aggregation_bits: ElectraCommitteeValidatorsBits) =
+    aggregation_bits: AggregationBits) =
   attCache.withValue(key, v) do:
     v[].incl(aggregation_bits)
   do:
@@ -602,7 +602,7 @@ func init(
       for slot in epoch.slots():
         let committee_len =
           get_beacon_committee_len(state.data, slot, committee_index, cache)
-        var validator_bits = ElectraCommitteeValidatorsBits.init(committee_len.int)
+        var validator_bits = AggregationBits.init(committee_len.int)
         for index_in_committee, validator_index in get_beacon_committee(
           state.data, slot, committee_index, cache
         ):
@@ -619,7 +619,7 @@ func init(
 
 func score(
     attCache: var AttestationCache, key: AttestationCacheKey,
-    aggregation_bits: ElectraCommitteeValidatorsBits): int =
+    aggregation_bits: AggregationBits): int =
   # The score of an attestation is loosely based on how many new votes it brings
   # to the state - a more accurate score function would also look at inclusion
   # distance and effective balance.

--- a/beacon_chain/consensus_object_pools/spec_cache.nim
+++ b/beacon_chain/consensus_object_pools/spec_cache.nim
@@ -98,7 +98,7 @@ iterator get_attesting_indices*(
     shufflingRef: ShufflingRef,
     slot: Slot,
     committee_bits: AttestationCommitteeBits,
-    aggregation_bits: ElectraCommitteeValidatorsBits,
+    aggregation_bits: AggregationBits,
 ): ValidatorIndex =
   if slot.epoch == shufflingRef.epoch:
     var committee_offset = 0
@@ -118,7 +118,7 @@ func get_attesting_indices*(
     shufflingRef: ShufflingRef,
     slot: Slot,
     committee_bits: AttestationCommitteeBits,
-    aggregation_bits: ElectraCommitteeValidatorsBits,
+    aggregation_bits: AggregationBits,
 ): seq[ValidatorIndex] =
   for vidx in shufflingRef.get_attesting_indices(slot, committee_bits, aggregation_bits):
     result.add vidx

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -778,7 +778,7 @@ iterator get_attesting_indices*(
     state: ForkyBeaconState,
     slot: Slot,
     committee_bits: AttestationCommitteeBits,
-    aggregation_bits: ElectraCommitteeValidatorsBits,
+    aggregation_bits: AggregationBits,
     cache: var StateCache): ValidatorIndex =
   ## Return the set of attesting indices corresponding to ``aggregation_bits``
   ## and ``committee_bits``.

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -420,14 +420,14 @@ type
 
     root* {.dontSerialize.}: Eth2Digest # cached root of signed beacon block
 
-  ElectraCommitteeValidatorsBits* =
+  AggregationBits* =
     BitList[Limit MAX_VALIDATORS_PER_COMMITTEE * MAX_COMMITTEES_PER_SLOT]
 
   AttestationCommitteeBits* = BitArray[MAX_COMMITTEES_PER_SLOT.int]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/electra/beacon-chain.md#attestation
   Attestation* = object
-    aggregation_bits*: ElectraCommitteeValidatorsBits
+    aggregation_bits*: AggregationBits
     data*: AttestationData
     signature*: ValidatorSig
     committee_bits*: AttestationCommitteeBits  # [New in Electra:EIP7549]
@@ -436,7 +436,7 @@ type
     # The Trusted version, at the moment, implies that the cryptographic signature was checked.
     # It DOES NOT imply that the state transition was verified.
     # Currently the code MUST verify the state transition as soon as the signature is verified
-    aggregation_bits*: ElectraCommitteeValidatorsBits
+    aggregation_bits*: AggregationBits
     data*: AttestationData
     signature*: TrustedSig
     committee_bits*: AttestationCommitteeBits  # [New in Electra:EIP7549]
@@ -544,7 +544,7 @@ iterator getValidatorIndices*(
       continue
     yield validator_index
 
-func shortLog*(v: ElectraCommitteeValidatorsBits): auto =
+func shortLog*(v: AggregationBits): auto =
   $v.countOnes() & "/" & $v.len()
 
 func shortLog*(v: electra.Attestation | electra.TrustedAttestation): auto =
@@ -573,7 +573,7 @@ func init*(
   var committee_bits: AttestationCommitteeBits
   committee_bits[int(committee_index)] = true
 
-  var bits = ElectraCommitteeValidatorsBits.init(committee_len)
+  var bits = AggregationBits.init(committee_len)
   for index_in_committee in indices_in_committee:
     if index_in_committee >= committee_len.uint64: return err("Invalid index for committee")
     bits.setBit index_in_committee

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -48,7 +48,7 @@ const
       aggregation_bits: CommitteeValidatorsBits(BitSeq.init(1)))
   LowestScoreAggregatedElectraAttestation* =
     electra.Attestation(
-      aggregation_bits: ElectraCommitteeValidatorsBits(BitSeq.init(1)))
+      aggregation_bits: AggregationBits(BitSeq.init(1)))
 
 static:
   doAssert(ClientMaximumValidatorIds <= ServerMaximumValidatorIds)

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -786,7 +786,7 @@ proc compute_on_chain_aggregate*(
   prev_committee_index.reset()
 
   var
-    aggregation_bits = ElectraCommitteeValidatorsBits.init(totalLen)
+    aggregation_bits = AggregationBits.init(totalLen)
     pos = 0
     filledLen = 0
   for i, a in aggregates:

--- a/tests/test_attestation_pool.nim
+++ b/tests/test_attestation_pool.nim
@@ -766,7 +766,7 @@ suite "Attestation pool electra processing" & preset():
 
           # Create a bitfield filled with the given count per attestation,
           # exactly on the right-most part of the committee field.
-          var aggregation_bits = init(ElectraCommitteeValidatorsBits, committee.len)
+          var aggregation_bits = init(AggregationBits, committee.len)
           for v in 0 ..< committee.len * 2 div 3 + 1:
             aggregation_bits[v] = true
 

--- a/tests/test_toblindedblock.nim
+++ b/tests/test_toblindedblock.nim
@@ -58,7 +58,7 @@ template bellatrix_steps() =
   check:
     when typeof(b).kind >= ConsensusFork.Electra:
       b.message.body.attestations.add(electra.Attestation(
-        aggregation_bits: ElectraCommitteeValidatorsBits.init(1)))
+        aggregation_bits: AggregationBits.init(1)))
     else:
       b.message.body.attestations.add(phase0.Attestation(
         aggregation_bits: CommitteeValidatorsBits.init(1)))

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -601,7 +601,7 @@ func makeAttestationData*(
 func makeAttestationSig(
     fork: Fork, genesis_validators_root: Eth2Digest, data: AttestationData,
     committee: openArray[ValidatorIndex],
-    bits: CommitteeValidatorsBits | ElectraCommitteeValidatorsBits): ValidatorSig =
+    bits: CommitteeValidatorsBits | AggregationBits): ValidatorSig =
   let signing_root = compute_attestation_signing_root(
     fork, genesis_validators_root, data)
 
@@ -725,7 +725,7 @@ func makeElectraAttestation(
 
   doAssert index_in_committee != -1, "find_beacon_committee should guarantee this"
 
-  var aggregation_bits = ElectraCommitteeValidatorsBits.init(committee.len)
+  var aggregation_bits = AggregationBits.init(committee.len)
   aggregation_bits.setBit index_in_committee
 
   let sig = if skipBlsValidation in flags:
@@ -773,7 +773,7 @@ func makeFullElectraAttestations*(
 
     doAssert committee.len() >= 1
     var attestation = electra.Attestation(
-      aggregation_bits: ElectraCommitteeValidatorsBits.init(committee.len),
+      aggregation_bits: AggregationBits.init(committee.len),
       committee_bits: committee_bits,
       data: data)
     for i in 0..<committee.len:
@@ -793,7 +793,7 @@ func makeElectraIndexedAttestation*(
   let
     data = AttestationData(slot: slot, beacon_block_root: beacon_block_root)
     committee = validator_indices.mapIt(it.ValidatorIndex)
-  var bits = ElectraCommitteeValidatorsBits.init(committee.len)
+  var bits = AggregationBits.init(committee.len)
   for i in 0 ..< committee.len:
     bits.setBit i
   electra.IndexedAttestation(


### PR DESCRIPTION
Cleaner name, reflecting the field name / removing "Electra" redundancy.