### PR TITLE
fix: use correct condition for withdrawal computation

### DIFF
--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -380,10 +380,11 @@ proc getExecutionPayload*(
         # - If `should_extend_payload(store, parent_root)`:
         #     `withdrawals = get_expected_withdrawals(state).withdrawals`.
         # - else `withdrawals = state.payload_expected_withdrawals`.
-        if forkyState.data.latest_execution_payload_bid.block_hash.isZero():
-          forkyState.data.payload_expected_withdrawals.asSeq()
-        else:
+        if forkyState.data.latest_block_hash ==
+            forkyState.data.latest_execution_payload_bid.block_hash:
           get_expected_withdrawals(forkyState.data).withdrawals
+        else:
+          forkyState.data.payload_expected_withdrawals.asSeq()
       elif consensusFork >= ConsensusFork.Capella:
         get_expected_withdrawals(forkyState.data)
       else:


### PR DESCRIPTION
When a parent block had a bid but its payload was never delivered, the old check computed fresh withdrawals instead of using                                                               the cached `payload_expected_withdrawals` causing "withdrawals mismatch"  when preparing payload attributes to send to the EL which later fails when `verify_execution_payload_envelope` is called on the built payload