### PR TITLE
Ensure confirmed chain includes greatest unrealized checkpoint

### DIFF
--- a/beacon_chain/fork_choice/fast_confirmation.nim
+++ b/beacon_chain/fork_choice/fast_confirmation.nim
@@ -539,7 +539,7 @@ func `$`*(diag: FcrDiagnostics): string =
 
 chronicles.formatIt FcrDiagnostics: $it
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/phase0/fast-confirmation.md#is_confirmed_chain_safe
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/phase0/fast-confirmation.md#is_confirmed_chain_safe
 func is_confirmed_chain_safe(
     self: ForkChoiceBackend, dag: ChainDAGRef, confirmed: BlockId,
     current_slot: Slot, diag: var FcrDiagnostics): FcResult[bool] =
@@ -571,8 +571,8 @@ func is_confirmed_chain_safe(
     chain = self.get_ancestor_support_by_slot(
       balance_source, dag.heads, confirmed, current_justified, current_slot)
 
-  # Check if the confirmed.root is descendant of
-  # current_epoch_observed_justified.checkpoint.
+  # Check if the confirmed.root has current_epoch_observed_justified.checkpoint
+  # in its chain.
   if chain.len == 0:
     return ok false
 


### PR DESCRIPTION
The spec was updated to match our implementation, the current epoch GU has to not be just any ancestor but actually be the expected checkpoint.

- https://github.com/ethereum/consensus-specs/pull/5288