### PR TITLE
Fix incorrect ERA files check.

### DIFF
--- a/beacon_chain/consensus_object_pools/block_clearance.nim
+++ b/beacon_chain/consensus_object_pools/block_clearance.nim
@@ -472,6 +472,10 @@ proc addBackfillBlock*(
 
   let putBlockTick = Moment.now
   debug "Block backfilled",
+    blockRoot = shortLog(signedBlock.root),
+    blck = shortLog(signedBlock.message),
+    signature = shortLog(signedBlock.signature),
+    backfill = shortLog(dag.backfill),
     sigVerifyDur = sigVerifyTick - startTick,
     putBlockDur = putBlockTick - sigVerifyTick
 

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1438,10 +1438,16 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
     #      regular syncing instead of waiting for backfill.
     for bid in dag.era.getBlockIds(
         historical_roots, historical_summaries, Slot(0), Eth2Digest()):
-      # If backfill has not yet started, the backfill slot itself also needs
-      # to be served from era files. Checkpoint sync starts from state only
-      if bid.slot > backfillSlot or
-          (bid.slot == backfillSlot and bid.root != dag.tail.root):
+      # We perform this check to avoid situation, where the database history is
+      # not connected to the ERA files blocks. Connection check performed lower
+      # in the code via ``bid.root == dag.backfill.parent_root``.
+      # This check SHOULD not fail in any other cases, such as:
+      # 1) The last slot of ERA files is greater than the lowest known slot in
+      #    the database (dag.backfill.slot).
+      # 2) The last slot of ERA files is lower than or equal to the lowest known
+      #    slot in database (dag.backfill.slot).
+      # 3) The node was started immediately after checkpoint sync.
+      if bid.slot > backfillSlot:
         # If we end up in here, we failed the root comparison just below in
         # an earlier iteration
         fatal "Era summaries don't lead up to backfill, database or era files corrupt?",

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -261,9 +261,9 @@ proc processSignedBeaconBlock*(
 
   # Start of block processing - in reality, we have already gone through SSZ
   # decoding at this stage, which may be significant
-  let bid = BlockId(root: signedBlock.root, slot: signedBlock.message.slot)
   debug "Block received",
-    bid = shortLog(bid),
+    bid = shortLog(
+      BlockId(root: signedBlock.root, slot: signedBlock.message.slot)),
     blck = shortLog(signedBlock.message),
     signature = shortLog(signedBlock.signature),
     wallSlot,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -261,7 +261,13 @@ proc processSignedBeaconBlock*(
 
   # Start of block processing - in reality, we have already gone through SSZ
   # decoding at this stage, which may be significant
-  debug "Block received", delay
+  let bid = BlockId(root: signedBlock.root, slot: signedBlock.message.slot)
+  debug "Block received",
+    bid = shortLog(bid),
+    blck = shortLog(signedBlock.message),
+    signature = shortLog(signedBlock.signature),
+    wallSlot,
+    delay
 
   self.dag.validateBeaconBlock(
       self.quarantine, self.envelopeQuarantine, signedBlock,

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -262,8 +262,7 @@ proc processSignedBeaconBlock*(
   # Start of block processing - in reality, we have already gone through SSZ
   # decoding at this stage, which may be significant
   debug "Block received",
-    bid = shortLog(
-      BlockId(root: signedBlock.root, slot: signedBlock.message.slot)),
+    bid = shortLog(signedBlock.toBlockId()),
     blck = shortLog(signedBlock.message),
     signature = shortLog(signedBlock.signature),
     wallSlot,


### PR DESCRIPTION
This fix should finally address #6059

* Fix missing fields in logs `Block backfilled` and `Block received` because of `logScope` in generic functions.
