### PR TITLE
Fix ColumnQuarantine to start  use correct amount of supernode columns.

### DIFF
--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -102,6 +102,13 @@ func maxSidecars(maxSidecarsPerBlock: uint64): int =
   # blobs may arrive before an orphan is tagged `blobless`
   3 * int(SLOTS_PER_EPOCH) * int(maxSidecarsPerBlock)
 
+func enoughColumns*[A, B](q: SidecarQuarantine[A, B], count: int): bool =
+  if count >= NUMBER_OF_COLUMNS div 2:
+    return true
+  if count == len(q.custodyMap):
+    return true
+  false
+
 func init[A, B](
     t: typedesc[RootTableRecord],
     q: SidecarQuarantine[A, B]
@@ -443,19 +450,10 @@ func hasSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
   let node = quarantine.roots.getOrDefault(blockRoot)
   if isNil(node):
     return false
-
-  let
-    supernode = (len(quarantine.custodyColumns) == NUMBER_OF_COLUMNS)
-    columnsCount =
-      if supernode:
-        (NUMBER_OF_COLUMNS div 2 + 1)
-      else:
-        len(quarantine.custodyColumns)
-
-  if node[].value.count < columnsCount:
-    # Quarantine does not hold enough column sidecars.
-    return false
-  true
+  if quarantine.enoughColumns(node[].value.count):
+    # Quarantine holds enough column sidecars.
+    return true
+  false
 
 func hasSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     quarantine: SidecarQuarantine[A, B],
@@ -486,14 +484,9 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     return Opt.none(seq[ref A])
 
   let
-    supernode = (len(quarantine.custodyColumns) == NUMBER_OF_COLUMNS)
-    columnsCount =
-      if supernode:
-        (NUMBER_OF_COLUMNS div 2 + 1)
-      else:
-        len(quarantine.custodyColumns)
+    supernode = (len(quarantine.custodyMap) == NUMBER_OF_COLUMNS)
 
-  if node[].value.count < columnsCount:
+  if not(quarantine.enoughColumns(node[].value.count)):
     # Quarantine does not hold enough column sidecars.
     return Opt.none(seq[ref A])
 
@@ -504,6 +497,7 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
 
   var sidecars: seq[ref A]
   if supernode:
+    # When supernode - we pop all sidecars.
     for sidecar in node[].value.sidecars:
       # Supernode could have some of the columns not filled.
       if not(sidecar.isEmpty()):
@@ -511,21 +505,15 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
           "Record should only have loaded values, but it is `" &
             $sidecar.kind & "`")
         sidecars.add(sidecar.data)
-      if len(sidecars) >= (NUMBER_OF_COLUMNS div 2 + 1):
-        break
-
-    doAssert(len(sidecars) >= (NUMBER_OF_COLUMNS div 2 + 1),
-      "Incorrect amount of sidecars in record for supernode - " &
-        $len(sidecars))
   else:
-    for cindex in quarantine.custodyColumns:
+    for cindex in quarantine.custodyMap:
       let index = quarantine.getIndex(cindex)
       doAssert(node[].value.sidecars[index].isLoaded(),
         "Record should only have loaded values, but it is `" &
           $node[].value.sidecars[index].kind & "`")
       sidecars.add(node[].value.sidecars[index].data)
 
-    doAssert(len(sidecars) == len(quarantine.custodyColumns),
+    doAssert(len(sidecars) == len(quarantine.custodyMap),
       "Incorrect amount of sidecars in record for node - " & $len(sidecars))
 
   # popSidecars() should remove all the artifacts from the quarantine in both
@@ -557,34 +545,20 @@ func fetchMissingSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallb
       indices: DataColumnIndices(default(seq[ColumnIndex])))
 
   let
-    supernode = (len(quarantine.custodyColumns) == NUMBER_OF_COLUMNS)
-    columnsCount =
-      if supernode:
-        (NUMBER_OF_COLUMNS div 2)
-      else:
-        len(quarantine.custodyColumns)
+    supernode = (len(quarantine.custodyMap) == NUMBER_OF_COLUMNS)
 
   if supernode:
     if isNil(node):
       for column in peerMap.items():
-        if len(res) > columnsCount:
-          # We don't need to request more than (NUMBER_OF_COLUMNS div 2)
-          # columns.
-          break
         res.incl(column)
     else:
