### PR TITLE
Fix lightClientDataImportBackfill property getting accessed in tns

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2940,8 +2940,7 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
     let
       metadata = loadEth2Network(config)
       db = BeaconChainDB.new(
-        config.databaseDir, metadata.cfg, inMemory = false,
-        lightClientDataImportBackfill = config.lightClientDataImportBackfill)
+        config.databaseDir, metadata.cfg, inMemory = false)
       genesisState = (waitFor fetchGenesisState(metadata, config.eraDir)).valueOr:
         quit 1
     waitFor db.doRunTrustedNodeSync(


### PR DESCRIPTION
When starting in trustedNodeSync mode, the lightClientDataImportBackfill property is not available, so don't try to access it, use default. Regression from #8445