### PR TITLE
Add metrics to nimbus_light_client

### DIFF
--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -161,6 +161,23 @@ type LightClientConf* = object
     defaultValue: 0
     name: "debug-stop-at-epoch" .}: uint64
 
+  # Metrics
+  metricsEnabled* {.
+    desc: "Enable the metrics server"
+    defaultValue: false
+    name: "metrics" .}: bool
+
+  metricsAddress* {.
+    desc: "Listening address of the metrics server"
+    defaultValue: defaultAdminListenAddress
+    defaultValueDesc: $defaultAdminListenAddressDesc
+    name: "metrics-address" .}: IpAddress
+
+  metricsPort* {.
+    desc: "Listening HTTP port of the metrics server"
+    defaultValue: 8008
+    name: "metrics-port" .}: Port
+
   logFile* {.
     obsolete: "Logging to file has been deprecated since v1.5.3, see https://nimbus.guide/logging.html#logging-to-a-file"
     name: "log-file" .}: Option[OutFile]

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -978,6 +978,14 @@ proc updateBeaconMetrics(
         0'u64.toGaugeValue
     )
 
+proc updateHeadBlockMetrics*(headBlockId: BlockId) =
+  beacon_head_root.set(headBlockId.root.toGaugeValue)
+  beacon_head_slot.set(headBlockId.slot.toGaugeValue)
+
+proc updateFinalizedBlockMetrics*(finalizedBlockId: BlockId) =
+  beacon_finalized_epoch.set(finalizedBlockId.slot.epoch.toGaugeValue)
+  beacon_finalized_root.set(finalizedBlockId.root.toGaugeValue)
+
 proc updateSafeBlockMetrics*(safeBlockId: BlockId) =
   beacon_safe_root.set(safeBlockId.root.toGaugeValue)
   beacon_safe_slot.set(safeBlockId.slot.toGaugeValue)

--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -9,7 +9,7 @@
 
 import
   std/os,
-  chronicles, chronos, stew/io2,
+  chronicles, chronos, metrics, stew/io2,
   eth/db/kvstore_sqlite3,
   ./el/el_manager,
   ./gossip_processing/block_processor_light_client,
@@ -20,8 +20,14 @@ import
     beacon_clock, buildinfo, filepath, light_client, light_client_db,
     nimbus_binary_common, process_state, version]
 
+from ./consensus_object_pools/blockchain_dag import
+  updateFinalizedBlockMetrics, updateHeadBlockMetrics
 from ./gossip_processing/block_processor import newExecutionPayload
 from ./gossip_processing/eth2_processor import toValidationResult
+
+# https://github.com/ethereum/eth2.0-metrics/blob/master/metrics.md#interop-metrics
+declareGauge beacon_slot, "Latest slot of the beacon chain state"
+declareGauge beacon_current_epoch, "Current epoch"
 
 # noinline to keep it in stack traces
 proc main() {.noinline, raises: [CatchableError].} =
@@ -114,6 +120,14 @@ proc main() {.noinline, raises: [CatchableError].} =
       network, rng, config, cfg, forkDigests, getBeaconTime,
       genesis_validators_root, LightClientFinalizationMode.Optimistic)
 
+  # Nim GC metrics (for the main thread) will be collected in onSecond(), but
+  # we disable piggy-backing on other metrics here.
+  setSystemMetricsAutomaticUpdate(false)
+
+  let metricsServer = waitFor(config.initMetricsServer()).valueOr:
+    quit QuitFailure
+  defer: waitFor metricsServer.stopMetricsServer()
+
   # Run `exchangeTransitionConfiguration` loop
   if elManager != nil:
     elManager.start()
@@ -157,6 +171,7 @@ proc main() {.noinline, raises: [CatchableError].} =
       when lcDataFork > LightClientDataFork.None:
         info "New LC finalized header",
           finalized_header = shortLog(forkyHeader)
+        updateFinalizedBlockMetrics(forkyHeader.beacon.toBlockId())
         let
           period = forkyHeader.beacon.slot.sync_committee_period
           syncCommittee = lightClient.finalizedSyncCommittee.expect("Init OK")
@@ -171,6 +186,7 @@ proc main() {.noinline, raises: [CatchableError].} =
       return
     withForkyHeader(optimisticHeader):
       when lcDataFork > LightClientDataFork.None:
+        updateHeadBlockMetrics(forkyHeader.beacon.toBlockId())
         logScope: optimistic_header = shortLog(forkyHeader)
         when lcDataFork >= LightClientDataFork.Capella:
           let
@@ -337,6 +353,9 @@ proc main() {.noinline, raises: [CatchableError].} =
       finalized = shortLog(finalizedBid),
       delay = shortLog(delay)
 
+    beacon_slot.set wallSlot.toGaugeValue
+    beacon_current_epoch.set wallSlot.epoch.toGaugeValue
+
   proc runOnSlotLoop() {.async.} =
     var
       curSlot = beaconClock.currentSlot
@@ -358,6 +377,9 @@ proc main() {.noinline, raises: [CatchableError].} =
         nextSlot.start_beacon_time(cfg.timeParams) - beaconClock.now()
 
   proc onSecond(time: Moment) =
+    # Nim GC metrics (for the main thread)
+    updateThreadMetrics()
+
     let wallSlot = beaconClock.currentSlot
     if checkIfShouldStopAtEpoch(wallSlot, config.stopAtEpoch):
       quit(0)


### PR DESCRIPTION
Replicate the most important BN metrics to the nimbus_light_client, and enable configuration via `--metrics`.