-      if node[].value.count > columnsCount:
-        # We already have enough columns for reconstruction.
+      if quarantine.enoughColumns(node[].value.count):
         return
           DataColumnsByRootIdentifier(
             block_root: blockRoot,
             indices: DataColumnIndices(default(seq[ColumnIndex])))
 
       for column in peerMap.items():
-        if node[].value.count + len(res) > columnsCount:
-          # We don't need to request more than (NUMBER_OF_COLUMNS div 2)
-          # columns.
-          break
         let index = quarantine.getIndex(column)
         if (index == -1) or node[].value.sidecars[index].isEmpty():
           res.incl(column)
@@ -617,25 +591,27 @@ func getMissingColumnsMap*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallb
     quarantine: SidecarQuarantine[A, B],
     blockRoot: Eth2Digest,
 ): ColumnMap =
-  var res: ColumnMap
-  let node = quarantine.roots.getOrDefault(blockRoot)
+  let
+    node = quarantine.roots.getOrDefault(blockRoot)
+    supernode = (len(quarantine.custodyMap) == NUMBER_OF_COLUMNS)
 
-  if (len(quarantine.custodyColumns) == NUMBER_OF_COLUMNS):
+  if supernode:
     if isNil(node):
-      for index in 0 ..< NUMBER_OF_COLUMNS:
-        res.incl(ColumnIndex(index))
+      supernodeMap()
     else:
-      if len(node[].value.sidecars) > NUMBER_OF_COLUMNS div 2:
-        return res
+      var res: ColumnMap
+      if quarantine.enoughColumns(node[].value.count):
+        return default(ColumnMap)
       for index in 0 ..< NUMBER_OF_COLUMNS:
         if node[].value.sidecars[index].isEmpty():
           res.incl(ColumnIndex(index))
   else:
+    var res: ColumnMap
     for column in quarantine.custodyMap.items():
       let index = quarantine.getIndex(column)
       if isNil(node) or (index == -1) or node[].value.sidecars[index].isEmpty():
         res.incl(column)
-  res
+    res
 
 func getMissingSidecarIndices*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     quarantine: SidecarQuarantine[A, B],

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -9,7 +9,8 @@
 
 import
   chronicles, chronos, metrics,
-  ../spec/[forks, helpers_el, signatures, signatures_batch, peerdas_helpers],
+  ../spec/[forks, helpers_el, signatures, signatures_batch, column_map,
+           peerdas_helpers],
   ../sszdump
 
 from std/deques import Deque, addLast, contains, initDeque, items, len, shrink

--- a/beacon_chain/spec/column_map.nim
+++ b/beacon_chain/spec/column_map.nim
@@ -109,3 +109,9 @@ func shortLog*(a: ColumnMap): string =
   if len(a) > NUMBER_OF_COLUMNS div 2:
     return "[supernode]"
   $a
+
+func supernodeMap*(): ColumnMap =
+  ColumnMap(data: [0xFFFF_FFFF_FFFF_FFFF'u64, 0xFFFF_FFFF_FFFF_FFFF'u64])
+
+func lightSupernodeMap*(): ColumnMap =
+  ColumnMap(data: [0xFFFF_FFFF_FFFF_FFFF'u64, 0'u64])

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -385,14 +385,14 @@ suite "ColumnQuarantine data structure test suite " & preset():
       sidecars1 =
         block:
           var res: seq[ref fulu.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< (len(custodyColumns) div 2):
             res.add(newClone(genFuluDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1, proposer_index = 5)))
           res
       sidecars2 =
         block:
           var res: seq[ref fulu.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< (len(custodyColumns) div 2):
             res.add(newClone(genFuluDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1, proposer_index = 6)))
           res
@@ -546,7 +546,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
     let
       custodyColumns = supernodeColumns()
       peerCustodyColumns1 =
-        [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
+        [15, 20, 33, 41, 42, 97, 100, 126].mapIt(ColumnIndex(it))
 
     var bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 0, nil)
     let
