### PR TITLE
add fork choice types for gloas

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -173,7 +173,7 @@ type
     balances*: seq[ForkChoiceBalance]
     execution_payload_states*: HashSet[Eth2Digest]
     ptc_vote*: Table[Eth2Digest, PtcVotes]
-    ptc_data_availability*: Table[Eth2Digest, PtcVotes]
+    ptc_data_availability_vote*: Table[Eth2Digest, PtcVotes]
     block_timeliness*: Table[Eth2Digest, array[2, bool]]
 
   QueuedAttestation* = object

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -184,10 +184,6 @@ type
     checkpoints*: Checkpoints
     queuedAttestations*: seq[QueuedAttestation]
 
-  ForkChoiceNode* = object
-    root*: Eth2Digest
-    payloadStatus*: PayloadStatus
-
 func shortLog*(vote: VoteTracker): auto =
   (
     slot: vote.slot,

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -146,14 +146,13 @@ type
     current_root*: Eth2Digest
     next_root*: Eth2Digest
     slot*: Slot
-    next_epoch*: Epoch
-    next_slot*: Slot
     payload_present*: bool
     next_payload_present*: bool
 
   PtcVotes* = object
     voted*: BitArray[int(PTC_SIZE)]
-    value*: BitArray[int(PTC_SIZE)]
+    payload_present*: BitArray[int(PTC_SIZE)]
+    data_available*: BitArray[int(PTC_SIZE)]
 
   BalanceSource* = object
     # Effective balances / slashings in `info` based on historical checkpoint.
@@ -175,7 +174,6 @@ type
     balances*: seq[ForkChoiceBalance]
     execution_payload_states*: HashSet[Eth2Digest]
     ptc_vote*: Table[Eth2Digest, PtcVotes]
-    ptc_data_availability_vote*: Table[Eth2Digest, PtcVotes]
     block_timeliness*: Table[Eth2Digest, array[2, bool]]
 
   QueuedAttestation* = object
@@ -198,8 +196,6 @@ func shortLog*(vote: VoteTracker): auto =
     slot: vote.slot,
     current_root: shortLog(vote.current_root),
     next_root: shortLog(vote.next_root),
-    next_epoch: vote.next_epoch,
-    next_slot: vote.next_slot,
     payload_present: vote.payload_present,
     next_payload_present: vote.next_payload_present
   )

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -147,11 +147,6 @@ type
     payload_present*: bool
     next_payload_present*: bool
 
-  PtcVotes* = object
-    voted*: BitArray[int(PTC_SIZE)]
-    payload_present*: BitArray[int(PTC_SIZE)]
-    data_available*: BitArray[int(PTC_SIZE)]
-
   BalanceSource* = object
     # Effective balances / slashings in `info` based on historical checkpoint.
     # The `assigned_slots` (`fast_confirmation.nim`) are based on `dag.head`
@@ -170,7 +165,6 @@ type
     previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
-    ptc_vote*: Table[Eth2Digest, PtcVotes]
     block_timeliness*: Table[Eth2Digest, array[2, bool]]
 
   QueuedAttestation* = object

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/tables,
+  std/[sets, tables],
   # Status
   results,
   chronicles,
@@ -121,6 +121,9 @@ type
     invalid*: bool
     bestChild*: Opt[Index]
     bestDescendant*: Opt[Index]
+    parentPayloadStatus*: PayloadStatus
+    bidBlockHash*: Eth2Digest
+    proposerIndex*: uint64
 
   BalanceCheckpoint* = object
     checkpoint*: Checkpoint
@@ -142,6 +145,13 @@ type
     current_root*: Eth2Digest
     next_root*: Eth2Digest
     slot*: Slot
+    next_epoch*: Epoch
+    next_slot*: Slot
+    payload_present*: bool
+
+  PtcVotes* = object
+    voted*: BitArray[int(PTC_SIZE)]
+    value*: BitArray[int(PTC_SIZE)]
 
   BalanceSource* = object
     # Effective balances / slashings in `info` based on historical checkpoint.
