### PR TITLE
avoid redundant KZG column verification

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -210,6 +210,7 @@ AllTests-mainnet
 + put()/hasSidecar(index, slot, proposer_index)/remove() test                                OK
 + put(sidecar)/put([sidecars])/hasSidecars/popSidecars/remove() [node] test                  OK
 + put(sidecar)/put([sidecars])/hasSidecars/popSidecars/remove() [supernode] test             OK
++ verified flag survives database unload/load [node]                                         OK
 ```
 ## Combined scenarios [Beacon Node] [Preset: mainnet]
 ```diff

--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -164,6 +164,7 @@ func unload[A](holder: var SidecarHolder[A]): ref A =
     slot: holder.slot,
     index: holder.index,
     proposer_index: holder.proposer_index,
+    verified: holder.verified,
   )
   res
 
@@ -389,6 +390,7 @@ func load[A](holder: var SidecarHolder[A], sidecar: ref A) =
     slot: holder.slot,
     index: holder.index,
     proposer_index: holder.proposer_index,
+    verified: holder.verified,
     data: sidecar
   )
 

--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -36,6 +36,7 @@ type
     index: uint64
     proposer_index: uint64
     slot: Slot
+    verified: bool
     case kind: SidecarHolderKind
     of SidecarHolderKind.Empty:
       discard
@@ -62,6 +63,7 @@ type
     custodyMap*: ColumnMap
     lastMemoryNode: DoublyLinkedNode[RootTableRecord[A]]
     roots: Table[Eth2Digest, DoublyLinkedNode[RootTableRecord[A]]]
+    pendingVerify: Table[Eth2Digest, ColumnMap]
     list: DoublyLinkedList[RootTableRecord[A]]
     indexMap: seq[int]
     db: QuarantineDB
