### PR TITLE
Move BlockRef.init helper to block_dag

### DIFF
--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -74,6 +74,22 @@ func init*(
   )
 
 func init*(
+    T: type BlockRef, cfg: RuntimeConfig,
+    root: Eth2Digest, slot: Slot): BlockRef =
+  # The execution block root gets filled in as needed. Nonfinalized Bellatrix
+  # and later blocks are loaded as optimistic, which gets adjusted that first
+  # `VALID` fcU from an EL plus markExecutionValid. Pre-merge blocks still get
+  # marked as `VALID`.
+  if cfg.consensusForkAtEpoch(slot.epoch) >= ConsensusFork.Bellatrix:
+    BlockRef.init(
+      root, Opt.none Eth2Digest, Opt.none Eth2Digest,
+      OptimisticStatus.notValidated, slot)
+  else:
+    BlockRef.init(
+      root, Opt.some ZERO_HASH, Opt.some ZERO_HASH,
+      OptimisticStatus.valid, slot)
+
+func init*(
     T: type BlockRef, root: Eth2Digest, _: OptimisticStatus,
     blck: phase0.SomeBeaconBlock | altair.SomeBeaconBlock |
           phase0.TrustedBeaconBlock | altair.TrustedBeaconBlock): BlockRef =

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1236,24 +1236,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # Load head -> finalized, or all summaries in case the finalized block table
   # hasn't been written yet
   for blck in db.getAncestorSummaries(head.root):
-    # The execution block root gets filled in as needed. Nonfinalized Bellatrix
-    # and later blocks are loaded as optimistic, which gets adjusted that first
-    # `VALID` fcU from an EL plus markExecutionValid. Pre-merge blocks still get
-    # marked as `VALID`.
-    let newRef =
-      if cfg.consensusForkAtEpoch(blck.summary.slot.epoch) >= ConsensusFork.Bellatrix:
-        BlockRef.init(
-          blck.root,
-          Opt.none Eth2Digest,
-          Opt.none Eth2Digest,
-          OptimisticStatus.notValidated,
-          blck.summary.slot,
-        )
-      else:
-        BlockRef.init(
-          blck.root, Opt.some ZERO_HASH, Opt.some ZERO_HASH,
-          OptimisticStatus.valid, blck.summary.slot
-        )
+    let newRef = BlockRef.init(dag.cfg, blck.root, blck.summary.slot)
 
     if headRef == nil:
       headRef = newRef


### PR DESCRIPTION
There is some inline logic in ChainDAGRef init for constructing BlockRef that is represented more cleanly as a convenience initializer next to the others. Reduces code duplication in future multiple-head storage.