### PR TITLE
Use separate default port for BN and VC apis

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -1034,8 +1034,8 @@ type
 
     keymanagerPort* {.
       desc: "Listening port for the REST keymanager API"
-      defaultValue: defaultEth2RestPort
-      defaultValueDesc: $defaultEth2RestPortDesc
+      defaultValue: defaultVcKeymanagerPort
+      defaultValueDesc: $defaultVcKeymanagerPortDesc
       name: "keymanager-port" .}: Port
 
     keymanagerAddress* {.

--- a/beacon_chain/spec/network.nim
+++ b/beacon_chain/spec/network.nim
@@ -50,6 +50,8 @@ const
   # This is not part of the spec! But it's port which Lighthouse uses
   defaultEth2RestPort* = 5052
   defaultEth2RestPortDesc* = $defaultEth2RestPort
+  defaultVcKeymanagerPort* = 5062
+  defaultVcKeymanagerPortDesc* = $defaultVcKeymanagerPort
 
   enrAttestationSubnetsField* = "attnets"
   enrSyncSubnetsField* = "syncnets"

--- a/nix/services/validator-client.nix
+++ b/nix/services/validator-client.nix
@@ -100,7 +100,7 @@ in {
 
               keymanager-port = mkOption {
                 type = types.port;
-                default = 5052;
+                default = 5062;
                 description = "Listening port for the REST keymanager API";
               };
 


### PR DESCRIPTION
For VC, keymanagerPort default is 5052, which conflicts with BN rest. Bump it to 5062 so that both BN and VC can run side by side. This matches the Lighthouse config, which was used for BN rest. infra-nimbus seems to override these ports so should not be affected.