### PR TITLE
Avoid debug log defect when receiving block older than backfill

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -206,12 +206,16 @@ proc checkHeadBlock*(
         debug "Duplicate block"
         return err(VerifierError.Duplicate)
 
-    # Block is older than finalized, but different from the block in our
-    # canonical history: it must be from an unviable branch
-    debug "Block from unviable fork",
-      existing = shortLog(existing.get()),
-      finalizedHead = shortLog(dag.finalizedHead),
-      tail = shortLog(dag.tail)
+      # Block is older than finalized, but different from the block in our
+      # canonical history: it must be from an unviable branch
+      debug "Block from unviable fork",
+        existing = shortLog(existing.get()),
+        finalizedHead = shortLog(dag.finalizedHead),
+        tail = shortLog(dag.tail)
+    else:
+      debug "Block from unviable fork (slot not backfilled)",
+        finalizedHead = shortLog(dag.finalizedHead),
+        tail = shortLog(dag.tail)
 
     return err(VerifierError.UnviableFork)
 


### PR DESCRIPTION
When a block's parent_root points to a pre-finalized slot during regular forward sync, we mark it as unviable, as it does not descend finalized history (#3478). For pre-backfilled slots, that would happen implicitly via the `dag.getBlockRef(blck.parent_root)` logic -> MissingParent, and then because it's pre-finalized would be marked unviable lateron.

In #5169, the checks for "trivial conditions" were moved earlier, not sure if intentionally as it was possibly accidental re-indent noise. That left a reference to `existing.get()` in the debug log, which is also logged when `existing.isNone`, so triggers ResultDefect in debug. Fix the log, and keep the UnviableFork treatment from #5169 in place.