### PR TITLE
feat(rest): expose peer score and disconnect reason on /eth/v1/node/peers

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -129,6 +129,8 @@ type
     direction*: PeerType
     disconnectedFut: Future[void]
     statistics*: SyncResponseStats
+    lastDisconnectReason*: Opt[DisconnectionReason]
+    lastDisconnectAt*: Opt[chronos.Moment]
 
   PeerAddr* = object
     peerId*: PeerId
@@ -569,6 +571,8 @@ proc disconnect*(peer: Peer, reason: DisconnectionReason,
   # we currently don't - the fact that we're disconnecting is obvious and the
   # reason already known (wrong network is known from status message) or doesn't
   # greatly matter for the listening side (since it can't be trusted anyway)
+  peer.lastDisconnectReason = Opt.some(reason)
+  peer.lastDisconnectAt = Opt.some(chronos.Moment.now())
   try:
     if peer.connectionState notin {Disconnecting, Disconnected}:
       peer.connectionState = Disconnecting

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -221,8 +221,12 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
           agent: node.network.switch.peerStore[AgentBook][peer.peerId],
           proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId],
           score: Opt.some(peer.score),
+          # Per beacon-API spec, `disconnect_reason` MUST only be populated
+          # when `state` is `disconnected` or `disconnecting`.
           disconnect_reason:
-            if peer.lastDisconnectReason.isSome():
+            if peer.connectionState in
+                {ConnectionState.Disconnected, ConnectionState.Disconnecting} and
+                peer.lastDisconnectReason.isSome():
               Opt.some(mapDisconnectReason(peer.lastDisconnectReason.get()))
             else:
               Opt.none(string)
@@ -276,7 +280,11 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
           # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
           # part of specification
         disconnect_reason:
-            if peer.lastDisconnectReason.isSome():
+            # Per beacon-API spec, `disconnect_reason` MUST only be populated
+            # when `state` is `disconnected` or `disconnecting`.
+            if peer.connectionState in
+                {ConnectionState.Disconnected, ConnectionState.Disconnecting} and
+                peer.lastDisconnectReason.isSome():
               Opt.some(mapDisconnectReason(peer.lastDisconnectReason.get()))
             else:
               Opt.none(string)

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -203,9 +203,10 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
           last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
           state: peer.connectionState.toString(),
           direction: peer.direction.toString(),
-          # Fields `agent` and `proto` are not part of specification
+          # Fields `agent`, `proto` and `score` are not part of specification
           agent: node.network.switch.peerStore[AgentBook][peer.peerId],
-          proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId]
+          proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId],
+          score: Opt.some(peer.score)
         )
         res.add(peer)
     RestApiResponse.jsonResponseWMeta(res, (count: RestNumeric(len(res))))
@@ -247,9 +248,11 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
         state: peer.connectionState.toString(),
         direction: peer.direction.toString(),
         agent: node.network.switch.peerStore[AgentBook][peer.peerId],
-          # Fields `agent` and `proto` are not part of specification
-        proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId]
-          # Fields `agent` and `proto` are not part of specification
+          # Fields `agent`, `proto` and `score` are not part of specification
+        proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId],
+          # Fields `agent`, `proto` and `score` are not part of specification
+        score: Opt.some(peer.score)
+          # Fields `agent`, `proto` and `score` are not part of specification
       )
     )
 

--- a/beacon_chain/rpc/rest_node_api.nim
+++ b/beacon_chain/rpc/rest_node_api.nim
@@ -109,6 +109,19 @@ proc toString(direction: PeerType): string =
   of PeerType.Outgoing:
     "outbound"
 
+proc mapDisconnectReason(reason: DisconnectionReason): string =
+  # Maps Nimbus's internal `DisconnectionReason` enum onto the controlled
+  # vocabulary proposed for `/eth/v1/node/peers` `disconnect_reason`.
+  case reason
+  of ClientShutDown:
+    "client_shutdown"
+  of IrrelevantNetwork:
+    "irrelevant_network"
+  of FaultOrError:
+    "io_error"
+  of PeerScoreLow:
+    "bad_score"
+
 proc getLastSeenAddress(node: BeaconNode, id: PeerId): string =
   let
     address = node.network.switch.peerStore[LastSeenBook][id].valueOr:
@@ -203,10 +216,16 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
           last_seen_p2p_address: getLastSeenAddress(node, peer.peerId),
           state: peer.connectionState.toString(),
           direction: peer.direction.toString(),
