### PR TITLE
catch the first column gossip addition event for getBlobs

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -58,6 +58,7 @@ type
     attSlashQueue*: AsyncEventQueue[electra.AttesterSlashing]
     blobSidecarQueue*: AsyncEventQueue[BlobSidecarInfoObject]
     columnSidecarQueue*: AsyncEventQueue[DataColumnSidecarInfoObject]
+    columnSidecarFullQueue*: AsyncEventQueue[ref fulu.DataColumnSidecar]
     finalQueue*: AsyncEventQueue[FinalizationInfoObject]
     reorgQueue*: AsyncEventQueue[ReorgInfoObject]
     contribQueue*: AsyncEventQueue[SignedContributionAndProof]
@@ -209,6 +210,8 @@ func init*(T: type EventBus): T =
       newAsyncEventQueue[BlobSidecarInfoObject](),
     columnSidecarQueue:
       newAsyncEventQueue[DataColumnSidecarInfoObject](),
+    columnSidecarFullQueue:
+      newAsyncEventQueue[ref fulu.DataColumnSidecar](),
     finalQueue:
       newAsyncEventQueue[FinalizationInfoObject](),
     reorgQueue:

--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -705,40 +705,6 @@ template onFuluDataColumnSidecarAddedCallback*[A: SomeDataColumnSidecar, B: OnDa
 ): OnFuluDataColumnSidecarAddedCallback =
   quarantine.onFuluColumnAddedCallback
 