@@ -555,14 +555,14 @@ suite "ColumnQuarantine data structure test suite " & preset():
       sidecars1 =
         block:
           var res: seq[ref fulu.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< len(custodyColumns):
             res.add(newClone(genFuluDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1, proposer_index = 5)))
           res
       sidecars2 =
         block:
           var res: seq[ref fulu.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< len(custodyColumns):
             res.add(newClone(genFuluDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 2, proposer_index = 50)))
           res
@@ -573,18 +573,15 @@ suite "ColumnQuarantine data structure test suite " & preset():
       missing: DataColumnsByRootIdentifier
     ): bool =
       const ExpectedVectors = [
-        (@[63, 64, 65, 66, 95, 96, 97, 98], 0 .. 57),
-        (@[63, 64, 65, 66, 95, 96, 97], 58 .. 58),
-        (@[63, 64, 65, 66, 95, 96], 59 .. 59),
-        (@[63, 64, 65, 66, 95], 60 .. 60),
-        (@[63, 64, 65, 66], 61 .. 61),
-        (@[63, 64, 65], 62 .. 62),
-        (@[63, 64], 63 .. 63),
-        (@[64], 64 .. 64),
-        (@[], 65 .. 65)
+        (@[15, 20, 33, 41, 42, 97, 100, 126], 0 .. 15),
+        (@[20, 33, 41, 42, 97, 100, 126], 16 .. 20),
+        (@[33, 41, 42, 97, 100, 126], 21 .. 33),
+        (@[41, 42, 97, 100, 126], 34 .. 41),
+        (@[42, 97, 100, 126], 42 .. 42),
+        (@[97, 100, 126], 43 .. 63)
       ]
 
-      doAssert(index in 0 .. 65)
+      doAssert(index in 0 .. 63)
       for expect in ExpectedVectors:
         if index in expect[1]:
           if len(expect[0]) != len(missing.indices):
@@ -597,7 +594,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
           return true
       false
 
-    for i in 0 ..< len(sidecars1) + 1:
+    for i in 0 ..< len(sidecars1) div 2:
       let
         missing1 = bq.fetchMissingSidecars(broot1)
         missing2 = bq.fetchMissingSidecars(broot2)
@@ -610,12 +607,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         compareSidecars(
           broot2,
           sidecars2.toOpenArray(i, len(sidecars2) - 1), missing2) == true
-        checkSupernodeExpected(
-          broot1,
-          i, missing3) == true
-
-      if i >= len(sidecars1):
-        break
+        checkSupernodeExpected(broot1, i, missing3) == true
 
       bq.put(broot1, sidecars1[i])
       bq.put(broot2, sidecars2[i])
@@ -1506,10 +1498,15 @@ suite "ColumnQuarantine data structure test suite " & preset():
         block2 = genFuluSignedBeaconBlock(
           sidecars[0 + len(custodyColumns)].blockRoot, commitments)
 
-      # Both blocks should be incomplete.
-      check:
-        bq.hasSidecars(block1) == false
-        bq.hasSidecars(block2) == false
+      case cvec[0]:
+      of "node":
+        check:
+          bq.hasSidecars(block1) == false
+          bq.hasSidecars(block2) == false
+      of "supernode":
+        check:
+          bq.hasSidecars(block1) == true
+          bq.hasSidecars(block2) == true
 
       case cvec[0]
       of "node":
@@ -1567,7 +1564,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
             # rebuild.
             let
               start = 0
-              finish = len(custodyColumns) div 2 + 1
+              finish = len(custodyColumns)
             sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
           else:
             raiseAssert "inaccessible"
@@ -1584,7 +1581,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
             # rebuild.
             let
               start = len(custodyColumns)
-              finish = start + len(custodyColumns) div 2 + 1
+              finish = start + len(custodyColumns)
             sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
           else:
             raiseAssert "inaccessible"
@@ -2083,14 +2080,14 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       sidecars1 =
         block:
           var res: seq[ref gloas.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< (len(custodyColumns) div 2):
             res.add(newClone(genGloasDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1)))
           res
       sidecars2 =
         block:
           var res: seq[ref gloas.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< (len(custodyColumns) div 2):
             res.add(newClone(genGloasDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1)))
           res
@@ -2244,7 +2241,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
     let
       custodyColumns = supernodeColumns()
       peerCustodyColumns1 =
