### PR TITLE
Handle zero filled beacon chain file

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -89,6 +89,7 @@ AllTests-mainnet
 + Auto check/repair test (missing footer)                                                    OK
 + Auto check/repair test (missing last chunk)                                                OK
 + Auto check/repair test (only header)                                                       OK
++ Auto check/repair test (zero-filled file)                                                  OK
 + Fixture file validation                                                                    OK
 ```
 ## Beacon state [Preset: mainnet]

--- a/beacon_chain/beacon_chain_file.nim
+++ b/beacon_chain/beacon_chain_file.nim
@@ -728,6 +728,8 @@ proc seekForChunkBackward(
     if indexOpt.isNone():
       setFilePos(handle, offset, SeekPosition.SeekBegin).isOkOr:
         return err(ioErrorMsg(error))
+      if offset == 0'i64:
+        return ok(Opt.none(int64))
       continue
 
     state = 0

--- a/tests/test_beacon_chain_file.nim
+++ b/tests/test_beacon_chain_file.nim
@@ -60,14 +60,15 @@ type
 suite "Beacon chain file test suite":
   var fixtureData: seq[byte]
 
-  proc doAutoCheckRepairTest(id, size: int): Result[AutoRepairObject, string] =
+  proc doAutoCheckRepairTest(
+      id: int, data: openArray[byte]): Result[AutoRepairObject, string] =
     let path =
       block:
         let res = getTempPath().valueOr:
           return err(ioErrorMsg(error))
-        res & DirSep & "tmp_" & $id & "_" & $size & ".tmp"
+        res & DirSep & "tmp_" & $id & "_" & $len(data) & ".tmp"
     discard removeFile(path)
-    io2.writeFile(path, fixtureData.toOpenArray(0, size - 1)).isOkOr:
+    io2.writeFile(path, data).isOkOr:
       return err(ioErrorMsg(error))
     let
       flags = {ChainFileFlag.Repair}
@@ -79,6 +80,9 @@ suite "Beacon chain file test suite":
     removeFile(path).isOkOr:
       return err(ioErrorMsg(error))
     ok(AutoRepairObject(data: fres.data, size: filesize))
+
+  proc doAutoCheckRepairTest(id, size: int): Result[AutoRepairObject, string] =
+    doAutoCheckRepairTest(id, fixtureData.toOpenArray(0, size - 1))
 
   template check01(adata: untyped): untyped =
     check:
@@ -339,4 +343,19 @@ suite "Beacon chain file test suite":
           adata.data.head.isNone()
           adata.data.tail.isNone()
           adata.size == 0
+      inc(counter)
+
+  test "Auto check/repair test (zero-filled file)":
+    var counter = 1
+
+    for size in [32 * 1024, 4096, 512]:
+      let
+        zeros = newSeq[byte](size)
+        tres = doAutoCheckRepairTest(counter, zeros)
+      check tres.isOk()
+      let adata = tres.get()
+      check:
+        adata.data.head.isNone()
+        adata.data.tail.isNone()
+        adata.size == 0
       inc(counter)

--- a/tests/test_beacon_chain_file.nim
+++ b/tests/test_beacon_chain_file.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2024 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).


### PR DESCRIPTION
When file does not contain NIMB header, avoid getting stuck when seeking for chunk when there is none (offset stays 0 forever otherwise).