### PR TITLE
nix: add NixOS BN and VC service definitions

### DIFF
--- a/ci/nix.Jenkinsfile
+++ b/ci/nix.Jenkinsfile
@@ -55,6 +55,12 @@ pipeline {
         sh 'result/bin/nimbus_beacon_node --version'
       } }
     }
+
+    stage('Service check') {
+      steps { script {
+        sh 'nix run ".#checks.x86_64-linux.beacon-node.driver"'
+      } }
+    }
   }
 
   post {

--- a/flake.nix
+++ b/flake.nix
@@ -56,5 +56,18 @@
       devShells = forAllSystems (system: {
         default = pkgsFor.${system}.callPackage ./nix/shell.nix { };
       });
+
+      nixosModules = rec {
+        beacon-node = import ./nix/services/beacon-node.nix { inherit (self) packages; };
+        validator-client = import ./nix/services/validator-client.nix { inherit (self) packages; };
+        default = { imports = [ beacon-node validator-client ]; };
+      };
+
+      checks = forAllSystems (system: let
+        inherit (nixpkgs.legacyPackages.${system}) callPackage;
+      in {
+        beacon-node = callPackage ./nix/services/checks/beacon-node.nix { inherit self; };
+        validator-client = callPackage ./nix/services/checks/validator-client.nix { inherit self; };
+      });
     };
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -38,7 +38,6 @@ in stdenv.mkDerivation rec {
     ];
   };
 
-
   nativeBuildInputs = let
     fakeGit = writeScriptBin "git" "echo ${version}";
   in

--- a/nix/services/beacon-node.nix
+++ b/nix/services/beacon-node.nix
@@ -1,0 +1,227 @@
+{ packages }:
+
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption mkIf
+    types filterAttrs escapeShellArgs literalExpression
+    optionals optionalAttrs optionalString;
+
+  cfg = config.services.nimbus-beacon-node;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  toml = pkgs.formats.toml { };
+  removeNull = k: v: v != null;
+  cleanSettings = filterAttrs removeNull cfg.settings;
+  configFile = toml.generate "nimbus-beacon-node.toml" cleanSettings;
+in {
+  options = {
+    services = {
+      nimbus-beacon-node = {
+        enable = mkEnableOption "Nimbus Eth2 Beacon Node service.";
+
+        package = mkOption {
+          type = types.package;
+          default = packages.${system}.beacon_node;
+          defaultText = literalExpression "inputs.nimbus-eth2.packages.${system}.beacon-node";
+          description = lib.mdDoc "Package to use as Go Ethereum node.";
+        };
+
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          description = lib.mdDoc "Additional arguments passed to node.";
+          default = [];
+        };
+
+        settings = mkOption {
+          description = "TOML config file settings for Nimbus Eth2 beacon node.";
+          default = {};
+          type = types.submodule {
+            freeformType = toml.type;
+            options = {
+              data-dir = mkOption {
+                type = types.path;
+                default = "/var/lib/nimbus-beacon-node";
+                description = "Directory for Nimbus Eth2 blockchain data.";
+              };
+
+              era-dir = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = "Directory for Nimbus Eth2 ERA files.";
+              };
+
+              network = mkOption {
+                type = types.str;
+                default = "mainnet";
+                description = "Name of Eth2 network to connect to.";
+              };
+
+              graffiti = mkOption {
+                type = types.str;
+                default = "nimbus-beacon-node";
+                description = "Name of Eth2 network to connect to.";
+              };
+
+              genesis-state = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "SSZ file specifying the genesis state of the network";
+              };
+
+              log-level = mkOption {
+                type = types.str;
+                default = "info";
+                description = "Logging level for the node.";
+              };
+
+              log-format = mkOption {
+                type = types.str;
+                default = "auto";
+                description = "Logging formatting (auto, colors, nocolors, json).";
+              };
+
+              num-threads = mkOption {
+                type = types.int;
+                default = 0;
+                description = "Number of worker threads. Use 0 to detect CPU cores.";
+              };
+
+              nat = mkOption {
+                type = types.str;
+                default = "any";
+                example = "extip:12.34.56.78";
+                description = "Way to detect public IP address of the node to advertise.";
+              };
+
+              web3-url = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = "URL for the Web3 RPC endpoint.";
+              };
+
+              jwt-secret = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = "Path of JWT secret for Auth RPC endpoint.";
+              };
+
+              subscribe-all-subnets = mkOption {
+                type = types.bool;
+                default = false;
+                description = "Subscribe to all attestation subnet topics.";
+              };
+
+              doppelganger-detection = mkOption {
+                type = types.bool;
+                default = true;
+                description = ''
+                  Protection against slashing due to double-voting.
+                  Means you will miss two attestations when restarting.
+                '';
+              };
+
+              suggested-fee-recipient = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = ''
+                  Wallet address where transaction fee tips - priority fees,
+                  unburnt portion of gas fees - will be sent.
+                '';
+              };
+
+              tcp-port = mkOption {
+                type = types.int;
+                default = 9000;
+                description = "Listen port for libp2p protocol.";
+              };
+
+              udp-port = mkOption {
+                type = types.int;
+                default = 9000;
+                description = "Listen port for libp2p protocol.";
+              };
+
+              metrics = mkEnableOption "Nimbus Eth2 metrics endpoint";
+
+              metrics-address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = "Metrics address for beacon node.";
+              };
+
+              metrics-port = mkOption {
+                type = types.int;
+                default = 9100;
+                description = "Metrics port for beacon node.";
+              };
+
+              rest = mkEnableOption "Nimbus Eth2 REST API";
+
+              rest-address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = "Listening address of the REST API server";
+              };
+
+              rest-port = mkOption {
+                type = types.int;
+                default = 5052;
+                description = "Port for the REST API server";
+              };
+
+              payload-builder = mkEnableOption "Nimbus Eth2 REST API";
+
+              payload-builder-url = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "URL of builder API endpoint.";
+              };
+
+              local-block-value-boost = mkOption {
+                type = types.int;
+                default = 10;
+                description = "Bump exec layer builder bid comparison by a percentage.";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."ethereum/nimbus-beacon-node.toml".source = configFile;
+
+    systemd.services.nimbus-beacon-node = {
+      enable = true;
+      serviceConfig = {
+        DynamicUser = true;
+
+        # Hardening measures
+        PrivateTmp = "true";
+        ProtectSystem = "full";
+        NoNewPrivileges = "true";
+        PrivateDevices = "true";
+        MemoryDenyWriteExecute = "true";
+        WorkingDirectory = "%S/nimbus-beacon-node";
+        StateDirectory = "nimbus-beacon-node";
+        LoadCredential = optionals (cfg.settings.jwt-secret != null) [
+          "jwt-secret:${cfg.settings.jwt-secret}"
+        ];
+
+        Restart = "on-failure";
+        ExecStart = let
+          jwtFlag = optionalString (cfg.settings.jwt-secret != null)
+            "--jwt-secret=%d/jwt-secret";
+        in ''
+          ${cfg.package}/bin/nimbus_beacon_node \
+            --config-file=${configFile} ${jwtFlag} \
+            ${escapeShellArgs cfg.extraArgs}
+        '';
+      };
+      wantedBy = [ "multi-user.target" ];
+      requires = [ "network.target" ];
+    };
+  };
+}

