### PR TITLE
fix: gloas block gossip validation (2)

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -805,6 +805,11 @@ AllTests-mainnet
 + Period boundary                                                                            OK
 + validateSyncCommitteeMessage - Duplicate pubkey                                            OK
 ```
+## Gossip validation - Gloas
+```diff
++ validateBeaconBlock - finalized head execution parent                                      OK
++ validateBeaconBlock - mismatched execution parent                                          OK
+```
 ## Graffiti management [Beacon Node] [Preset: mainnet]
 ```diff
 + Configuring the graffiti [Beacon Node] [Preset: mainnet]                                   OK

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -429,16 +429,15 @@ template validateBeaconBlockGloas(
       i = 0
       found = false
 
-    # Search execution parent up to 2 ancestors. Also stop searching when there
-    # is not any parents, means that it is either a finalized or genesis block.
-    while not isNil(cur.parent) and i < 2:
+    while i < 2:
       let pBhash = dag.loadExecutionBlockHash(cur).valueOr:
         return errIgnore("validateBeaconBlockGloas: cannot load block hash")
       if pBhash == bid.parent_block_hash:
         found = true
         break
-      else:
-        cur = cur.parent
+      if isNil(cur.parent):
+        break
+      cur = cur.parent
       inc i
     if not found:
       return errIgnore("validateBeaconBlockGloas: invalid execution parent")
@@ -461,8 +460,8 @@ template validateBeaconBlockGloas(
       return dag.checkedReject("validateBeaconBlockGloas: unviable execution parent")
     # The genesis block would not have an envelope. Otherwise, we should have
     # the envelope for the execution parent.
-    elif not (executionParent.slot != GENESIS_SLOT and
-        dag.db.containsExecutionPayloadEnvelope(executionParent.root)):
+    elif executionParent.slot != GENESIS_SLOT and
+        not dag.db.containsExecutionPayloadEnvelope(executionParent.root):
       envelopeQuarantine[].addMissing(executionParent.root)
       discard quarantine[].addOrphan(dag.finalizedHead.slot, signed_beacon_block)
       return errIgnore("validateBeaconBlockGloas: parent payload not yet seen")

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -20,7 +20,7 @@ import
   ../beacon_chain/consensus_object_pools/[
     block_quarantine, blockchain_dag, block_clearance, attestation_pool,
     envelope_quarantine, sync_committee_msg_pool],
-  ../beacon_chain/spec/datatypes/[phase0, altair],
+  ../beacon_chain/spec/datatypes/[phase0, altair, gloas],
   ../beacon_chain/spec/[
     beaconstate, state_transition, helpers, network, validator],
   ../beacon_chain/validators/validator_pool,
@@ -573,3 +573,34 @@ suite "Proposer preferences validation " & preset():
     tampered.signature = default(ValidatorSig)
     check:
       validateProposerPreferences(dag, seen, tampered, wallTime).isErr
+
+suite "Gossip validation - Gloas":
+  setup:
+    let
+      cfg = genesisTestRuntimeConfig(ConsensusFork.Gloas)
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg))
+      dag = ChainDAGRef.init(
+        cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3),
+        validatorMonitor, {})
+      quarantine = newClone(Quarantine.init(dag.cfg))
+      envelopeQuarantine = newClone(EnvelopeQuarantine.init())
+      wallTime = (GENESIS_SLOT + 1).start_beacon_time(cfg.timeParams)
+    var cache = StateCache()
+
+  test "validateBeaconBlock - finalized head execution parent":
+    let
+      blck = makeTestBlock(dag.headState, cache, cfg = cfg).gloasData
+      res = dag.validateBeaconBlock(
+        quarantine, envelopeQuarantine, blck, wallTime, {})
+    check:
+      res.isOk
+
+  test "validateBeaconBlock - mismatched execution parent":
+    var blck = makeTestBlock(dag.headState, cache, cfg = cfg).gloasData
+    template bid: untyped =
+      blck.message.body.signed_execution_payload_bid.message
+    bid.parent_block_hash.data[0] = not bid.parent_block_hash.data[0]
+    let res = dag.validateBeaconBlock(
+      quarantine, envelopeQuarantine, blck, wallTime, {})
+    check:
+      res.isErr


### PR DESCRIPTION
Followup from #8422 to correctly handle the case when a new block points to the finalized / genesis as the parent payload (e.g., testnet slot 1). Old logic triggers IGNORE on these, as "found = false" is stuck and also puts the genesis payload into the quarantine as code mismatches comment.