### PR TITLE
rm unused code

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -5,7 +5,7 @@
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 # BLS signatures can be combined such that multiple signatures are aggregated.
 # Each time a new signature is added, the corresponding public key must be
@@ -118,14 +118,6 @@ func toPubKey*(pubKey: CookedPubKey): ValidatorPubKey =
   ValidatorPubKey(blob: pubKey.toRaw())
 
 func load*(v: ValidatorPubKey): Opt[CookedPubKey] =
-  ## Parse signature blob - this may fail
-  var val: blscurve.PublicKey
-  if fromBytes(val, v.blob):
-    Opt.some CookedPubKey(val)
-  else:
-    Opt.none CookedPubKey
-
-func load*(v: UncompressedPubKey): Opt[CookedPubKey] =
   ## Parse signature blob - this may fail
   var val: blscurve.PublicKey
   if fromBytes(val, v.blob):
@@ -295,14 +287,6 @@ proc blsFastAggregateVerify*(
 
   fastAggregateVerify(unwrapped, message, blscurve.Signature(signature))
 
-func blsFastAggregateVerify*(
-       publicKeys: openArray[CookedPubKey],
-       message: openArray[byte],
-       signature: ValidatorSig
-     ): bool =
-  let parsedSig = signature.load()
-  parsedSig.isSome and blsFastAggregateVerify(publicKeys, message, parsedSig.get())
-
 proc blsFastAggregateVerify*(
        publicKeys: openArray[ValidatorPubKey],
        message: openArray[byte],
@@ -395,12 +379,6 @@ func toHex*(x: BlsCurveType): string =
 
 func toHex*(x: CookedPubKey): string =
   toHex(x.toPubKey())
-
-func `$`*(x: CookedPubKey): string =
-  $(x.toPubKey())
-
-func toValidatorSig*(x: TrustedSig): ValidatorSig =
-  ValidatorSig(blob: x.blob)
 
 func toValidatorSig*(x: CookedSig): ValidatorSig =
   ValidatorSig(blob: blscurve.Signature(x).exportRaw())
@@ -527,20 +505,6 @@ func shortLog*(x: ValidatorPrivKey): string =
 # For confutils
 func init*(T: typedesc[ValidatorPrivKey], hex: string): T {.noinit, raises: [ValueError].} =
   let v = T.fromHex(hex)
-  if v.isErr:
-    raise (ref ValueError)(msg: $v.error)
-  v[]
-
-# For mainchain monitor
-func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte]): T {.noinit, raises: [ValueError].} =
-  let v = T.fromRaw(data)
-  if v.isErr:
-    raise (ref ValueError)(msg: $v.error)
-  v[]
-
-# For mainchain monitor
-func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte]): T {.noinit, raises: [ValueError].} =
-  let v = T.fromRaw(data)
   if v.isErr:
     raise (ref ValueError)(msg: $v.error)
   v[]

--- a/beacon_chain/spec/keystore.nim
+++ b/beacon_chain/spec/keystore.nim
@@ -969,7 +969,6 @@ func decryptCryptoField*(crypto: Crypto, decKey: openArray[byte],
   let valid =
     case crypto.checksum.function
     of sha256Checksum:
-      template params: auto {.used.} = crypto.checksum.params
       template message: auto = crypto.checksum.message
       message == shaChecksum(decKey.toOpenArray(16, 31),
                              crypto.cipher.message.bytes)
@@ -1084,10 +1083,6 @@ func `==`*(a, b: Kdf): bool =
 func `==`*(a, b: Cipher): bool =
   # We do not care about `params` and `message` fields.
   a.function == b.function
-
-func `==`*(a, b: KeystoreCacheItem): bool =
-  (a.kdf == b.kdf) and (a.cipher == b.cipher) and
-  (a.decryptionKey == b.decryptionKey)
 
 func init*(t: typedesc[KeystoreCacheRef],
            expireTime = KeystoreCachePruningTime): KeystoreCacheRef =

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1147,14 +1147,6 @@ proc registerAttestation*(
 
   ok()
 
-proc registerAttestation*(
-       db: SlashingProtectionDB_v2,
-       validator: ValidatorPubKey,
-       source, target: Epoch,
-       attestation_root: Eth2Digest): Result[void, BadVote] =
-  registerAttestation(
-    db, Opt.none(ValidatorIndex), validator, source, target, attestation_root)
-
 template withContext*(dbParam: SlashingProtectionDB_v2, body: untyped): untyped =
   let
     db = dbParam


### PR DESCRIPTION
- https://github.com/status-im/nimbus-eth2/commit/31bd13a5d382105bbaeddafcf77ebc6e0938fc9b added `func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte])`
- https://github.com/status-im/nimbus-eth2/commit/14bc9e60ca9b7c4521a985efa72907098d2d3fd4 added `func init*(T: typedesc[ValidatorSig], data: array[96, byte])`
- #2528 added this `registerAttestation(...)` overload, even then the same wrapper as now
- https://github.com/status-im/nimbus-eth2/commit/abe0d7b4aeee6093c30fa3ae74145a5e63d13293 introduced this `blsFastAggregateVerify(...)` overload, along with `func `$`*(x: CookedPubKey)`
- #2639 added `func load*(v: UncompressedPubKey)` but did not use it, nor did anything else
- https://github.com/status-im/nimbus-eth2/commit/54d0d588b13d3e3ea6b0015f53d09a92301daa27 removed the last `func `$`*(x: CookedPubKey)` caller, by changing `saveKeystore(...)`
- #3393 removed the last caller of this `registerAttestation(...)` overload
- #4248 removed the `is_valid_indexed_attestation(...)` overload using the `blsFastAggregateVerify(...)` overload here
- #4372 introduced func `==`*(a, b: KeystoreCacheItem), but it was unused
- #5050 added `template params: auto {.used.} = crypto.checksum.params`, but it likewise was never used
- #6566 added `func toValidatorSig*(x: TrustedSig)`
- #7114 removed the last users of `func init*(T: typedesc[ValidatorPubKey], data: array[RawPubKeySize, byte])` and `func init*(T: typedesc[ValidatorSig], data: array[RawSigSize, byte])`
- #7408 removed the last user of `func toValidatorSig*(x: TrustedSig)`