--- a/nix/services/checks/beacon-node.nix
+++ b/nix/services/checks/beacon-node.nix
@@ -1,0 +1,36 @@
+{ self, pkgs, ... }:
+
+pkgs.testers.runNixOSTest {
+  name = "nimbus-beacon-node-check";
+
+  nodes.machine = {
+    imports = [ self.nixosModules.beacon-node ];
+
+    services.nimbus-beacon-node = {
+      enable = true;
+      settings = {
+        rest = true;
+        metrics = true;
+        # Avoid wasting time on Genesis download
+        genesis-state = toString (pkgs.fetchurl {
+          url = "https://github.com/eth-clients/hoodi/releases/download/genesis/genesis.ssz";
+          sha256 = "sha256-f0IlfvaeBVSWyWSnU7sH5UABzNV6tGfvctZ68Ia8/Oc=";
+        });
+      };
+    };
+  };
+
+  testScript = { nodes, ... }: with nodes.machine.services.nimbus-beacon-node.settings; ''
+    machine.wait_for_unit("nimbus-beacon-node.service")
+
+    # Port checks
+    machine.wait_for_open_port(${toString rest-port})
+    machine.wait_for_open_port(${toString metrics-port})
+    machine.wait_for_open_port(${toString tcp-port})
+    machine.wait_for_open_port(${toString udp-port})
+
+    # API checks
+    machine.succeed("curl -fsS localhost:${toString rest-port}/eth/v1/node/health")
+    machine.succeed("curl -fsS localhost:${toString metrics-port}/metrics | grep -E '^beacon_'")
+  '';
+}

--- a/nix/services/checks/validator-client.nix
+++ b/nix/services/checks/validator-client.nix
@@ -1,0 +1,26 @@
+{ self, pkgs, ... }:
+
+pkgs.testers.runNixOSTest {
+  name = "nimbus-validator-client-check";
+
+  nodes.machine = {
+    imports = [ self.nixosModules.validator-client ];
+
+    services.nimbus-validator-client = {
+      enable = true;
+      settings.keymanager = true;
+    };
+  };
+
+  testScript = { nodes, ... }: with nodes.machine.services.nimbus-validator-client.settings; ''
+    machine.wait_for_unit("nimbus-validator-client.service")
+
+    # Port checks
+    machine.wait_for_open_port(${toString keymanager-port})
+    machine.wait_for_open_port(${toString metrics-port})
+
+    # API checks
+    machine.succeed("curl -fsS localhost:${toString metrics-port}/metrics | grep -E '^beacon_'")
+    machine.succeed("curl -fsS localhost:${toString keymanager-port}/eth/v1/keystores")
+  '';
+}