-          # Fields `agent`, `proto` and `score` are not part of specification
+          # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
+          # part of specification
           agent: node.network.switch.peerStore[AgentBook][peer.peerId],
           proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId],
-          score: Opt.some(peer.score)
+          score: Opt.some(peer.score),
+          disconnect_reason:
+            if peer.lastDisconnectReason.isSome():
+              Opt.some(mapDisconnectReason(peer.lastDisconnectReason.get()))
+            else:
+              Opt.none(string)
         )
         res.add(peer)
     RestApiResponse.jsonResponseWMeta(res, (count: RestNumeric(len(res))))
@@ -248,11 +267,21 @@ proc installNodeApiHandlers*(router: var RestRouter, node: BeaconNode) =
         state: peer.connectionState.toString(),
         direction: peer.direction.toString(),
         agent: node.network.switch.peerStore[AgentBook][peer.peerId],
-          # Fields `agent`, `proto` and `score` are not part of specification
+          # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
+          # part of specification
         proto: node.network.switch.peerStore[ProtoVersionBook][peer.peerId],
-          # Fields `agent`, `proto` and `score` are not part of specification
-        score: Opt.some(peer.score)
-          # Fields `agent`, `proto` and `score` are not part of specification
+          # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
+          # part of specification
+        score: Opt.some(peer.score),
+          # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
+          # part of specification
+        disconnect_reason:
+            if peer.lastDisconnectReason.isSome():
+              Opt.some(mapDisconnectReason(peer.lastDisconnectReason.get()))
+            else:
+              Opt.none(string)
+          # Fields `agent`, `proto`, `score` and `disconnect_reason` are not
+          # part of specification
       )
     )
 

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -257,6 +257,7 @@ type
     agent*: string # This is not part of specification
     proto*: string # This is not part of specification
     score*: Opt[int] # This is not part of specification
+    disconnect_reason*: Opt[string] # This is not part of specification
 
   RestSyncPeer* = object
     peer_id*: string

--- a/beacon_chain/spec/eth2_apis/rest_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_types.nim
@@ -256,6 +256,7 @@ type
     direction*: string
     agent*: string # This is not part of specification
     proto*: string # This is not part of specification
+    score*: Opt[int] # This is not part of specification
 
   RestSyncPeer* = object
     peer_id*: string


### PR DESCRIPTION
## Summary

Extends `/eth/v1/node/peers` (and `/eth/v1/node/peers/{peer_id}`) with two optional fields per a simplified beacon-API spec extension currently under discussion:

- `score` — from `Peer.score: int` (Nimbus's application-level reputation score, [0, 1000] with default 300)
- `disconnect_reason` — from a new `lastDisconnectReason` field on `Peer`, mapped to the spec controlled vocab

`agent_version` is already exposed in Nimbus's current response (under field name `agent`).

`downscore_reasons` is **deliberately omitted** — Nimbus doesn't currently track per-event reason history. Adding it would require instrumenting the ~30 call sites that adjust `Peer.score`. Happy to follow up if there's interest.

## Spec proposal

ethereum/beacon-APIs#606

## What's in this PR

### Commit 1: expose `score`
- `beacon_chain/spec/eth2_apis/rest_types.nim` — add `score*: Opt[int]` to `RestNodePeer`.
- `beacon_chain/rpc/rest_node_api.nim` — populate from `peer.score` in both the list and single-peer handlers.

### Commit 2: expose `disconnect_reason`
- `beacon_chain/networking/eth2_network.nim` — add `lastDisconnectReason*: Opt[DisconnectionReason]` + `lastDisconnectAt*: Opt[chronos.Moment]` to the `Peer` object. Instrument `proc disconnect*` at the top, so all ~20 disconnect call sites are caught at the single choke point.
- `beacon_chain/spec/eth2_apis/rest_types.nim` — add `disconnect_reason*: Opt[string]` to `RestNodePeer`.
- `beacon_chain/rpc/rest_node_api.nim` — add `mapDisconnectReason()` translating Nimbus's 4-value `DisconnectionReason` enum to the spec controlled vocab (`ClientShutDown → client_shutdown`, `IrrelevantNetwork → irrelevant_network`, `FaultOrError → io_error`, `PeerScoreLow → bad_score`).

## Coordinated implementations

Part of a coordinated multi-client effort — see ethereum/beacon-APIs#606 for the other five client PRs.

## Status

**Draft.** `nim check` on all three patched files: identical error counts vs. pre-patch baseline (only pre-existing version.nim / forks.nim issues, none introduced by this patch).