### PR TITLE
Load keymanager-token in Nix via systemd

### DIFF
--- a/nix/services/validator-client.nix
+++ b/nix/services/validator-client.nix
@@ -4,7 +4,8 @@
 
 let
   inherit (lib) mkEnableOption mkOption mkIf
-    types filterAttrs escapeShellArgs literalExpression;
+    types filterAttrs escapeShellArgs literalExpression
+    optionals optionalString;
 
   cfg = config.services.nimbus-validator-client;
   system = pkgs.stdenv.hostPlatform.system;
@@ -158,15 +159,21 @@ in {
         ProtectSystem = "full";
         NoNewPrivileges = "true";
         PrivateDevices = "true";
-        StateDirectory = "nimbus-validator-client";
-        WorkingDirectory = "%S/nimbus-validator-client";
         MemoryDenyWriteExecute = "true";
+        WorkingDirectory = "%S/nimbus-validator-client";
+        StateDirectory = "nimbus-validator-client";
+        LoadCredential = optionals (cfg.settings.keymanager-token-file != null) [
+          "keymanager-token-file:${cfg.settings.keymanager-token-file}"
+        ];
 
         Restart = "on-failure";
-        ExecStart = ''
+        ExecStart = let
+          keymanagerTokenFlag = optionalString (cfg.settings.keymanager-token-file != null)
+            "--keymanager-token-file=%d/keymanager-token-file";
+        in ''
           ${cfg.package}/bin/nimbus_validator_client \
             --data-dir=${cfg.settings.data-dir} \
-            --config-file=${configFile} \
+            --config-file=${configFile} ${keymanagerTokenFlag} \
             ${escapeShellArgs cfg.extraArgs}
         '';
       };

--- a/scripts/launch_local_testnet.sh
+++ b/scripts/launch_local_testnet.sh
@@ -398,7 +398,7 @@ rm -rf "${DATA_DIR}/pids/*"
 mkdir -p "${DATA_DIR}/pids" "${DATA_DIR}/logs"
 
 scripts/makedir.sh "${DATA_DIR}"
-echo x > "${DATA_DIR}/keymanager-token"
+echo testToken > "${DATA_DIR}/keymanager-token"
 
 JWT_FILE="${DATA_DIR}/jwtsecret"
 echo "Generating JWT file '$JWT_FILE'..."


### PR DESCRIPTION
Reuse the mechanism that we use for jwtsecret in the beacon node for the keymanager-token-file in the validator client. This should enable to use 0400 chmod with root:root for the token file (systemd does handoff).