-        [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
+        [15, 20, 33, 41, 42, 97, 100, 126].mapIt(ColumnIndex(it))
 
     var bq = GloasColumnQuarantine.init(cfg, custodyColumns, quarantine, 0, nil)
     let
@@ -2253,14 +2250,14 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       sidecars1 =
         block:
           var res: seq[ref gloas.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< len(custodyColumns):
             res.add(newClone(genGloasDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 1)))
           res
       sidecars2 =
         block:
           var res: seq[ref gloas.DataColumnSidecar]
-          for i in 0 ..< (len(custodyColumns) div 2 + 1):
+          for i in 0 ..< len(custodyColumns):
             res.add(newClone(genGloasDataColumnSidecar(
               index = int(custodyColumns[i]), slot = 2)))
           res
@@ -2271,18 +2268,15 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       missing: DataColumnsByRootIdentifier
     ): bool =
       const ExpectedVectors = [
-        (@[63, 64, 65, 66, 95, 96, 97, 98], 0 .. 57),
-        (@[63, 64, 65, 66, 95, 96, 97], 58 .. 58),
-        (@[63, 64, 65, 66, 95, 96], 59 .. 59),
-        (@[63, 64, 65, 66, 95], 60 .. 60),
-        (@[63, 64, 65, 66], 61 .. 61),
-        (@[63, 64, 65], 62 .. 62),
-        (@[63, 64], 63 .. 63),
-        (@[64], 64 .. 64),
-        (@[], 65 .. 65)
+        (@[15, 20, 33, 41, 42, 97, 100, 126], 0 .. 15),
+        (@[20, 33, 41, 42, 97, 100, 126], 16 .. 20),
+        (@[33, 41, 42, 97, 100, 126], 21 .. 33),
+        (@[41, 42, 97, 100, 126], 34 .. 41),
+        (@[42, 97, 100, 126], 42 .. 42),
+        (@[97, 100, 126], 43 .. 63)
       ]
 
-      doAssert(index in 0 .. 65)
+      doAssert(index in 0 .. 63)
       for expect in ExpectedVectors:
         if index in expect[1]:
           if len(expect[0]) != len(missing.indices):
@@ -2295,7 +2289,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
           return true
       false
 
-    for i in 0 ..< len(sidecars1) + 1:
+    for i in 0 ..< len(sidecars1) div 2:
       let
         missing1 = bq.fetchMissingSidecars(broot1)
         missing2 = bq.fetchMissingSidecars(broot2)
@@ -2311,9 +2305,6 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         checkSupernodeExpected(
           broot1,
           i, missing3) == true
-
-      if i >= len(sidecars1):
-        break
 
       bq.put(broot1, sidecars1[i])
       bq.put(broot2, sidecars2[i])
@@ -3165,10 +3156,16 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         envl2 = genGloasSignedExecutionPayloadEnvelope(
           sidecars[0 + len(custodyColumns)].blockRoot, commitments)
 
-      # Both blocks should be incomplete.
-      check:
-        bq.hasSidecars(envl1) == false
-        bq.hasSidecars(envl2) == false
+
+      case cvec[0]
+      of "node":
+        check:
+          bq.hasSidecars(envl1) == false
+          bq.hasSidecars(envl2) == false
+      of "supernode":
+        check:
+          bq.hasSidecars(envl1) == true
+          bq.hasSidecars(envl2) == true
 
       case cvec[0]
       of "node":
@@ -3226,7 +3223,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
             # rebuild.
             let
               start = 0
-              finish = len(custodyColumns) div 2 + 1
+              finish = len(custodyColumns)
             sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
           else:
             raiseAssert "inaccessible"
@@ -3243,7 +3240,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
             # rebuild.
             let
               start = len(custodyColumns)
-              finish = start + len(custodyColumns) div 2 + 1
+              finish = start + len(custodyColumns)
             sidecars.toOpenArray(start, finish - 1).mapIt(it.sidecar)
           else:
             raiseAssert "inaccessible"


### PR DESCRIPTION
Changes:

1. Its enough to obtain only `NUMBER_OF_COLUMNS div 2` columns for `hasSidecars`  returning `true` and `popSidecars` returning you list of columns (all columns will be retrieved, not only `NUMBER_OF_COLUMNS div 2`).
2. If remote peer is `supernode` - `fetchMissingSidecars()` returns `NUMBER_OF_COLUMNS` columns request.