### PR TITLE
fix parallel column recovery race and test fixture taskpool leaks

### DIFF
--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -293,26 +293,11 @@ proc recover_cells_and_proofs_parallel*(
       inc spawned
 
   # ---- CRITICAL: Complete all spawned tasks before returning ----
-  while true:
-    for t in tasks.mitems():
-      if t.ok.isSpawned() and t.ok.isReady():
-        # Always consume ok
-        hadError = not t.ok.sync() or hadError
-        t.ok.reset()
-
-    if tasks.anyIt(it.ok.isSpawned):
-      try:
-        await wait
-      except CatchableError:
-        # Waiting for a signal should never fail, but if it does anyway we have
-        # to make sure that the tasks are all finished to retain memory safety
-        for t in tasks.mitems():
-          if t.ok.isSpawned():
-            if not t.ok.sync():
-              hadError = true
-      wait = tsp.wait()
-    else:
-      break
+  for t in tasks.mitems():
+    # Always consume ok
+    if t.ok.isSpawned():
+      hadError = not t.ok.sync() or hadError
+      t.ok.reset()
 
   if hadError:
     return err("Data column reconstruction failed")

--- a/tests/consensus_spec/test_fixture_kzg.nim
+++ b/tests/consensus_spec/test_fixture_kzg.nim
@@ -384,6 +384,7 @@ proc runRecoverCellsAndKzgProofsParallelValidTest(suiteName, suitePath: string) 
       # check recovered cells and proofs
       # assuming columns are sorted
       var tp = Taskpool.new()
+      defer: tp.shutdown()
       let v = waitFor tp.recover_cells_and_proofs_parallel(colInput)
       check v.isOk
       let val = v.get
@@ -454,6 +455,7 @@ proc runRecoverCellsAndKzgProofsParallelInvalidTest(suiteName, suitePath: string
 
       # check error
       var tp = Taskpool.new()
+      defer: tp.shutdown()
       let v = waitFor tp.recover_cells_and_proofs_parallel(colInput)
       check v.isErr
 


### PR DESCRIPTION
Addresses regression from:
- https://github.com/status-im/nimbus-eth2/pull/8346

This was periodically causing CI timeouts on, mostly, GitHub Actions Linux/amd64 runners. It would typically look like
```
2026-05-18T15:23:21.5438404Z DBG 2026-05-18 15:23:21.511+00:00 Received response from handler             status=400 meth=POST peer=127.0.0.1:35680 uri=/api/v1/eth2/sign/0xacf31f9b1ecf65dbb198e380599b6c81fc1a1f5db4457482cc697d81b1fdfb6e49cf8eff4980477f6e32749eef61dc4d content_type=text/plain content_size=45
2026-05-18T15:23:21.5439697Z 
2026-05-18T15:23:21.5439843Z EF - BPO forkdigests .......... (0.00s)
2026-05-18T15:23:29.1729143Z EF - KZG ............................................................................................................................................................................................................................................................. (4.05s)
2026-05-18T20:26:38.8829317Z ##[error]The operation was canceled.
2026-05-18T20:26:38.9063582Z Post job cleanup.
```
Or similar: it would finish the EF - KZG suite but not the PeerDAS KZG tests following it.

When eventually captured locally, the stack trace was:
```
/root/nimbus-eth2/tests/consensus_spec/test_fixture_kzg.nim(551): test_fixture_kzg
/root/nimbus-eth2/vendor/nim-unittest2/unittest2.nim(1175): test_fixture_kzg::runRecoverCellsAndKzgProofsParallelInvalidTest(string, string)
/root/nimbus-eth2/vendor/nim-unittest2/unittest2.nim(1095): unittest2::runDirect(unittest2::Test)
/root/nimbus-eth2/tests/consensus_spec/test_fixture_kzg.nim(468): runRecoverCellsAndKzgProofsParallelInvalidTest::runTestX60gensym899_(string, string)
/root/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(1875): asyncfutures::waitFor(InternalRaisesFuture<Result<seq<kzg::KzgCellsAndKzgProofs>, cstring>, void>)
/root/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncfutures.nim(640): asyncfutures::pollFor(InternalRaisesFuture<Result<seq<kzg::KzgCellsAndKzgProofs>, cstring>, void>)
/root/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncengine.nim(1018): asyncengine::poll
/root/nimbus-eth2/vendor/nim-chronos/chronos/ioselects/ioselectors_epoll.nim(643): selectors2::selectInto2(Selector<asyncengine::SelectorData>, int, var<openArray<selectors2::ReadyKey> >)
```

It's also possible to intentionally widen the race window and cause it to happen nearly deterministically:
```nim
diff --git a/beacon_chain/spec/peerdas_helpers.nim b/beacon_chain/spec/peerdas_helpers.nim
index 99643bf5..a790f9b9 100644
--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -19,10 +19,11 @@ import
   ./crypto,
   ./[helpers, digest, column_map],
   ./datatypes/[fulu, deneb]
 
 from std/algorithm import sort
+from std/os import sleep
 from std/sequtils import anyIt, mapIt, repeat, toSeq
 from stew/staticfor import staticFor
 
 type
   CellBytes = array[fulu.CELLS_PER_EXT_BLOB, Cell]
@@ -207,10 +208,11 @@ proc recover_cells_and_proofs_parallel*(
       idxArr = cast[ptr UncheckedArray[CellIndex]](idxPtr)
       cellsArr = cast[ptr UncheckedArray[Cell]](cellsPtr)
     # Use toOpenArray to create views without copying
     defer:
       discard tsp.fireSync()
+      sleep(1)
 
     res[] = recoverCellsAndKzgProofsTask(
       idxArr.toOpenArray(0, columnCount - 1),
       cellsArr.toOpenArray(0, columnCount - 1)).valueOr:
         return false
```

The race involved `discard tsp.fireSync()` in each thread and `isReady`: https://github.com/status-im/nimbus-eth2/blob/279fd945ae7ee3b3a51d3d56a3beb80b14ec45e5/beacon_chain/spec/peerdas_helpers.nim#L285-L315

`workerRecover` is followed by effectively `readyWith` due to the [macro expansion](https://github.com/status-im/nim-taskpools/blob/4acdc6ef005a93dba09f902ed75197548cf7b451/taskpools/taskpools.nim#L478-L494):
```nim
    let asyncBody = quote do:
      # XXX: can't test that when the RootTask is default(Task) instead of a sentinel value
      # preCondition: not isRootTask(workerContext.currentTask.task)

      let res = `fnCallIdents`
      readyWith(`futFnParam`, res)

    let asyncFn = ident("taskpool_" & fnName)
    result.add nnkProcDef.newTree(
      asyncFn,
      newEmptyNode(),
      genericParams,
      asyncParams,
      nnkPragma.newTree(ident("nimcall")),
      newEmptyNode(),
      asyncBody
    )
```

So depending on which order the main thread observes the `readyWith` (`trySend`) and `fireSync` communications from the worker thread, e.g., if the main thread observes `fireSync` before `readyWith` has had a chance to be main-thread-observable, it can deadlock.

The tradeoff is allowing `sync` to block the main thread, typically briefly (microseconds) if at all. There are alternate approaches, but this is reasonable enough to unblock, CI, and it has to wait for all of them anyway; otherwise in the previous implementation it would run that recovery loop.

The missing `tp.shutdown()`s were mostly unrelated, but they did allow potential taskpool leakage.