### PR TITLE
fix: gloas block gossip validation

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -462,11 +462,11 @@ template validateBeaconBlockGloas(
   #
   # - [REJECT] The block's execution payload parent (defined by
   #   bid.parent_block_hash) passes all validation.
-  if dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >=
+  if executionParent.root in envelopeQuarantine.unviable:
+    return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
+  elif dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >=
       ConsensusFork.Gloas:
-    if executionParent.root in envelopeQuarantine.unviable:
-      return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
-    elif not (
+    if not (
         dag.db.containsExecutionPayloadEnvelope(executionParent.root) or
         executionParent.root in envelopeQuarantine.orphans
     ):
@@ -474,10 +474,8 @@ template validateBeaconBlockGloas(
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
-    # We don't have a reliable source of truth of execution validity for
-    # pre-Gloas blocks. Probably we could check with EL.
-    #
-    # TODO: execution validity of blocks
+    # The execution parent is a pre-Gloas block. It has been validated and
+    # imported to DAG so we could assume it is execution valid.
     discard
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -474,7 +474,7 @@ template validateBeaconBlockGloas(
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
-    # We don't have a reliable source of truth of the execution validity for
+    # We don't have a reliable source of truth of execution validity for
     # pre-Gloas blocks. Probably we could check with EL.
     #
     # TODO: execution validity of blocks

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -423,34 +423,26 @@ template validateBeaconBlockGloas(
   template bid: untyped = blck.body.signed_execution_payload_bid.message
 
   let executionParent = block:
-    let
-      parent = dag.getBlockRef(bid.parent_block_root).valueOr:
+    var
+      cur = dag.getBlockRef(bid.parent_block_root).valueOr:
         return errIgnore("validateBeaconBlockGloas: parent not yet seen")
-      pBhash = dag.loadExecutionBlockHash(parent).valueOr:
+      i = 0
+      found = false
+
+    # Search execution parent up to 2 ancestors. Also stop searching if there is
+    # not any parents, that could be a finalized block or genesis.
+    while not isNil(cur.parent) and i < 2:
+      let pBhash = dag.loadExecutionBlockHash(cur).valueOr:
         return errIgnore("validateBeaconBlockGloas: cannot load block hash")
-    if pBhash == bid.parent_block_hash:
-      # Parent's payload status is FULL
-      parent.bid
-    else:
-      # Parent's payload status is EMPTY, i.e. check with grandparent.
-      let res = block:
-        if not isNil(parent.parent):
-          # Grandparent is non-finalized yet.
-          let gpBhash = dag.loadExecutionBlockHash(parent.parent).valueOr:
-            return errIgnore("validateBeaconBlockGloas: cannot load block hash")
-          (parent.parent.bid, gpBhash)
-        else:
-          # Grandparent should be either finalized or nonexistent.
-          let
-            gpBid = dag.parent(parent.bid).valueOr:
-              return errIgnore("validateBeaconBlockGloas: invalid execution parent")
-            gpBhash = dag.loadExecutionBlockHash(gpBid).valueOr:
-              return errIgnore("validateBeaconBlockGloas: cannot load block hash")
-          (gpBid, gpBhash)
-      if res[1] == bid.parent_block_hash:
-        res[0]
+      if pBhash == bid.parent_block_hash:
+        found = true
+        break
       else:
-        return errIgnore("validateBeaconBlockGloas: invalid execution parent")
+        cur = cur.parent
+      inc i
+    if not found:
+      return errIgnore("validateBeaconBlockGloas: invalid execution parent")
+    cur
 
   # - [IGNORE] The block's parent execution payload (defined by
   #   bid.parent_block_hash) has been seen (via gossip or non-gossip sources)
@@ -466,15 +458,17 @@ template validateBeaconBlockGloas(
     # The executionParent exists in DAG, so we should check unviable envelope
     # and the database for the validation rules.
     if executionParent.root in envelopeQuarantine.unviable:
-      return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
+      return dag.checkedReject("validateBeaconBlockGloas: unviable execution parent")
     elif not dag.db.containsExecutionPayloadEnvelope(executionParent.root):
       envelopeQuarantine[].addMissing(executionParent.root)
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
-    # The execution parent is a pre-Gloas block. It has been validated and
-    # imported to DAG so we could assume that it is execution valid.
-    discard
+    # For pre-Gloas block, we validate that it is an execution block.
+    let parentBlck = dag.getForkedBlock(executionParent.bid).valueOr:
+      return errIgnore("validateBeaconBlockGloas: missing parent block")
+    if not parentBlck.is_execution_block:
+      return dag.checkedReject("validateBeaconBlockGloas: invalid execution parent")
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   # block's parent (defined by `block.parent_root`).

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -462,15 +462,23 @@ template validateBeaconBlockGloas(
   #
   # - [REJECT] The block's execution payload parent (defined by
   #   bid.parent_block_hash) passes all validation.
-  if executionParent.root in envelopeQuarantine.unviable:
-    return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
-  elif not (
-      dag.db.containsExecutionPayloadEnvelope(executionParent.root) or
-      executionParent.root in envelopeQuarantine.orphans
-  ):
-    envelopeQuarantine[].addMissing(executionParent.root)
-    discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
-    return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
+  if dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >=
+      ConsensusFork.Gloas:
+    if executionParent.root in envelopeQuarantine.unviable:
+      return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
+    elif not (
+        dag.db.containsExecutionPayloadEnvelope(executionParent.root) or
+        executionParent.root in envelopeQuarantine.orphans
+    ):
+      envelopeQuarantine[].addMissing(executionParent.root)
+      discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
+      return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
+  else:
+    # We don't have a reliable source of truth of the execution validity for
+    # pre-Gloas blocks. Probably we could check with EL.
+    #
+    # TODO: execution validity of blocks
+    discard
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   # block's parent (defined by `block.parent_root`).

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -467,14 +467,10 @@ template validateBeaconBlockGloas(
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
-    # The executionParent is found from DAG, which is a validated Fulu block. We
-    # do not need to check with the block quarantine but at least we want to be
-    # sure that it is execution enabled.
-    let parentBlck = dag.getForkedBlock(executionParent.bid).valueOr:
-      return errIgnore("validateBeaconBlockGloas: missing parent block")
-    withBlck(parentBlck):
-      if not forkyBlck.message.body.is_execution_block:
-        return dag.checkedReject("validateBeaconBlockGloas: invalid execution parent")
+    # The executionParent is found from DAG, which is a validated pre-Gloas
+    # block. It could also be pre-merge or optimistic block. In either case,
+    # they shouldn't be rejected.
+    discard
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   # block's parent (defined by `block.parent_root`).

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -462,20 +462,18 @@ template validateBeaconBlockGloas(
   #
   # - [REJECT] The block's execution payload parent (defined by
   #   bid.parent_block_hash) passes all validation.
-  if executionParent.root in envelopeQuarantine.unviable:
-    return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
-  elif dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >=
-      ConsensusFork.Gloas:
-    if not (
-        dag.db.containsExecutionPayloadEnvelope(executionParent.root) or
-        executionParent.root in envelopeQuarantine.orphans
-    ):
+  if dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >= ConsensusFork.Gloas:
+    # The executionParent exists in DAG, so we should check unviable envelope
+    # and the database for the validation rules.
+    if executionParent.root in envelopeQuarantine.unviable:
+      return dag.checkedReject("validateBeaconBlockGloas: invalid parent payload")
+    elif not dag.db.containsExecutionPayloadEnvelope(executionParent.root):
       envelopeQuarantine[].addMissing(executionParent.root)
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
     # The execution parent is a pre-Gloas block. It has been validated and
-    # imported to DAG so we could assume it is execution valid.
+    # imported to DAG so we could assume that it is execution valid.
     discard
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -429,8 +429,8 @@ template validateBeaconBlockGloas(
       i = 0
       found = false
 
-    # Search execution parent up to 2 ancestors. Also stop searching if there is
-    # not any parents, that could be a finalized block or genesis.
+    # Search execution parent up to 2 ancestors. Also stop searching when there
+    # is not any parents, means that it is either a finalized or genesis block.
     while not isNil(cur.parent) and i < 2:
       let pBhash = dag.loadExecutionBlockHash(cur).valueOr:
         return errIgnore("validateBeaconBlockGloas: cannot load block hash")
@@ -459,16 +459,22 @@ template validateBeaconBlockGloas(
     # and the database for the validation rules.
     if executionParent.root in envelopeQuarantine.unviable:
       return dag.checkedReject("validateBeaconBlockGloas: unviable execution parent")
-    elif not dag.db.containsExecutionPayloadEnvelope(executionParent.root):
+    # The genesis block would not have an envelope. Otherwise, we should have
+    # the envelope for the execution parent.
+    elif not (executionParent.slot != GENESIS_SLOT and
+        dag.db.containsExecutionPayloadEnvelope(executionParent.root)):
       envelopeQuarantine[].addMissing(executionParent.root)
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")
   else:
-    # For pre-Gloas block, we validate that it is an execution block.
+    # The executionParent is found from DAG, which is a validated Fulu block. We
+    # do not need to check with the block quarantine but at least we want to be
+    # sure that it is execution enabled.
     let parentBlck = dag.getForkedBlock(executionParent.bid).valueOr:
       return errIgnore("validateBeaconBlockGloas: missing parent block")
-    if not parentBlck.is_execution_block:
-      return dag.checkedReject("validateBeaconBlockGloas: invalid execution parent")
+    withBlck(parentBlck):
+      if not forkyBlck.message.body.is_execution_block:
+        return dag.checkedReject("validateBeaconBlockGloas: invalid execution parent")
 
   # [REJECT] The bid's parent (defined by `bid.parent_block_root`) equals the
   # block's parent (defined by `block.parent_root`).


### PR DESCRIPTION
- On checking parent envelope, we should also ensure that the parent is a Gloas or later block.