### PR TITLE
Remove EngineApiRole configuration

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -616,7 +616,6 @@ AllTests-mainnet
 ## EL Configuration
 ```diff
 + Empty config file                                                                          OK
-+ Invalid URls                                                                               OK
 + New style config files                                                                     OK
 + Old style config files                                                                     OK
 + URL parsing                                                                                OK

--- a/beacon_chain/el/el_conf.nim
+++ b/beacon_chain/el/el_conf.nim
@@ -17,33 +17,22 @@ import
   toml_serialization/std/uri as confTomlUri,
   ../spec/engine_authentication
 
-from std/strutils import toLowerAscii, split, startsWith
+from std/strutils import toLowerAscii, startsWith
 
 export
   toml_serialization, confTomlDefs, confTomlNet, confTomlUri
 
 type
-  EngineApiRole* = enum
-    DepositSyncing = "sync-deposits"
-    BlockValidation = "validate-blocks"
-    BlockProduction = "produce-blocks"
-
-  EngineApiRoles* = set[EngineApiRole]
-
   EngineApiUrl* = object
     url: string
     jwtSecret: Opt[JwtSharedKey]
-    roles: EngineApiRoles
 
   EngineApiUrlConfigValue* = object
     url*: string # TODO: Use the URI type here
     jwtSecret* {.serializedFieldName: "jwt-secret".}: Option[string]
     jwtSecretFile* {.serializedFieldName: "jwt-secret-file".}: Option[InputFile]
-    roles*: Option[EngineApiRoles]
 
 const
-  defaultEngineApiRoles* = { DepositSyncing, BlockValidation, BlockProduction }
-
   # https://github.com/ethereum/execution-apis/pull/302
   defaultJwtSecret = "d4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3"
 
@@ -52,9 +41,8 @@ chronicles.formatIt EngineApiUrl:
 
 proc init*(T: type EngineApiUrl,
            url: string,
-           jwtSecret = Opt.none JwtSharedKey,
-           roles = defaultEngineApiRoles): T =
-  T(url: url, jwtSecret: jwtSecret, roles: roles)
+           jwtSecret = Opt.none JwtSharedKey): T =
+  T(url: url, jwtSecret: jwtSecret)
 
 func url*(engineUrl: EngineApiUrl): string =
   engineUrl.url
@@ -62,47 +50,12 @@ func url*(engineUrl: EngineApiUrl): string =
 func jwtSecret*(engineUrl: EngineApiUrl): Opt[JwtSharedKey] =
   engineUrl.jwtSecret
 
-func roles*(engineUrl: EngineApiUrl): EngineApiRoles =
-  engineUrl.roles
-
-func unknownRoleMsg(role: string): string =
-  "'" & role & "' is not a valid EL function"
-
-template raiseError(reader: var TomlReader, msg: string) =
-  raiseTomlErr(reader.lex, msg)
-
-proc readValue*(reader: var TomlReader, value: var EngineApiRoles)
-               {.raises: [SerializationError, IOError].} =
-  let roles = reader.readValue seq[string]
-  if roles.len == 0:
-    reader.raiseError "At least one role should be provided"
-  for role in roles:
-    case role.toLowerAscii
-    of $DepositSyncing:
-      value.incl DepositSyncing
-    of $BlockValidation:
-      value.incl BlockValidation
-    of $BlockProduction:
-      value.incl BlockProduction
-    else:
-      reader.raiseError(unknownRoleMsg role)
-
-proc writeValue*(
-    writer: var JsonWriter, roles: EngineApiRoles) {.raises: [IOError].} =
-  var strRoles: seq[string]
-
-  for role in EngineApiRole:
-    if role in roles: strRoles.add $role
-
-  writer.writeValue strRoles
-
 proc parseCmdArg*(T: type EngineApiUrlConfigValue, input: string): T
                  {.raises: [ValueError].} =
   var
     uri = parseUri(input)
     jwtSecret: Option[string]
     jwtSecretFile: Option[InputFile]
-    roles: Option[EngineApiRoles]
 
   if uri.anchor != "":
     for key, value in decodeQuery(uri.anchor):
@@ -111,21 +64,6 @@ proc parseCmdArg*(T: type EngineApiUrlConfigValue, input: string): T
         jwtSecret = some value
       of "jwtSecretFile", "jwt-secret-file":
         jwtSecretFile = some InputFile.parseCmdArg(value)
-      of "roles":
-        var uriRoles: EngineApiRoles = {}
-        for role in split(value, ","):
-          case role.toLowerAscii
-          of $DepositSyncing:
-            uriRoles.incl DepositSyncing
-          of $BlockValidation:
-            uriRoles.incl BlockValidation
-          of $BlockProduction:
-            uriRoles.incl BlockProduction
-          else:
-            raise newException(ValueError, unknownRoleMsg role)
-        if uriRoles == {}:
-          raise newException(ValueError, "The list of roles should not be empty")
-        roles = some uriRoles
       else:
         raise newException(ValueError, "'" & key & "' is not a recognized Engine URL property")
     uri.anchor = ""
@@ -133,8 +71,7 @@ proc parseCmdArg*(T: type EngineApiUrlConfigValue, input: string): T
   EngineApiUrlConfigValue(
     url: $uri,
     jwtSecret: jwtSecret,
-    jwtSecretFile: jwtSecretFile,
-    roles: roles)
+    jwtSecretFile: jwtSecretFile)
 
 proc readValue*(reader: var TomlReader, value: var EngineApiUrlConfigValue)
                {.raises: [SerializationError, IOError].} =
@@ -186,8 +123,7 @@ proc toFinalUrl*(confValue: EngineApiUrlConfigValue,
 
   ok EngineApiUrl.init(
     url = url,
-    jwtSecret = jwtSecret,
-    roles = confValue.roles.get(defaultEngineApiRoles))
+    jwtSecret = jwtSecret)
 
 proc loadJwtSecret*(jwtSecret: Opt[InputFile]): Opt[JwtSharedKey] =
   if jwtSecret.isSome:

--- a/tests/test_el_conf.nim
+++ b/tests/test_el_conf.nim
@@ -39,7 +39,6 @@ suite "EL Configuration":
     let url1 = EngineApiUrlConfigValue.parseCmdArg("localhost:8484")
     check:
       url1.url == "localhost:8484"
-      url1.roles.isNone
       url1.jwtSecret.isNone
       url1.jwtSecretFile.isNone
 
@@ -51,26 +50,22 @@ suite "EL Configuration":
       url1Final1.isOk
       url1Final1.get.url == "ws://localhost:8484"
       url1Final1.get.jwtSecret.get == validJwtToken
-      url1Final1.get.roles == defaultEngineApiRoles
 
       url1Final2.isOk
       url1Final2.get.url == "ws://localhost:8484"
       url1Final2.get.jwtSecret.isNone
-      url1Final2.get.roles == defaultEngineApiRoles
 
     let url2 = EngineApiUrlConfigValue.parseCmdArg(
       "https://eth-node.io:2020#jwt-secret-file=tests/media/jwt.hex")
     check:
       url2.url == "https://eth-node.io:2020"
-      url2.roles.isNone
       url2.jwtSecret.isNone
       url2.jwtSecretFile.get.string == "tests/media/jwt.hex"
 
     let url3 = EngineApiUrlConfigValue.parseCmdArg(
-      "http://localhost/#roles=sync-deposits&jwt-secret=ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba")
+      "http://localhost/#jwt-secret=ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba")
     check:
       url3.url == "http://localhost/"
-      url3.roles == some({DepositSyncing})
       url3.jwtSecret == some("ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba")
       url3.jwtSecretFile.isNone
 
@@ -78,43 +73,11 @@ suite "EL Configuration":
     check:
       url3Final.isOk
       url3Final.get.jwtSecret.get.toHex == "ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba"
-      url3Final.get.roles == {DepositSyncing}
-
-    let url4 = EngineApiUrlConfigValue.parseCmdArg(
-      "localhost#roles=sync-deposits,validate-blocks&jwt-secret=ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba23")
-    check:
-      url4.url == "localhost"
-      url4.roles == some({DepositSyncing, BlockValidation})
-      url4.jwtSecret == some("ee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba23")
-      url4.jwtSecretFile.isNone
-
-    let url4Final = url4.toFinalUrl(Opt.some validJwtToken)
-    check:
-      not url4Final.isOk # the JWT secret is invalid
-
-    let url5 = EngineApiUrlConfigValue.parseCmdArg(
-      "http://127.0.0.1:9090/#roles=sync-deposits,validate-blocks,produce-blocks,sync-deposits")
-    check:
-      url5.url == "http://127.0.0.1:9090/"
-      url5.roles == some({DepositSyncing, BlockValidation, BlockProduction})
-      url5.jwtSecret.isNone
-      url5.jwtSecretFile.isNone
-
-  test "Invalid URls":
-    template testInvalidUrl(url: string) =
-      expect ValueError:
-        echo "This URL should be invalid: ", EngineApiUrlConfigValue.parseCmdArg(url)
-
-    testInvalidUrl "http://127.0.0.1:9090/#roles="
-    testInvalidUrl "http://127.0.0.1:9090/#roles=sy"
-    testInvalidUrl "http://127.0.0.1:9090/#roles=sync-deposits,"
-    testInvalidUrl "http://127.0.0.1:9090/#roles=sync-deposits;validate-blocks"
-    testInvalidUrl "http://127.0.0.1:9090/#roles=validate-blocks,sync-deps"
 
   test "Old style config files":
     let cfg = loadExampleConfig """
       data-dir = "/foo"
-      el = ["http://localhost:8585", "eth-data.io#roles=sync-deposits", "wss://eth-nodes.io/21312432"]
+      el = ["http://localhost:8585", "eth-data.io", "wss://eth-nodes.io/21312432"]
     """
 
     check:
@@ -122,7 +85,6 @@ suite "EL Configuration":
       cfg.el.len == 3
       cfg.el[0].url == "http://localhost:8585"
       cfg.el[1].url == "eth-data.io"
-      cfg.el[1].roles == some({DepositSyncing})
       cfg.el[2].url == "wss://eth-nodes.io/21312432"
 
   test "New style config files":
@@ -135,7 +97,6 @@ suite "EL Configuration":
 
       [[el]]
       url = "eth-data.io"
-      roles = ["sync-deposits", "produce-blocks"]
 
       [[el]]
       url = "wss://eth-nodes.io/21312432"
@@ -147,17 +108,14 @@ suite "EL Configuration":
 
       cfg.el.len == 3
       cfg.el[0].url == "http://localhost:8585"
-      cfg.el[0].roles.isNone
       cfg.el[0].jwtSecret.isNone
       cfg.el[0].jwtSecretFile.get.string == "tests/media/jwt.hex"
 
       cfg.el[1].url == "eth-data.io"
-      cfg.el[1].roles == some({DepositSyncing, BlockProduction})
       cfg.el[1].jwtSecret.isNone
       cfg.el[1].jwtSecretFile.isNone
 
       cfg.el[2].url == "wss://eth-nodes.io/21312432"
-      cfg.el[2].roles.isNone
       cfg.el[2].jwtSecret.get == "0xee95565a2cc95553d4bf2185f58658939ba3074ce5695cbabfab4a1eaf7098ba"
       cfg.el[2].jwtSecretFile.isNone
 


### PR DESCRIPTION
The EL roles feature from #4465 was never implemented or documented, only the BN roles feature shipped. The three original EL roles were:

- DepositSyncing --> not relevant anymore since Electra
- BlockValidation --> normal operation
- BlockProduction --> kinda weird as a standalone, implies validation

Notably, this doesn't align with the way how external MEVboost works, and also doesn't align with the ePBS work from Gloas where production can be outsourced over the decentralized marketplace.

As EL roles never advanced past the config parsing stage, and this feature wasn't documented or advertised, just drop it for now. It wasn't used for >3 years.