### PR TITLE
route and validate gloas attestation votes in fork choice

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -210,10 +210,10 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
 proc addForkChoiceVotes(
     pool: var AttestationPool, slot: Slot,
     attesting_indices: openArray[ValidatorIndex], block_root: Eth2Digest,
-    wallTime: BeaconTime) =
+    committee_index: CommitteeIndex, wallTime: BeaconTime) =
   # Add attestation votes to fork choice
   if (let v = pool.forkChoice.on_attestation(
-    pool.dag, slot, block_root, attesting_indices, wallTime);
+    pool.dag, slot, block_root, attesting_indices, committee_index, wallTime);
     v.isErr):
       # This indicates that the fork choice and the chain dag are out of sync -
       # this is most likely the result of a bug, but we'll try to keep going -
@@ -476,7 +476,7 @@ proc addAttestation*(
 
   pool.addForkChoiceVotes(
     attestation.data.slot, attesting_indices, attestation.data.beacon_block_root,
-    wallTime,
+    CommitteeIndex(attestation.data.index), wallTime,
   )
 
   # There does not seem to be an SSE stream event corresponding to Attestation,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -369,7 +369,7 @@ proc on_attestation*(
   ? self.update_time(dag,
     max(wallTime, attestation_slot.start_beacon_time(dag.timeParams)))
 
-  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.9/specs/gloas/fork-choice.md#modified-validate_on_attestation
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/fork-choice.md#modified-validate_on_attestation
   if attestation_slot.epoch >= dag.cfg.GLOAS_FORK_EPOCH:
     let index = attestation_committee_index.uint64
     if index notin [0'u64, 1'u64]:

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -122,7 +122,7 @@ func process_attestation(
         new_vote = shortLog(vote)
 
 proc process_attestation_queue(
-    self: var ForkChoice, slot: Slot, dag: ChainDAGRef) =
+    self: var ForkChoice, slot: Slot, cfg: RuntimeConfig) =
   # Spec:
   # Attestations can only affect the fork choice of subsequent slots.
   # Delay consideration in the fork choice until their slot is in the past.
@@ -132,7 +132,7 @@ proc process_attestation_queue(
       for validator_index in it.attesting_indices:
         self.backend.process_attestation(
           validator_index, it.block_root, it.slot,
-          it.committee_index == CommitteeIndex(1), dag.cfg)
+          it.committee_index == CommitteeIndex(1), cfg)
       false
     else:
       true
@@ -255,7 +255,7 @@ proc reconfirm_fcr(
 
   # Reconfirm with previous balance source after attestations
   # from past slots have been applied
-  self.process_attestation_queue(current_slot, dag)
+  self.process_attestation_queue(current_slot, dag.cfg)
   if ? fcr.should_revert_confirmed_on_new_epoch(
       dag, confirmed, current_slot, diag):
     reason = "epoch"
@@ -353,7 +353,7 @@ proc update_time*(
       ? self.on_tick(dag, time)
 
     if preSlot != postSlot:
-      self.process_attestation_queue(postSlot, dag)
+      self.process_attestation_queue(postSlot, dag.cfg)
 
   ok()
 

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -92,21 +92,36 @@ proc init*(
 
 func process_attestation(
     self: var ForkChoiceBackend,
-    validator_index: ValidatorIndex, block_root: Eth2Digest, slot: Slot) =
+    validator_index: ValidatorIndex, block_root: Eth2Digest, slot: Slot,
+    payload_present: bool, cfg: RuntimeConfig) =
   ## Add an attestation to the fork choice context
   self.votes.extend(validator_index.int + 1)
 
   template vote: untyped = self.votes[validator_index]
-  if vote.slot != FAR_FUTURE_SLOT:
-    if slot.epoch > vote.slot.epoch or vote.next_root.isZero:
+
+  if slot.epoch >= cfg.GLOAS_FORK_EPOCH:
+    # slot based tracking with payload preference
+    if slot > vote.slot or vote.next_root.isZero:
       vote.next_root = block_root
       vote.slot = slot
+      vote.next_payload_present = payload_present
+
+      trace "Integrating Gloas vote in fork choice",
+        validator_index = validator_index,
+        slot = slot,
+        payload_present = payload_present,
+        new_vote = shortLog(vote)
+  else:
+    if vote.slot != FAR_FUTURE_SLOT:
+      if slot.epoch > vote.slot.epoch or vote.next_root.isZero:
+        vote.next_root = block_root
+        vote.slot = slot
 
       trace "Integrating vote in fork choice",
         validator_index = validator_index,
         new_vote = shortLog(vote)
 
-proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
+proc process_attestation_queue(self: var ForkChoice, slot: Slot, dag: ChainDAGRef) =
   # Spec:
   # Attestations can only affect the fork choice of subsequent slots.
   # Delay consideration in the fork choice until their slot is in the past.
@@ -115,7 +130,8 @@ proc process_attestation_queue(self: var ForkChoice, slot: Slot) =
     if it.slot < slot:
       for validator_index in it.attesting_indices:
         self.backend.process_attestation(
-          validator_index, it.block_root, it.slot)
+          validator_index, it.block_root, it.slot,
+          it.committee_index == CommitteeIndex(1), dag.cfg)
       false
     else:
       true
@@ -238,7 +254,7 @@ proc reconfirm_fcr(
 
   # Reconfirm with previous balance source after attestations
   # from past slots have been applied
-  self.process_attestation_queue(current_slot)
+  self.process_attestation_queue(current_slot, dag)
   if ? fcr.should_revert_confirmed_on_new_epoch(
       dag, confirmed, current_slot, diag):
     reason = "epoch"
@@ -336,7 +352,7 @@ proc update_time*(
       ? self.on_tick(dag, time)
 
     if preSlot != postSlot:
-      self.process_attestation_queue(postSlot)
+      self.process_attestation_queue(postSlot, dag)
 
   ok()
 
@@ -347,15 +363,30 @@ proc on_attestation*(
     attestation_slot: Slot,
     beacon_block_root: Eth2Digest,
     attesting_indices: openArray[ValidatorIndex],
+    attestation_committee_index: CommitteeIndex,
     wallTime: BeaconTime): FcResult[void] =
   ? self.update_time(dag,
     max(wallTime, attestation_slot.start_beacon_time(dag.timeParams)))
+
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.9/specs/gloas/fork-choice.md#modified-validate_on_attestation
+  if attestation_slot.epoch >= dag.cfg.GLOAS_FORK_EPOCH:
+    let index = attestation_committee_index.uint64
+    if index notin [0'u64, 1'u64]:
+      return err ForkChoiceError(kind: fcInvalidAttestation)
+    let block_slot = self.backend.proto_array.slot(beacon_block_root)
+    if block_slot.isSome and block_slot.get == attestation_slot and index != 0:
+      return err ForkChoiceError(kind: fcInvalidAttestation)
+    # If attesting for a full node, the payload must be known
+    if index == 1 and
+        beacon_block_root notin self.backend.proto_array.fullBlockIndices:
+      return err ForkChoiceError(kind: fcInvalidAttestation)
 
   if attestation_slot < self.checkpoints.time.slotOrZero(dag.timeParams):
     for validator_index in attesting_indices:
       # attestation_slot and target epoch must match, per attestation rules
       self.backend.process_attestation(
-        validator_index, beacon_block_root, attestation_slot)
+        validator_index, beacon_block_root, attestation_slot,
+        attestation_committee_index == CommitteeIndex(1), dag.cfg)
   else:
     # Spec:
     # Attestations can only affect the fork choice of subsequent slots.
@@ -363,6 +394,7 @@ proc on_attestation*(
     self.queuedAttestations.add QueuedAttestation(
       attesting_indices: @attesting_indices,
       block_root: beacon_block_root,
+      committee_index: attestation_committee_index,
       slot: attestation_slot)
   ok()
 
@@ -434,9 +466,17 @@ proc process_block*(
 
   for attestation in blck.body.attestations:
     if attestation.data.beacon_block_root in self.backend:
-      for vidx in dag.get_attesting_indices(attestation):
-        self.backend.process_attestation(
-          vidx, attestation.data.beacon_block_root, attestation.data.slot)
+      when typeof(blck).kind >= ConsensusFork.Gloas:
+        let payloadPresent = attestation.data.index == 1
+        for vidx in dag.get_attesting_indices(attestation):
+          self.backend.process_attestation(
+            vidx, attestation.data.beacon_block_root, attestation.data.slot,
+            payloadPresent, dag.cfg)
+      else:
+        for vidx in dag.get_attesting_indices(attestation):
+          self.backend.process_attestation(
+            vidx, attestation.data.beacon_block_root, attestation.data.slot,
+            false, dag.cfg)
 
   trace "Integrating block in fork choice",
     block_root = shortLog(blckRef)
@@ -669,7 +709,7 @@ func compute_deltas(
 
       if vote.slot != FAR_FUTURE_SLOT and not vote.next_root.isZero:
         if vote.next_root in indices:
-          let index = resolveIndex(vote.next_root, vote.payload_present)
+          let index = resolveIndex(vote.next_root, vote.next_payload_present)
           if index >= deltas.len:
             return err ForkChoiceError(
               kind: fcInvalidNodeDelta,

--- a/beacon_chain/fork_choice/fork_choice.nim
+++ b/beacon_chain/fork_choice/fork_choice.nim
@@ -121,7 +121,8 @@ func process_attestation(
         validator_index = validator_index,
         new_vote = shortLog(vote)
 
-proc process_attestation_queue(self: var ForkChoice, slot: Slot, dag: ChainDAGRef) =
+proc process_attestation_queue(
+    self: var ForkChoice, slot: Slot, dag: ChainDAGRef) =
   # Spec:
   # Attestations can only affect the fork choice of subsequent slots.
   # Delay consideration in the fork choice until their slot is in the past.

--- a/beacon_chain/fork_choice/fork_choice_types.nim
+++ b/beacon_chain/fork_choice/fork_choice_types.nim
@@ -55,6 +55,7 @@ type
     fcPruningFromOutdatedFinalizedRoot
     fcUnknownBlockIdAtSlot
     fcUnknownShufflingRef
+    fcInvalidAttestation
 
   Index* = int
   Delta* = int64
@@ -68,7 +69,8 @@ type
        fcPreviousHeadUnknown,
        fcCurrentHeadUnknown:
          blockRoot*: Eth2Digest
-    of fcInconsistentTick:
+    of fcInconsistentTick,
+       fcInvalidAttestation:
       discard
     of fcInvalidNodeIndex,
        fcInvalidJustifiedIndex,

--- a/tests/consensus_spec/test_fixture_fork_choice.nim
+++ b/tests/consensus_spec/test_fixture_fork_choice.nim
@@ -384,13 +384,15 @@ proc doRunTest(
     of opOnPhase0Attestation:
       let status = stores.fkChoice[].on_attestation(
         stores.dag, step.phase0Att.data.slot, step.phase0Att.data.beacon_block_root,
-        toSeq(stores.dag.get_attesting_indices(step.phase0Att.asTrusted)), time)
+        toSeq(stores.dag.get_attesting_indices(step.phase0Att.asTrusted)),
+        CommitteeIndex(step.phase0Att.data.index), time)
       doAssert status.isOk == step.valid
     of opOnElectraAttestation:
       let status = stores.fkChoice[].on_attestation(
         stores.dag, step.electraAtt.data.slot,
         step.electraAtt.data.beacon_block_root,
-        toSeq(stores.dag.get_attesting_indices(step.electraAtt)), time)
+        toSeq(stores.dag.get_attesting_indices(step.electraAtt)),
+        CommitteeIndex(step.electraAtt.data.index), time)
       doAssert status.isOk == step.valid
     of opOnBlock:
       withBlck(step.blck):


### PR DESCRIPTION
Makes attestation votes actually weight a block's EMPTY vs FULL node until now every vote landed on EMPTY because payload_present was never set and validates gloas attestations, matching alpha.9.

- process_attestation records the vote's payload preference, and compute_deltas routes the vote to the FULL node when it's a payload-present vote and that node exists, else EMPTY.
- on_attestation and process_block read the payload vote from `attestation.data.index` and thread it through.
- validate_on_attestation: data.index must be 0 or 1; a same-slot vote must be EMPTY; a full vote requires the payload to be known.