### PR TITLE
Harden block processor against future cancellation

### DIFF
--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -770,55 +770,57 @@ proc addBlock*(
     # because there are no state rewinds to deal with
     return self.storeBackfillBlock(blck, sidecarsOpt)
 
-  let queueTick = Moment.now()
-
-  # If the lock is acquired already, the current block will be put on hold
-  # meaning that we'll form an unbounded queue of blocks to be processed
-  # waiting for the lock - this is similar to using an `AsyncQueue` but
-  # without the copying and transition to/from `Forked`.
-  # The lock is important to ensure that we don't process blocks out-of-order
-  # which both would upset the `storeBlock` logic and cause unnecessary
-  # quarantine traffic.
-  self.pendingStores += 1
-  await self.storeLock.acquire()
-
-  let res =
-    try:
-      # Since block processing is async, we want to make sure it doesn't get
-      # (re)added there while we're busy - the start of processing also removes
-      # the block from the various quarantines.
-      # The processing status is cleared in the finally block below.
-      quarantine[].startProcessing(blck)
-
-      # Cooperative concurrency: one block per loop iteration - because
-      # we run both networking and CPU-heavy things like block processing
-      # on the same thread, we need to make sure that there is steady progress
-      # on the networking side or we get long lockups that lead to timeouts.
-      const
-        # We cap waiting for an idle slot in case there's a lot of network traffic
-        # taking up all CPU - we don't want to _completely_ stop processing blocks
-        # in this case - doing so also allows us to benefit from more batching /
-        # larger network reads when under load.
-        idleTimeout = chronos.milliseconds(10)
-
-      discard await idleAsync().withTimeout(idleTimeout)
-
-      let wallTime = self.getBeaconTime()
-      if not wallTime.afterGenesis:
-        fatal "Processing block before genesis, clock turned back?"
-        quit 1
-
-      await self.storeBlock(
-        src, wallTime, blck, sidecarsOpt, maybeFinalized, queueTick, validationDur
-      )
-    finally:
-      quarantine[].clearProcessing()
-
+  let
+    queueTick = Moment.now()
+    res =
       try:
-        self.storeLock.release()
+        # If the lock is acquired already, the current block will be put on hold
+        # meaning that we'll form an unbounded queue of blocks to be processed
+        # waiting for the lock - this is similar to using an `AsyncQueue` but
+        # without the copying and transition to/from `Forked`.
+        # The lock is important to ensure that we don't process blocks
+        # out-of-order which both would upset the `storeBlock` logic and cause
+        # unnecessary quarantine traffic.
+        self.pendingStores += 1
+        await self.storeLock.acquire()
+
+        try:
+          # Since block processing is async, we want to make sure it doesn't get
+          # (re)added there while we're busy - the start of processing also
+          # removes the block from the various quarantines.
+          # The processing status is cleared in the finally block below.
+          quarantine[].startProcessing(blck)
+
+          # Cooperative concurrency: one block per loop iteration - because
+          # we run both networking and CPU-heavy things like block processing
+          # on the same thread, we need to ensure that there is steady progress
+          # on the networking side or we get long lockups that lead to timeouts.
+          const
+            # We cap waiting for an idle slot in case there's a lot of network
+            # traffic taking up all CPU - we don't want to _completely_ stop
+            # processing blocks in this case - doing so also allows us to
+            # benefit from more batching / larger network reads when under load.
+            idleTimeout = chronos.milliseconds(10)
+
+          discard await idleAsync().withTimeout(idleTimeout)
+
+          let wallTime = self.getBeaconTime()
+          if not wallTime.afterGenesis:
+            fatal "Processing block before genesis, clock turned back?"
+            quit 1
+
+          await self.storeBlock(
+            src, wallTime, blck, sidecarsOpt, maybeFinalized,
+            queueTick, validationDur)
+        finally:
+          quarantine[].clearProcessing()
+
+          try:
+            self.storeLock.release()
+          except AsyncLockError:
+            raiseAssert "release matched with acquire, shouldn't happen"
+      finally:
         self.pendingStores -= 1
-      except AsyncLockError:
-        raiseAssert "release matched with acquire, shouldn't happen"
 
   self[].dumpBlock(blck, res)
 


### PR DESCRIPTION
When cancelling block processing (e.g., legacy sync manager resets) if cancellation hits during the 'await self.storeLock.acquire' then the pendingStores counter doesn't reset, potentially slowing down the batch verification of signatures. Add try/finally so it does.