### PR TITLE
allow a slot gap while still remaining synced or synced/opt

### DIFF
--- a/beacon_chain/sync/sync_overseer.nim
+++ b/beacon_chain/sync/sync_overseer.nim
@@ -595,7 +595,7 @@ proc syncStatusMessage*(
           ""
 
   if len(res) == 0:
-    if overseer.syncDistance() <= 1:
+    if overseer.syncDistance() <= 2:
       if optimistic:
         "synced/opt"
       else:


### PR DESCRIPTION
Especially on any testnet, there are frequently missed slots, and this heuristic is too sensitive.