### PR TITLE
Add bounds to envelope quarantine

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -677,7 +677,9 @@ AllTests-mainnet
 ```diff
 + Add missing                                                                                OK
 + Add orphan                                                                                 OK
++ Add unviable                                                                               OK
 + Clean up orphans                                                                           OK
++ Has orphan                                                                                 OK
 + Pop orphan                                                                                 OK
 ```
 ## Eth2 specific discovery tests

--- a/beacon_chain/consensus_object_pools/envelope_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/envelope_quarantine.nim
@@ -12,25 +12,31 @@ import
   minilru,
   ../spec/[digest, forks]
 
+export tables, minilru, forks
+
 const
   MaxRetriesPerMissingItem = 7
     ## Exponential backoff, double interval between each attempt
-  MaxMissingItems* = 1024
+  MaxMissingItems = 1024
     ## Revisit the setting and same as block quarantine for now
+  MaxOrphans = int(SLOTS_PER_EPOCH * 3)
+    ## Set to same as max block orphans
   MaxUnviables = 16 * 1024
-    ## Set to same as max unviable blocks.
+    ## Set to same as max unviable blocks
 
 type
+  OrphanLru = LruCache[(Eth2Digest, uint64), SignedExecutionPayloadEnvelope]
   UnviableLru = LruCache[Eth2Digest, ()]
 
   MissingEnvelope* = object
     tries*: int
 
   EnvelopeQuarantine* = object
-    orphans*: Table[Eth2Digest, Table[uint64, SignedExecutionPayloadEnvelope]]
+    orphans*: OrphanLru
       ## Envelopes that we have received but did not have a block yet. In the
       ## ideal scenario, block should arrive before envelope but that is not
-      ## guaranteed.
+      ## guaranteed. Indexed by `(beacon_block_root, builder_index)` as the
+      ## canonical builder is unknown until the block arrives.
 
     missing*: Table[Eth2Digest, MissingEnvelope]
       ## List of block roots that we would like to have the envelopes but we
@@ -38,10 +44,11 @@ type
       ## received a block, blob or data column.
 
     unviable*: UnviableLru
-      ## List of block roots that their envelopes are unviable.
+      ## List of block roots whose canonical envelopes are unviable.
 
 func init*(T: typedesc[EnvelopeQuarantine]): T =
   T(
+    orphans: OrphanLru.init(MaxOrphans),
     unviable: UnviableLru.init(MaxUnviables),
   )
 
@@ -72,51 +79,54 @@ func checkMissing*(self: var EnvelopeQuarantine, max: int): seq[Eth2Digest] =
       if result.len >= max:
         break
 
+func cleanupOrphans(self: var EnvelopeQuarantine, finalizedSlot: Slot) =
+  var toDel: seq[(Eth2Digest, uint64)]
+
+  for k, e in self.orphans:
+    if e.message.slot <= finalizedSlot:
+      toDel.add k
+
+  for k in toDel:
+    self.orphans.del k
+
 func addOrphan*(
     self: var EnvelopeQuarantine,
+    finalizedSlot: Slot,
     envelope: SignedExecutionPayloadEnvelope) =
-  discard self.orphans
-    .mgetOrPut(envelope.root)
-    .hasKeyOrPut(envelope.message.builder_index, envelope)
+  self.cleanupOrphans(finalizedSlot)
+  self.orphans.put((envelope.root, envelope.message.builder_index), envelope)
 
 func popOrphan*(
     self: var EnvelopeQuarantine,
     blck: gloas.SignedBeaconBlock | heze.SignedBeaconBlock,
 ): Opt[SignedExecutionPayloadEnvelope] =
-  if blck.root notin self.orphans:
-    return Opt.none(SignedExecutionPayloadEnvelope)
-
-  template builderIdx(): auto =
+  let bidBuilder =
     blck.message.body.signed_execution_payload_bid.message.builder_index
