### PR TITLE
Add `parent_block_root` to bid filtering key

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -699,7 +699,8 @@ AllTests-mainnet
 + Duplicate detection - same builder same slot                                               OK
 + Empty pool returns none                                                                    OK
 + Highest bid selection - different builders                                                 OK
-+ Multiple bids for different parents same slot                                              OK
++ Multiple bids for different beacon parent roots same slot                                  OK
++ Multiple bids for different execution parent hashes same slot                              OK
 + Pruning removes old bids                                                                   OK
 + Track seen bids                                                                            OK
 ```

--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -14,33 +14,51 @@ import
   ../beacon_clock,
   ./blockchain_dag
 
-from std/sequtils import filterIt
-
 logScope: topics = "bidpool"
 
 type
+  PayloadAvailability* {.pure.} = enum
+    Timely
+    Withheld
+
+  BidKey = tuple
+    parentBlockRoot: Eth2Digest
+    payloadAvailability: PayloadAvailability
+
   SlotBids* = object
-    highestBids*: Table[Eth2Digest, gloas.SignedExecutionPayloadBid]
+    highestBids*: Table[BidKey, gloas.SignedExecutionPayloadBid]
     seenBuilders*: HashSet[uint64]
 
   ExecutionPayloadBidPool* = object
-    ## Pool for tracking execution payload bids received from builders
-    ## Only stores the highest-value bid per (slot, parent_block_hash)
+    ## Pool for tracking execution payload bids received from builders.
+    ## Only stores the highest-value bid per (slot, parentBlockRoot,
+    ## payloadAvailability).
     dag*: ChainDAGRef
     slotBids*: Table[Slot, SlotBids]
-    blockRootIndex*: Table[Eth2Digest, seq[(Slot, Eth2Digest)]]
 
 func init*(
     T: type ExecutionPayloadBidPool,
     dag: ChainDAGRef): ExecutionPayloadBidPool =
   ExecutionPayloadBidPool(
     dag: dag,
-    slotBids: initTable[Slot, SlotBids](),
-    blockRootIndex: initTable[Eth2Digest, seq[(Slot, Eth2Digest)]]())
+    slotBids: initTable[Slot, SlotBids]())
+
+proc payloadAvailability*(
+    dag: ChainDAGRef,
+    blck: BlockRef,
+    executionBlockHash: Eth2Digest): Opt[PayloadAvailability] =
+  let (blockHash, parentHash) = dag.loadExecutionAndParentBlockHash(blck)
+  if blockHash.isSome and executionBlockHash == blockHash.unsafeGet:
+    Opt.some PayloadAvailability.Timely
+  elif parentHash.isSome and executionBlockHash == parentHash.unsafeGet:
+    Opt.some PayloadAvailability.Withheld
+  else:
+    Opt.none PayloadAvailability
 
 proc addBid*(
     pool: var ExecutionPayloadBidPool,
     signedBid: gloas.SignedExecutionPayloadBid,
+    payloadAvailability: PayloadAvailability,
     wallTime: BeaconTime) =
   template bid: untyped = signedBid.message
 
@@ -55,7 +73,9 @@ proc addBid*(
     debug "Duplicate bid from builder, ignoring"
     return
 
-  let currentBid = slotData.highestBids.getOrDefault(bid.parent_block_hash)
+  let
+    key = (bid.parent_block_root, payloadAvailability)
+    currentBid = slotData.highestBids.getOrDefault(key)
   if currentBid != static(default(gloas.SignedExecutionPayloadBid)):
     if bid.value <= currentBid.message.value:
       debug "Bid value not higher than current best",
@@ -67,10 +87,7 @@ proc addBid*(
   else:
     debug "First bid for this slot and parent"
 
-  slotData.highestBids[bid.parent_block_hash] = signedBid
-
-  pool.blockRootIndex.mgetOrPut(
-    bid.parent_block_root, @[]).add((bid.slot, bid.parent_block_hash))
+  slotData.highestBids[key] = signedBid
 
 func getBidForSlotAndBuilder*(
     pool: ExecutionPayloadBidPool, slot: Slot,
@@ -84,27 +101,16 @@ func getBidForSlotAndBuilder*(
 
 func getHighestBidForSlotAndParent*(
     pool: ExecutionPayloadBidPool, slot: Slot,
-    parentBlockHash: Eth2Digest): Opt[gloas.SignedExecutionPayloadBid] =
+    parentBlockRoot: Eth2Digest, payloadAvailability: PayloadAvailability
+): Opt[gloas.SignedExecutionPayloadBid] =
   let
     slotData = pool.slotBids.getOrDefault(slot)
-    bid = slotData.highestBids.getOrDefault(parentBlockHash)
+    key = (parentBlockRoot, payloadAvailability)
+    bid = slotData.highestBids.getOrDefault(key)
   if bid != static(default(gloas.SignedExecutionPayloadBid)):
     Opt.some(bid)
   else:
     Opt.none(gloas.SignedExecutionPayloadBid)
-
-func getBidForBlockRoot*(
-    pool: ExecutionPayloadBidPool,
-    blockRoot: Eth2Digest): Opt[gloas.SignedExecutionPayloadBid] =
-  let references = pool.blockRootIndex.getOrDefault(blockRoot, @[])
-  if references.len > 0:
-    let (slot, parentHash) = references[0]
-    return pool.getHighestBidForSlotAndParent(slot, parentHash)
-  Opt.none(gloas.SignedExecutionPayloadBid)
-
-func hasBidForBlockRoot*(
-    pool: ExecutionPayloadBidPool, blockRoot: Eth2Digest): bool =
-  pool.blockRootIndex.getOrDefault(blockRoot, @[]).len > 0
 
 func hasSeenBidFromBuilder*(
     pool: ExecutionPayloadBidPool, slot: Slot,
@@ -113,24 +119,9 @@ func hasSeenBidFromBuilder*(
   builderIndex in slotData.seenBuilders
 
 proc prune*(pool: var ExecutionPayloadBidPool, beforeSlot: Slot) =
-  try:
-    var slotsToRemove: seq[Slot]
-    for slot in pool.slotBids.keys:
-      if slot < beforeSlot:
-        slotsToRemove.add(slot)
-
-    for slot in slotsToRemove:
-      if slot in pool.slotBids:
-        for parentHash, bid in pool.slotBids[slot].highestBids:
-          let blockRoot = bid.message.parent_block_root
-          if blockRoot in pool.blockRootIndex:
-            pool.blockRootIndex[blockRoot] =
-              pool.blockRootIndex[blockRoot].filterIt(
-                it != (slot, parentHash))
-            if pool.blockRootIndex[blockRoot].len == 0:
-              pool.blockRootIndex.del(blockRoot)
-
-      pool.slotBids.del(slot)
-
-  except KeyError:
-    error "KeyError during bid pruning"
+  var slotsToRemove: seq[Slot]
+  for slot in pool.slotBids.keys:
+    if slot < beforeSlot:
+      slotsToRemove.add(slot)
+  for slot in slotsToRemove:
+    pool.slotBids.del(slot)

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -934,8 +934,14 @@ proc processExecutionPayloadBid*(
     signedBid, wallTime)
   if v.isOk():
     debug "Execution payload bid validated"
-    self.executionPayloadBidPool[].addBid(signedBid, wallTime)
+
+    let payloadAvailability = v.get
+
+    self.executionPayloadBidPool[].addBid(
+      signedBid, payloadAvailability, wallTime)
+
     beacon_execution_payload_bids_received.inc()
+
     ok()
   else:
     debug "Dropping execution payload bid", reason = $v.error

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2055,7 +2055,7 @@ proc validateExecutionPayloadBid*(
     seenProposerPreferences:
       var array[2, array[SLOTS_PER_EPOCH, Opt[ProposerPreferences]]],
     signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
-    wallTime: BeaconTime): Result[void, ValidationError] =
+    wallTime: BeaconTime): Result[PayloadAvailability, ValidationError] =
   template bid: untyped = signed_execution_payload_bid.message
 
   withState(dag.headState):
@@ -2080,10 +2080,20 @@ proc validateExecutionPayloadBid*(
         return errIgnore(
           "ExecutionPayloadBid: already seen bid from this builder for this slot")
 
-      # [IGNORE] This bid is the highest value bid seen for the corresponding
-      # slot and the given parent block hash
-      let highestBid = executionPayloadBidPool[].getHighestBidForSlotAndParent(
-        bid.slot, bid.parent_block_hash)
+      # [IGNORE] bid.parent_block_hash is the block hash of a known execution
+      # payload in fork choice
+      let parentBlck = dag.getBlockRef(bid.parent_block_root).valueOr:
+        return errIgnore(
+          "ExecutionPayloadBid: parent block root not found in fork choice")
+
+      # [IGNORE] this bid is the highest value bid seen for the tuple
+      # `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`.
+      let
+        payloadAvailability =
+          dag.payloadAvailability(parentBlck, bid.parent_block_hash).valueOr:
+            return errIgnore("ExecutionPayloadBid: parent block hash unknown")
+        highestBid = executionPayloadBidPool[].getHighestBidForSlotAndParent(
+          bid.slot, bid.parent_block_root, payloadAvailability)
       if highestBid.isSome() and highestBid.get().message.value > bid.value:
         return errIgnore(
           "ExecutionPayloadBid: not the highest value bid for this slot and parent")
@@ -2093,22 +2103,6 @@ proc validateExecutionPayloadBid*(
           forkyState.data, bid.builder_index.BuilderIndex, bid.value):
         return errIgnore(
           "ExecutionPayloadBid: insufficient builder balance")
-
-      # [IGNORE] bid.parent_block_hash is the block hash of a known execution
-      # payload in fork choice
-      let parentBlck = dag.getBlockRef(bid.parent_block_root).valueOr:
-        return errIgnore("ExecutionPayloadBid: parent block root not found in fork choice")
-
-      try:
-        let parentExecHash = dag.loadExecutionBlockHash(parentBlck).valueOr:
-          return errIgnore("Bid: parent has no execution payload")
-
-        # Verify the bid references the correct execution payload
-        if parentExecHash != bid.parent_block_hash:
-          return dag.checkedReject(
-            "Bid: parent_block_hash doesn't match parent beacon block")
-      except KeyError:
-        return errIgnore("Bid: error loading parent execution hash")
 
       let seenPref = block:
         let
@@ -2168,11 +2162,11 @@ proc validateExecutionPayloadBid*(
           signed_execution_payload_bid.signature):
         return dag.checkedReject(
           "ExecutionPayloadBid: invalid signature")
-    else:
-      return dag.checkedReject(
-        "ExecutionPayloadBid: only valid for Gloas fork or later")
 
-  ok()
+      ok payloadAvailability
+    else:
+      dag.checkedReject(
+        "ExecutionPayloadBid: only valid for Gloas fork or later")
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.3/specs/gloas/p2p-interface.md#payload_attestation_message
 proc validatePayloadAttestationMessage*(

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -48,7 +48,7 @@ from eth/async_utils import awaitWithTimeout
 from ./message_router_mev import unblindAndRouteBlockMEV
 from ../spec/beaconstate import proposalExecutionHead
 from ../consensus_object_pools/execution_payload_pool import
-  getHighestBidForSlotAndParent
+  getHighestBidForSlotAndParent, payloadAvailability
 
 # Metrics for tracking attestation and beacon block loss
 declareCounter beacon_light_client_finality_updates_sent,
@@ -583,10 +583,14 @@ proc proposeBlockAux(
 
   when fork >= ConsensusFork.Gloas:
     let
-      executionHead = proposalExecutionHead(
-        state[].forky(fork).data)
-      poolBid = node.executionPayloadBidPool[].getHighestBidForSlotAndParent(
-        slot, executionHead)
+      executionHead = proposalExecutionHead(state[].forky(fork).data)
+      payloadAvailability = node.dag.payloadAvailability(head, executionHead)
+      poolBid =
+        if payloadAvailability.isSome:
+          node.executionPayloadBidPool[].getHighestBidForSlotAndParent(
+            slot, head.root, payloadAvailability.unsafeGet)
+        else:
+          Opt.none gloas.SignedExecutionPayloadBid
       localBlockValueBoost =
         BoostFactor.init(node.config.localBlockValueBoost)
       usePoolBid =

--- a/tests/test_execution_payload_pool.nim
+++ b/tests/test_execution_payload_pool.nim
@@ -54,42 +54,51 @@ suite "Execution Payload Bid Pool":
 
   test "Empty pool returns none":
     check:
-      not pool.getHighestBidForSlotAndParent(1.Slot, parentHash1).isSome()
-      not pool.hasBidForBlockRoot(blockRoot)
-      not pool.getBidForBlockRoot(blockRoot).isSome()
+      not pool.getHighestBidForSlotAndParent(
+        1.Slot, blockRoot, PayloadAvailability.Timely).isSome()
       not pool.hasSeenBidFromBuilder(1.Slot, 0)
 
   test "Add and retrieve highest bid":
     let bid = makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei)
 
-    pool.addBid(bid, wallTime)
+    pool.addBid(bid, PayloadAvailability.Timely, wallTime)
 
+    let highest = pool.getHighestBidForSlotAndParent(
+      10.Slot, blockRoot, PayloadAvailability.Timely)
     check:
-      pool.getHighestBidForSlotAndParent(10.Slot, parentHash1).isSome()
-      pool.getHighestBidForSlotAndParent(10.Slot, parentHash1).get().message.value == 100.Gwei
-      pool.getHighestBidForSlotAndParent(10.Slot, parentHash1).get().message.builder_index == 1
+      highest.isSome()
+      highest.get().message.value == 100.Gwei
+      highest.get().message.builder_index == 1
 
   test "Duplicate detection - same builder same slot":
     let
       bid1 = makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei)
       bid2 = makeBid(10.Slot, 1, blockRoot, parentHash1, 200.Gwei)
 
-    pool.addBid(bid1, wallTime)
+    pool.addBid(bid1, PayloadAvailability.Timely, wallTime)
     check pool.hasSeenBidFromBuilder(10.Slot, 1)
 
-    pool.addBid(bid2, wallTime)
+    pool.addBid(bid2, PayloadAvailability.Timely, wallTime)
 
-    let highest = pool.getHighestBidForSlotAndParent(10.Slot, parentHash1)
+    let highest = pool.getHighestBidForSlotAndParent(
+      10.Slot, blockRoot, PayloadAvailability.Timely)
     check:
       highest.isSome()
       highest.get().message.value == 100.Gwei
 
   test "Highest bid selection - different builders":
-    pool.addBid(makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 2, blockRoot, parentHash1, 200.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 3, blockRoot, parentHash1, 150.Gwei), wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 2, blockRoot, parentHash1, 200.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 3, blockRoot, parentHash1, 150.Gwei),
+      PayloadAvailability.Timely, wallTime)
 
-    let highest = pool.getHighestBidForSlotAndParent(10.Slot, parentHash1)
+    let highest = pool.getHighestBidForSlotAndParent(
+      10.Slot, blockRoot, PayloadAvailability.Timely)
     check:
       highest.isSome()
       highest.get().message.value == 200.Gwei
@@ -102,23 +111,33 @@ suite "Execution Payload Bid Pool":
       newRoot = Eth2Digest.fromHex(
         "0x2222222222222222222222222222222222222222222222222222222222222222")
 
-    pool.addBid(makeBid(10.Slot, 1, oldRoot, parentHash1, 100.Gwei), wallTime)
-    pool.addBid(makeBid(100.Slot, 2, newRoot, parentHash1, 200.Gwei), wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 1, oldRoot, parentHash1, 100.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(100.Slot, 2, newRoot, parentHash1, 200.Gwei),
+      PayloadAvailability.Timely, wallTime)
 
     check:
-      pool.hasBidForBlockRoot(oldRoot)
-      pool.hasBidForBlockRoot(newRoot)
+      10.Slot in pool.slotBids
+      100.Slot in pool.slotBids
 
     pool.prune(50.Slot)
 
     check:
-      not pool.hasBidForBlockRoot(oldRoot)
-      pool.hasBidForBlockRoot(newRoot)
+      10.Slot notin pool.slotBids
+      100.Slot in pool.slotBids
 
   test "Track seen bids":
-    pool.addBid(makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 2, blockRoot, parentHash1, 200.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 3, blockRoot, parentHash1, 50.Gwei), wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 2, blockRoot, parentHash1, 200.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 3, blockRoot, parentHash1, 50.Gwei),
+      PayloadAvailability.Timely, wallTime)
 
     check:
       pool.hasSeenBidFromBuilder(10.Slot, 1)
@@ -127,14 +146,26 @@ suite "Execution Payload Bid Pool":
 
     check pool.slotBids.len == 1
 
-  test "Multiple bids for different parents same slot":
-    pool.addBid(makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 2, blockRoot, parentHash2, 150.Gwei), wallTime)
-    pool.addBid(makeBid(10.Slot, 3, blockRoot, parentHash1, 120.Gwei), wallTime)
+  test "Multiple bids for different beacon parent roots same slot":
+    let
+      blockRoot1 = blockRoot
+      blockRoot2 = Eth2Digest.fromHex(
+        "0x3333333333333333333333333333333333333333333333333333333333333333")
+    pool.addBid(
+      makeBid(10.Slot, 1, blockRoot1, parentHash1, 100.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 2, blockRoot2, parentHash1, 150.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 3, blockRoot1, parentHash1, 120.Gwei),
+      PayloadAvailability.Timely, wallTime)
 
     let
-      highest1 = pool.getHighestBidForSlotAndParent(10.Slot, parentHash1)
-      highest2 = pool.getHighestBidForSlotAndParent(10.Slot, parentHash2)
+      highest1 = pool.getHighestBidForSlotAndParent(
+        10.Slot, blockRoot1, PayloadAvailability.Timely)
+      highest2 = pool.getHighestBidForSlotAndParent(
+        10.Slot, blockRoot2, PayloadAvailability.Timely)
 
     check:
       highest1.isSome()
@@ -145,11 +176,29 @@ suite "Execution Payload Bid Pool":
       highest2.get().message.value == 150.Gwei
       highest2.get().message.builder_index == 2
 
-    check:
-      pool.hasSeenBidFromBuilder(10.Slot, 1)
-      pool.hasSeenBidFromBuilder(10.Slot, 2)
-      pool.hasSeenBidFromBuilder(10.Slot, 3)
+    check pool.slotBids[10.Slot].highestBids.len == 2
 
-    check pool.slotBids.len == 1
+  test "Multiple bids for different execution parent hashes same slot":
+    pool.addBid(
+      makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei),
+      PayloadAvailability.Timely, wallTime)
+    pool.addBid(
+      makeBid(10.Slot, 2, blockRoot, parentHash2, 200.Gwei),
+      PayloadAvailability.Withheld, wallTime)
+
+    let
+      bidTimely = pool.getHighestBidForSlotAndParent(
+        10.Slot, blockRoot, PayloadAvailability.Timely)
+      bidWithheld = pool.getHighestBidForSlotAndParent(
+        10.Slot, blockRoot, PayloadAvailability.Withheld)
+
+    check:
+      bidTimely.isSome()
+      bidTimely.get().message.value == 100.Gwei
+      bidTimely.get().message.builder_index == 1
+
+      bidWithheld.isSome()
+      bidWithheld.get().message.value == 200.Gwei
+      bidWithheld.get().message.builder_index == 2
 
     check pool.slotBids[10.Slot].highestBids.len == 2


### PR DESCRIPTION
The gossip rule was changed from:

> [IGNORE] This bid is the highest value bid seen for the corresponding
>          slot and the given parent block hash

to:

> [IGNORE] this bid is the highest value bid seen for the tuple
>          (bid.slot, bid.parent_block_hash, bid.parent_block_root)`.

- https://github.com/ethereum/consensus-specs/pull/5001

This way, someone can't just abuse a reorg to bid a large amount on a non-canonical branch to purge the canonical bid. Catch up with spec.

Further, clean up the `parentExecHash != bid.parent_block_hash` check which is not from spec and rejected bids building on the timeline where the parent block's payload was withheld, by tracking the bids in the pool separately based on timeline.