### PR TITLE
improve KZG performance by precomputation

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2791,11 +2791,11 @@ proc doRunBeaconNode(
   # so it needs to be initalized from the main thread before anything else tries
   # to use it
   if config.trustedSetupFile.isSome:
-    kzg.loadTrustedSetup(config.trustedSetupFile.get(), 0).isOkOr:
+    kzg.loadTrustedSetup(config.trustedSetupFile.get(), 7).isOkOr:
       fatal "Cannot load KZG trusted setup from file", msg = error
       quit(QuitFailure)
   else:
-    kzg.loadTrustedSetupFromString(kzg.trustedSetup, 0).isOkOr:
+    kzg.loadTrustedSetupFromString(kzg.trustedSetup, 7).isOkOr:
       fatal "Cannot load KZG trusted setup using default data", msg = error
       quit(QuitFailure)
 

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -40,7 +40,7 @@ block:
   template sourceDir: string = currentSourcePath.rsplit(io2.DirSep, 1)[0]
   doAssert loadTrustedSetup(
     sourceDir &
-      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
+      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 7).isOk
 
 # Test format described at https://github.com/ethereum/consensus-specs/tree/v1.3.0/tests/formats/fork_choice
 # Note that our implementation has been optimized with "ProtoArray"

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024-2025 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -45,7 +45,7 @@ block:
   template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
   doAssert loadTrustedSetup(
     sourceDir &
-      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
+      "/../../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 7).isOk
 
 proc runBlobToKzgCommitmentTest(suiteName, suitePath, path: string) =
   let relativePathComponent = path.relativeTestPathComponent(suitePath)

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -40,7 +40,7 @@ block:
   template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
   doAssert kzg.loadTrustedSetup(
     sourceDir &
-      "/../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
+      "/../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 7).isOk
 
 # Helper to create valid KZG blobs
 func createValidKzgBlob(): kzg.KzgBlob =

--- a/tests/test_peerdas_helpers.nim
+++ b/tests/test_peerdas_helpers.nim
@@ -23,7 +23,7 @@ block:
   template sourceDir: string = currentSourcePath.rsplit(DirSep, 1)[0]
   doAssert loadTrustedSetup(
     sourceDir &
-      "/../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 0).isOk
+      "/../vendor/nim-kzg4844/kzg4844/csources/src/trusted_setup.txt", 7).isOk
 
 # 114 is the MSB (most/max significant byte)
 # such that BLS modulus does not overflow


### PR DESCRIPTION
https://github.com/ethereum/c-kzg-4844/blob/v2.1.7/README.md#precompute using the `precompute` parameter 7: 48 MiB of memory and about 1.6x faster.