### PR TITLE
Move Altair EpochParticipationFlags from Base to Altair

### DIFF
--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -128,6 +128,12 @@ type
 
   ### Modified/overloaded
 
+  EpochParticipationFlags* =
+    distinct List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
+    ## Not a HashList because the list sees significant updates every block
+    ## effectively making the cost of clearing the cache higher than the typical
+    ## gains
+
   InactivityScores* = HashList[uint64, Limit VALIDATOR_REGISTRY_LIMIT]
 
   # https://github.com/ethereum/consensus-specs/blob/v1.4.0/specs/altair/beacon-chain.md#beaconstate
@@ -397,6 +403,54 @@ type
 
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
+
+template asList*(epochFlags: EpochParticipationFlags): untyped =
+  List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
+template asList*(epochFlags: var EpochParticipationFlags): untyped =
+  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr epochFlags)
+  tmp[]
+
+template asSeq*(epochFlags: EpochParticipationFlags): untyped =
+  seq[ParticipationFlags] asList(epochFlags)
+
+template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
+  let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
+  tmp[]
+
+template item*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex): ParticipationFlags =
+  asList(epochFlags)[idx]
+
+template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
+  asList(epochFlags)[idx]
+
+template `[]=`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex, flags: ParticipationFlags) =
+  asList(epochFlags)[idx] = flags
+
+template add*(epochFlags: var EpochParticipationFlags, flags: ParticipationFlags): bool =
+  asList(epochFlags).add flags
+
+template len*(epochFlags: EpochParticipationFlags): int =
+  asList(epochFlags).len
+
+template low*(epochFlags: EpochParticipationFlags): int =
+  asSeq(epochFlags).low
+template high*(epochFlags: EpochParticipationFlags): int =
+  asSeq(epochFlags).high
+
+template assign*(v: var EpochParticipationFlags, src: EpochParticipationFlags) =
+  # TODO https://github.com/nim-lang/Nim/issues/21123
+  mixin assign
+  var tmp = cast[ptr seq[ParticipationFlags]](addr v)
+  assign(tmp[], distinctBase src)
+
+template toSszType*(v: EpochParticipationFlags): auto = asList v
+
+func fromSszBytes*(
+    T: type EpochParticipationFlags, bytes: openArray[byte]
+): T {.raises: [SszError].} =
+  # TODO https://github.com/nim-lang/Nim/issues/21123
+  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr result)
+  readSszValue(bytes, tmp[])
 
 template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
   a[i.asInt]

--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -221,12 +221,6 @@ type
   # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/specs/altair/beacon-chain.md#custom-types
   ParticipationFlags* = uint8
 
-  EpochParticipationFlags* =
-    distinct List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]
-    ## Not a HashList because the list sees significant updates every block
-    ## effectively making the cost of clearing the cache higher than the typical
-    ## gains
-
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/phase0/beacon-chain.md#proposerslashing
   ProposerSlashing* = object
     signed_header_1*: SignedBeaconBlockHeader
@@ -703,45 +697,6 @@ iterator vindices*(
 
 template `==`*(x, y: JustificationBits): bool =
   distinctBase(x) == distinctBase(y)
-
-template asList*(epochFlags: EpochParticipationFlags): untyped =
-  List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
-template asList*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr epochFlags)
-  tmp[]
-
-template asSeq*(epochFlags: EpochParticipationFlags): untyped =
-  seq[ParticipationFlags] asList(epochFlags)
-
-template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
-  tmp[]
-
-template item*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex): ParticipationFlags =
-  asList(epochFlags)[idx]
-
-template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
-  asList(epochFlags)[idx]
-
-template `[]=`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex, flags: ParticipationFlags) =
-  asList(epochFlags)[idx] = flags
-
-template add*(epochFlags: var EpochParticipationFlags, flags: ParticipationFlags): bool =
-  asList(epochFlags).add flags
-
-template len*(epochFlags: EpochParticipationFlags): int =
-  asList(epochFlags).len
-
-template low*(epochFlags: EpochParticipationFlags): int =
-  asSeq(epochFlags).low
-template high*(epochFlags: EpochParticipationFlags): int =
-  asSeq(epochFlags).high
-
-template assign*(v: var EpochParticipationFlags, src: EpochParticipationFlags) =
-  # TODO https://github.com/nim-lang/Nim/issues/21123
-  mixin assign
-  var tmp = cast[ptr seq[ParticipationFlags]](addr v)
-  assign(tmp[], distinctBase src)
 
 func `as`*(d: DepositData, T: type DepositMessage): T =
   T(pubkey: d.pubkey,

--- a/beacon_chain/spec/ssz_codec.nim
+++ b/beacon_chain/spec/ssz_codec.nim
@@ -22,7 +22,6 @@ template toSszType*(v: BlsCurveType): auto = toRaw(v)
 template toSszType*(v: ForkDigest|GraffitiBytes): auto = distinctBase(v)
 template toSszType*(v: Version): auto = distinctBase(v)
 template toSszType*(v: JustificationBits): auto = distinctBase(v)
-template toSszType*(v: EpochParticipationFlags): auto = asList v
 template toSszType*(v: Eth1Address): auto = v.data()
 
 func fromSszBytes*(
@@ -61,13 +60,6 @@ func fromSszBytes*(
   if bytes.len != sizeof(result):
     raiseIncorrectSize T
   copyMem(result.addr, unsafeAddr bytes[0], sizeof(result))
-
-func fromSszBytes*(
-    T: type EpochParticipationFlags, bytes: openArray[byte]
-): T {.raises: [SszError].} =
-  # TODO https://github.com/nim-lang/Nim/issues/21123
-  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr result)
-  readSszValue(bytes, tmp[])
 
 func fromSszBytes*(
     T: type Eth1Address, bytes: openArray[byte]): T {.raises: [SszError].} =


### PR DESCRIPTION
Preparation for potential 7688 work where Gloas uses a different hashing for EpochParticipationFlags: Move from base to altair