### PR TITLE
Set maxResponseItems when requesting data from peers

### DIFF
--- a/beacon_chain/sync/light_client_manager.nim
+++ b/beacon_chain/sync/light_client_manager.nim
@@ -133,7 +133,8 @@ proc doRequest(
 ): Future[LightClientUpdatesByRangeResponse] {.async: (raises: [ResponseError, CancelledError]).} =
   let (startPeriod, count) = key
   doAssert count > 0 and count <= MAX_REQUEST_LIGHT_CLIENT_UPDATES
-  let response = await peer.lightClientUpdatesByRange(startPeriod, count)
+  let response = await peer.lightClientUpdatesByRange(
+    startPeriod, count, maxResponseItems = count.int)
   if response.isOk:
     let e = distinctBase(response.get)
       .checkLightClientUpdates(startPeriod, count)

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -153,16 +153,6 @@ func cmpColumnIndex(x: ColumnIndex, y: ref fulu.DataColumnSidecar): int =
 func checkColumnResponse(idList: seq[DataColumnsByRootIdentifier],
                          columns: openArray[ref fulu.DataColumnSidecar]):
                          Opt[seq[DataColumnResponseRecord]] =
-  # The response is a list of DataColumnSidecar whose length is
-  # less than or equal to requested_columns_count, where
-  # requested_columns_count = sum(len(r.columns) for r in request).
-  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/fulu/p2p-interface.md#datacolumnsidecarsbyroot-v1
-  var expectedMax = 0
-  for id in idList:
-    expectedMax += id.indices.len
-  if columns.len > expectedMax:
-    return Opt.none(seq[DataColumnResponseRecord])
-
   var colRec: seq[DataColumnResponseRecord]
   for colresp in columns:
     let block_root =
@@ -187,7 +177,8 @@ proc requestBlocksByRoot(rman: RequestManager, items: seq[Eth2Digest]) {.async: 
     debug "Requesting blocks by root", peer = peer, blocks = shortLog(items),
                                        peer_score = peer.getScore()
 
-    let blocks = (await beaconBlocksByRoot_v2(peer, BlockRootsList items))
+    let blocks = (await beaconBlocksByRoot_v2(
+      peer, BlockRootsList items, maxResponseItems = items.len))
 
     if blocks.isOk:
       let ublocks = blocks.get()
@@ -428,7 +419,13 @@ proc fetchDataColumnsFromNetwork(rman: RequestManager,
       peer = peer,
       columns = shortLog(intColIdList),
       peer_score = peer.getScore()
-    let columns = await dataColumnSidecarsByRoot(peer, DataColumnsByRootIdentifierList intColIdList)
+    let expectedColumnCount = block:
+      var n = 0
+      for id in intColIdList: n += id.indices.len
+      n
+    let columns = await dataColumnSidecarsByRoot(
+      peer, DataColumnsByRootIdentifierList intColIdList,
+      maxResponseItems = expectedColumnCount)
     if columns.isOk:
       var ucolumns = columns.get().asSeq()
       ucolumns.sort(cmpSidecarIndexes)

--- a/beacon_chain/sync/sync_manager.nim
+++ b/beacon_chain/sync/sync_manager.nim
@@ -200,7 +200,9 @@ proc getBlocks[A, B](man: SyncManager[A, B], peer: A,
         sync_ident = man.ident,
         topics = "syncman"
 
-  beaconBlocksByRange_v2(peer, req.data.slot, req.data.count, 1'u64)
+  beaconBlocksByRange_v2(
+    peer, req.data.slot, req.data.count, 1'u64,
+    maxResponseItems = req.data.count.int)
 
 proc remainingSlots(man: SyncManager): uint64 =
   let
@@ -232,7 +234,8 @@ proc getSyncBlockData*[T](
 
   let blocksRange =
     block:
-      let res = await beaconBlocksByRange_v2(peer, slot, 1'u64, 1'u64)
+      let res = await beaconBlocksByRange_v2(
+        peer, slot, 1'u64, 1'u64, maxResponseItems = 1)
       if res.isErr():
         peer.updateScore(PeerScoreNoValues)
         return err("Failed to receive blocks on request [" & $res.error & "]")


### PR DESCRIPTION
- #4844 added BlobSidecar req/resp, no resp length check
- #6741 copies logic to data column, also no resp length check
- #6954 infra to check resp length
- #6961 add resp length check for blobs, but not for in development cols
- #8254 removed blob support, resp length check now gone
- Now: Add resp length check for all requests with list responses