### PR TITLE
avoid column quarantine crash with partial custody

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -202,6 +202,7 @@ AllTests-mainnet
 + overfill protection test [node]                                                            OK
 + overfill test [node]                                                                       OK
 + overfill test [supernode]                                                                  OK
++ popSidecars tolerates partial custody at DA threshold [node]                               OK
 + pruneAfterFinalization() test [node]                                                       OK
 + put() duplicate items should not affect counters [node]                                    OK
 + put()/fetchMissingSidecars/remove test [node]                                              OK
@@ -786,6 +787,7 @@ AllTests-mainnet
 + overfill protection test [node]                                                            OK
 + overfill test [node]                                                                       OK
 + overfill test [supernode]                                                                  OK
++ popSidecars tolerates partial custody at DA threshold [node]                               OK
 + pruneAfterFinalization() test [node]                                                       OK
 + put() duplicate items should not affect counters [node]                                    OK
 + put()/fetchMissingSidecars/remove test [node]                                              OK

--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -528,14 +528,19 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
             $sidecar.kind & "`")
         sidecars.add(sidecar.data)
   else:
+    let allowPartial = node[].value.count >= NUMBER_OF_COLUMNS div 2
     for cindex in quarantine.custodyMap:
-      let index = quarantine.getIndex(cindex)
-      doAssert(node[].value.sidecars[index].isLoaded(),
+      let sidecar = node[].value.sidecars[quarantine.getIndex(cindex)]
+      if allowPartial and sidecar.isEmpty():
+        continue
+      doAssert(sidecar.isLoaded(),
         "Record should only have loaded values, but it is `" &
-          $node[].value.sidecars[index].kind & "`")
-      sidecars.add(node[].value.sidecars[index].data)
+          $sidecar.kind & "`")
+      sidecars.add(sidecar.data)
 
-    doAssert(len(sidecars) == len(quarantine.custodyMap),
+    doAssert(
+      (allowPartial and len(sidecars) >= NUMBER_OF_COLUMNS div 2) or
+        len(sidecars) == len(quarantine.custodyMap),
       "Incorrect amount of sidecars in record for node - " & $len(sidecars))
 
   # popSidecars() should remove all the artifacts from the quarantine in both

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -454,6 +454,31 @@ suite "ColumnQuarantine data structure test suite " & preset():
     bq.remove(broot2)
     check len(bq) == 0
 
+  test "popSidecars tolerates partial custody at DA threshold [node]":
+    const custodyColumns =
+      (0 ..< (NUMBER_OF_COLUMNS div 2 + 32)).mapIt(it.ColumnIndex)
+    var bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 0, nil)
+    let broot = genBlockRoot(1)
+
+    # Populate exactly half the column space — the DA threshold — at
+    # the first half of custody indices, leaving the rest of custody
+    # Empty.
+    var present: seq[ref fulu.DataColumnSidecar]
+    for i in 0 ..< (NUMBER_OF_COLUMNS div 2):
+      let sc = newClone(genFuluDataColumnSidecar(
+        index = int(custodyColumns[i]), slot = 1, proposer_index = 5))
+      bq.put(broot, sc)
+      present.add(sc)
+
+    check len(bq) == NUMBER_OF_COLUMNS div 2
+    let res = bq.popSidecars(broot)
+    check:
+      res.isOk()
+      # Populated subset is returned; Empty custody slots are silently
+      # skipped instead of crashing the node.
+      res.get().len == NUMBER_OF_COLUMNS div 2
+      compareSidecars(res.get(), present) == true
+
   test "put()/fetchMissingSidecars/remove test [node]":
     let
       custodyColumns =
@@ -2151,6 +2176,26 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
     bq.remove(broot1)
     bq.remove(broot2)
     check len(bq) == 0
+
+  test "popSidecars tolerates partial custody at DA threshold [node]":
+    const custodyColumns =
+      (0 ..< (NUMBER_OF_COLUMNS div 2 + 32)).mapIt(it.ColumnIndex)
+    var bq = GloasColumnQuarantine.init(cfg, custodyColumns, quarantine, 0, nil)
+    let broot = genBlockRoot(1)
+
+    var present: seq[ref gloas.DataColumnSidecar]
+    for i in 0 ..< (NUMBER_OF_COLUMNS div 2):
+      let sc = newClone(genGloasDataColumnSidecar(
+        index = int(custodyColumns[i]), slot = 1))
+      bq.put(broot, sc)
+      present.add(sc)
+
+    check len(bq) == NUMBER_OF_COLUMNS div 2
+    let res = bq.popSidecars(broot)
+    check:
+      res.isOk()
+      res.get().len == NUMBER_OF_COLUMNS div 2
+      compareSidecars(res.get(), present) == true
 
   test "put()/fetchMissingSidecars/remove test [node]":
     let