-proc init*(
-    T: typedesc[ColumnQuarantine],
-    cfg: RuntimeConfig,
-    database: QuarantineDB,
-    maxDiskSizeMultipler: int,
-    onBlobSidecarCallback: OnBlobSidecarCallback
-): ColumnQuarantine =
-  var indexMap = newSeqUninit[int](cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
-  for index in 0 ..< len(indexMap):
-    indexMap[index] = index
-
-  let size = maxSidecars(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
-
-  blob_quarantine_memory_slots_total.set(int64(size))
-  blob_quarantine_database_slots_total.set(
-    int64(size) * int64(maxDiskSizeMultipler))
-  blob_quarantine_memory_slots_occupied.set(0'i64)
-  blob_quarantine_database_slots_occupied.set(0'i64)
-
-  ColumnQuarantine(
-    minEpochsForSidecarsRequests:
-      cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS,
-    maxSidecarsPerBlockCount:
-      int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA),
-    maxMemSidecarsCount: size,
-    maxDiskSidecarsCount: size * maxDiskSizeMultipler,
-    memSidecarsCount: 0,
-    diskSidecarsCount: 0,
-    indexMap: indexMap,
-    onSidecarCallback: onBlobSidecarCallback,
-    list: initDoublyLinkedList[RootTableRecord[BlobSidecar]](),
-    db: database
-  )
-
 proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     T: typedesc[SidecarQuarantine[A, B]],
     cfg: RuntimeConfig,

--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -66,9 +66,12 @@ type
     indexMap: seq[int]
     db: QuarantineDB
     onSidecarCallback*: B
+    onFuluColumnAddedCallback*: OnFuluDataColumnSidecarAddedCallback
 
   OnDataColumnSidecarCallback* = proc(
     data: DataColumnSidecarInfoObject) {.gcsafe, raises: [].}
+  OnFuluDataColumnSidecarAddedCallback* = proc(
+    data: ref fulu.DataColumnSidecar) {.gcsafe, raises: [].}
 
   SomeSidecarRef* = ref fulu.DataColumnSidecar | ref gloas.DataColumnSidecar
   SomeSidecarIndex* = fulu.ColumnIndex
@@ -697,19 +700,59 @@ template onDataColumnSidecarCallback*[A: SomeDataColumnSidecar, B: OnDataColumnS
 ): OnDataColumnSidecarCallback =
   quarantine.onSidecarCallback
 
+template onFuluDataColumnSidecarAddedCallback*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
+    quarantine: SidecarQuarantine[A, B]
+): OnFuluDataColumnSidecarAddedCallback =
+  quarantine.onFuluColumnAddedCallback
+
+proc init*(
+    T: typedesc[ColumnQuarantine],
+    cfg: RuntimeConfig,
+    database: QuarantineDB,
+    maxDiskSizeMultipler: int,
+    onBlobSidecarCallback: OnBlobSidecarCallback
+): ColumnQuarantine =
+  var indexMap = newSeqUninit[int](cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
+  for index in 0 ..< len(indexMap):
+    indexMap[index] = index
+
+  let size = maxSidecars(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA)
+
+  blob_quarantine_memory_slots_total.set(int64(size))
+  blob_quarantine_database_slots_total.set(
+    int64(size) * int64(maxDiskSizeMultipler))
+  blob_quarantine_memory_slots_occupied.set(0'i64)
+  blob_quarantine_database_slots_occupied.set(0'i64)
+
+  ColumnQuarantine(
+    minEpochsForSidecarsRequests:
+      cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS,
+    maxSidecarsPerBlockCount:
+      int(cfg.MAX_BLOBS_PER_BLOCK_ELECTRA),
+    maxMemSidecarsCount: size,
+    maxDiskSidecarsCount: size * maxDiskSizeMultipler,
+    memSidecarsCount: 0,
+    diskSidecarsCount: 0,
+    indexMap: indexMap,
+    onSidecarCallback: onBlobSidecarCallback,
+    list: initDoublyLinkedList[RootTableRecord[BlobSidecar]](),
+    db: database
+  )
+
 proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     T: typedesc[SidecarQuarantine[A, B]],
     cfg: RuntimeConfig,
     custodyColumns: openArray[ColumnIndex],
     database: QuarantineDB,
     maxDiskSizeMultipler: int,
-    onDataColumnSidecarCallback: OnDataColumnSidecarCallback
+    onDataColumnSidecarCallback: OnDataColumnSidecarCallback,
+    onFuluColumnAddedCallback: OnFuluDataColumnSidecarAddedCallback = nil
 ): SidecarQuarantine[A, B] =
   doAssert(len(custodyColumns) <= NUMBER_OF_COLUMNS)
   let custodyMap = ColumnMap.init(custodyColumns)
   T.init(
     cfg, custodyMap, database, maxDiskSizeMultipler,
-    onDataColumnSidecarCallback)
+    onDataColumnSidecarCallback, onFuluColumnAddedCallback)
 
 proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     T: typedesc[SidecarQuarantine[A, B]],
@@ -717,7 +760,8 @@ proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     custodyMap: ColumnMap,
     database: QuarantineDB,
     maxDiskSizeMultipler: int,
-    onDataColumnSidecarCallback: OnDataColumnSidecarCallback
+    onDataColumnSidecarCallback: OnDataColumnSidecarCallback,
+    onFuluColumnAddedCallback: OnFuluDataColumnSidecarAddedCallback = nil
 ): SidecarQuarantine[A, B] =
   var indexMap = newSeqUninit[int](NUMBER_OF_COLUMNS)
   if len(custodyMap) < NUMBER_OF_COLUMNS:
@@ -747,7 +791,8 @@ proc init*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     custodyMap: custodyMap,
     list: initDoublyLinkedList[RootTableRecord[A]](),
     db: database,
-    onSidecarCallback: onDataColumnSidecarCallback
+    onSidecarCallback: onDataColumnSidecarCallback,
+    onFuluColumnAddedCallback: onFuluColumnAddedCallback
   )
 
 proc update*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -37,6 +37,7 @@ declareGauge beacon_engine_getblobs_slot_hit_rate,
 type
   GetBlobsService* = object
     blockGossipBus*: AsyncEventQueue[EventBeaconBlockGossipPeerObject]
+    columnSidecarBus*: AsyncEventQueue[DataColumnSidecarInfoObject]
     blockProcessor*: ref BlockProcessor
     dataColumnQuarantine*: ref ColumnQuarantine
     validatorCustody*: ValidatorCustodyRef
@@ -52,12 +53,14 @@ type
 proc new*(
     t: typedesc[GetBlobsServiceRef],
     blockGossipBus: AsyncEventQueue[EventBeaconBlockGossipPeerObject],
+    columnSidecarBus: AsyncEventQueue[DataColumnSidecarInfoObject],
     blockProcessor: ref BlockProcessor,
     dataColumnQuarantine: ref ColumnQuarantine,
     validatorCustody: ValidatorCustodyRef
 ): GetBlobsServiceRef =
   GetBlobsServiceRef(
     blockGossipBus: blockGossipBus,
+    columnSidecarBus: columnSidecarBus,
     blockProcessor: blockProcessor,
     dataColumnQuarantine: dataColumnQuarantine,
     validatorCustody: validatorCustody,
@@ -151,9 +154,9 @@ proc attemptGetBlobs*(
     else:
       discard
 
-proc run*(self: GetBlobsServiceRef) {.async: (raises: []).} =
+proc consumeBlockGossip(
+    self: GetBlobsServiceRef) {.async: (raises: []).} =
   let ticket = self.blockGossipBus.register()
-  debug "Engine GetBlobs service started"
   try:
     while true:
       let events = await self.blockGossipBus.waitEvents(ticket)
@@ -165,6 +168,32 @@ proc run*(self: GetBlobsServiceRef) {.async: (raises: []).} =
             discard
   except AsyncEventQueueFullError:
     raiseAssert "Unlimited AsyncEventQueue should not raise exception"
+  except CancelledError:
+    discard
+  finally:
+    self.blockGossipBus.unregister(ticket)
+
+proc consumeColumnSidecars(
+    self: GetBlobsServiceRef) {.async: (raises: []).} =
+  let ticket = self.columnSidecarBus.register()
+  try:
+    while true:
+      let events = await self.columnSidecarBus.waitEvents(ticket)
+      for event in events:
+        await self.attemptGetBlobs(event.block_root)
+  except AsyncEventQueueFullError:
+    raiseAssert "Unlimited AsyncEventQueue should not raise exception"
+  except CancelledError:
+    discard
+  finally:
+    self.columnSidecarBus.unregister(ticket)
+
+proc run*(self: GetBlobsServiceRef) {.async: (raises: []).} =
+  debug "Engine GetBlobs service started"
+  try:
+    await allFutures(
+      self.consumeBlockGossip(),
+      self.consumeColumnSidecars())
   except CancelledError:
     discard
   debug "Engine GetBlobs service stopped"

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -8,6 +8,9 @@
 {.push raises: [], gcsafe.}
 
 import
+  # Standard library
+  std/[sequtils, sets],
+
   # Status libraries
   chronicles,
   chronos,
@@ -37,7 +40,7 @@ declareGauge beacon_engine_getblobs_slot_hit_rate,
 type
   GetBlobsService* = object
     blockGossipBus*: AsyncEventQueue[EventBeaconBlockGossipPeerObject]
-    columnSidecarBus*: AsyncEventQueue[DataColumnSidecarInfoObject]
+    columnSidecarBus*: AsyncEventQueue[ref fulu.DataColumnSidecar]
     blockProcessor*: ref BlockProcessor
     dataColumnQuarantine*: ref ColumnQuarantine
     validatorCustody*: ValidatorCustodyRef
@@ -47,13 +50,17 @@ type
     slotInFlight: Slot
     slotRequests: uint64
     slotHits: uint64
+    # Roots for which the column-first path has already invoked the EL.
+    # Bounds the per-block fan-out: each custody column arriving via gossip
+    # would otherwise trigger a redundant getBlobsV2 roundtrip.
+    columnFirstFetched: HashSet[Eth2Digest]
 
   GetBlobsServiceRef* = ref GetBlobsService
 
 proc new*(
     t: typedesc[GetBlobsServiceRef],
     blockGossipBus: AsyncEventQueue[EventBeaconBlockGossipPeerObject],
-    columnSidecarBus: AsyncEventQueue[DataColumnSidecarInfoObject],
+    columnSidecarBus: AsyncEventQueue[ref fulu.DataColumnSidecar],
     blockProcessor: ref BlockProcessor,
     dataColumnQuarantine: ref ColumnQuarantine,
     validatorCustody: ValidatorCustodyRef
@@ -101,6 +108,22 @@ proc attemptGetBlobs*(
 
   withBlck(sidecarlessBlock):
     when consensusFork == ConsensusFork.Fulu:
+      # If the column-first path already populated quarantine for this root,
+      # skip the EL fetch and enqueue with the existing columns.
+      if forkyBlck.root in self.columnFirstFetched:
+        let sidecarsOpt =
+          self.dataColumnQuarantine[].popSidecars(forkyBlck.root)
+        if sidecarsOpt.isSome():
+          if not quarantine[].removeSidecarless(forkyBlck.root):
+            return
+          debug "Added data columns from EL blobpool to quarantine",
+            root = forkyBlck.root, slot = forkyBlck.message.slot
+          self.columnFirstFetched.excl(forkyBlck.root)
+          self.blockProcessor.enqueueBlock(
+            MsgSource.gossip, forkyBlck, sidecarsOpt)
+          return
+        # Columns vanished (pruned?) — fall through to EL fetch as fallback.
+
       let blobsEl = (await elManager.getBlobsV2(forkyBlck)).valueOr:
         self.recordEngineGetBlobs(forkyBlck.message.slot, hit = false)
         return
@@ -154,6 +177,72 @@ proc attemptGetBlobs*(
     else:
       discard
 
+proc attemptGetBlobsFromColumn*(
+    self: GetBlobsServiceRef,
+    sidecar: ref fulu.DataColumnSidecar) {.async: (raises: [CancelledError]).} =
+  ## Column-first variant: invoked when a column sidecar arrives via gossip
+  ## before the block has been seen. Uses the per-column metadata
+  ## (signed_block_header, kzg_commitments, kzg_commitments_inclusion_proof)
+  ## to derive versioned hashes and reconstruct columns from EL blobs, then
+  ## stores the recovered custody columns in the quarantine. Does NOT enqueue
+  ## a block — when the block later arrives via gossip, eth2_processor will
+  ## see the columns already waiting and proceed.
+  let
+    elManager = self.blockProcessor[].consensusManager.elManager
+    quarantine = self.blockProcessor[].consensusManager.quarantine
+    block_root = hash_tree_root(sidecar[].signed_block_header.message)
+    slot = sidecar[].signed_block_header.message.slot
+
+  # Dedup: only fire EL fetch once per block_root. Subsequent column
+  # arrivals for the same block are no-ops on this path.
+  if block_root in self.columnFirstFetched:
+    return
+
+  # If the sidecarless block is already in the block quarantine, the
+  # block-first path (consumeBlockGossip → attemptGetBlobs) owns this
+  # block — leave it alone.
+  if quarantine[].getSidecarless(block_root).isSome():
+    return
+
+  let blobsEl = (await elManager.getBlobsV2(sidecar[].kzg_commitments)).valueOr:
+    self.recordEngineGetBlobs(slot, hit = false)
+    return
+  if blobsEl.len != sidecar[].kzg_commitments.len:
+    self.recordEngineGetBlobs(slot, hit = false)
+    return
+  self.recordEngineGetBlobs(slot, hit = true)
+
+  var flat_proof = newSeqOfCap[kzg.KzgProof](
+    blobsEl.len * fulu_preset.CELLS_PER_EXT_BLOB)
+  for item in blobsEl:
+    for proof in item.proofs:
+      flat_proof.add kzg.KzgProof(bytes: proof.data)
+
+  let recovered_columns = assemble_data_column_sidecars(
+    sidecar[].signed_block_header,
+    sidecar[].kzg_commitments,
+    sidecar[].kzg_commitments_inclusion_proof,
+    blobsEl.mapIt(kzg.KzgBlob(bytes: it.blob.data)),
+    flat_proof)
+
+  let custodyMap = self.validatorCustody.getMap()
+  var batch = newSeqOfCap[ref fulu.DataColumnSidecar](len(custodyMap))
+  for col in recovered_columns:
+    if col.index in custodyMap:
+      batch.add newClone(col)
+
+  if batch.len == 0:
+    return
+
+  debug "Added data columns from EL blobpool to quarantine (column-first)",
+    root = block_root,
+    slot = slot,
+    batch_len = batch.len
+  self.dataColumnQuarantine[].put(block_root, batch)
+  # Mark only after a successful put so failed attempts can be retried by
+  # subsequent column arrivals for the same root.
+  self.columnFirstFetched.incl(block_root)
+
 proc consumeBlockGossip(
     self: GetBlobsServiceRef) {.async: (raises: []).} =
   let ticket = self.blockGossipBus.register()
@@ -180,7 +269,7 @@ proc consumeColumnSidecars(
     while true:
       let events = await self.columnSidecarBus.waitEvents(ticket)
       for event in events:
-        await self.attemptGetBlobs(event.block_root)
+        await self.attemptGetBlobsFromColumn(event)
   except AsyncEventQueueFullError:
     raiseAssert "Unlimited AsyncEventQueue should not raise exception"
   except CancelledError:

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -38,7 +38,7 @@ declareGauge beacon_engine_getblobs_slot_hit_rate,
 type
   GetBlobsService* = object
     blockGossipBus*: AsyncEventQueue[EventBeaconBlockGossipPeerObject]
-    columnSidecarBus*: AsyncEventQueue[ref fulu.DataColumnSidecar]
+    fuluColumnSidecarBus*: AsyncEventQueue[ref fulu.DataColumnSidecar]
     blockProcessor*: ref BlockProcessor
     dataColumnQuarantine*: ref ColumnQuarantine
     validatorCustody*: ValidatorCustodyRef
@@ -58,14 +58,14 @@ type
 proc new*(
     t: typedesc[GetBlobsServiceRef],
     blockGossipBus: AsyncEventQueue[EventBeaconBlockGossipPeerObject],
-    columnSidecarBus: AsyncEventQueue[ref fulu.DataColumnSidecar],
+    fuluColumnSidecarBus: AsyncEventQueue[ref fulu.DataColumnSidecar],
     blockProcessor: ref BlockProcessor,
     dataColumnQuarantine: ref ColumnQuarantine,
     validatorCustody: ValidatorCustodyRef
 ): GetBlobsServiceRef =
   GetBlobsServiceRef(
     blockGossipBus: blockGossipBus,
-    columnSidecarBus: columnSidecarBus,
+    fuluColumnSidecarBus: fuluColumnSidecarBus,
     blockProcessor: blockProcessor,
     dataColumnQuarantine: dataColumnQuarantine,
     validatorCustody: validatorCustody,
@@ -262,10 +262,10 @@ proc consumeBlockGossip(
 
 proc consumeColumnSidecars(
     self: GetBlobsServiceRef) {.async: (raises: []).} =
-  let ticket = self.columnSidecarBus.register()
+  let ticket = self.fuluColumnSidecarBus.register()
   try:
     while true:
-      let events = await self.columnSidecarBus.waitEvents(ticket)
+      let events = await self.fuluColumnSidecarBus.waitEvents(ticket)
       for event in events:
         await self.attemptGetBlobsFromColumn(event)
   except AsyncEventQueueFullError:
@@ -273,7 +273,7 @@ proc consumeColumnSidecars(
   except CancelledError:
     discard
   finally:
-    self.columnSidecarBus.unregister(ticket)
+    self.fuluColumnSidecarBus.unregister(ticket)
 
 proc run*(self: GetBlobsServiceRef) {.async: (raises: []).} =
   debug "Engine GetBlobs service started"

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -197,7 +197,7 @@ proc attemptGetBlobsFromColumn*(
     return
 
   # If the sidecarless block is already in the block quarantine, the
-  # block-first path (consumeBlockGossip → attemptGetBlobs) owns this
+  # block-first path (consumeBlockGossip - attemptGetBlobs) owns this
   # block — leave it alone.
   if quarantine[].getSidecarless(block_root).isSome():
     return

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -26,8 +26,6 @@ import
   ../sync/validator_custody,
   ./el_manager
 
-from std/sequtils import mapIt
-
 declareCounter beacon_engine_getblobs_requests_total,
   "Total engine_getBlobs invocations issued by the sidecarless retrieval service"
 

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -787,6 +787,24 @@ proc getBlobsV2*(
       )
       .firstOrCancel(deadline)
 
+proc getBlobsV2*(
+    m: ELManager, kzg_commitments: KzgCommitments
+): Future[Opt[seq[BlobAndProofV2]]] {.async: (raises: [CancelledError], raw: true).} =
+  ## Variant used by the column-first sidecar retrieval path: derives
+  ## versioned hashes from `kzg_commitments` directly, without requiring the
+  ## block (which has not yet been seen via gossip).
+  mixin getBlobsV2
+
+  let deadline = sleepAsync(GETBLOBS_TIMEOUT)
+
+  m.elConnections
+    .mapIt(
+      it.getBlobsV2(
+        kzg_commitments.mapIt(kzg_commitment_to_versioned_hash(it))
+      )
+    )
+    .firstOrCancel(deadline)
+
 proc getBlobsV3*(
     m: ELManager, blck: fulu.SignedBeaconBlock
 ): Future[Opt[seq[Opt[BlobAndProofV2]]]] {.

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -782,7 +782,7 @@ proc validateDataColumnSidecar*(
       slot: data_column_sidecar.signed_block_header.message.slot,
       kzg_commitments: data_column_sidecar.kzg_commitments)
 
-  # Fire the path-2 (column-first) hook with the full sidecar so the EL
+  # Notify with the full sidecar so the EL (out of spec)
   # getBlobs service can derive header/commitments/inclusion proof when the
   # block has not yet been seen via gossip.
   let onFuluColumnAddedCallback =

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -782,6 +782,14 @@ proc validateDataColumnSidecar*(
       slot: data_column_sidecar.signed_block_header.message.slot,
       kzg_commitments: data_column_sidecar.kzg_commitments)
 
+  # Fire the path-2 (column-first) hook with the full sidecar so the EL
+  # getBlobs service can derive header/commitments/inclusion proof when the
+  # block has not yet been seen via gossip.
+  let onFuluColumnAddedCallback =
+    dataColumnQuarantine[].onFuluDataColumnSidecarAddedCallback()
+  if not(isNil(onFuluColumnAddedCallback)):
+    onFuluColumnAddedCallback newClone(data_column_sidecar)
+
   ok()
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/p2p-interface.md#data_column_sidecar_subnet_id

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -870,6 +870,7 @@ proc initFullNode(
                                           syncManager, backfiller,
                                           untrustedManager)
   node.getBlobsService = GetBlobsServiceRef.new(node.eventBus.blockGossipPeerQueue,
+                                                node.eventBus.columnSidecarQueue,
                                                 node.blockProcessor,
                                                 node.dataColumnQuarantine,
                                                 node.validatorCustody)

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -466,6 +466,8 @@ proc initFullNode(
     node.eventBus.attSlashQueue.emit(data)
   proc onColumnSidecarAdded(data: DataColumnSidecarInfoObject) =
     node.eventBus.columnSidecarQueue.emit(data)
+  proc onFuluColumnSidecarAdded(data: ref fulu.DataColumnSidecar) =
+    node.eventBus.columnSidecarFullQueue.emit(data)
   proc onBlockAdded(data: ForkedTrustedSignedBeaconBlock) =
     let optimistic =
       if node.currentSlot().epoch() >= dag.cfg.BELLATRIX_FORK_EPOCH:
@@ -586,7 +588,7 @@ proc initFullNode(
   let
     dataColumnQuarantine = newClone(ColumnQuarantine.init(
       dag.cfg, validatorCustody.getMap(), dag.db.getQuarantineDB(), 10,
-      onColumnSidecarAdded))
+      onColumnSidecarAdded, onFuluColumnSidecarAdded))
     gloasColumnQuarantine = newClone(GloasColumnQuarantine.init(
       dag.cfg, validatorCustody.getMap(), dag.db.getQuarantineDB(), 10,
       onColumnSidecarAdded))
@@ -870,7 +872,7 @@ proc initFullNode(
                                           syncManager, backfiller,
                                           untrustedManager)
   node.getBlobsService = GetBlobsServiceRef.new(node.eventBus.blockGossipPeerQueue,
-                                                node.eventBus.columnSidecarQueue,
+                                                node.eventBus.columnSidecarFullQueue,
                                                 node.blockProcessor,
                                                 node.dataColumnQuarantine,
                                                 node.validatorCustody)

--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -322,6 +322,54 @@ proc recover_cells_and_proofs_parallel*(
   ok(res)
 
 proc assemble_data_column_sidecars*(
+    signed_block_header: SignedBeaconBlockHeader,
+    kzg_commitments: KzgCommitments,
+    kzg_commitments_inclusion_proof:
+      array[KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH, Eth2Digest],
+    blobs: seq[KzgBlob],
+    cell_proofs: seq[KzgProof]): seq[fulu.DataColumnSidecar] =
+  ## Variant used by the column-first sidecar retrieval path: assembles
+  ## column sidecars from the per-block constants carried by an existing
+  ## column sidecar (header, commitments, inclusion proof) plus blobs and
+  ## cell proofs recovered from the EL. The block itself is not required.
+  var sidecars = newSeqOfCap[fulu.DataColumnSidecar](CELLS_PER_EXT_BLOB)
+
+  if kzg_commitments.len == 0 or blobs.len == 0:
+    return sidecars
+  if blobs.len != kzg_commitments.len:
+    return sidecars
+  if cell_proofs.len != blobs.len * CELLS_PER_EXT_BLOB:
+    return sidecars
+
+  var
+    cells = newSeq[CellBytes](blobs.len)
+    proofs = newSeq[ProofBytes](blobs.len)
+
+  for i in 0 ..< blobs.len:
+    cells[i] = computeCells(blobs[i]).get
+    let proofElem = addr proofs[i]
+    staticFor j, 0 ..< CELLS_PER_EXT_BLOB:
+      assign(proofElem[][j], cell_proofs[i * CELLS_PER_EXT_BLOB + j])
+
+  for columnIndex in 0 ..< CELLS_PER_EXT_BLOB:
+    var
+      column = newSeqOfCap[KzgCell](blobs.len)
+      kzgProofOfColumn = newSeqOfCap[KzgProof](blobs.len)
+    for rowIndex in 0 ..< blobs.len:
+      column.add(cells[rowIndex][columnIndex])
+      kzgProofOfColumn.add(proofs[rowIndex][columnIndex])
+
+    sidecars.add fulu.DataColumnSidecar(
+      index: ColumnIndex(columnIndex),
+      column: DataColumn.init(column),
+      kzg_commitments: kzg_commitments,
+      kzg_proofs: deneb.KzgProofs.init(kzgProofOfColumn),
+      signed_block_header: signed_block_header,
+      kzg_commitments_inclusion_proof: kzg_commitments_inclusion_proof)
+
+  sidecars
+
+proc assemble_data_column_sidecars*(
     signed_beacon_block: fulu.SignedBeaconBlock,
     blobs: seq[KzgBlob], cell_proofs: seq[KzgProof]): seq[fulu.DataColumnSidecar] =
   template blck(): auto = signed_beacon_block.message


### PR DESCRIPTION
improves overall getBlobs efficiency even if the first column sidecar arrives before the designated block
