### PR TITLE
Remove nim-eth2-scenarios from autobump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     ignore:
       - dependency-name: vendor/nim-libp2p
         versions: ["<= 0.0.0"]
+      - dependency-name: vendor/nim-eth2-scenarios
     schedule:
       interval: daily
     target-branch: unstable


### PR DESCRIPTION
Manually track nim-eth2-scenarios, the autobumps can't work as at the very least the SPEC_VERSION has to be bumped.