### PR TITLE
Move a couple DAG helpers to a more convenient location

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -96,17 +96,8 @@ proc addResolvedHeadBlock(
 
   # Resolved blocks should be stored in database
   dag.putBlock(trustedBlock)
+  dag.registerHead(blockRef)
   let putBlockTick = Moment.now()
-
-  var foundHead: bool
-  for head in dag.heads.mitems():
-    if head.isAncestorOf(blockRef):
-      head = blockRef
-      foundHead = true
-      break
-
-  if not foundHead:
-    dag.heads.add(blockRef)
 
   # Regardless of the chain we're on, the deposits come in the same order so
   # as soon as we import a block, we'll also update the shared public key

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1133,6 +1133,41 @@ proc applyBlock(
 proc genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
   dag.headState.genesis_validators_root
 
+proc registerHead*(dag: ChainDAGRef, headRef: BlockRef, persistToDb = true) =
+  var foundHead: bool
+  for head in dag.heads.mitems():
+    if head.isAncestorOf(headRef):
+      head = headRef
+      foundHead = true
+      break
+  if not foundHead:
+    dag.heads.add(headRef)
+
+proc delState(dag: ChainDAGRef, bsi: BlockSlotId) =
+  # Delete state and mapping for a particular block+slot
+  if not dag.isStateCheckpoint(bsi):
+    return # We only ever save epoch states
+
+  if (let root = dag.db.getStateRoot(bsi.bid.root, bsi.slot); root.isSome()):
+    dag.db.withManyWrites:
+      dag.db.delStateRoot(bsi.bid.root, bsi.slot)
+      dag.db.delState(
+        dag.cfg.consensusForkAtEpoch(bsi.slot.epoch), root.get())
+
+proc pruneBlockSlot(dag: ChainDAGRef, bs: BlockSlot) =
+  # TODO: should we move that disk I/O to `onSlotEnd`
+  dag.delState(bs.toBlockSlotId().expect("not nil"))
+
+  if bs.isProposed():
+    # Update light client data
+    dag.deleteLightClientData(bs.blck.bid)
+
+    dag.forkBlocks.excl(KeyedBlockRef.init(bs.blck))
+    let fork = dag.cfg.consensusForkAtEpoch(bs.blck.slot.epoch)
+    discard dag.db.delBlock(fork, bs.blck.root)
+    if fork >= ConsensusFork.Gloas:
+      discard dag.db.delExecutionPayloadEnvelope(bs.blck.root)
+
 proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
            validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
            eraPath = ".",
@@ -1312,7 +1347,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#testing
   if stateFork.current_version != configFork.current_version:
     error "State from database does not match network, check --network parameter",
-      tail = dag.tail, headRef, stateFork, configFork
+      tail = dag.tail, headRef = shortLog(dag.head), stateFork, configFork
     quit 1
 
   # Need to load state to find genesis validators root, before loading era db
@@ -1321,7 +1356,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # We used an interim finalizedHead while loading the head state above - now
   # that we have loaded the dag up to the finalized slot, we can also set
   # finalizedHead to its real value
-  dag.finalizedHead = headRef.atSlot(finalizedSlot)
+  dag.finalizedHead = dag.head.atSlot(finalizedSlot)
   dag.lastPrunePoint = dag.finalizedHead.toBlockSlotId().expect("not nil")
 
   doAssert dag.finalizedHead.blck != nil,
@@ -1363,7 +1398,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
       "tail at least")
     if finalized != dag.finalizedHead.blck.root:
       fatal "Head does not lead to finalized block, database corrupt?",
-        head = shortLog(head), finalizedHead = shortLog(dag.finalizedHead),
+        head = shortLog(dag.head), finalizedHead = shortLog(dag.finalizedHead),
         tail = shortLog(dag.tail), finalized = shortLog(finalized)
       quit 1
 
@@ -2048,31 +2083,6 @@ proc updateState*(
       replayDur
 
   true
-
-proc delState(dag: ChainDAGRef, bsi: BlockSlotId) =
-  # Delete state and mapping for a particular block+slot
-  if not dag.isStateCheckpoint(bsi):
-    return # We only ever save epoch states
-
-  if (let root = dag.db.getStateRoot(bsi.bid.root, bsi.slot); root.isSome()):
-    dag.db.withManyWrites:
-      dag.db.delStateRoot(bsi.bid.root, bsi.slot)
-      dag.db.delState(
-        dag.cfg.consensusForkAtEpoch(bsi.slot.epoch), root.get())
-
-proc pruneBlockSlot(dag: ChainDAGRef, bs: BlockSlot) =
-  # TODO: should we move that disk I/O to `onSlotEnd`
-  dag.delState(bs.toBlockSlotId().expect("not nil"))
-
-  if bs.isProposed():
-    # Update light client data
-    dag.deleteLightClientData(bs.blck.bid)
-
-    dag.forkBlocks.excl(KeyedBlockRef.init(bs.blck))
-    let fork = dag.cfg.consensusForkAtEpoch(bs.blck.slot.epoch)
-    discard dag.db.delBlock(fork, bs.blck.root)
-    if fork >= ConsensusFork.Gloas:
-      discard dag.db.delExecutionPayloadEnvelope(bs.blck.root)
 
 proc pruneBlocksDAG(dag: ChainDAGRef) =
   ## This prunes the block DAG


### PR DESCRIPTION
To prepare for multi-head storage:

- Extract registerHead from block_clearance into blockchain_dag
- Move delState / pruneBlockSlot earlier
- Replace a couple headRef references with dag.head (same value)

No semantic changes.