### PR TITLE
Revert "Apply KZG check to columns fetched via Req/Resp (#8458)"

### DIFF
--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -428,21 +428,12 @@ proc fetchDataColumnsFromNetwork(rman: RequestManager,
     if columns.isOk:
       var ucolumns = columns.get().asSeq()
       ucolumns.sort(cmpSidecarIndexes)
-      let
-        records = checkColumnResponse(colIdList, ucolumns).valueOr:
-          debug "Response to columns by root is not a subset",
-            peer = peer,
-            columns = shortLog(colIdList),
-            ucolumns = len(ucolumns)
-          peer.updateScore(PeerScoreBadResponse)
-          return
-        v = verify_data_column_sidecar_kzg_proofs(records.mapIt(it.sidecar))
-      if v.isErr:
-        debug "Data columns failed KZG verification",
+      let records = checkColumnResponse(colIdList, ucolumns).valueOr:
+        debug "Response to columns by root is not a subset",
           peer = peer,
           columns = shortLog(colIdList),
           ucolumns = len(ucolumns)
-        peer.updateScore(PeerScoreBadValues)
+        peer.updateScore(PeerScoreBadResponse)
         return
       for col in records:
         debug "Received column responses",


### PR DESCRIPTION
This reverts commit 8b56bbcfbe9b05e5ab6d85f5c0dff7db5b5ace38.

In the original PR #8458 I overlooked the flow in block_processor that already contains the KZG check (at a later stage). It's not perfect, as it penalizes the incorrect peer (the one who sent the block, instead of the one that sent us the bad column), and because it allows quarantine pollution with bad data, but the check is indeed there! Double checking just for minor benefits in peer score accounting is too expensive. Should revisit later with a proper solution to avoid double-checking, ideally with a type-system approach similar to blocks.