### PR TITLE
nix: introduce our nix cache to flake and ci

### DIFF
--- a/ci/nix.Jenkinsfile
+++ b/ci/nix.Jenkinsfile
@@ -6,7 +6,9 @@
  *   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
  * at your option. This file may not be copied, modified, or distributed except according to those terms.
  */
-library 'status-jenkins-lib@v1.9.41'
+library 'status-jenkins-lib@v1.9.44'
+
+def result = ''
 
 pipeline {
   agent {
@@ -23,6 +25,11 @@ pipeline {
       name: 'VERBOSITY',
       description: 'Value for the V make flag to increase log verbosity',
       choices: [0, 1, 2]
+    )
+    choice(
+      name: 'NIX_TARGET',
+      description: 'Nix flake target to build',
+      choices: ['beacon_node', 'validator_client']
     )
   }
 
@@ -44,15 +51,32 @@ pipeline {
   }
 
   stages {
-    stage('Beacon Node') {
+    stage('Deps') {
       steps { script {
-        nix.flake('beacon_node')
+        sh 'git submodule update --init --recursive'
+      } }
+    }
+
+    stage('Build') {
+      steps { script {
+        result = nix.flake(params.NIX_TARGET)
       } }
     }
 
     stage('Version check') {
       steps { script {
-        sh 'result/bin/nimbus_beacon_node --version'
+        sh "${result}/bin/nimbus_${params.NIX_TARGET} --version"
+      } }
+    }
+
+    stage('Push to Nix cache') {
+      when {
+        expression {
+          env.JOB_NAME.toLowerCase().contains('nightly')
+        }
+      }
+      steps { script {
+        nix.copyToCache(derivations: [result])
       } }
     }
   }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,12 @@
 {
   description = "nimbus-eth2";
 
+  nixConfig = {
+    extra-substituters = [ "https://nix-cache.status.im/" ];
+    extra-trusted-public-keys = [ "nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY=" ];
+  };
+
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs?rev=2a777ace4b722f2714cc06d596f2476ee628c04a";
     # WARNING: Do not use relative path, it breaks caching of NBS.


### PR DESCRIPTION
## Changes
- adapt the nix CI so it builds VC as well
- push the build artefacts to our nix cache
- add the usage of nix cache in flake.nix settings - speed up the builds

## Note
Before merging this I need to merge the:
* https://github.com/status-im/status-jenkins-lib/pull/138