### PR TITLE
avoid pointless copies of KZG cells and proofs during parallel recovery

### DIFF
--- a/beacon_chain/spec/peerdas_helpers.nim
+++ b/beacon_chain/spec/peerdas_helpers.nim
@@ -155,10 +155,6 @@ proc recover_matrix*(partial_matrix: seq[MatrixEntry],
 
   ok(extended_matrix)
 
-proc recoverCellsAndKzgProofsTask(cellIndices: openArray[CellIndex],
-                                  cells: openArray[Cell]): Result[CellsAndProofs, void] =
-  recoverCellsAndKzgProofs(cellIndices, cells).mapConvertErr(void)
-
 proc recover_cells_and_proofs_parallel*(
     tp: Taskpool,
     dataColumns: seq[ref fulu.DataColumnSidecar]):
@@ -210,7 +206,7 @@ proc recover_cells_and_proofs_parallel*(
     defer:
       discard tsp.fireSync()
 
-    res[] = recoverCellsAndKzgProofsTask(
+    res[] = recoverCellsAndKzgProofs(
       idxArr.toOpenArray(0, columnCount - 1),
       cellsArr.toOpenArray(0, columnCount - 1)).valueOr:
         return false

--- a/config.nims
+++ b/config.nims
@@ -66,8 +66,8 @@ if defined(limitStackUsage):
   # available on some GCC versions but not all - run with `-d:limitStackUsage`
   # and look for .su files in "./build/", "./nimcache/" or $TMPDIR that list the
   # stack size of each function.
-  switch("passC", "-fstack-usage -Werror=stack-usage=917504")
-  switch("passL", "-fstack-usage -Werror=stack-usage=917504")
+  switch("passC", "-fstack-usage -Werror=stack-usage=851968")
+  switch("passL", "-fstack-usage -Werror=stack-usage=851968")
   
   # QUIC does variable stack allocations
   put("lsquic_enc_sess_ietf.always", "-fno-lto -Wno-stack-usage")


### PR DESCRIPTION
The error part of that `Result` gets discarded regardless by this usage/body of `valueOr`.

`sizeof(Result[CellsAndProofs, void]) == 268289`, so this had been an extra almost 270KB copy for each worker.

Similarly, reducing stack limit to help automatically ensure that this doesn't pop back up.