### PR TITLE
complete EMPTY/FULL sibling support in proto_array

### DIFF
--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -112,6 +112,7 @@ type
     unrealized*: Table[Index, FinalityCheckpoints]
     previousProposerBoostRoot*: Eth2Digest
     previousProposerBoostScore*: Gwei
+    emptyPreferredRoot*: Eth2Digest
 
   ProtoNode* = object
     bid*: BlockId

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -186,7 +186,8 @@ func applyScoreChanges*(
     currentSlot: Slot,
     checkpoints: FinalityCheckpoints,
     justifiedTotalActiveBalance: Gwei,
-    proposerBoostRoot: Eth2Digest): FcResult[void] =
+    proposerBoostRoot: Eth2Digest,
+    emptyPreferredRoot: Eth2Digest = ZERO_HASH): FcResult[void] =
   ## Iterate backwards through the array, touching all nodes and their parents
   ## and potentially the best-child of each parent.
   #
@@ -216,6 +217,7 @@ func applyScoreChanges*(
     checkpoints.finalized.root == self.checkpoints.finalized.root or
     self.checkpoints.finalized.epoch == GENESIS_EPOCH
   self.checkpoints = checkpoints
+  self.emptyPreferredRoot = emptyPreferredRoot
 
   ## Alias
   # This cannot raise the IndexError exception, how to tell compiler?
@@ -384,9 +386,6 @@ func onBlock*(
 
 func onPayloadVerified*(
     self: var ProtoArray, root: Eth2Digest): FcResult[void] =
-  ## Register the FULL payload variant of a block once its execution payload
-  ## has been verified, as a sibling of the EMPTY/PENDING node sharing the same
-  ## parent. Subsequent blocks that build on the full parent attach here.
   if root in self.fullBlockIndices:
     return ok()
 
@@ -403,6 +402,7 @@ func onPayloadVerified*(
     parent: blockNode.parent,
     checkpoints: blockNode.checkpoints,
     sharedFinalizedEpoch: blockNode.sharedFinalizedEpoch,
+    weight: 0,
     invalid: blockNode.invalid)
 
   self.fullBlockIndices[root] = fullIdx
@@ -431,9 +431,8 @@ func findHead*(self: var ProtoArray, head: var Eth2Digest): FcResult[void] =
       kind: fcInvalidJustifiedIndex,
       index: justifiedIdx)
 
-  # If the justified EMPTY/PENDING node has no descendants, the chain continued
-  # on its FULL sibling (subsequent blocks built on the full payload); follow
-  # the FULL sibling's best-descendant instead.
+  # If the justified EMPTY node has no descendants (children parented to
+  # FULL), use the FULL sibling's bestDescendant instead.
   var bestDescendantIdx = justifiedNode.bestDescendant.get(justifiedIdx)
   if bestDescendantIdx == justifiedIdx:
     let fullIdx = self.fullBlockIndices.getOrDefault(justifiedRoot, -1)
@@ -458,6 +457,15 @@ func findHead*(self: var ProtoArray, head: var Eth2Digest): FcResult[void] =
 
   head = bestNode.bid.root
   ok()
+
+func remapIdx(idx: Opt[Index], oldToNew: Table[Index, Index]): Opt[Index] =
+  # Remap a logical node index through the prune survivor table; drops it if
+  # the referenced node did not survive.
+  if idx.isSome:
+    let n = oldToNew.getOrDefault(idx.unsafeGet, -1)
+    if n >= 0:
+      return Opt.some(n)
+  Opt.none(Index)
 
 func prune*(
     self: var ProtoArray,
@@ -490,23 +498,48 @@ func prune*(
 
   trace "Pruning blocks from fork choice", checkpoints
 
-  let finalPhysicalIdx = finalizedIdx - self.nodes.offset
-  for nodePhysicalIdx in 0 ..< finalPhysicalIdx:
-    let nodeLogicalIdx = nodePhysicalIdx + self.nodes.offset
-    self.unrealized.del nodeLogicalIdx
-    self.indices.del(self.nodes.buf[nodePhysicalIdx].bid.root)
-    self.fullBlockIndices.del(self.nodes.buf[nodePhysicalIdx].bid.root)
+  # `onPayloadVerified` appends a FULL node whenever a payload is
+  # verified, so a pruned ancestor whose payload verified late can have its FULL
+  # node sitting after the finalized block. Truncating would keep that stray
+  # node while deleting its index entry, breaking the
+  # `indices.len + fullBlockIndices.len == nodes.len` invariant.
+  # So we rebuild rather than truncate by buffer position 
+  let newOffset = finalizedIdx
+  var
+    newBuf = newSeqOfCap[ProtoNode](self.nodes.buf.len)
+    oldToNew: Table[Index, Index]
+    isFull: seq[bool]
+  for physIdx in 0 ..< self.nodes.buf.len:
+    let
+      oldLogicalIdx = physIdx + self.nodes.offset
+      root = self.nodes.buf[physIdx].bid.root
+    if self.indices.getOrDefault(root, -1) >= finalizedIdx:
+      oldToNew[oldLogicalIdx] = newOffset + newBuf.len
+      isFull.add(self.fullBlockIndices.getOrDefault(root, -1) == oldLogicalIdx)
+      newBuf.add self.nodes.buf[physIdx]
 
-  # Drop all nodes prior to finalization.
-  # This is done in-place with `moveMem` to avoid costly reallocations.
-  static: doAssert ProtoNode.supportsCopyMem(), "ProtoNode must be a trivial type"
-  let tail = self.nodes.len - finalPhysicalIdx
-  # TODO: can we have an unallocated `self.nodes`? i.e. self.nodes[0] is nil
-  moveMem(self.nodes.buf[0].addr, self.nodes.buf[finalPhysicalIdx].addr, tail * sizeof(ProtoNode))
-  self.nodes.buf.setLen(tail)
+  # Rebuild the index tables, `unrealized`, and the parent/best-child/
+  # best-descendant links against the new logical indices of the survivors.
+  let oldUnrealized = self.unrealized
+  self.indices.clear()
+  self.fullBlockIndices.clear()
+  self.unrealized.clear()
+  for i in 0 ..< newBuf.len:
+    let newLogicalIdx = newOffset + i
+    newBuf[i].parent = remapIdx(newBuf[i].parent, oldToNew)
+    newBuf[i].bestChild = remapIdx(newBuf[i].bestChild, oldToNew)
+    newBuf[i].bestDescendant = remapIdx(newBuf[i].bestDescendant, oldToNew)
+    if isFull[i]:
+      self.fullBlockIndices[newBuf[i].bid.root] = newLogicalIdx
+    else:
+      self.indices[newBuf[i].bid.root] = newLogicalIdx
+  for oldLogicalIdx, cp in oldUnrealized:
+    let n = oldToNew.getOrDefault(oldLogicalIdx, -1)
+    if n >= 0:
+      self.unrealized[n] = cp
 
-  # update offset
-  self.nodes.offset = finalizedIdx
+  self.nodes.buf = newBuf
+  self.nodes.offset = newOffset
 
   ok()
 
@@ -536,12 +569,18 @@ func maybeUpdateBestChildAndDescendant(
     childLeadsToViableHead =
       ? self.nodeLeadsToViableHead(child, childIdx)
 
+    # A block's EMPTY and FULL nodes fork the descendant tree: a block that
+    # built on EMPTY is not a descendant of FULL (and vice versa). A childless
+    # node's best-descendant is itself.
+    childIsFull =
+      self.fullBlockIndices.getOrDefault(child.bid.root, -1) == childIdx
+    effectiveBestDescendant = child.bestDescendant
+
     # Aliases to the 3 possible (bestChild, bestDescendant) tuples
     changeToNone = (Opt.none(Index), Opt.none(Index))
     changeToChild = (
         Opt.some(childIdx),
-        # Nim `options` module doesn't implement option `or`
-        if child.bestDescendant.isSome(): child.bestDescendant
+        if effectiveBestDescendant.isSome(): effectiveBestDescendant
         else: Opt.some(childIdx)
       )
     noChange = (parent.bestChild, parent.bestDescendant)
@@ -573,34 +612,24 @@ func maybeUpdateBestChildAndDescendant(
             # The best child leads to a viable head, but the child doesn't
             noChange
           elif child.bid.root == bestChild.bid.root:
-            # Pick the sibling with more attestation weight, and if tied, prefer FULL.
-            # But proposer boost shouldn't influence this choice since boost applies to
-            # the block itself
-            let childisFull =
-              self.fullBlockIndices.getOrDefault(
-                child.bid.root, -1) == childIdx
-            var
-              childEffective = child.weight
-              bestEffective = bestChild.weight
-            if  (not self.previousProposerBoostRoot.isZero) and
-                self.previousProposerBoostRoot == child.bid.root:
-              let boost = self.previousProposerBoostScore.int64
-              if not childIsFull:
-                childEffective -= boost
+            let
+              isPrevSlot = child.bid.slot + 1 == self.currentSlot
+              childWeight = if isPrevSlot: 0'i64 else: child.weight
+              bestWeight = if isPrevSlot: 0'i64 else: bestChild.weight
+            template statusTiebreak(isFull: bool): int =
+              if isPrevSlot:
+                if isFull:
+                  (if child.bid.root != self.emptyPreferredRoot: 2 else: 0)
+                else: 1
               else:
-                bestEffective -= boost
-            if childEffective == bestEffective:
-              if childIsFull:
-                changeToChild
-              else:
-                noChange
-            elif childEffective > bestEffective:
+                (if isFull: 1 else: 0)
+            if childWeight != bestWeight:
+              if childWeight > bestWeight: changeToChild else: noChange
+            elif statusTiebreak(childIsFull) > statusTiebreak(not childIsFull):
               changeToChild
             else:
               noChange
-
           elif child.weight == bestChild.weight:
-            # Tie-breaker of equal weights by root
             if child.bid.root.tiebreak(bestChild.bid.root):
               changeToChild
             else:
@@ -748,7 +777,7 @@ func root(self: ProtoNodes, logicalIdx: Opt[Index]): Eth2Digest =
 
 iterator items*(self: ProtoArray): ProtoArrayItem =
   ## Iterate over all nodes known by fork choice.
-  doAssert self.indices.len == self.nodes.len
+  doAssert self.indices.len + self.fullBlockIndices.len == self.nodes.len
   for nodePhysicalIdx, node in self.nodes.buf:
     if node.bid.root.isZero:
       continue

--- a/beacon_chain/fork_choice/proto_array.nim
+++ b/beacon_chain/fork_choice/proto_array.nim
@@ -459,10 +459,10 @@ func findHead*(self: var ProtoArray, head: var Eth2Digest): FcResult[void] =
   ok()
 
 func remapIdx(idx: Opt[Index], oldToNew: Table[Index, Index]): Opt[Index] =
-  # Remap a logical node index through the prune survivor table; drops it if
-  # the referenced node did not survive.
-  if idx.isSome:
-    let n = oldToNew.getOrDefault(idx.unsafeGet, -1)
+  # Remap a logical node index through the prune survivor
+  # table; drops it if the referenced node did not survive.
+  idx.isErrOr:
+    let n = oldToNew.getOrDefault(value, -1)
     if n >= 0:
       return Opt.some(n)
   Opt.none(Index)


### PR DESCRIPTION
Follow-up to #8514.
This completes head selection and pruning for the EMPTY/FULL sibling nodes, matching alpha.9.

- Prune: rebuild the node array instead of chopping off the front. A block's FULL node is added whenever its payload arrives, which can be late and land after the finalized block. The old front-chop then kept that stray FULL node but deleted its index entry, crashing the `indices.len + fullBlockIndices.len == nodes.len` check.

- findHead: if a justified block's EMPTY node has no children because the chain continued on its FULL node, follow the FULL node's best descendant so head selection doesn't get stuck.

 - Tiebreak: choose between a block's EMPTY and FULL node by weight first, then by status (FULL beats EMPTY), matching [alpha.9](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.9/specs/gloas/fork-choice.md#modified-get_head), replacing the slot-based rule in #8514.
 
- applyScoreChanges takes an emptyPreferredRoot input that says when to prefer EMPTY for a block. The code that computes it (from PTC votes) lands in a later PR.