### PR TITLE
Fix gossip check for committee length

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1471,9 +1471,8 @@ proc validateAggregate*(
     shufflingRef.get_committee_index(agg_idx.uint64).valueOr:
       return pool.checkedReject("Aggregate: committee index not within expected range")
 
-  if not aggregate.aggregation_bits.lenu64 == get_beacon_committee_len(
-    shufflingRef, slot, committee_index
-  ):
+  if not (aggregate.aggregation_bits.lenu64 == get_beacon_committee_len(
+      shufflingRef, slot, committee_index)):
     return pool.checkedReject(
       "Aggregate: number of aggregation bits and committee size mismatch"
     )


### PR DESCRIPTION
As part of the #7999 clean ups, the `compatible_with_shuffling` helper from #5610 was removed and inlined. Original parens were not restored, making this a bitwise not instead of a !=