### PR TITLE
rm dead code in slashing protection init

### DIFF
--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -702,38 +702,6 @@ proc initCompatV1*(
 # Resource Management
 # -------------------------------------------------------------
 
-proc init*(T: type SlashingProtectionDB_v2,
-           genesis_validators_root: Eth2Digest,
-           databasePath: string,
-           databaseName: string): T =
-  ## Initialize a new slashing protection database
-  ## or load an existing one with matching genesis root
-  ## `dbname` MUST not be ending with .sqlite3
-  logScope:
-    databasePath
-    databaseName
-
-  let
-    alreadyExists = fileExists(databasePath / databaseName & ".sqlite3")
-    backendRes = SqStoreRef.init(databasePath, databaseName,
-                                 keyspaces = [])
-    backend = backendRes.valueOr: # TODO https://github.com/nim-lang/Nim/issues/22605
-      fatal "Failed to open slashing protection database", err = backendRes.error
-      quit 1
-
-  result = T(backend: backend)
-  if alreadyExists:
-    let status = result.checkDB(genesis_validators_root)
-    if status.isErr:
-      fatal "Slashing protection database check error",
-             reason = status.error
-      quit 1
-  else:
-    result.setupDB(genesis_validators_root)
-
-  # Cached queries
-  result.setupCachedQueries()
-
 proc loadUnchecked*(
        T: type SlashingProtectionDB_v2,
        basePath, dbname: string, readOnly: bool


### PR DESCRIPTION
Introduced by:
- https://github.com/status-im/nimbus-eth2/pull/2094

But no evidence it was ever used.