-  try:
-    var envelope: SignedExecutionPayloadEnvelope
-    if self.orphans[blck.root].pop(builderIdx, envelope):
-      Opt.some(envelope)
-    else:
-      Opt.none(SignedExecutionPayloadEnvelope)
-  except KeyError:
-    Opt.none(SignedExecutionPayloadEnvelope)
+  self.orphans.pop((blck.root, bidBuilder))
+
+func hasOrphan*(self: EnvelopeQuarantine, root: Eth2Digest): bool =
+  for k, _ in self.orphans:
+    if k[0] == root:
+      return true
+  false
 
 func delOrphan*(self: var EnvelopeQuarantine, blck: gloas.SignedBeaconBlock) =
-  self.orphans.del(blck.root)
+  var toDel: seq[(Eth2Digest, uint64)]
+  for k, _ in self.orphans:
+    if k[0] == blck.root:
+      toDel.add k
+  for k in toDel:
+    self.orphans.del k
 
 func remove*(self: var EnvelopeQuarantine, root: Eth2Digest) =
-  self.orphans.del(root)
+  var toDel: seq[(Eth2Digest, uint64)]
+  for k, _ in self.orphans:
+    if k[0] == root:
+      toDel.add k
+  for k in toDel:
+    self.orphans.del k
   self.missing.del(root)
 
 func addUnviable*(self: var EnvelopeQuarantine, root: Eth2Digest) =
   self.remove(root)
   self.unviable.put(root, ())
