### PR TITLE
Handle shrinking custody set in both column quarantine loops

### DIFF
--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -328,6 +328,7 @@ proc put*[A, B](
 
   for sidecar in sidecars:
     let index = q.getIndex(sidecar.index)
+    if index < 0: continue
     if isEmpty(node[].value.sidecars[index]):
       inc(node[].value.count)
       node[].value.slot = sidecar[].slot()

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -1832,6 +1832,9 @@ suite "ColumnQuarantine data structure test suite " & preset():
               item.sidecar[].signed_block_header.message.proposer_index,
               item.sidecar[].index) == false
 
+      # Re-add pre-update set (new root to force newSidecarsCount > 0)
+      bq.put(genBlockRoot(int.high), sidecars.mapIt(it.sidecar))
+
 suite "GloasColumnQuarantine data structure test suite " & preset():
   setup:
     let


### PR DESCRIPTION
First loop over sidecars skips `index < 0` (custody set shrank), but the second loop right below this misses it (IndexDefect).