### PR DESCRIPTION
An example of a crash that occurred in Kurtosis, testing `glamsterdam-devnet-4`, otherwise:
```
DBG 2026-05-21 20:54:36.010+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.014+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 7, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.022+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 7, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.022+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.022+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 8, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.026+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 8, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.030+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.034+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 40, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.038+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 40, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.038+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.042+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 12, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.046+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 12, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.046+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.046+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 11, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.054+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 11, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.054+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.054+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 50, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.058+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 50, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.058+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.058+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 33, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.066+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 33, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.066+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.066+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 13, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.070+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 13, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.070+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.074+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 72, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.078+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 72, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.078+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.078+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 66, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.086+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 66, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.086+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.086+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 23, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.090+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 23, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.090+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.090+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 17, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.098+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 17, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.098+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.098+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 20, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.106+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 20, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.106+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.106+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 21, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.114+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 21, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.114+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.114+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 123, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.118+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 123, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.122+00:00 Block without sidecars has been added to the quarantine topics="gossip_blocks" block_root=06c43b24
DBG 2026-05-21 20:54:36.122+00:00 Data column received (Gloas - quarantine not implemented) topics="gossip_eth2" dcs="(index: 22, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.126+00:00 Data column validated                      topics="gossip_eth2" dcs="(index: 22, kzg_proofs: 12, slot: 372, beacon_block_root: 06c43b24)" wallSlot=372
DBG 2026-05-21 20:54:36.126+00:00 exiting pubsub read loop                   topics="libp2p pubsubpeer" conn=16U*dvgDKj:6a0f5f78a1119f38509cf28a peer=16U*dvgDKj closed=false
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(3007) nimbus_beacon_node
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(3004) nimbus_beacon_node::main
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2928) nimbus_beacon_node::handleStartUpCmd(var<conf::BeaconNodeConf>)
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2831) nimbus_beacon_node::doRunBeaconNode(var<conf::BeaconNodeConf>, ref<bearssl_rand::HmacDrbgContext>)
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2623) nimbus_beacon_node::run(ref<beacon_node::BeaconNodecolonObjectType_>, InternalRaisesFuture<void, tuple<futures::CancelledError> >)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncengine.nim(150) asyncengine::poll
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(376) asyncfutures::internalContinue(pointer)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(387) asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/pubsubpeer.nim(250) runHandleLoop::runHandleLoop(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/pubsub.nim(471) handleConn::peerHandler(ref<pubsubpeer::PubSubPeercolonObjectType_>, sink<seq<uInt8> >)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(387) asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/pubsub.nim(472) peerHandler::peerHandler(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/gossipsub.nim(673) gossipsub::rpcHandler(ref<types::GossipSubcolonObjectType_>, ref<pubsubpeer::PubSubPeercolonObjectType_>, sink<seq<uInt8> >)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(387) asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/gossipsub.nim(786) rpcHandler::rpcHandler__OOZvendorZnim45libp2pZlibp2pZprotocolsZpubsubZgossipsub_u7459(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/gossipsub.nim(530) gossipsub::validateAndRelay(ref<types::GossipSubcolonObjectType_>, messages::Message, seq<uInt8>, messages::SaltedId, ref<pubsubpeer::PubSubPeercolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(387) asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/gossipsub.nim(548) validateAndRelay::validateAndRelay(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/pubsub.nim(656) pubsub::validate(ref<pubsub::PubSubcolonObjectType_>, messages::Message)
/home/user/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(387) asyncfutures::futureContinue(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/pubsub/pubsub.nim(665) validate::validate(ref<futures::FutureBasecolonObjectType_>)
/home/user/nimbus-eth2/beacon_chain/networking/eth2_network.nim(2658) addValidator::execValidator__nimbus95beacon95node_u110583(string, messages::Message)
/home/user/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2482) colonanonymous_::colonanonymous__nimbus95beacon95node_u113481_(gloas::DataColumnSidecar, peerid::PeerId)
/home/user/nimbus-eth2/beacon_chain/gossip_processing/eth2_processor.nim(496) eth2_processor::processDataColumnSidecar(var<eth2_processor::Eth2Processor>, validator_monitor::MsgSource, ref<gloas::DataColumnSidecar>, uInt64)
/home/user/nimbus-eth2/beacon_chain/gossip_processing/block_processor.nim(1078) block_processor::enqueuePayload_s256(ref<block_processor::BlockProcessor>, MDigest<>)
/home/user/nimbus-eth2/beacon_chain/gossip_processing/block_processor.nim(1037) block_processor::enqueuePayload(ref<block_processor::BlockProcessor>, gloas::SignedBeaconBlock)
/home/user/nimbus-eth2/beacon_chain/consensus_object_pools/column_quarantine.nim(534) column_quarantine::popSidecars_s256(var<SidecarQuarantine<gloas::DataColumnSidecar, proc<fulu::DataColumnSidecarInfoObject> > >, MDigest<>)
/home/user/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/std/assertions.nim(45) assertions::failedAssertImpl(string)
/home/user/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/std/assertions.nim(40) assertions::raiseAssert(string)
/home/user/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/fatal.nim(62) assertions::sysFatal(typeDesc<exceptions::AssertionDefect>, string)
```

It had been preceded by a reduction in custody from being a full supernode by weight of balance, leaving one of the columns empty:
```
INF 2026-05-21 20:54:33.998+00:00 New validator custody count detected       topics="validator_custody" total_node_balance=4095874498292 current_state=FullCustody current_slot=371
INF 2026-05-21 20:54:33.998+00:00 New validator custody set                  topics="validator_custody" custody_columns=127 current_slot=371 ea_slot=371
```