### PR TITLE
show block resolved at info level for gossip

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -13,7 +13,7 @@ import
   ../spec/[
     beaconstate, forks, signatures, signatures_batch,
     state_transition, state_transition_epoch],
-  "."/[block_pools_types, block_dag, blockchain_dag,
+  ./[block_pools_types, block_dag, blockchain_dag,
        blockchain_dag_light_client, block_quarantine]
 
 export results, signatures_batch, block_dag, blockchain_dag
@@ -72,7 +72,7 @@ proc addResolvedHeadBlock(
        trustedBlock: ForkyTrustedSignedBeaconBlock,
        optimisticStatus: OptimisticStatus,
        parent: BlockRef, cache: var StateCache,
-       onBlockAdded: OnBlockAdded,
+       onBlockAdded: OnBlockAdded, fromGossip: bool,
        stateDataDur, sigVerifyDur, stateVerifyDur: Duration
      ): BlockRef =
   doAssert state.matches_block_slot(
@@ -118,13 +118,22 @@ proc addResolvedHeadBlock(
     epochRef = dag.getEpochRef(state, cache)
     epochRefTick = Moment.now()
 
-  debug "Block resolved",
-    blockRoot = shortLog(blockRoot),
-    blck = shortLog(trustedBlock.message),
-    optimisticStatus, heads = dag.heads.len(),
-    stateDataDur, sigVerifyDur, stateVerifyDur,
-    putBlockDur = putBlockTick - startTick,
-    epochRefDur = epochRefTick - putBlockTick
+  if fromGossip:
+    info "Block resolved",
+      blockRoot = shortLog(blockRoot),
+      blck = shortLog(trustedBlock.message),
+      optimisticStatus, heads = dag.heads.len(),
+      stateDataDur, sigVerifyDur, stateVerifyDur,
+      putBlockDur = putBlockTick - startTick,
+      epochRefDur = epochRefTick - putBlockTick
+  else:
+    debug "Block resolved",
+      blockRoot = shortLog(blockRoot),
+      blck = shortLog(trustedBlock.message),
+      optimisticStatus, heads = dag.heads.len(),
+      stateDataDur, sigVerifyDur, stateVerifyDur,
+      putBlockDur = putBlockTick - startTick,
+      epochRefDur = epochRefTick - putBlockTick
 
   # Update light client data
   dag.processNewBlockForLightClient(state, trustedBlock, parent.bid)
@@ -251,8 +260,8 @@ proc checkHeadBlock*(
 proc addHeadBlockWithParent*(
     dag: ChainDAGRef, verifier: var BatchVerifier,
     signedBlock: ForkySignedBeaconBlock, parent: BlockRef,
-    optimisticStatus: OptimisticStatus, onBlockAdded: OnBlockAdded
-    ): Result[BlockRef, VerifierError] =
+    optimisticStatus: OptimisticStatus, onBlockAdded: OnBlockAdded,
+    fromGossip = false): Result[BlockRef, VerifierError] =
   ## Try adding a block to the chain, verifying first that it passes the state
   ## transition function and contains correct cryptographic signature.
   ##
@@ -335,6 +344,7 @@ proc addHeadBlockWithParent*(
     optimisticStatus,
     parent, cache,
     onBlockAdded,
+    fromGossip,
     stateDataDur = stateDataTick - startTick,
     sigVerifyDur = sigVerifyTick - stateDataTick,
     stateVerifyDur = stateVerifyTick - sigVerifyTick)
@@ -705,8 +715,9 @@ proc addLightForwardBlock*(
     OptimisticStatus.notValidated,
     parent, cache,
     onBlockAdded,
-    proposerVerifyTick - startTick,
-    stateDataTick - proposerVerifyTick,
-    stateVerifyTick - stateDataTick)
+    fromGossip = false,
+    stateDataDur = proposerVerifyTick - startTick,
+    sigVerifyDur = stateDataTick - proposerVerifyTick,
+    stateVerifyDur = stateVerifyTick - stateDataTick)
 
   ok()

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -382,6 +382,7 @@ proc addBlock*(
   sidecarsOpt: SomeOptSidecars,
   maybeFinalized = false,
   validationDur = Duration(),
+  fromGossip = false,
 ): Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).}
 
 proc enqueueBlock*(
@@ -405,7 +406,12 @@ proc enqueueBlock*(
   # don't care. However, because this acts as an unbounded queue, they have to
   # be careful not to enqueue too many blocks or we'll run out of memory -
   # `addBlock` should be used where managing backpressure is appropriate.
-  discard self.addBlock(src, blck, sidecarsOpt, maybeFinalized, validationDur)
+  #
+  # As such, `enqueueBlock` is the entry point for gossip processing; blocks
+  # from sync/request managers reach `addBlock` directly.
+  discard self.addBlock(
+    src, blck, sidecarsOpt, maybeFinalized, validationDur,
+    fromGossip = src == MsgSource.gossip)
 
 proc enqueueQuarantine(self: ref BlockProcessor, parent: BlockRef) =
   ## Enqueue the blocks that are no longer orphans as a result of `parent` being
@@ -585,6 +591,7 @@ proc storeBlock(
     maybeFinalized: bool,
     queueTick: Moment,
     validationDur: Duration,
+    fromGossip: bool,
 ): Future[Result[BlockRef, VerifierError]] {.async: (raises: [CancelledError]).} =
   ## storeBlock is the main entry point for unvalidated blocks - all untrusted
   ## blocks, regardless of origin, pass through here. When storing a block,
@@ -675,6 +682,7 @@ proc storeBlock(
       parent,
       optimisticStatus,
       onBlockAdded(dag, consensusFork, src, wallTime, ap, vm),
+      fromGossip,
     )
 
   # Even if the EL is not responding, we'll only try once every now and then
@@ -749,6 +757,7 @@ proc addBlock*(
     sidecarsOpt: SomeOptSidecars,
     maybeFinalized = false,
     validationDur = Duration(),
+    fromGossip = false
 ): Future[Result[void, VerifierError]] {.async: (raises: [CancelledError]).} =
   ## Enqueue a Gossip-validated block for consensus verification - only one
   ## block at a time gets processed
@@ -815,7 +824,7 @@ proc addBlock*(
 
           await self.storeBlock(
             src, wallTime, blck, sidecarsOpt, maybeFinalized,
-            queueTick, validationDur)
+            queueTick, validationDur, fromGossip)
         finally:
           quarantine[].clearProcessing()
 


### PR DESCRIPTION
It's a useful, high signal-to-noise, not particularly spammable log which provides hints in many debugging scenarios that e.g., attestations, sync committee messages, et cetera are not properly being constructed due to late blocks.