@@ -161,22 +171,34 @@ type
     previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
+    execution_payload_states*: HashSet[Eth2Digest]
+    ptc_vote*: Table[Eth2Digest, PtcVotes]
+    ptc_data_availability*: Table[Eth2Digest, PtcVotes]
+    block_timeliness*: Table[Eth2Digest, array[2, bool]]
 
   QueuedAttestation* = object
     attesting_indices*: seq[ValidatorIndex]
     block_root*: Eth2Digest
     slot*: Slot
+    committee_index*: CommitteeIndex
 
   ForkChoice* = object
     backend*: ForkChoiceBackend
     checkpoints*: Checkpoints
     queuedAttestations*: seq[QueuedAttestation]
 
+  ForkChoiceNode* = object
+    root*: Eth2Digest
+    payloadStatus*: PayloadStatus
+
 func shortLog*(vote: VoteTracker): auto =
   (
     slot: vote.slot,
     current_root: shortLog(vote.current_root),
     next_root: shortLog(vote.next_root),
+    next_epoch: vote.next_epoch,
+    next_slot: vote.next_slot,
+    payload_present: vote.payload_present
   )
 
 chronicles.formatIt VoteTracker: it.shortLog

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -108,6 +108,7 @@ type
     checkpoints*: FinalityCheckpoints
     nodes*: ProtoNodes
     indices*: Table[Eth2Digest, Index]
+    fullBlockIndices*: Table[Eth2Digest, Index]
     unrealized*: Table[Index, FinalityCheckpoints]
     previousProposerBoostRoot*: Eth2Digest
     previousProposerBoostScore*: Gwei
@@ -148,6 +149,7 @@ type
     next_epoch*: Epoch
     next_slot*: Slot
     payload_present*: bool
+    next_payload_present*: bool
 
   PtcVotes* = object
     voted*: BitArray[int(PTC_SIZE)]
@@ -198,7 +200,8 @@ func shortLog*(vote: VoteTracker): auto =
     next_root: shortLog(vote.next_root),
     next_epoch: vote.next_epoch,
     next_slot: vote.next_slot,
-    payload_present: vote.payload_present
+    payload_present: vote.payload_present,
+    next_payload_present: vote.next_payload_present
   )
 
 chronicles.formatIt VoteTracker: it.shortLog

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -165,7 +165,6 @@ type
     previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
-    block_timeliness*: Table[Eth2Digest, array[2, bool]]
 
   QueuedAttestation* = object
     attesting_indices*: seq[ValidatorIndex]

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -122,7 +122,6 @@ type
     invalid*: bool
     bestChild*: Opt[Index]
     bestDescendant*: Opt[Index]
-    proposerIndex*: uint64
 
   BalanceCheckpoint* = object
     checkpoint*: Checkpoint

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -9,7 +9,7 @@
 
 import
   # Standard library
-  std/[sets, tables],
+  std/tables,
   # Status
   results,
   chronicles,
@@ -122,8 +122,6 @@ type
     invalid*: bool
     bestChild*: Opt[Index]
     bestDescendant*: Opt[Index]
-    parentPayloadStatus*: PayloadStatus
-    bidBlockHash*: Eth2Digest
     proposerIndex*: uint64
 
   BalanceCheckpoint* = object
@@ -172,7 +170,6 @@ type
     previous_slot_head*, current_slot_head*: Eth2Digest
     votes*: seq[VoteTracker]
     balances*: seq[ForkChoiceBalance]
-    execution_payload_states*: HashSet[Eth2Digest]
     ptc_vote*: Table[Eth2Digest, PtcVotes]
     block_timeliness*: Table[Eth2Digest, array[2, bool]]
 

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -335,7 +335,10 @@ func onBlock*(
     bid: BlockId,
     parent: Eth2Digest,
     checkpoints: FinalityCheckpoints,
-    unrealized = Opt.none(FinalityCheckpoints)): FcResult[void] =
+    unrealized = Opt.none(FinalityCheckpoints),
+    parent_payload_status = PAYLOAD_STATUS_PENDING,
+    bidBlockHash = ZERO_HASH,
+    proposerIndex = 0'u64): FcResult[void] =
   ## Register a block with the fork choice
   ## A block `hasParentInForkChoice` may be false
   ## on fork choice initialization:
@@ -360,7 +363,10 @@ func onBlock*(
   let node = ProtoNode(
     bid: bid,
     parent: Opt.some(parentIdx),
-    checkpoints: checkpoints)
+    checkpoints: checkpoints,
+    parentPayloadStatus: parent_payload_status,
+    bidBlockHash: bidBlockHash,
+    proposerIndex: proposerIndex)
 
   self.indices[node.bid.root] = nodeLogicalIdx
   self.nodes.add node

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -335,8 +335,7 @@ func onBlock*(
     bid: BlockId,
     parent: Eth2Digest,
     checkpoints: FinalityCheckpoints,
-    unrealized = Opt.none(FinalityCheckpoints),
-    proposerIndex = 0'u64): FcResult[void] =
+    unrealized = Opt.none(FinalityCheckpoints)): FcResult[void] =
   ## Register a block with the fork choice
   ## A block `hasParentInForkChoice` may be false
   ## on fork choice initialization:
@@ -361,8 +360,7 @@ func onBlock*(
   let node = ProtoNode(
     bid: bid,
     parent: Opt.some(parentIdx),
-    checkpoints: checkpoints,
-    proposerIndex: proposerIndex)
+    checkpoints: checkpoints)
 
   self.indices[node.bid.root] = nodeLogicalIdx
   self.nodes.add node

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -336,8 +336,6 @@ func onBlock*(
     parent: Eth2Digest,
     checkpoints: FinalityCheckpoints,
     unrealized = Opt.none(FinalityCheckpoints),
-    parent_payload_status = PAYLOAD_STATUS_PENDING,
-    bidBlockHash = ZERO_HASH,
     proposerIndex = 0'u64): FcResult[void] =
   ## Register a block with the fork choice
   ## A block `hasParentInForkChoice` may be false
@@ -364,8 +362,6 @@ func onBlock*(
     bid: bid,
     parent: Opt.some(parentIdx),
     checkpoints: checkpoints,
-    parentPayloadStatus: parent_payload_status,
-    bidBlockHash: bidBlockHash,
     proposerIndex: proposerIndex)
 
   self.indices[node.bid.root] = nodeLogicalIdx


### PR DESCRIPTION
Context:
Implements EIP-7732 fork choice changes. Beacon blocks no longer contain execution payloads directly; a proposer commits to a builder's bid, the builder (self-built or external) delivers the payload seperately, and a Payload Timeliness Committee  (PTC) votes on whether it arrived timely.

In this implementation the forkchoice now handles blocks in two states (with and without a verified payload). Using a dual-node architecture where each block can expand into `EMPTY` and `FULL` variants.

Proposed implementation will follow the following steps:
  1. Fork choice types (this PR)
    - New fields on ProtoNode, VoteTracker, QueuedAttestation, ForkChoiceBackend
    - New PtcVotes, ForkChoiceNode types; ProtoArray object gains fullBlockIndices
  2. Dual-node proto_array
    - FULL virtual nodes as siblings to EMPTY, parent routing, head payload status, sibling resolution, prune cleanup. ~2x nodes worst case (assuming no empty blocks), bounded by pruning; no special-casing in tree traversal
  3. Payload-aware vote delta computation
    - Route vote weight to FULL or EMPTY node based on payload preference with one extra table lookup per vote change.
  4. PTC vote recording, block timeliness tracking with indexed equivocation lookup, payload envelope verification
  5. Attestation pipeline
    - Slot-based vote tracking, full-payload vote filtering, committee index as
  payload preference signal. The epoch-level dedup is replaced with slot-level dedup.
  6. Proposer boost gating
    - Conditional boost based on weak-head detection and equivocation checks with constant-time per head computation with no tree walks
  7. process_block integration
    - Parent payload status computation, batch PTC processing from in-block payload attestations.