@@ -294,7 +296,8 @@ proc moveToFront[A, B](
 proc put*[A, B](
     q: var SidecarQuarantine[A, B],
     blockRoot: Eth2Digest,
-    sidecars: openArray[ref A]
+    sidecars: openArray[ref A],
+    verified: bool
 ) =
   # Note: Sidecars with indices that are not in the current column custody set
   # are IGNORED.
@@ -338,6 +341,7 @@ proc put*[A, B](
           slot: sidecar[].slot(),
           index: uint64(sidecar[].index),
           proposer_index: sidecar[].proposer_index(),
+          verified: verified,
           data: sidecar)
 
   q.memSidecarsCount += newSidecarsCount
@@ -361,9 +365,10 @@ proc put*[A, B](
 proc put*[A, B](
     q: var SidecarQuarantine[A, B],
     blockRoot: Eth2Digest,
-    sidecar: ref A
+    sidecar: ref A,
+    verified: bool
 ) =
-  q.put(blockRoot, [sidecar])
+  q.put(blockRoot, [sidecar], verified)
 
 proc remove*[A, B](
     q: var SidecarQuarantine[A, B],
@@ -517,7 +522,11 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     # Quarantine unloaded some blobs to disk, we should load it back.
     quarantine.loadRoot(blockRoot, node[].value)
 
+  const isFulu = A is fulu.DataColumnSidecar
+
   var sidecars: seq[ref A]
+  when isFulu:
+    var unverified: ColumnMap
   if supernode:
     # When supernode - we pop all sidecars.
     for sidecar in node[].value.sidecars:
@@ -527,6 +536,9 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
           "Record should only have loaded values, but it is `" &
             $sidecar.kind & "`")
         sidecars.add(sidecar.data)
+        when isFulu:
+          if not sidecar.verified:
+            unverified.incl(ColumnIndex(sidecar.index))
   else:
     let allowPartial = node[].value.count >= NUMBER_OF_COLUMNS div 2
     for cindex in quarantine.custodyMap:
@@ -537,6 +549,9 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
         "Record should only have loaded values, but it is `" &
           $sidecar.kind & "`")
       sidecars.add(sidecar.data)
+      when isFulu:
+        if not sidecar.verified:
+          unverified.incl(ColumnIndex(sidecar.index))
 
     doAssert(
       (allowPartial and len(sidecars) >= NUMBER_OF_COLUMNS div 2) or
@@ -547,7 +562,20 @@ proc popSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
   # memory and disk.
   quarantine.removeNode(node, databaseCount)
 
+  # Gloas and newer forks verify columns separately
+  when A is fulu.DataColumnSidecar:
+    if not unverified.empty:
+      quarantine.pendingVerify[blockRoot] = unverified
+
   Opt.some(sidecars)
+
+func popPendingVerify*(
+    quarantine: var ColumnQuarantine,
+    blockRoot: Eth2Digest
+): ColumnMap =
+  var res: ColumnMap
+  discard quarantine.pendingVerify.pop(blockRoot, res)
+  res
 
 func fetchMissingSidecars*[A: SomeDataColumnSidecar, B: OnDataColumnSidecarCallback](
     quarantine: SidecarQuarantine[A, B],

--- a/beacon_chain/el/el_getblobs_service.nim
+++ b/beacon_chain/el/el_getblobs_service.nim
@@ -285,7 +285,7 @@ proc attemptGetBlobs*(
         root = forkyBlck.root,
         slot = forkyBlck.message.slot,
         batch_len = batch.len
-      self.dataColumnQuarantine[].put(forkyBlck.root, batch)
+      self.dataColumnQuarantine[].put(forkyBlck.root, batch, verified = true)
       # Any partial-cell state for this block is now superseded by the full
       # column sidecars we just installed.
       self.partialColumnQuarantine[].pruneForBlock(forkyBlck.root)
@@ -350,7 +350,7 @@ proc attemptGetBlobs*(
     root = blck.root,
     slot = blck.message.slot,
     batch_len = batch.len
-  self.gloasColumnQuarantine[].put(blck.root, batch)
+  self.gloasColumnQuarantine[].put(blck.root, batch, verified = true)
 
   # If the envelope is already orphaned waiting on sidecars, re-enqueuing the
   # payload will pop it and continue processing; otherwise this just marks
@@ -426,7 +426,7 @@ proc attemptGetBlobsFromColumn*(
     root = block_root,
     slot = slot,
     batch_len = batch.len
-  self.dataColumnQuarantine[].put(block_root, batch)
+  self.dataColumnQuarantine[].put(block_root, batch, verified = true)
   # Any partial-cell state for this block is now superseded by the full
   # column sidecars we just installed.
   self.partialColumnQuarantine[].pruneForBlock(block_root)

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -14,7 +14,7 @@ import
   ../sszdump
 
 from std/deques import Deque, addLast, contains, initDeque, items, len, shrink
-from std/sequtils import anyIt
+from std/sequtils import anyIt, filterIt
 from ../consensus_object_pools/consensus_manager import
   ConsensusManager, to, updateHead, updateExecutionHead
 from ../consensus_object_pools/blockchain_dag import
@@ -29,7 +29,8 @@ from ../consensus_object_pools/block_quarantine import
   addMissing, addSidecarless, addOrphan, addUnviable, clearProcessing, contains,
   get, pop, remove, startProcessing, clearProcessing, UnviableKind
 from ../consensus_object_pools/column_quarantine import
-  ColumnQuarantine, GloasColumnQuarantine, popSidecars, put, slot
+  ColumnQuarantine, GloasColumnQuarantine, popSidecars, put, slot,
+  popPendingVerify
 from ../consensus_object_pools/envelope_quarantine import
   EnvelopeQuarantine, addMissing, addOrphan, addUnviable,
   delOrphan, popOrphan, remove
@@ -191,21 +192,17 @@ proc verifySidecars(
     envelope: gloas.SignedExecutionPayloadEnvelope,
     sidecarsOpt: Opt[gloas.DataColumnSidecars],
 ): Result[void, VerifierError] =
-  if sidecarsOpt.isSome:
-    let columns = sidecarsOpt.get()
+  sidecarsOpt.isErrOr:
     template bid(): auto =
       signedBlock.message.body.signed_execution_payload_bid
-    template kzgCommits(): auto =
-      bid.message.blob_kzg_commitments.asSeq
-    if columns.len > 0 and kzgCommits.len > 0:
-      let r = verify_data_column_sidecar_kzg_proofs(
-        columns, bid.message.blob_kzg_commitments)
-      if r.isErr():
+    template kzgCommits: auto = bid.message.blob_kzg_commitments
+    if value.len > 0 and kzgCommits.len > 0:
+      verify_data_column_sidecar_kzg_proofs(value, kzgCommits).isOkOr:
         debug "data column validation failed",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),
           signature = shortLog(signedBlock.signature),
-          msg = r.error()
+          msg = error
         return err(VerifierError.Invalid)
   ok()
 
@@ -214,17 +211,14 @@ proc verifySidecars(
     envelope: NoEnvelope,
     sidecarsOpt: Opt[fulu.DataColumnSidecars],
 ): Result[void, VerifierError] =
-  if sidecarsOpt.isSome:
-    let columns = sidecarsOpt.get()
-    let kzgCommits = signedBlock.message.body.blob_kzg_commitments.asSeq
-    if columns.len > 0 and kzgCommits.len > 0:
-      let r = verify_data_column_sidecar_kzg_proofs(columns)
-      if r.isErr():
+  sidecarsOpt.isErrOr:
+    if value.len > 0 and signedBlock.message.body.blob_kzg_commitments.len > 0:
+      verify_data_column_sidecar_kzg_proofs(value).isOkOr:
         debug "data column validation failed",
           blockRoot = shortLog(signedBlock.root),
           blck = shortLog(signedBlock.message),
           signature = shortLog(signedBlock.signature),
-          msg = r.error()
+          msg = error
         return err(VerifierError.Invalid)
   ok()
 
@@ -669,7 +663,15 @@ proc storeBlock(
   let newPayloadTick = Moment.now()
 
   when consensusFork == ConsensusFork.Fulu:
-    ?verifySidecars(signedBlock, noEnvelope, sidecarsOpt)
+    # Only request manager-sourced columns arrive unverified; getBlobsV2/V3/V4
+    # and CL gossip are both either trusted or verified.
+    let pendingVerify =
+      self.dataColumnQuarantine[].popPendingVerify(signedBlock.root)
+    if not pendingVerify.empty:
+      sidecarsOpt.isErrOr:
+        let toVerify = value.filterIt(it[].index in pendingVerify)
+        if toVerify.len > 0:
+          ?verifySidecars(signedBlock, noEnvelope, Opt.some(toVerify))
     debug "block_processor verifySidecars completed",
       verifySidecarsDur = Moment.now() - newPayloadTick,
       blck = shortLog(signedBlock.message),
@@ -863,7 +865,8 @@ proc addBlock*(
 
       when sidecarsOpt is Opt[fulu.DataColumnSidecars]:
         if sidecarsOpt.isSome:
-          self.dataColumnQuarantine[].put(blockRoot, sidecarsOpt.get)
+          self.dataColumnQuarantine[].put(
+            blockRoot, sidecarsOpt.get, verified = false)
       elif sidecarsOpt is Opt[gloas.DataColumnSidecars]:
         # In Gloas, block is enqueued with NoSidecar so we need not to care
         # about quarantine.
@@ -1011,7 +1014,8 @@ proc addPayload*(
       self.envelopeQuarantine[].addOrphan(
         self.consensusManager.dag.finalizedHead.slot, signedEnvelope)
       if sidecarsOpt.isSome():
-        self.gloasColumnQuarantine[].put(signedBlock.root, sidecarsOpt.get())
+        self.gloasColumnQuarantine[].put(
+          signedBlock.root, sidecarsOpt.get(), verified = false)
     of VerifierError.Invalid, VerifierError.UnviableFork:
       # The block is verified and has added to the DAG, but the envelope isn't
       # valid. It should be marked as invalid so that we can ignore it from

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -441,7 +441,8 @@ proc processDataColumnSidecar*(
     data_column_sidecar_delay.observe(delay.toFloatSeconds())
     return v
 
-  self.dataColumnQuarantine[].put(block_root, dataColumnSidecar)
+  self.dataColumnQuarantine[].put(
+    block_root, dataColumnSidecar, verified = true)
 
   if block_root in self.quarantine[].sidecarless:
     let cres = self.dataColumnQuarantine[].popSidecars(block_root)
@@ -492,7 +493,7 @@ proc processDataColumnSidecar*(
     return v
 
   self.gloasColumnQuarantine[].put(
-    dataColumnSidecar[].beacon_block_root, dataColumnSidecar)
+    dataColumnSidecar[].beacon_block_root, dataColumnSidecar, verified = true)
   self.blockProcessor.enqueuePayload(dataColumnSidecar[].beacon_block_root)
 
   data_column_sidecars_received.inc()

--- a/beacon_chain/sync/request_manager.nim
+++ b/beacon_chain/sync/request_manager.nim
@@ -500,7 +500,7 @@ template fetchDataColumnsFromNetworkImpl(
           peer = peer,
           column_sidecars = shortLog(col.sidecar[]),
           peer_score = peer.getScore()
-        columnQuarantine[].put(col.block_root, col.sidecar)
+        columnQuarantine[].put(col.block_root, col.sidecar, verified = false)
       var curRoot: Eth2Digest
       for col in records:
         if col.block_root != curRoot:
@@ -743,7 +743,7 @@ proc requestManagerDataColumnLoop(
               discard blockRoots.pop()
             continue
           debug "Loaded orphaned data columns from storage", columnId
-          columnQuarantine[].put(curRoot, data_column_sidecar)
+          columnQuarantine[].put(curRoot, data_column_sidecar, verified = false)
       var verifiers = newSeqOfCap[
         Future[Result[void, VerifierError]]
           .Raising([CancelledError])](blockRoots.len)

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -1109,6 +1109,61 @@ suite "ColumnQuarantine data structure test suite " & preset():
       lenDisk(bq) == 0
       quarantine.sidecarsCount(typedesc[fulu.DataColumnSidecar]) == 0
 
+  test "verified flag survives database unload/load [node]":
+    let
+      custodyColumns =
+        [63, 64, 65, 66, 95, 96, 97, 98].mapIt(ColumnIndex(it))
+
+    var
+      bq = ColumnQuarantine.init(cfg, custodyColumns, quarantine, 2, nil)
+      sidecars: seq[tuple[sidecar: ref fulu.DataColumnSidecar,
+                          blockRoot: Eth2Digest]]
+
+    let maxSidecars = int(NUMBER_OF_COLUMNS * SLOTS_PER_EPOCH) * 3
+    for i in 0 ..< maxSidecars:
+      let
+        index = i mod len(custodyColumns)
+        slot = i div len(custodyColumns) + 100
+        blockRoot = genBlockRoot(slot)
+        sidecar = newClone(
+          genFuluDataColumnSidecar(index = int(custodyColumns[index]),
+                                   slot, proposer_index = i))
+      sidecars.add((sidecar, blockRoot))
+
+    # Fill the in-memory quarantine to capacity with `verified` sidecars.
+    for item in sidecars:
+      bq.put(item.blockRoot, item.sidecar, verified = true)
+
+    check:
+      lenMemory(bq) == maxSidecars
+      lenDisk(bq) == 0
+
+    # Adding one more sidecar overfills memory and forces the oldest node
+    # (`genBlockRoot(100)`, holding all custody columns of the first block) to
+    # be offloaded to disk.
+    let
+      extra = newClone(
+        genFuluDataColumnSidecar(index = int(custodyColumns[0]), slot = 10000,
+                                 proposer_index = 1000000))
+      extraRoot = genBlockRoot(10000)
+    bq.put(extraRoot, extra, verified = true)
+
+    let offloadedRoot = genBlockRoot(100)
+    check:
+      lenDisk(bq) == len(custodyColumns)
+      quarantine.sidecarsCount(typedesc[fulu.DataColumnSidecar]) ==
+        len(custodyColumns)
+
+    # Popping reloads the offloaded columns from disk. Because the `verified`
+    # flag is now carried through the unload/load cycle, none of them should be
+    # queued for re-verification.
+    let dres = bq.popSidecars(offloadedRoot)
+    check:
+      dres.isOk()
+      dres.get().len == len(custodyColumns)
+      lenDisk(bq) == 0
+      bq.popPendingVerify(offloadedRoot).empty() == true
+
   test "database and memory overfill protection and pruning test [node]":
     let
       custodyColumns =

--- a/tests/test_quarantine.nim
+++ b/tests/test_quarantine.nim
@@ -179,7 +179,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(5), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar1)
+    bq.put(broot1, sidecar1, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -190,7 +190,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(8), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar2)
+    bq.put(broot1, sidecar2, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -201,7 +201,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(8), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar3)
+    bq.put(broot1, sidecar3, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -212,7 +212,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(8), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot2, sidecar4)
+    bq.put(broot2, sidecar4, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -223,7 +223,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(8), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot3, sidecar5)
+    bq.put(broot3, sidecar5, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -234,7 +234,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, Slot(3), uint64(8), ColumnIndex(31)) == false
       bq.hasSidecar(broot5, Slot(10), uint64(100), ColumnIndex(3)) == false
 
-    bq.put(broot4, sidecar6)
+    bq.put(broot4, sidecar6, verified = false)
 
     check:
       bq.hasSidecar(broot1, Slot(1), uint64(5), ColumnIndex(0)) == true
@@ -326,14 +326,14 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
 
-    bq.put(broot1, sidecars1)
+    bq.put(broot1, sidecars1, verified = false)
     check:
       len(bq) == len(sidecars1)
 
     var counter = 0
     for index in 0 ..< len(sidecars2):
       if index notin [1, 3, 5, 7]:
-        bq.put(broot2, sidecars2[index])
+        bq.put(broot2, sidecars2[index], verified = false)
         inc(counter)
         check len(bq) == len(sidecars1) + counter
 
@@ -347,25 +347,25 @@ suite "ColumnQuarantine data structure test suite " & preset():
       compareSidecars(dres.get(), sidecars1) == true
       len(bq) == counter
 
-    bq.put(broot2, sidecars2[1])
+    bq.put(broot2, sidecars2[1], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
       len(bq) == counter + 1
 
-    bq.put(broot2, sidecars2[3])
+    bq.put(broot2, sidecars2[3], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
       len(bq) == counter + 2
 
-    bq.put(broot2, sidecars2[5])
+    bq.put(broot2, sidecars2[5], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
       len(bq) == counter + 3
 
-    bq.put(broot2, sidecars2[7])
+    bq.put(broot2, sidecars2[7], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == true
       len(bq) == len(sidecars2)
@@ -411,11 +411,11 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
 
-    bq.put(broot1, sidecars1)
+    bq.put(broot1, sidecars1, verified = false)
 
     for index in 0 ..< len(sidecars2):
       if index notin [1, 3, 5, 7]:
-        bq.put(broot2, sidecars2[index])
+        bq.put(broot2, sidecars2[index], verified = false)
 
     check:
       bq.hasSidecars(fuluBlock1) == true
@@ -426,22 +426,22 @@ suite "ColumnQuarantine data structure test suite " & preset():
       dres.isOk()
       compareSidecars(dres.get(), sidecars1) == true
 
-    bq.put(broot2, sidecars2[1])
+    bq.put(broot2, sidecars2[1], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
 
-    bq.put(broot2, sidecars2[3])
+    bq.put(broot2, sidecars2[3], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
 
-    bq.put(broot2, sidecars2[5])
+    bq.put(broot2, sidecars2[5], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == false
       bq.popSidecars(fuluBlock2.root).isNone() == true
 
-    bq.put(broot2, sidecars2[7])
+    bq.put(broot2, sidecars2[7], verified = false)
     check:
       bq.hasSidecars(fuluBlock2) == true
 
@@ -467,7 +467,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
     for i in 0 ..< (NUMBER_OF_COLUMNS div 2):
       let sc = newClone(genFuluDataColumnSidecar(
         index = int(custodyColumns[i]), slot = 1, proposer_index = 5))
-      bq.put(broot, sc)
+      bq.put(broot, sc, verified = false)
       present.add(sc)
 
     check len(bq) == NUMBER_OF_COLUMNS div 2
@@ -560,8 +560,8 @@ suite "ColumnQuarantine data structure test suite " & preset():
       if i >= len(sidecars1):
         break
 
-      bq.put(broot1, sidecars1[i])
-      bq.put(broot2, sidecars2[i])
+      bq.put(broot1, sidecars1[i], verified = false)
+      bq.put(broot2, sidecars2[i], verified = false)
 
     bq.remove(broot1)
     bq.remove(broot2)
@@ -634,8 +634,8 @@ suite "ColumnQuarantine data structure test suite " & preset():
           sidecars2.toOpenArray(i, len(sidecars2) - 1), missing2) == true
         checkSupernodeExpected(broot1, i, missing3) == true
 
-      bq.put(broot1, sidecars1[i])
-      bq.put(broot2, sidecars2[i])
+      bq.put(broot1, sidecars1[i], verified = false)
+      bq.put(broot2, sidecars2[i], verified = false)
 
     bq.remove(broot1)
     bq.remove(broot2)
@@ -663,7 +663,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       sidecars.add((sidecar, blockRoot))
 
     for item in sidecars:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     check len(bq) == maxSidecars
 
@@ -691,7 +691,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(blockRoot = blockRoot, slot = Slot(10000),
                     proposer_index = 1000000'u64,
                     index = custodyColumns[0]) == false
-    bq.put(blockRoot, sidecar)
+    bq.put(blockRoot, sidecar, verified = false)
     check:
       len(bq) == (len(sidecars) - len(custodyColumns) + 1)
       bq.hasSidecar(blockRoot = blockRoot, slot = Slot(10000),
@@ -738,7 +738,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
                       s.signed_block_header.message.proposer_index,
                       s.index) == false
 
-    bq.put(mblockRoot, msidecars)
+    bq.put(mblockRoot, msidecars, verified = false)
     check len(bq) == beforeLength
 
     for s in msidecars:
@@ -796,13 +796,13 @@ suite "ColumnQuarantine data structure test suite " & preset():
         broot2, custodyColumns).indices) == len(custodyColumns)
 
     for index in 0 ..< len(custodyColumns):
-      bq.put(broot1, sidecars1[index])
+      bq.put(broot1, sidecars1[index], verified = false)
       check:
         len(bq) == (index + 1)
         len(bq.fetchMissingSidecars(
           broot1, custodyColumns).indices) ==
             len(custodyColumns) - (index + 1)
-      bq.put(broot1, sidecars1d[index])
+      bq.put(broot1, sidecars1d[index], verified = false)
       check:
         len(bq) == (index + 1)
         len(bq.fetchMissingSidecars(
@@ -810,13 +810,13 @@ suite "ColumnQuarantine data structure test suite " & preset():
             len(custodyColumns) - (index + 1)
 
     for index in 0 ..< len(custodyColumns):
-      bq.put(broot2, sidecars2[index])
+      bq.put(broot2, sidecars2[index], verified = false)
       check:
         len(bq) == len(custodyColumns) + (index + 1)
         len(bq.fetchMissingSidecars(
           broot2, custodyColumns).indices) ==
             len(custodyColumns) - (index + 1)
-      bq.put(broot2, sidecars2d[index])
+      bq.put(broot2, sidecars2d[index], verified = false)
       check:
         len(bq) == len(custodyColumns) + (index + 1)
         len(bq.fetchMissingSidecars(
@@ -876,7 +876,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         newClone(
           genFuluDataColumnSidecar(index = item.index, slot = item.slot,
                                    proposer_index = item.proposer_index))
-      bq.put(genBlockRoot(item.root), sidecar)
+      bq.put(genBlockRoot(item.root), sidecar, verified = false)
 
     check:
       len(bq) == len(TestVectors)
@@ -964,7 +964,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
       sidecars.add((sidecar, blockRoot))
 
     for item in sidecars:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     # put(sidecar) test
 
@@ -997,7 +997,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         blockRoot = blockRoot1, slot = Slot(10000),
         proposer_index = 1000000'u64, index = custodyColumns[0]) == false
 
-    bq.put(blockRoot1, sidecar)
+    bq.put(blockRoot1, sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars) + 1
@@ -1063,7 +1063,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
                       s.signed_block_header.message.proposer_index,
                       s.index) == false
 
-    bq.put(mblockRoot, msidecars)
+    bq.put(mblockRoot, msidecars, verified = false)
 
     check:
       lenDisk(bq) == len(custodyColumns)
@@ -1147,7 +1147,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         epochs2.add(epoch2)
 
     for item in sidecars1:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars1)
@@ -1160,7 +1160,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         finish = start + len(custodyColumns) - 1
         blockRoot = sidecars2[start].blockRoot
         sidecars = sidecars2.toOpenArray(start, finish).mapIt(it.sidecar)
-      bq.put(blockRoot, sidecars)
+      bq.put(blockRoot, sidecars, verified = false)
 
     check:
       len(bq) == len(sidecars1) + len(sidecars2)
@@ -1206,7 +1206,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
                     proposer_index = 2000000'u64,
                     index = custodyColumns[0]) == false
 
-    bq.put(blockRoot, sidecar)
+    bq.put(blockRoot, sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars1) + len(sidecars2) - len(custodyColumns) + 1
@@ -1296,7 +1296,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         sidecars.add((sidecar, blockRoot))
 
       for item in sidecars:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       # At this stage only last sidecars in range
       # [maxSidecars - quarantine.size, maxSidecars] should be present in
@@ -1355,7 +1355,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         sidecars.add((sidecar, blockRoot))
 
       for item in sidecars:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -1387,7 +1387,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
 
       # Now we should be able to add new columns to in-memory storage.
       for item in sidecars2:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == len(custodyColumns)
@@ -1415,23 +1415,23 @@ suite "ColumnQuarantine data structure test suite " & preset():
       of "node":
         # Add only first 3 sidecars for first block
         for i in 0 ..< 3:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add only first 5 sidecars for second block
         for i in 8 ..< 13:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add all other sidecars
         for item in sidecars.toOpenArray(16, bq.sizeMemory - 1):
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
       of "supernode":
         # Add only 64 sidecars for first block.
         for i in 0 ..< 64:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add only 64 sidecars for second block.
         for i in 128 ..< 192:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add all other sidecars
         for item in sidecars.toOpenArray(256, bq.sizeMemory - 1):
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory() - len(custodyColumns)
@@ -1441,7 +1441,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         let offset = bq.sizeMemory()
         for i in 0 ..< len(custodyColumns):
           let item = sidecars[offset + i]
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -1452,7 +1452,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
         let offset = bq.sizeMemory() + len(custodyColumns)
         for i in 0 ..< len(custodyColumns):
           let item = sidecars[offset + i]
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -1537,17 +1537,17 @@ suite "ColumnQuarantine data structure test suite " & preset():
       of "node":
         # Add last 5 sidecars for first block
         for i in 3 ..< 8:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add last 3 sidecars for second block
         for i in 13 ..< 16:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
       of "supernode":
         # Add last 64 sidecars for first block.
         for i in 64 ..< 128:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add last 64 sidecars for second block.
         for i in 192 ..< 256:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -1709,7 +1709,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
           sidecar = newClone(genFuluDataColumnSidecar(
             int(bq.custodyColumns[index]), slot, proposer_index = i))
         sidecars.add((sidecar, blockRoot))
-        bq.put(blockRoot, sidecar)
+        bq.put(blockRoot, sidecar, verified = false)
 
       let rootsCount = bq.sizeMemory() div len(bq.custodyColumns)
 
@@ -1803,7 +1803,7 @@ suite "ColumnQuarantine data structure test suite " & preset():
           sidecar = newClone(genFuluDataColumnSidecar(
             int(bq.custodyColumns[index]), slot, proposer_index = i))
         sidecars.add((sidecar, blockRoot))
-        bq.put(blockRoot, sidecar)
+        bq.put(blockRoot, sidecar, verified = false)
 
       let rootsCount = (bq.sizeMemory() * 2) div len(bq.custodyColumns)
 
@@ -1858,7 +1858,8 @@ suite "ColumnQuarantine data structure test suite " & preset():
               item.sidecar[].index) == false
 
       # Re-add pre-update set (new root to force newSidecarsCount > 0)
-      bq.put(genBlockRoot(int.high), sidecars.mapIt(it.sidecar))
+      bq.put(
+        genBlockRoot(int.high), sidecars.mapIt(it.sidecar), verified = false)
 
 suite "GloasColumnQuarantine data structure test suite " & preset():
   setup:
@@ -1902,7 +1903,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar1)
+    bq.put(broot1, sidecar1, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -1913,7 +1914,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar2)
+    bq.put(broot1, sidecar2, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -1924,7 +1925,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot1, sidecar3)
+    bq.put(broot1, sidecar3, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -1935,7 +1936,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot2, sidecar4)
+    bq.put(broot2, sidecar4, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -1946,7 +1947,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot3, sidecar5)
+    bq.put(broot3, sidecar5, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -1957,7 +1958,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(broot4, ColumnIndex(31)) == false
       bq.hasSidecar(broot5, ColumnIndex(3)) == false
 
-    bq.put(broot4, sidecar6)
+    bq.put(broot4, sidecar6, verified = false)
 
     check:
       bq.hasSidecar(broot1, ColumnIndex(0)) == true
@@ -2049,14 +2050,14 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
 
-    bq.put(broot1, sidecars1)
+    bq.put(broot1, sidecars1, verified = false)
     check:
       len(bq) == len(sidecars1)
 
     var counter = 0
     for index in 0 ..< len(sidecars2):
       if index notin [1, 3, 5, 7]:
-        bq.put(broot2, sidecars2[index])
+        bq.put(broot2, sidecars2[index], verified = false)
         inc(counter)
         check len(bq) == len(sidecars1) + counter
 
@@ -2070,25 +2071,25 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       compareSidecars(dres.get(), sidecars1) == true
       len(bq) == counter
 
-    bq.put(broot2, sidecars2[1])
+    bq.put(broot2, sidecars2[1], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
       len(bq) == counter + 1
 
-    bq.put(broot2, sidecars2[3])
+    bq.put(broot2, sidecars2[3], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
       len(bq) == counter + 2
 
-    bq.put(broot2, sidecars2[5])
+    bq.put(broot2, sidecars2[5], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
       len(bq) == counter + 3
 
-    bq.put(broot2, sidecars2[7])
+    bq.put(broot2, sidecars2[7], verified = false)
     check:
       bq.hasSidecars(envl2) == true
       len(bq) == len(sidecars2)
@@ -2134,11 +2135,11 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
 
-    bq.put(broot1, sidecars1)
+    bq.put(broot1, sidecars1, verified = false)
 
     for index in 0 ..< len(sidecars2):
       if index notin [1, 3, 5, 7]:
-        bq.put(broot2, sidecars2[index])
+        bq.put(broot2, sidecars2[index], verified = false)
 
     check:
       bq.hasSidecars(envl1) == true
@@ -2149,22 +2150,22 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       dres.isOk()
       compareSidecars(dres.get(), sidecars1) == true
 
-    bq.put(broot2, sidecars2[1])
+    bq.put(broot2, sidecars2[1], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
 
-    bq.put(broot2, sidecars2[3])
+    bq.put(broot2, sidecars2[3], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
 
-    bq.put(broot2, sidecars2[5])
+    bq.put(broot2, sidecars2[5], verified = false)
     check:
       bq.hasSidecars(envl2) == false
       bq.popSidecars(broot2).isNone() == true
 
-    bq.put(broot2, sidecars2[7])
+    bq.put(broot2, sidecars2[7], verified = false)
     check:
       bq.hasSidecars(envl2) == true
 
@@ -2187,7 +2188,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
     for i in 0 ..< (NUMBER_OF_COLUMNS div 2):
       let sc = newClone(genGloasDataColumnSidecar(
         index = int(custodyColumns[i]), slot = 1))
-      bq.put(broot, sc)
+      bq.put(broot, sc, verified = false)
       present.add(sc)
 
     check len(bq) == NUMBER_OF_COLUMNS div 2
@@ -2278,8 +2279,8 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       if i >= len(sidecars1):
         break
 
-      bq.put(broot1, sidecars1[i])
-      bq.put(broot2, sidecars2[i])
+      bq.put(broot1, sidecars1[i], verified = false)
+      bq.put(broot2, sidecars2[i], verified = false)
 
     bq.remove(broot1)
     bq.remove(broot2)
@@ -2354,8 +2355,8 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
           broot1,
           i, missing3) == true
 
-      bq.put(broot1, sidecars1[i])
-      bq.put(broot2, sidecars2[i])
+      bq.put(broot1, sidecars1[i], verified = false)
+      bq.put(broot2, sidecars2[i], verified = false)
 
     bq.remove(broot1)
     bq.remove(broot2)
@@ -2383,7 +2384,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       sidecars.add((sidecar, blockRoot))
 
     for item in sidecars:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     check len(bq) == maxSidecars
 
@@ -2411,7 +2412,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(blockRoot = blockRoot, slot = Slot(10000),
                     proposer_index = 0'u64,
                     index = custodyColumns[0]) == false
-    bq.put(blockRoot, sidecar)
+    bq.put(blockRoot, sidecar, verified = false)
     check:
       len(bq) == (len(sidecars) - len(custodyColumns) + 1)
       bq.hasSidecar(blockRoot = blockRoot, slot = Slot(10000),
@@ -2455,7 +2456,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
                       0'u64,
                       s.index) == false
 
-    bq.put(mblockRoot, msidecars)
+    bq.put(mblockRoot, msidecars, verified = false)
     check len(bq) == beforeLength
 
     for s in msidecars:
@@ -2512,13 +2513,13 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         broot2, custodyColumns).indices) == len(custodyColumns)
 
     for index in 0 ..< len(custodyColumns):
-      bq.put(broot1, sidecars1[index])
+      bq.put(broot1, sidecars1[index], verified = false)
       check:
         len(bq) == (index + 1)
         len(bq.fetchMissingSidecars(
           broot1, custodyColumns).indices) ==
             len(custodyColumns) - (index + 1)
-      bq.put(broot1, sidecars1d[index])
+      bq.put(broot1, sidecars1d[index], verified = false)
       check:
         len(bq) == (index + 1)
         len(bq.fetchMissingSidecars(
@@ -2526,13 +2527,13 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
             len(custodyColumns) - (index + 1)
 
     for index in 0 ..< len(custodyColumns):
-      bq.put(broot2, sidecars2[index])
+      bq.put(broot2, sidecars2[index], verified = false)
       check:
         len(bq) == len(custodyColumns) + (index + 1)
         len(bq.fetchMissingSidecars(
           broot2, custodyColumns).indices) ==
             len(custodyColumns) - (index + 1)
-      bq.put(broot2, sidecars2d[index])
+      bq.put(broot2, sidecars2d[index], verified = false)
       check:
         len(bq) == len(custodyColumns) + (index + 1)
         len(bq.fetchMissingSidecars(
@@ -2592,7 +2593,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         newClone(
           genGloasDataColumnSidecar(
             index = item.index, slot = item.slot))
-      bq.put(genBlockRoot(item.root), sidecar)
+      bq.put(genBlockRoot(item.root), sidecar, verified = false)
 
     check:
       len(bq) == len(TestVectors)
@@ -2679,7 +2680,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       sidecars.add((sidecar, blockRoot))
 
     for item in sidecars:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     # put(sidecar) test
 
@@ -2709,7 +2710,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         blockRoot = blockRoot1, slot = Slot(10000),
         index = custodyColumns[0]) == false
 
-    bq.put(blockRoot1, sidecar)
+    bq.put(blockRoot1, sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars) + 1
@@ -2771,7 +2772,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
                       s.slot,
                       s.index) == false
 
-    bq.put(mblockRoot, msidecars)
+    bq.put(mblockRoot, msidecars, verified = false)
 
     check:
       lenDisk(bq) == len(custodyColumns)
@@ -2850,7 +2851,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         epochs2.add(epoch2)
 
     for item in sidecars1:
-      bq.put(item.blockRoot, item.sidecar)
+      bq.put(item.blockRoot, item.sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars1)
@@ -2863,7 +2864,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         finish = start + len(custodyColumns) - 1
         blockRoot = sidecars2[start].blockRoot
         sidecars = sidecars2.toOpenArray(start, finish).mapIt(it.sidecar)
-      bq.put(blockRoot, sidecars)
+      bq.put(blockRoot, sidecars, verified = false)
 
     check:
       len(bq) == len(sidecars1) + len(sidecars2)
@@ -2903,7 +2904,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       bq.hasSidecar(blockRoot = blockRoot, slot = Slot(1000000),
                     index = custodyColumns[0]) == false
 
-    bq.put(blockRoot, sidecar)
+    bq.put(blockRoot, sidecar, verified = false)
 
     check:
       len(bq) == len(sidecars1) + len(sidecars2) - len(custodyColumns) + 1
@@ -2987,7 +2988,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         sidecars.add((sidecar, blockRoot))
 
       for item in sidecars:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       # At this stage only last sidecars in range
       # [maxSidecars - quarantine.size, maxSidecars] should be present in
@@ -3042,7 +3043,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         sidecars.add((sidecar, blockRoot))
 
       for item in sidecars:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -3074,7 +3075,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
 
       # Now we should be able to add new columns to in-memory storage.
       for item in sidecars2:
-        bq.put(item.blockRoot, item.sidecar)
+        bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == len(custodyColumns)
@@ -3102,23 +3103,23 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       of "node":
         # Add only first 3 sidecars for first block
         for i in 0 ..< 3:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add only first 5 sidecars for second block
         for i in 8 ..< 13:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add all other sidecars
         for item in sidecars.toOpenArray(16, bq.sizeMemory - 1):
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
       of "supernode":
         # Add only 64 sidecars for first block.
         for i in 0 ..< 64:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add only 64 sidecars for second block.
         for i in 128 ..< 192:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add all other sidecars
         for item in sidecars.toOpenArray(256, bq.sizeMemory - 1):
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory() - len(custodyColumns)
@@ -3128,7 +3129,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         let offset = bq.sizeMemory()
         for i in 0 ..< len(custodyColumns):
           let item = sidecars[offset + i]
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -3139,7 +3140,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
         let offset = bq.sizeMemory() + len(custodyColumns)
         for i in 0 ..< len(custodyColumns):
           let item = sidecars[offset + i]
-          bq.put(item.blockRoot, item.sidecar)
+          bq.put(item.blockRoot, item.sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -3219,17 +3220,17 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
       of "node":
         # Add last 5 sidecars for first block
         for i in 3 ..< 8:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add last 3 sidecars for second block
         for i in 13 ..< 16:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
       of "supernode":
         # Add last 64 sidecars for first block.
         for i in 64 ..< 128:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
         # Add last 64 sidecars for second block.
         for i in 192 ..< 256:
-          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar)
+          bq.put(sidecars[i].blockRoot, sidecars[i].sidecar, verified = false)
 
       check:
         bq.lenMemory() == bq.sizeMemory()
@@ -3391,7 +3392,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
           sidecar = newClone(genGloasDataColumnSidecar(
             int(bq.custodyColumns[index]), slot))
         sidecars.add((sidecar, blockRoot))
-        bq.put(blockRoot, sidecar)
+        bq.put(blockRoot, sidecar, verified = false)
 
       let rootsCount = bq.sizeMemory() div len(bq.custodyColumns)
 
@@ -3483,7 +3484,7 @@ suite "GloasColumnQuarantine data structure test suite " & preset():
           sidecar = newClone(genGloasDataColumnSidecar(
             int(bq.custodyColumns[index]), slot))
         sidecars.add((sidecar, blockRoot))
-        bq.put(blockRoot, sidecar)
+        bq.put(blockRoot, sidecar, verified = false)
 
       let rootsCount = (bq.sizeMemory() * 2) div len(bq.custodyColumns)
 


### PR DESCRIPTION
Looking at this `verifySidecars` in `storeBlock` timing on `geth-05` `unstable`:
```
geth-05% grep "block_processor verifySidecars completed" service.log | jq .verifySidecarsDur.value | tail -n1000 | shuf -n50 | sort -n
32783514
33785078
44786558
45740867
46321962
47269376
47693099
55445906
58939326
67306793
83088443
87429848
102247079
133697049
151571156
164757022
166982133
168621517
171179344
190254750
224724556
225229254
234603094
235560210
235921521
237511433
239138910
241477100
244489928
297118716
302614775
352826596
388947593
398996593
402232047
423195551
425972812
426943822
427205760
429343692
449389745
451077913
454315387
458569320
459645845
460559202
462130709
462654094
467245072
473332215
```
in nanoseconds, i.e. it's often taking 350+ milliseconds, which can push supernodes into resolving blocks too late.

This PR exploits that of the three paths by which columns arrive:
- `getBlobV2`/`getBlobsV3`/`getBlobsV4`: the EL is trusted, by spec. No further verification required;
- CL gossip: it already happened as part of gossip validation
- request manager: it does not validate fully, and therefore this validation does need to run

One can isolate the validation to only the request manager case, and in most cases avoid any further column validation at all as part of `storeBlock` and avoid these sometimes half-second additional delays in a hot path.