### PR TITLE
Remove skipLastEnvelope and clean up envelope processing

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -525,28 +525,12 @@ proc addHeadExecutionPayload*(
   # envelope with state, as the block could be older than the head.
   let blckBsi = BlockSlotId.init(blck.bid, envelopeSlot)
   if not updateState(
-      dag, dag.clearanceState, blckBsi, false, cache,
-      dag.updateFlags + {skipLastEnvelope}):
+      dag, dag.clearanceState, blckBsi, false, cache, dag.updateFlags):
     # If updateState() fails, it means there may be some missing blocks and
     # envelopes of its parents, or the database is corrupted.
     error "Unable to load clearance state for envelope, database corrupt?",
       clearanceBlock = shortLog(blckBsi)
     return err(VerifierError.MissingParent)
-
-  # Validate the envelope with state. Slot and latest block root in state should
-  # match with the envelope.
-  if not (
-      dag.clearanceState.slot() == envelopeSlot and
-      dag.clearanceState.latest_block_root() == envelopeBlockRoot
-  ):
-    debug "Envelope is not for the current head"
-    return err(VerifierError.Invalid)
-  # With skipLastEnvelope flag and containsExecutionPayloadEnvelope() check
-  # above, the envelope should have not been applied but double check.
-  elif dag.clearanceState.forky(consensusFork).data.latest_block_hash ==
-       signedEnvelope.message.payload.block_hash:
-    debug "Envelope has been applied to the state"
-    return err(VerifierError.Duplicate)
 
   # Verify with state transition function.
   verify_execution_payload_envelope(

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2548,8 +2548,7 @@ proc updateHead*(
   # to use existing in-memory states to make this smooth
   var cache: StateCache
   if not updateState(
-      dag, dag.headState, newHead.bid.atSlot(), false, cache,
-      dag.updateFlags + {skipLastEnvelope}):
+      dag, dag.headState, newHead.bid.atSlot(), false, cache, dag.updateFlags):
     # Advancing the head state should never fail, given that the tail is
     # implicitly finalised, the head is an ancestor of the tail and we always
     # store the tail state in the database, as well as every epoch slot state in

--- a/beacon_chain/extras.nim
+++ b/beacon_chain/extras.nim
@@ -38,10 +38,6 @@ type
     ## When process_slots() is being called as part of a state_transition(),
     ## the hash_tree_root() from the block will fill in the state.root so it
     ## should skip calculating that last state root.
-    skipLastEnvelope ##\
-    ## As a full beacon block consists of a beacon block and envelope since
-    ## Gloas, the last envelope may not be there yet. This is used to toggle the
-    ## strict state transition of the last envelope in updateState().
 
   UpdateFlags* = set[UpdateFlag]
 


### PR DESCRIPTION
- Remove `skipLastEnvelope`
- Remove duplicate checks as they have been covered by `verify_execution_payload_envelope`