### PR TITLE
rm unused support for deprecated builder API from BN

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2200,15 +2200,6 @@ template syncCommitteeParticipants*(
     subcommitteeIdx: SyncSubcommitteeIndex): seq[ValidatorIndex] =
   toSeq(syncSubcommittee(dag.syncCommitteeParticipants(slot), subcommitteeIdx))
 
-iterator syncCommitteeParticipants*(
-    dag: ChainDAGRef,
-    slot: Slot,
-    subcommitteeIdx: SyncSubcommitteeIndex,
-    aggregationBits: SyncCommitteeAggregationBits): ValidatorIndex =
-  for pos, valIdx in dag.syncCommitteeParticipants(slot, subcommitteeIdx):
-    if pos < aggregationBits.bits and aggregationBits[pos]:
-      yield valIdx
-
 func needStateCachesAndForkChoicePruning*(dag: ChainDAGRef): bool =
   dag.lastPrunePoint != dag.finalizedHead.toBlockSlotId().expect("not nil")
 

--- a/beacon_chain/consensus_object_pools/blockchain_list.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_list.nim
@@ -46,15 +46,6 @@ proc init*(T: type ChainListRef, directory: string): ChainListRef =
         Opt.some(res.get())
   ChainListRef(path: directory, handle: handle)
 
-proc init*(T: type ChainListRef, directory: string,
-           slot: Slot): Result[ChainListRef, string] =
-  let
-    flags = {ChainFileFlag.Repair, ChainFileFlag.OpenAlways}
-    filename = directory.chainFilePath()
-    handle = ? ChainFileHandle.init(filename, flags)
-    offset {.used.} = ? seekForSlot(handle, slot)
-  ok(ChainListRef(path: directory, handle: Opt.some(handle)))
-
 proc seekForSlot*(clist: ChainListRef, slot: Slot): Result[void, string] =
   if clist.handle.isNone():
     let

--- a/beacon_chain/el/el_manager.nim
+++ b/beacon_chain/el/el_manager.nim
@@ -386,28 +386,20 @@ proc getPayload(
       limit = MAX_EXTRA_DATA_BYTES
     raise newException(CatchableError, "Execution payload extraData exceeds max size")
 
-  when compiles(payload.executionPayload.withdrawals):
-    when payload.executionPayload.withdrawals is Opt:
-      template maybeEmpty(v: Opt): untyped =
-        v.valueOr(@[])
-    else:
-      template maybeEmpty(v: auto): untyped =
-        v
-
-    if params.attributes.withdrawals != payload.executionPayload.withdrawals.maybeEmpty:
-      warn "Execution client returned unexpected payload withdrawals",
-        url = connection.engineUrl.url,
-        payloadId,
-        withdrawals_from_cl_len = params.attributes.withdrawals.len,
-        withdrawals_from_el_len = payload.executionPayload.withdrawals.maybeEmpty.len,
-        withdrawals_from_cl =
-          mapIt(params.attributes.withdrawals, it.asConsensusWithdrawal),
-        withdrawals_from_el = mapIt(
-          payload.executionPayload.withdrawals.maybeEmpty, it.asConsensusWithdrawal
-        )
-      raise newException(
-        CatchableError, "Execution client returned mismatching withdrawals"
+  if params.attributes.withdrawals != payload.executionPayload.withdrawals:
+    warn "Execution client returned unexpected payload withdrawals",
+      url = connection.engineUrl.url,
+      payloadId,
+      withdrawals_from_cl_len = params.attributes.withdrawals.len,
+      withdrawals_from_el_len = payload.executionPayload.withdrawals.len,
+      withdrawals_from_cl =
+        mapIt(params.attributes.withdrawals, it.asConsensusWithdrawal),
+      withdrawals_from_el = mapIt(
+        payload.executionPayload.withdrawals, it.asConsensusWithdrawal
       )
+    raise newException(
+      CatchableError, "Execution client returned mismatching withdrawals"
+    )
 
   payload
 

--- a/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_beacon_calls.nim
@@ -8,15 +8,9 @@
 {.push raises: [], gcsafe.}
 
 import
-  chronos, presto/client, chronicles,
-  ".."/".."/validators/slashing_protection_common,
-  ".."/[helpers, forks, keystore, eth2_ssz_serialization],
-  "."/[rest_types, rest_common, eth2_rest_serialization]
-
-from ../mev/bellatrix_mev import SignedBlindedBeaconBlock
-from ../mev/capella_mev import SignedBlindedBeaconBlock
-from ../mev/deneb_mev import SignedBlindedBeaconBlock
-from ../datatypes/gloas import SignedExecutionPayloadEnvelope
+  chronos, presto/client,
+  ../[forks, eth2_ssz_serialization],
+  ./[rest_types, rest_common, eth2_rest_serialization]
 
 export chronos, client, rest_types, eth2_rest_serialization
 
@@ -245,58 +239,6 @@ proc publishSszBlockV2*(
     broadcast_validation,
     blck,
     restContentType = $OctetStreamMediaType,
-    extraHeaders = @[("eth-consensus-version", consensus)])
-
-proc publishBlindedBlock*(body: phase0.SignedBeaconBlock): RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: altair.SignedBeaconBlock): RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: bellatrix_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: capella_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: deneb_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: electra_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishBlindedBlock*(body: fulu_mev.SignedBlindedBeaconBlock):
-       RestPlainResponse {.
-     rest, endpoint: "/eth/v1/beacon/blinded_blocks",
-     meth: MethodPost.}
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-
-proc publishSszBlindedBlock*(
-    client: RestClientRef,
-    blck: ForkySignedBeaconBlock
-): Future[RestPlainResponse] {.
-   async: (raises: [CancelledError, RestEncodingError, RestDnsResolveError,
-                    RestCommunicationError], raw: true).} =
-  ## https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlock
-  let consensus = typeof(blck).kind.toString()
-  client.publishBlindedBlock(
-    blck, restContentType = $OctetStreamMediaType,
     extraHeaders = @[("eth-consensus-version", consensus)])
 
 proc publishBlindedBlockV2*(

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -14,28 +14,27 @@ import
   chronos,
   taskpools,
   # Internal
-  ../beacon_chain/[beacon_clock],
+  ../beacon_chain/beacon_clock,
   ../beacon_chain/gossip_processing/[gossip_validation, batch_validation],
   ../beacon_chain/fork_choice/fork_choice,
   ../beacon_chain/consensus_object_pools/[
     block_quarantine, blockchain_dag, block_clearance, attestation_pool,
     envelope_quarantine, sync_committee_msg_pool],
-  ../beacon_chain/spec/datatypes/[phase0, altair, gloas],
-  ../beacon_chain/spec/[
-    beaconstate, state_transition, helpers, network, validator],
+  ../beacon_chain/spec/[state_transition, helpers, network, validator],
   ../beacon_chain/validators/validator_pool,
   # Test utilities
   ./testutil, ./testdbutil, ./testblockutil, ./consensus_spec/fixtures_utils
 
 from std/sequtils import count, toSeq
 from ./testbcutil import addHeadBlock
+from ../beacon_chain/spec/beaconstate import dependent_root, latest_block_root
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
     dag.pruneStateCachesDAG()
     # pool[].prune(dag) # We test without att_1_0 pool / fork choice pruning
 
-proc signProposerPreferences(
+func signProposerPreferences(
     dag: ChainDAGRef, prefs: ProposerPreferences,
     privkey: ValidatorPrivKey): SignedProposerPreferences =
   let
@@ -523,9 +522,9 @@ suite "Proposer preferences validation " & preset():
             break
         # wrongValidator just needs to differ from the scheduled proposer at
         # proposerSlot; other slots don't matter for is_valid_proposal_slot.
-        wrongValidator = proposerIndex + 1
+        wrongValidator = proposer_index + 1
         if forkyState.data.proposer_lookahead.item(
-            proposerSlot - startSlot) == wrongValidator:
+            proposer_slot - startSlot) == wrongValidator:
           wrongValidator += 1
     check proposerFound
 
@@ -537,7 +536,7 @@ suite "Proposer preferences validation " & preset():
         fee_recipient: default(ExecutionAddress),
         target_gas_limit: 30_000_000)
       signed = signProposerPreferences(
-        dag, prefs, MockPrivKeys[proposerIndex.ValidatorIndex])
+        dag, prefs, MockPrivKeys[proposer_index.ValidatorIndex])
       wallTime = dag.head.slot.start_beacon_time(dag.cfg.timeParams)
 
   test "validateProposerPreferences - happy case":
