### PR TITLE
Revert "Do not compute shuffling for answering total_active_balance query (#8214)"

### DIFF
--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1083,7 +1083,7 @@ func get_total_active_balance*(state: ForkyBeaconState, cache: var StateCache): 
     return tab[]
   do:
     let tab = get_total_balance(
-      state, get_active_validator_indices(state, epoch))
+      state, cache.get_shuffled_active_validator_indices(state, epoch))
     cache.total_active_balance[epoch] = tab
     return tab
 


### PR DESCRIPTION
This reverts commit 0c28bd8a6bca84f6af6a8b3ee84f8a716de7235d.