### PR TITLE
Harden against malformed era files

### DIFF
--- a/beacon_chain/era_db.nim
+++ b/beacon_chain/era_db.nim
@@ -32,7 +32,7 @@ type
 
     files: seq[EraFile]
 
-proc open*(_: type EraFile, name: string): Result[EraFile, string] =
+proc open*(_: type EraFile, name: string, era: Era): Result[EraFile, string] =
   var
     f = Opt[IoHandle].ok(? openFile(name, {OpenFlags.Read}).mapErr(ioErrorMsg))
 
@@ -52,6 +52,8 @@ proc open*(_: type EraFile, name: string): Result[EraFile, string] =
     stateIdx = ? f[].readIndex()
   if stateIdx.offsets.len() != 1:
     return err("State index length invalid")
+  if stateIdx.startSlot.era != era:
+    return err("State index does not match era")
 
   ? f[].setFilePos(stateIdxPos, SeekPosition.SeekCurrent).mapErr(ioErrorMsg)
 
@@ -63,6 +65,8 @@ proc open*(_: type EraFile, name: string): Result[EraFile, string] =
     let idx = ? f[].readIndex()
     if idx.offsets.lenu64() != SLOTS_PER_HISTORICAL_ROOT:
       return err("Block index length invalid")
+    if idx.startSlot + idx.offsets.lenu64() != stateIdx.startSlot:
+      return err("Block index does not match state")
 
     idx
   else:
@@ -312,7 +316,7 @@ proc getEraFile(
     return err("No such era file")
 
   let
-    f = EraFile.open(path).valueOr:
+    f = EraFile.open(path, era).valueOr:
       # TODO allow caller to differentiate between invalid and missing era file,
       #      then move logging elsewhere
       warn "Failed to open era file", path, error = error
@@ -559,7 +563,7 @@ when isMainModule:
         "0xbacd20f09da907734434f052bd4c9503aa16bab1960e89ea20610d08d064481c")
 
   let
-    f = EraFile.open(dbPath & "/mainnet-00001-40cf2f3c.era").expect(
+    f = EraFile.open(dbPath & "/mainnet-00001-40cf2f3c.era", Era(1)).expect(
       "opening works")
   doAssert f.verify(cfg).isOk()
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -93,7 +93,7 @@ proc readEraState(
   ##
   ## If the Era file is corrup
   debug "Reading era state", file
-  let ef = EraFile.open(file.path).valueOr:
+  let ef = EraFile.open(file.path, file.era).valueOr:
     error "Could not open era file", file, error
     return Opt.none(ref ForkedHashedBeaconState)
 

--- a/docs/the_nimbus_book/src/era-store.md
+++ b/docs/the_nimbus_book/src/era-store.md
@@ -20,11 +20,17 @@ To import an era archive, place the files in a folder called `era` in the [data 
 # Go to the nimbus directory
 cd build/data/shared_mainnet_0
 
-# Create era directory
+# Create era directory and enter it
 mkdir -p era
+cd era
 
 # Download era store from era provider
 wget --no-parent  -A '*.era' -q --show-progress -nd -r -c https://provider/era
+
+# Verify the downloaded files (requires `make ncli_db`)
+for f in *.era; do
+  ../../../ncli_db verifyEra --eraFile="$f"
+done
 ```
 
 The beacon node will automatically serve data from the Era files.

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -556,11 +556,14 @@ proc cmdRewindState(conf: DbConf, cfg: RuntimeConfig) =
 
 proc cmdVerifyEra(conf: DbConf, cfg: RuntimeConfig) =
   let
-    f = EraFile.open(conf.eraFile).valueOr:
-      echo error
+    era = Era.fromEraFile(cfg, io2.splitPath(conf.eraFile).tail).valueOr:
+      echo conf.eraFile & ": name does not match {network}-{era:05d}-{root}.era"
+      quit 1
+    f = EraFile.open(conf.eraFile, era).valueOr:
+      echo conf.eraFile & ": " & error
       quit 1
     root = f.verify(cfg).valueOr:
-      echo error
+      echo conf.eraFile & ": " & error
       quit 1
   echo root
 


### PR DESCRIPTION
When getBlockSZ is called on a malformed era file that does not cover the expected slot range, an IndexDefect may be hit in getBlockSZ. Add checks for internal consistency (state/blocks both match era).

Also extend verifyEra tool to catch incorrect file names so that fetches from an untrusted source can be properly verified (e.g., file swaps). Otherwise, verifyEra returns ok, but served data could still be wrong.