### PR TITLE
nix: update flake.lock file

### DIFF
--- a/ci/nix.Jenkinsfile
+++ b/ci/nix.Jenkinsfile
@@ -51,16 +51,15 @@ pipeline {
   }
 
   stages {
+    stage('Lockfile check') {
+      steps { script {
+        sh 'nix flake lock --no-update-lock-file'
+      } }
+    }
+
     stage('Build') {
       steps { script {
-        def gitRef = env.BRANCH_NAME ==~ /PR-\d+/
-          ? "refs/pull/${env.BRANCH_NAME.replace('PR-', '')}/head"
-          : env.BRANCH_NAME
-    
-        result = nix.flake(params.NIX_TARGET, [
-            path: "git+https://github.com/status-im/nimbus-eth2?ref=${gitRef}&submodules=1",
-            noWriteLockFile: true,
-        ])
+        result = nix.flake(params.NIX_TARGET)
       } }
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -49,8 +49,8 @@
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
         "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       }
     },


### PR DESCRIPTION
Fixes the issue we faced with nix builds and 000000 rev:
* https://github.com/NixOS/nix/issues/15875#issuecomment-4572856884

Can be reproduced in Jakub's repository:
* https://github.com/jakubgs/nix-rev-bug-repro/tree/outdated-lock-file

```bash
 nix run --refresh --no-write-lock-file 'git+https://github.com/jakubgs/nix-rev-bug-repro?ref=outdated-lock-file'                                                                                                   [12:54:12]
warning: not writing modified lock file of flake 'git+https://github.com/jakubgs/nix-rev-bug-repro?ref=outdated-lock-file':
• Updated input 'flake-utils':
    'github:numtide/flake-utils/c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a?narHash=sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ%3D' (2024-09-17)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
COMMIT: unknown
```
