### PR TITLE
Init AttPool EpochRef every 1024 slots instead of every 1024 blocks

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -121,27 +121,8 @@ func init(T: type AttestationData, entry: AttestationEntry): T =
     target: entry.target,
   )
 
-proc init*(T: type AttestationPool, dag: ChainDAGRef,
-           quarantine: ref Quarantine, wallTime = default(BeaconTime),
-           onSingleAttestation: OnSingleAttestationCallback = nil): T =
-  ## Initialize an AttestationPool from the dag `headState`
-  ## The `finalized_root` works around the finalized_checkpoint of the genesis block
-  ## holding a zero_root.
-  let
-    currentSlot = wallTime.slotOrZero(dag.timeParams)
-    finalizedEpochRef = dag.getFinalizedEpochRef()
-  var forkChoice = ForkChoice.init(
-    dag.cfg.CONFIRMATION_BYZANTINE_THRESHOLD,
-    finalizedEpochRef, dag.finalizedHead.blck, currentSlot, wallTime)
-
-  # Feed fork choice with unfinalized history - during startup, block pool only
-  # keeps track of a single history so we just need to follow it
-  doAssert dag.heads.len == 1, "Init only supports a single history"
-
-  var
-    blocks: seq[BlockRef]
-    cur = dag.head
-
+func collectShallowAncestors(
+    shallow: var HashSet[BlockRef], head: BlockRef) =
   # When the chain is finalizing, the votes between the head block and the
   # finalized checkpoint should be enough for a stable fork choice - when the
   # chain is not finalizing, we want to seed it with as many votes as possible
@@ -150,24 +131,42 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
   # it takes to replay that many blocks during startup and thus miss _new_
   # votes.
   const ForkChoiceHorizon = 256
+  var
+    i = 0
+    cur = head
+  while cur != nil and i < ForkChoiceHorizon:
+    shallow.incl cur
+    cur = cur.parent
+    inc i
+
+proc loadHead(
+    forkChoice: var ForkChoice, dag: ChainDAGRef,
+    head: BlockRef, shallow: HashSet[BlockRef]) =
+  var
+    blocks: seq[BlockRef]
+    cur = head
   while cur != dag.finalizedHead.blck:
     blocks.add cur
     cur = cur.parent
 
-  info "Initializing fork choice", unfinalized_blocks = blocks.len
-
-  var epochRef = finalizedEpochRef
-  for i in 0..<blocks.len:
+  var epochRef: EpochRef
+  for i in countdown(blocks.high, 0):
     let
-      blckRef = blocks[blocks.len - i - 1]
+      blckRef = blocks[i]
+      areInaccurateCheckpointsAcceptable =
+        # Fork choice needs to know about the full block tree back through the
+        # finalization point, but doesn't really need to have overly accurate
+        # justification and finalization points until we get close to head -
+        # nonetheless, we'll make sure to pass a fresh finalization point now
+        # and then to make sure the fork choice data structure doesn't grow
+        # too big - getting an EpochRef can be expensive.
+        if blckRef in shallow or i >= blocks.high:
+          false
+        else:
+          # Must be deterministic across heads
+          (blckRef.slot div 1024) == (blocks[i + 1].slot div 1024)
       status =
-        if i < (blocks.len - ForkChoiceHorizon) and (i mod 1024 != 0):
-          # Fork choice needs to know about the full block tree back through the
-          # finalization point, but doesn't really need to have overly accurate
-          # justification and finalization points until we get close to head -
-          # nonetheless, we'll make sure to pass a fresh finalization point now
-          # and then to make sure the fork choice data structure doesn't grow
-          # too big - getting an EpochRef can be expensive.
+        if areInaccurateCheckpointsAcceptable:
           forkChoice.backend.process_block(
             blckRef.bid, blckRef.parent.root, epochRef.checkpoints)
         else:
@@ -195,7 +194,29 @@ proc init*(T: type AttestationPool, dag: ChainDAGRef,
               dag, epochRef, blckRef, unrealized, forkyBlck.message,
               blckRef.slot.start_beacon_time(dag.timeParams))
 
-    doAssert status.isOk(), "Error in preloading the fork choice: " & $status.error
+    doAssert status.isOk(), "Error preloading the fork choice: " & $status.error
+
+proc init*(
+    T: type AttestationPool, dag: ChainDAGRef,
+    quarantine: ref Quarantine, wallTime = default(BeaconTime),
+    onSingleAttestation: OnSingleAttestationCallback = nil): T =
+  ## Initialize an AttestationPool from the dag `headState`
+  ## The `finalized_root` works around the finalized_checkpoint of the genesis block
+  ## holding a zero_root.
+  let
+    currentSlot = wallTime.slotOrZero(dag.timeParams)
+    finalizedEpochRef = dag.getFinalizedEpochRef()
+  var forkChoice = ForkChoice.init(
+    dag.cfg.CONFIRMATION_BYZANTINE_THRESHOLD,
+    finalizedEpochRef, dag.finalizedHead.blck, currentSlot, wallTime)
+
+  # Feed fork choice with unfinalized history
+  info "Initializing fork choice", head = dag.head
+
+  var shallow: HashSet[BlockRef]
+  shallow.collectShallowAncestors(dag.head)
+  
+  forkChoice.loadHead(dag, dag.head, shallow)
 
   info "Fork choice initialized",
     justified = shortLog(dag.headState.current_justified_checkpoint),

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -58,6 +58,9 @@ type
 template root*(blck: BlockRef): Eth2Digest = blck.bid.root
 template slot*(blck: BlockRef): Slot = blck.bid.slot
 
+template hash*(blck: BlockRef): Hash =
+  hash blck.root
+
 func init*(
     T: type BlockRef,
     root: Eth2Digest,


### PR DESCRIPTION
As preparation for persisting all DAG heads in DB across restarts, prepare the initialization of the AttestationPool by extracting the per-head work into a helper. The performance optimization of #1910 in periods of long finality is slightly adjusted to ensure that calling the helper on extra heads produces monotonically increasing checkpoints.

Old logic fetches accurate checkpoints for the latest 256 blocks (from the head), and also every 1024 blocks (from the finalized).

New logic retains the former (eventually becomes union across all heads) and changes the second condition to the first block in each 1024 slot interval. This still skips most of the state replays but makes it so that if additional heads are imported, checkpoints increase at the same slot in each ancestry, i.e., on the first block introducing a new branch and at the first block entering a new 1024 slot interval.

Note that in situations that have lots of empty slots, this reduces startup performance compared to the old logic which only counted blocks, if there is nonfinality > 1024 slots (32 epochs, ~3.4 hours Mainnet).