--- a/nix/services/validator-client.nix
+++ b/nix/services/validator-client.nix
@@ -1,0 +1,176 @@
+{ packages }:
+
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkEnableOption mkOption mkIf
+    types filterAttrs escapeShellArgs literalExpression;
+
+  cfg = config.services.nimbus-validator-client;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  toml = pkgs.formats.toml {};
+  removeNull = k: v: v != null;
+  cleanSettings = filterAttrs removeNull cfg.settings;
+  configFile = toml.generate "nimbus-validator-client.toml" cleanSettings;
+in {
+  options = {
+    services = {
+      nimbus-validator-client = {
+        enable = mkEnableOption "Nimbus Eth2 Validator Client service.";
+
+        package = mkOption {
+          type = types.package;
+          default = packages.${system}.validator_client;
+          defaultText = literalExpression "inputs.nimbus-eth2.packages.${system}.validator-client";
+          description = lib.mdDoc "Package to use as Go Ethereum node.";
+        };
+
+        extraArgs = mkOption {
+          type = types.listOf types.str;
+          description = lib.mdDoc "Additional arguments passed to node.";
+          default = [];
+        };
+
+        settings = mkOption {
+          description = "TOML config file settings for Nimbus Eth2 validator client.";
+          default = {};
+          type = types.submodule {
+            freeformType = toml.type;
+            options = {
+              data-dir = mkOption {
+                type = types.str;
+                default = "%S/nimbus-validator-client";
+                description = "Directory for client keys and slashing DB.";
+              };
+
+              log-level = mkOption {
+                type = types.str;
+                default = "info";
+                description = "Logging level for the node.";
+              };
+
+              log-format = mkOption {
+                type = types.str;
+                default = "auto";
+                description = "Logging formatting (auto, colors, nocolors, json).";
+              };
+
+              doppelganger-detection = mkOption {
+                type = types.bool;
+                default = true;
+                description = ''
+                  Protection against slashing due to double-voting.
+                  Means you will miss two attestations when restarting.
+                '';
+              };
+
+              beacon-node = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = "URL addresses to one or more beacon node HTTP REST APIs [=$defaultBeaconNodeUri].";
+              };
+
+              payload-builder = mkOption {
+                type = types.nullOr types.bool;
+                default = null;
+                description = "Enable usage of beacon node with external payload builder (BETA) [=false].";
+              };
+
+              web3-signer-url = mkOption {
+                type = types.listOf types.str;
+                default = [];
+                description = "Remote Web3Signer URLs that will be used as a source of validators.";
+              };
+
+              # INFO: Shorter than slot time (12s) makes little sense. There's also some overhead.
+              web3-signer-update-interval = mkOption {
+                type = types.int;
+                default = 3600;
+                description = "Number of seconds between validator list updates [=3600].";
+              };
+
+              suggested-fee-recipient = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = "Suggested fee recipient.";
+              };
+
+              keymanager = mkEnableOption "Enable the REST keymanager API";
+
+              keymanager-port = mkOption {
+                type = types.port;
+                default = 5052;
+                description = "Listening port for the REST keymanager API";
+              };
+
+              keymanager-address = mkOption {
+                type = types.nullOr types.str;
+                default = "127.0.0.1";
+                description = "Listening port for the REST keymanager API";
+              };
+
+              keymanager-allow-origin = mkOption {
+                type = types.nullOr types.str;
+                default = null;
+                description = ''
+                  Limit the access to the Keymanager API to a particular hostname
+                  (for CORS-enabled clients such as browsers).
+                '';
+              };
+
+              keymanager-token-file = mkOption {
+                type = types.nullOr types.path;
+                default = null;
+                description = "A file specifying the authorizition token required for accessing the keymanager";
+              };
+
+              metrics = mkEnableOption "Nimbus Eth2 metrics endpoint";
+
+              metrics-address = mkOption {
+                type = types.str;
+                default = "127.0.0.1";
+                description = "Metrics address for validator-client.";
+              };
+
+              metrics-port = mkOption {
+                type = types.port;
+                default = 8008;
+                description = "Metrics port for validator client.";
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."ethereum/nimbus-validator-client.toml".source = configFile;
+
+    systemd.services.nimbus-validator-client = {
+      enable = true;
+      serviceConfig = {
+        DynamicUser = true;
+
+        # Hardening measures
+        PrivateTmp = "true";
+        ProtectSystem = "full";
+        NoNewPrivileges = "true";
+        PrivateDevices = "true";
+        StateDirectory = "nimbus-validator-client";
+        WorkingDirectory = "%S/nimbus-validator-client";
+        MemoryDenyWriteExecute = "true";
+
+        Restart = "on-failure";
+        ExecStart = ''
+          ${cfg.package}/bin/nimbus_validator_client \
+            --data-dir=${cfg.settings.data-dir} \
+            --config-file=${configFile} \
+            ${escapeShellArgs cfg.extraArgs}
+        '';
+      };
+      wantedBy = ["multi-user.target"];
+    };
+  };
+}


### PR DESCRIPTION
This adds NixOS service definitions that have been used for more than a year on our production fleets for ease of re-use in multiple fleet repos.