### PR TITLE
use v1.7.0-alpha.10 consensus reference tests

### DIFF
--- a/beacon_chain/spec/datatypes/base.nim
+++ b/beacon_chain/spec/datatypes/base.nim
@@ -80,7 +80,7 @@ export
   eth_types_json_serialization.writeValue
 
 # https://github.com/ethereum/consensus-specs/releases
-const SPEC_VERSION* = "1.7.0-alpha.9"
+const SPEC_VERSION* = "1.7.0-alpha.10"
 ## Spec version we're aiming to be compatible with, right now
 
 const


### PR DESCRIPTION
https://github.com/ethereum/consensus-specs/releases/tag/v1.7.0-alpha.10

Required for [`glamsterdam-devnet-5`](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-5#Test-Releases)