### PR TITLE
Drop redundant 'item' template

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1572,10 +1572,9 @@ proc maybeUpdateActionTrackerNextEpoch(
       # with Holesky epoch 2041, 83% of active validators.
       let
         participation_flags =
-          forkyState.data.previous_epoch_participation.item(
-            nextEpochFirstProposer)
-        effective_balance = forkyState.data.validators.item(
-          nextEpochFirstProposer).effective_balance
+          forkyState.data.previous_epoch_participation[nextEpochFirstProposer]
+        effective_balance =
+          forkyState.data.validators[nextEpochFirstProposer].effective_balance
 
       # Maximal potential accuracy primarily useful during the last slot of
       # each epoch to prepare for a possible proposal the first slot of the

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1263,9 +1263,9 @@ func get_proposer_reward*(
       base_reward = get_base_reward(state, vidx, base_reward_per_increment)
     for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
       if flag_index in participation_flag_indices and
-         not has_flag(epoch_participation[vidx.int], flag_index):
-        epoch_participation[vidx.int] =
-          add_flag(epoch_participation[vidx.int], flag_index)
+         not has_flag(epoch_participation[vidx], flag_index):
+        epoch_participation[vidx] =
+          add_flag(epoch_participation[vidx], flag_index)
         # these are all valid; TODO statically verify or do it type-safely
         result += base_reward * weight.uint64
 
@@ -1389,9 +1389,9 @@ proc process_attestation*(
       var will_set_new_flag = false
       for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
         if flag_index in participation_flag_indices and
-           not has_flag(epoch_participation[vidx.int], flag_index):
-          epoch_participation[vidx.int] =
-            add_flag(epoch_participation[vidx.int], flag_index)
+           not has_flag(epoch_participation[vidx], flag_index):
+          epoch_participation[vidx] =
+            add_flag(epoch_participation[vidx], flag_index)
           proposer_reward_numerator +=
             get_base_reward(
               state, vidx, base_reward_per_increment) * weight.uint64

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1263,9 +1263,9 @@ func get_proposer_reward*(
       base_reward = get_base_reward(state, vidx, base_reward_per_increment)
     for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
       if flag_index in participation_flag_indices and
-         not has_flag(epoch_participation.item(vidx), flag_index):
-        asList(epoch_participation)[vidx] =
-          add_flag(epoch_participation.item(vidx), flag_index)
+         not has_flag(epoch_participation[vidx.int], flag_index):
+        epoch_participation[vidx.int] =
+          add_flag(epoch_participation[vidx.int], flag_index)
         # these are all valid; TODO statically verify or do it type-safely
         result += base_reward * weight.uint64
 
@@ -1389,9 +1389,9 @@ proc process_attestation*(
       var will_set_new_flag = false
       for flag_index, weight in PARTICIPATION_FLAG_WEIGHTS:
         if flag_index in participation_flag_indices and
-           not has_flag(epoch_participation.item(vidx), flag_index):
-          asList(epoch_participation)[vidx] =
-            add_flag(epoch_participation.item(vidx), flag_index)
+           not has_flag(epoch_participation[vidx.int], flag_index):
+          epoch_participation[vidx.int] =
+            add_flag(epoch_participation[vidx.int], flag_index)
           proposer_reward_numerator +=
             get_base_reward(
               state, vidx, base_reward_per_increment) * weight.uint64
@@ -2200,7 +2200,7 @@ func translate_participation(
     ):
       for flag_index in participation_flag_indices:
         state.previous_epoch_participation[vidx] =
-          add_flag(state.previous_epoch_participation.item(vidx), flag_index)
+          add_flag(state.previous_epoch_participation[vidx], flag_index)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#new-get_index_for_new_builder
 func get_index_for_new_builder(

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -407,20 +407,22 @@ chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
 template asList*(epochFlags: EpochParticipationFlags): untyped =
   List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
 template asList*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr epochFlags)
-  tmp[]
+  List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
 
 template asSeq*(epochFlags: EpochParticipationFlags): untyped =
-  seq[ParticipationFlags] asList(epochFlags)
-
+  distinctBase(epochFlags)
 template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
-  let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
-  tmp[]
+  distinctBase(epochFlags)
 
-template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
+template `[]`*(
+    epochFlags: EpochParticipationFlags,
+    idx: ValidatorIndex|uint64|int): ParticipationFlags =
   asList(epochFlags)[idx]
 
-template `[]=`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex, flags: ParticipationFlags) =
+template `[]=`*(
+    epochFlags: var EpochParticipationFlags,
+    idx: ValidatorIndex|uint64|int,
+    flags: ParticipationFlags) =
   asList(epochFlags)[idx] = flags
 
 template add*(epochFlags: var EpochParticipationFlags, flags: ParticipationFlags): bool =
@@ -435,19 +437,15 @@ template high*(epochFlags: EpochParticipationFlags): int =
   asSeq(epochFlags).high
 
 template assign*(v: var EpochParticipationFlags, src: EpochParticipationFlags) =
-  # TODO https://github.com/nim-lang/Nim/issues/21123
   mixin assign
-  var tmp = cast[ptr seq[ParticipationFlags]](addr v)
-  assign(tmp[], distinctBase src)
+  assign(distinctBase(v), distinctBase(src))
 
 template toSszType*(v: EpochParticipationFlags): auto = asList v
 
 func fromSszBytes*(
     T: type EpochParticipationFlags, bytes: openArray[byte]
 ): T {.raises: [SszError].} =
-  # TODO https://github.com/nim-lang/Nim/issues/21123
-  let tmp = cast[ptr List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT]](addr result)
-  readSszValue(bytes, tmp[])
+  readSszValue(bytes, asList(result))
 
 template `[]`*(a: auto; i: SyncSubcommitteeIndex): auto =
   a[i.asInt]

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -417,9 +417,6 @@ template asSeq*(epochFlags: var EpochParticipationFlags): untyped =
   let tmp = cast[ptr seq[ParticipationFlags]](addr epochFlags)
   tmp[]
 
-template item*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex): ParticipationFlags =
-  asList(epochFlags)[idx]
-
 template `[]`*(epochFlags: EpochParticipationFlags, idx: ValidatorIndex|uint64|int): ParticipationFlags =
   asList(epochFlags)[idx]
 

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -239,7 +239,7 @@ func is_unslashed_participating_index(
       unsafeAddr state.previous_epoch_participation
 
   is_active_validator(state.validators[validator_index], epoch) and
-    has_flag(epoch_participation[].item(validator_index), flag_index) and
+    has_flag(epoch_participation[][validator_index], flag_index) and
     not state.validators[validator_index].slashed
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/beacon-chain.md#justification-and-finalization
@@ -699,7 +699,7 @@ template get_flag_and_inactivity_delta(
     pflags =
       if  is_active_validator(state.validators[vidx], previous_epoch) and
           not state.validators[vidx].slashed:
-        epoch_participation[].item(vidx)
+        epoch_participation[][vidx]
       else:
         0
 


### PR DESCRIPTION
'item' does the same as '[]' on EpochParticipationFlags, can drop it.