### PR TITLE
Revert "use justified rather than fcr for engine API safe block hash"

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -891,10 +891,8 @@ proc getBeaconHead*(
           .get(ZERO_HASH)
 
     # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.4/fork_choice/safe-block.md#get_safe_execution_block_hash
-    # Use the justified checkpoint root as the safe block reported to the
-    # execution client via `engine_forkchoiceUpdated`.
-    safeBlock = pool.dag.getBlockRef(
-      pool.forkChoice.checkpoints.justified.checkpoint.root)
+    safeBlockRoot = pool.forkChoice.retrieve_fast_confirmed_root()
+    safeBlock = pool.dag.getBlockRef(safeBlockRoot)
     safeExecutionBlockHash =
       if safeBlock.isErr:
         # If finality already advanced beyond the current safe block,


### PR DESCRIPTION
Reverts status-im/nimbus-eth2#8280

https://github.com/NethermindEth/nethermind/releases/tag/1.38.0 fixes this.