-
-func cleanupOrphans*(self: var EnvelopeQuarantine, finalizedSlot: Slot) =
-  var toDel: seq[Eth2Digest]
-
-  for k, v in self.orphans:
-    for _, e in v:
-      if finalizedSlot >= e.message.slot:
-        toDel.add(k)
-      # check only the first envelope as slot should be the same by block root.
-      break
-
-  for k in toDel:
-    self.orphans.del(k)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -993,7 +993,8 @@ proc addPayload*(
       # any missing parents. In either case, they should be caught when
       # processing block. So we only put the envelope into the quarantine for
       # the next try.
-      self.envelopeQuarantine[].addOrphan(signedEnvelope)
+      self.envelopeQuarantine[].addOrphan(
+        self.consensusManager.dag.finalizedHead.slot, signedEnvelope)
       if sidecarsOpt.isSome():
         self.gloasColumnQuarantine[].put(signedBlock.root, sidecarsOpt.get())
     of VerifierError.Invalid, VerifierError.UnviableFork:
@@ -1035,7 +1036,8 @@ proc enqueuePayload*(self: ref BlockProcessor, blck: gloas.SignedBeaconBlock) =
         if sidecarsOpt.isNone():
           # As sidecars are missing, put envelope back to quarantine.
           self.consensusManager.quarantine[].addSidecarless(blck)
-          self.envelopeQuarantine[].addOrphan(envelope)
+          self.envelopeQuarantine[].addOrphan(
+            self.consensusManager.dag.finalizedHead.slot, envelope)
           return
         sidecarsOpt
 

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -340,7 +340,8 @@ proc processExecutionPayloadEnvelope*(
   debug "Envelope received", delay
 
   self.dag.validateExecutionPayload(
-      self.quarantine, self.envelopeQuarantine, signedEnvelope).isOkOr:
+      self.quarantine, self.envelopeQuarantine, signedEnvelope,
+      wallTime).isOkOr:
     debug "Dropping envelope", err = error
     execution_payload_envelopes_dropped.inc(1, [$error[0]])
     return err(error)
@@ -349,7 +350,8 @@ proc processExecutionPayloadEnvelope*(
     self.dag.onEnvelopeGossipAdded(signedEnvelope)
 
   trace "Envelope validated"
-  self.envelopeQuarantine[].addOrphan(signedEnvelope)
+  self.envelopeQuarantine[].addOrphan(
+    self.dag.finalizedHead.slot, signedEnvelope)
   self.blockProcessor.enqueuePayload(signedEnvelope.message.beacon_block_root)
 
   execution_payload_envelopes_received.inc()

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1060,9 +1060,14 @@ proc validateBeaconBlock*(
 proc validateExecutionPayload*(
     dag: ChainDAGRef, quarantine: ref Quarantine,
     envelopeQuarantine: ref EnvelopeQuarantine,
-    signed_execution_payload_envelope: SignedExecutionPayloadEnvelope):
-    Result[void, ValidationError] =
+    signed_execution_payload_envelope: SignedExecutionPayloadEnvelope,
+    wallTime: BeaconTime): Result[void, ValidationError] =
   template envelope: untyped = signed_execution_payload_envelope.message
+
+  # No matching block can exist: blocks [IGNORE] future slots.
+  if not (envelope.slot <=
+      (wallTime + MAXIMUM_GOSSIP_CLOCK_DISPARITY).slotOrZero(dag.timeParams)):
+    return errIgnore("ExecutionPayload: slot too high")
 
   # [IGNORE] The envelope's block root `envelope.beacon_block_root` has been
   # seen (via gossip or non-gossip sources) (a client MAY queue payload for
@@ -1084,7 +1089,8 @@ proc validateExecutionPayload*(
     # processed locally once the block arrives, but never re-gossiped to peers
     # who may also be missing it.
     discard quarantine[].addMissing(envelope.beacon_block_root)
-    envelopeQuarantine[].addOrphan(signed_execution_payload_envelope)
+    envelopeQuarantine[].addOrphan(
+      dag.finalizedHead.slot, signed_execution_payload_envelope)
     return errIgnore("ExecutionPayload: block not found")
 
   # [IGNORE] The node has not seen another valid SignedExecutionPayloadEnvelope
@@ -1234,7 +1240,7 @@ proc validateAttestation*(
     if attestation.data.index == 1:
       template block_root: untyped = attestation.data.beacon_block_root
       if not pool.dag.db.containsExecutionPayloadEnvelope(block_root) and
-          block_root notin envelopeQuarantine[].orphans:
+          not envelopeQuarantine[].hasOrphan(block_root):
         return errIgnore(
           "SingleAttestation: execution payload not yet seen")
   else:
@@ -1447,7 +1453,7 @@ proc validateAggregate*(
       template block_root: untyped = aggregate.data.beacon_block_root
       debugGloasComment("unviable envelope")
       if not pool.dag.db.containsExecutionPayloadEnvelope(block_root) and
-          block_root notin envelopeQuarantine[].orphans:
+          not envelopeQuarantine[].hasOrphan(block_root):
         return errIgnore(
           "Aggregate: execution payload not yet seen")
   else:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -676,6 +676,7 @@ proc initFullNode(
       ## enqueuePayload() except when the valid block or any sidecars is
       ## missing, we will return ok() as it is not any types of VerifierError.
       ## Therefore, the call is discarded silently.
+      envelopeQuarantine[].addOrphan(dag.finalizedHead.slot, signedEnvelope)
       template blockRoot(): auto = signedEnvelope.message.beacon_block_root
 
       let
@@ -719,7 +720,7 @@ proc initFullNode(
             if sidecarsOpt.isNone():
               # As sidecars are missing, put envelope back to quarantine.
               consensusManager.quarantine[].addSidecarless(blck)
-              envelopeQuarantine[].addOrphan(envelope)
+              envelopeQuarantine[].addOrphan(dag.finalizedHead.slot, envelope)
               # Return ok() as columns may arrive late.
               return ok()
             sidecarsOpt

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -270,7 +270,6 @@ proc fetchEnvelopesFromNetwork(self: RequestManager, roots: seq[Eth2Digest])
           gotUnviableEnvelope = false
 
         for envelope in uenvelopes:
-          self.envelopeQuarantine[].addOrphan(envelope[])
           let res = await self.envelopeVerifier(envelope[])
           if res.isErr():
             case res.error():

--- a/beacon_chain/validators/message_router.nim
+++ b/beacon_chain/validators/message_router.nim
@@ -717,9 +717,11 @@ proc routeExecutionPayloadEnvelope*(
     sidecarsOpt: Opt[seq[gloas.DataColumnSidecar]],
 ): Future[Result[void, cstring]] {.async: (raises: [CancelledError]).} =
   # Validate with gossip
-  let vRes = validateExecutionPayload(
-    router[].dag, router[].quarantine,
-    router.processor.envelopeQuarantine, signedEnvelope)
+  let
+    wallTime = router[].getCurrentBeaconTime()
+    vRes = validateExecutionPayload(
+      router[].dag, router[].quarantine,
+      router.processor.envelopeQuarantine, signedEnvelope, wallTime)
   if not isGoodForSending(vRes):
     warn "Envelope failed validation",
       envelope = shortLog(signedEnvelope.message),

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -403,7 +403,7 @@ suite "Block processor" & preset():
             )
           )
         )
-        envelopeQuarantine[].addOrphan(envelope)
+        envelopeQuarantine[].addOrphan(dag.finalizedHead.slot, envelope)
 
         let res = await processor.addBlock(
           MsgSource.gossip, engineBlock.blck, noSidecars)
@@ -412,7 +412,8 @@ suite "Block processor" & preset():
           res.isOk
           dag.containsForkBlock(engineBlock.blck.root)
           # Envelope was popped, not marked as orphan
-          engineBlock.blck.root notin envelopeQuarantine[].orphans
+          (engineBlock.blck.root, BUILDER_INDEX_SELF_BUILD) notin
+            envelopeQuarantine[].orphans
 
   asyncTest "Gloas consecutive blocks accumulate missing envelopes" & preset():
     # Multiple blocks stored optimistically, each marks its envelope as missing.

--- a/tests/test_envelope_quarantine.nim
+++ b/tests/test_envelope_quarantine.nim
@@ -27,15 +27,14 @@ suite "Envelope Quarantine":
     check root1 in quarantine.checkMissing(32)
 
   test "Add orphan":
-    check root1 notin quarantine.orphans
-    quarantine.addOrphan(SignedExecutionPayloadEnvelope(
+    check (root1, 1'u64) notin quarantine.orphans
+    quarantine.addOrphan(Slot 0, SignedExecutionPayloadEnvelope(
       message: ExecutionPayloadEnvelope(
         beacon_block_root: root1,
         builder_index: 1'u64)))
-    check root1 in quarantine.orphans
-    check 1'u64 in quarantine.orphans[root1]
+    check (root1, 1'u64) in quarantine.orphans
     quarantine.delOrphan(gloas.SignedBeaconBlock(root: root1))
-    check root1 notin quarantine.orphans
+    check (root1, 1'u64) notin quarantine.orphans
 
   test "Pop orphan":
     let
@@ -51,19 +50,50 @@ suite "Envelope Quarantine":
           signed_execution_payload_bid: blckBid))
       signedBlck = gloas.SignedBeaconBlock(root: root1, message: blck)
 
-    quarantine.addOrphan(envelope)
+    quarantine.addOrphan(Slot 0, envelope)
     check quarantine.popOrphan(signedBlck) == Opt.some(envelope)
-    check root1 in quarantine.orphans
+    check (root1, 1'u64) notin quarantine.orphans
 
-    quarantine.addOrphan(envelope)
+    quarantine.addOrphan(Slot 0, envelope)
     check quarantine.popOrphan(gloas.SignedBeaconBlock(root: root1)) ==
       Opt.none(SignedExecutionPayloadEnvelope)
-    check root1 in quarantine.orphans
+    check (root1, 1'u64) in quarantine.orphans
 
-    quarantine.addOrphan(envelope)
+    quarantine.addOrphan(Slot 0, envelope)
     check quarantine.popOrphan(gloas.SignedBeaconBlock(message: blck)) ==
       Opt.none(SignedExecutionPayloadEnvelope)
-    check root1 in quarantine.orphans
+    check (root1, 1'u64) in quarantine.orphans
+
+  test "Has orphan":
+    let envelope = SignedExecutionPayloadEnvelope(
+      message: ExecutionPayloadEnvelope(
+        beacon_block_root: root1,
+        builder_index: 2'u64))
+
+    check not quarantine.hasOrphan(root1)
+    quarantine.addOrphan(Slot 0, envelope)
+    check quarantine.hasOrphan(root1)
+    quarantine.delOrphan(gloas.SignedBeaconBlock(root: root1))
+    check not quarantine.hasOrphan(root1)
+
+  test "Add unviable":
+    let envelope = SignedExecutionPayloadEnvelope(
+      message: ExecutionPayloadEnvelope(
+        beacon_block_root: root1,
+        builder_index: 1'u64))
+
+    quarantine.addOrphan(Slot 0, envelope)
+    quarantine.addMissing(root1)
+    check:
+      (root1, 1'u64) in quarantine.orphans
+      root1 in quarantine.missing
+      root1 notin quarantine.unviable
+
+    quarantine.addUnviable(root1)
+    check:
+      (root1, 1'u64) notin quarantine.orphans
+      root1 notin quarantine.missing
+      root1 in quarantine.unviable
 
   test "Clean up orphans":
     let
@@ -71,27 +101,52 @@ suite "Envelope Quarantine":
         "0x6aaaaaaaaa5aaaaaaaaa4aaaaaaaaa3aaaaaaaaa2aaaaaaaaa1aaaaaaaaa0002")
       root3 = Eth2Digest.fromHex(
         "0x6aaaaaaaaa5aaaaaaaaa4aaaaaaaaa3aaaaaaaaa2aaaaaaaaa1aaaaaaaaa0003")
+      root4 = Eth2Digest.fromHex(
+        "0x6aaaaaaaaa5aaaaaaaaa4aaaaaaaaa3aaaaaaaaa2aaaaaaaaa1aaaaaaaaa0004")
 
-    quarantine.addOrphan(SignedExecutionPayloadEnvelope(
+    quarantine.addOrphan(Slot 0, SignedExecutionPayloadEnvelope(
       message: ExecutionPayloadEnvelope(
         beacon_block_root: root1,
         payload: gloas.ExecutionPayload(slot_number: Slot(3))
       )
     ))
-    quarantine.addOrphan(SignedExecutionPayloadEnvelope(
+    quarantine.addOrphan(Slot 0, SignedExecutionPayloadEnvelope(
       message: ExecutionPayloadEnvelope(
         beacon_block_root: root2,
         payload: gloas.ExecutionPayload(slot_number: Slot(5))
       )
     ))
-    quarantine.addOrphan(SignedExecutionPayloadEnvelope(
+    quarantine.addOrphan(Slot 0, SignedExecutionPayloadEnvelope(
       message: ExecutionPayloadEnvelope(
         beacon_block_root: root3,
         payload: gloas.ExecutionPayload(slot_number: Slot(7))
       )
     ))
 
-    quarantine.cleanupOrphans(Slot(3))
-    check quarantine.orphans.len == 2
-    quarantine.cleanupOrphans(Slot(8))
-    check quarantine.orphans.len == 0
+    check:
+      (root1, 0'u64) in quarantine.orphans
+      (root2, 0'u64) in quarantine.orphans
+      (root3, 0'u64) in quarantine.orphans
+
+    quarantine.addOrphan(Slot 3, SignedExecutionPayloadEnvelope(
+      message: ExecutionPayloadEnvelope(
+        beacon_block_root: root4,
+        payload: gloas.ExecutionPayload(slot_number: Slot(9))
+      )
+    ))
+    check:
+      (root1, 0'u64) notin quarantine.orphans
+      (root2, 0'u64) in quarantine.orphans
+      (root3, 0'u64) in quarantine.orphans
+      (root4, 0'u64) in quarantine.orphans
+
+    quarantine.addOrphan(Slot 8, SignedExecutionPayloadEnvelope(
+      message: ExecutionPayloadEnvelope(
+        beacon_block_root: root4,
+        payload: gloas.ExecutionPayload(slot_number: Slot(9))
+      )
+    ))
+    check:
+      (root2, 0'u64) notin quarantine.orphans
+      (root3, 0'u64) notin quarantine.orphans
+      (root4, 0'u64) in quarantine.orphans


### PR DESCRIPTION
Apply same max capacity to envelope quarantine, as is also applied to beacon blocks. This should retain the same memory bounds as pre-Glaos. Beacon blocks will get smaller with Gloas, envelopes take over. Original envelope quarantine was introduced without bounds in #7623, with the cleanupOrphans function left unused.