@@ -550,16 +549,16 @@ suite "Proposer preferences validation " & preset():
       validateProposerPreferences(dag, seen, signed, wallTime).isErr
 
   test "validateProposerPreferences - proposal_slot already passed":
-    let past = (proposerSlot + 1).start_beacon_time(dag.cfg.timeParams)
+    let past = (proposer_slot + 1).start_beacon_time(dag.cfg.timeParams)
     # Still within current/next epoch window, but wallTime >= proposal_slot.
     check:
       validateProposerPreferences(dag, seen, signed, past).isErr
 
   test "validateProposerPreferences - proposal_slot outside current/next epoch":
     var msg = prefs
-    msg.proposal_slot = proposerSlot + SLOTS_PER_EPOCH * 3
+    msg.proposal_slot = proposer_slot + SLOTS_PER_EPOCH * 3
     let farAhead = signProposerPreferences(
-      dag, msg, MockPrivKeys[proposerIndex.ValidatorIndex])
+      dag, msg, MockPrivKeys[proposer_index.ValidatorIndex])
     check:
       validateProposerPreferences(dag, seen, farAhead, wallTime).isErr
 

--- a/tests/test_payload_attestation_pool.nim
+++ b/tests/test_payload_attestation_pool.nim
@@ -11,7 +11,6 @@
 import
   # Status libraries
   unittest2,
-  chronicles,
   # Internal
   ../beacon_chain/consensus_object_pools/[
     blockchain_dag, payload_attestation_pool, spec_cache],
@@ -329,7 +328,6 @@ suite "Payload attestation pool" & preset():
     withState(state[]):
       when consensusFork >= ConsensusFork.Gloas:
         # Get PTC using StateCache version
-        var cache = StateCache()
         let stateCacheResults = collect(newSeq):
           for validator_index in get_ptc(forkyState.data, slot):
             validator_index


### PR DESCRIPTION
[publishBlindedBlock V1](https://ethereum.github.io/beacon-APIs/?urls.primaryName=v3.1.0#/Beacon/publishBlindedBlock) has been deprecated and doesn't work for Fulu or later forks. It has been replaced by [publishBlindedBlockV2](https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlockV2). Its last (itself unused) caller was removed by:
- #8519

For the supported forks for validating, which is what EL manager works with, `compiles(payload.executionPayload.withdrawals)` was always true and `payload.executionPayload.withdrawals is Opt` was always false, which somewhat simplified the rest.

The changes from `proposerIndex` to `proposer_index` and `proposerSlot` to `proposer_slot` are to match the declarations of those variables; it had been triggering [`--styleCheck:usages`](https://nim-lang.org/docs/nimc.html#compiler-usage-commandminusline-switches) `Name` [hints](https://nim-lang.org/docs/nimc.html#compiler-usage-list-of-hints).