### PR TITLE
Fix subscribe/unsubscribe sequence which should not be introduced, un…

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1342,13 +1342,6 @@ proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
     let topic = getDataColumnSidecarTopic(forkDigest, i)
     node.network.subscribe(topic, basicParams())
     custody.add(i)
-
-  # Unsubscribe from custody groups we no longer have custody of.
-  for i in node.lastColumnCustodyIndices:
-    if i notin custody:
-      let topic = getDataColumnSidecarTopic(forkDigest, i)
-      node.network.unsubscribe(topic)
-
   node.lastColumnCustodyIndices = custody
 
 proc addAltairMessageHandlers(


### PR DESCRIPTION
Regression was introduced in #8344.

And so BN become unsubscribed to all the topics related to columns.

Unsubscribe process is happen in `removeFuluMessageHandlers()` which is executed before `updateDataColumnSidecarHandlers()`.