### PR TITLE
Honor --debug-invalidate-block-root on ChainDAG init

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -142,6 +142,7 @@ AllTests-mainnet
 + Gloas consecutive blocks accumulate missing envelopes [Preset: mainnet]                    OK
 + Gloas reverse order blocks with missing parent [Preset: mainnet]                           OK
 + Invalidate block root [Preset: mainnet]                                                    OK
++ Invalidate existing block root [Preset: mainnet]                                           OK
 + Process Deneb block without blob sidecars [Preset: mainnet]                                OK
 + Process Fulu block with data column sidecars [Preset: mainnet]                             OK
 + Process Fulu block without data column sidecars [Preset: mainnet]                          OK

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -1144,8 +1144,8 @@ proc registerHead*(dag: ChainDAGRef, headRef: BlockRef) =
     dag.heads.add(headRef)
 
 proc loadHead(
-    dag: ChainDAGRef, headRoot: Eth2Digest, finalizedSlot: Slot
-): Result[BlockRef, string] =
+    dag: ChainDAGRef, headRoot: Eth2Digest, finalizedSlot: Slot,
+    invalidBlockRoots: openArray[Eth2Digest]): Result[BlockRef, string] =
   template tmpState: var ForkedHashedBeaconState =
     dag.headState
 
@@ -1163,6 +1163,7 @@ proc loadHead(
 
   # Load head -> finalized, or all summaries in case the finalized block table
   # hasn't been written yet
+  var isInvalid = false
   for blck in dag.db.getAncestorSummaries(headRoot):
     let newRef = BlockRef.init(dag.cfg, blck.root, blck.summary.slot)
 
@@ -1175,6 +1176,15 @@ proc loadHead(
     curRef = newRef
 
     dag.forkBlocks.incl(KeyedBlockRef.init(curRef))
+
+    isInvalid = curRef.slot > finalizedSlot and curRef.root in invalidBlockRoots
+    if isInvalid:
+      while headRef != nil:
+        dag.forkBlocks.excl(KeyedBlockRef.init(headRef))
+        headRef = headRef.parent
+      foundHeadState = false
+      headBlocks.reset()
+      continue
 
     if not foundHeadState:
       foundHeadState = dag.db.getState(
@@ -1202,6 +1212,8 @@ proc loadHead(
       # Only non-finalized slots get a `BlockRef`
       break
 
+  if isInvalid:
+    return err "Head block marked invalid (--debug-invalidate-block-root)"
   if curRef == nil:
     return err "getAncestorSummaries did not yield any results"
 
@@ -1258,13 +1270,14 @@ proc pruneBlockSlot(dag: ChainDAGRef, bs: BlockSlot) =
     if fork >= ConsensusFork.Gloas:
       discard dag.db.delExecutionPayloadEnvelope(bs.blck.root)
 
-proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
-           validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
-           eraPath = ".",
-           onBlockCb: OnBlockCallback = nil, onHeadCb: OnHeadCallback = nil,
-           onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
-           vanityLogs = default(VanityLogs),
-           lcDataConfig = default(LightClientDataConfig)): ChainDAGRef =
+proc init*(
+    T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
+    validatorMonitor: ref ValidatorMonitor, updateFlags: UpdateFlags,
+    eraPath = ".", invalidBlockRoots: openArray[Eth2Digest] = [],
+    onBlockCb: OnBlockCallback = nil, onHeadCb: OnHeadCallback = nil,
+    onReorgCb: OnReorgCallback = nil, onFinCb: OnFinalizedCallback = nil,
+    vanityLogs = default(VanityLogs),
+    lcDataConfig = default(LightClientDataConfig)): ChainDAGRef =
   doAssert updateFlags - {strictVerification} == {},
     "Other flags not supported in ChainDAG"
 
@@ -1312,7 +1325,7 @@ proc init*(T: type ChainDAGRef, cfg: RuntimeConfig, db: BeaconChainDB,
   # state - the tail is implicitly finalized, and if we have a finalized block
   # table, that provides another hint
   var finalizedSlot = db.finalizedBlocks.high.get(tail.slot)
-  dag.head = dag.loadHead(headRoot, finalizedSlot).valueOr:
+  dag.head = dag.loadHead(headRoot, finalizedSlot, invalidBlockRoots).valueOr:
     fatal "Error while loading head from database", reason = error, headRoot
     quit 1
 

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -396,7 +396,8 @@ proc loadChainDag(
       if config.lightClientDataServe: onLightClientOptimisticUpdate
       else: nil
   dag = ChainDAGRef.init(
-    cfg, db, validatorMonitor, chainDagFlags, config.eraDir,
+    cfg, db, validatorMonitor, chainDagFlags,
+    config.eraDir, config.invalidBlockRoots,
     vanityLogs = getVanityLogs(detectTTY(config.logFormat)),
     lcDataConfig = LightClientDataConfig(
       serve: config.lightClientDataServe,

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -437,7 +437,7 @@ proc doTrustedNodeSync*(
   let
     validatorMonitor = newClone(
       ValidatorMonitor.init(cfg, false, false))
-    dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, eraPath = eraDir)
+    dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, eraDir)
     backfillSlot = max(dag.backfill.slot, 1.Slot) - 1
     horizon = max(dag.horizon, dag.frontfill.valueOr(BlockId()).slot)
 

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -75,7 +75,7 @@ suite "Block processor" & preset():
         res
       db = cfg.makeTestDB(SLOTS_PER_EPOCH)
       validatorMonitor = newClone(ValidatorMonitor.init(cfg))
-      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
+      dag = ChainDAGRef.init(cfg, db, validatorMonitor, {})
       taskpool = Taskpool.new()
       quarantine = newClone(Quarantine.init(cfg))
       dataColumnQuarantine = newClone(ColumnQuarantine())
@@ -153,9 +153,9 @@ suite "Block processor" & preset():
       dag.heads.mapIt(it) == @[b2Get.get()]
 
     # check that init also reloads block graph
-    var
+    let
       validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
-      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
+      dag2 = ChainDAGRef.init(cfg, db, validatorMonitor2, {})
 
     check:
       # ensure we loaded the correct head state
@@ -165,15 +165,16 @@ suite "Block processor" & preset():
       dag2.getBlockRef(b2.root).isSome()
       dag2.heads.len == 1
       dag2.heads[0].root == b2.root
+      dag2.forkBlocksMatchHeads()
 
   asyncTest "Invalidate block root" & preset():
     let
       b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       b2 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
       processor = BlockProcessor.new(
-        false, "", "", batchVerifier, consensusManager,
-        validatorMonitor, dataColumnQuarantine, gloasColumnQuarantine,
-        envelopeQuarantine, getTimeFn, invalidBlockRoots = @[b2.root])
+        false, "", "", batchVerifier, consensusManager, validatorMonitor,
+        dataColumnQuarantine, gloasColumnQuarantine, envelopeQuarantine,
+        getTimeFn, invalidBlockRoots = @[b2.root])
 
     block:
       let res = await processor.addBlock(MsgSource.gossip, b2, noSidecars)
@@ -200,6 +201,33 @@ suite "Block processor" & preset():
         res == Result[void, VerifierError].err VerifierError.Invalid
         dag.containsForkBlock(b1.root)
         not dag.containsForkBlock(b2.root)
+
+  asyncTest "Invalidate existing block root" & preset():
+    let
+      processor = BlockProcessor.new(
+        false, "", "", batchVerifier, consensusManager, validatorMonitor,
+        dataColumnQuarantine, gloasColumnQuarantine, envelopeQuarantine,
+        getTimeFn)
+
+      b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b2 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b3 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+    check:
+      (await processor.addBlock(MsgSource.gossip, b1, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b3, noSidecars)).isOk
+    dag.updateHead(dag.getBlockRef(b3.root).get(), quarantine[], [])
+
+    let
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
+      dag2 = ChainDAGRef.init(
+        cfg, db, validatorMonitor2, {}, invalidBlockRoots = @[b2.root])
+    check:
+      dag2.getBlockRef(b1.root).isSome
+      dag2.getBlockRef(b2.root).isNone
+      dag2.getBlockRef(b3.root).isNone
+      dag2.head == dag2.getBlockRef(b1.root).get
+      dag2.forkBlocksMatchHeads()
 
   asyncTest "Process a block from each fork (without blobs)" & preset():
     let processor = BlockProcessor.new(
@@ -535,9 +563,9 @@ suite "Block processor" & preset():
     # Simulate node restart: reinitialize DAG from the same DB.
     # All in-memory state caches are dropped, forcing updateState to
     # replay through b1-b3 slots from disk.
-    var
+    let
       validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
-      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
+      dag2 = ChainDAGRef.init(cfg, db, validatorMonitor2, {})
       quarantine2 = newClone(Quarantine.init(cfg))
       attestationPool2 = newClone(AttestationPool.init(dag2, quarantine2))
       consensusManager2 = ConsensusManager.new(
@@ -546,7 +574,6 @@ suite "Block processor" & preset():
         newClone(DynamicFeeRecipientsStore.init()),
         "", Opt.some default(Eth1Address), defaultGasLimit)
 
-    let
       state2 = newClone(dag2.headState)
       getTimeFn2 = proc(): BeaconTime =
         state2[].slot.start_beacon_time(cfg.timeParams)

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -8,6 +8,7 @@
 {.push raises: [], gcsafe.}
 
 import
+  std/sequtils,
   chronicles,
   ../beacon_chain/beacon_chain_db,
   ../beacon_chain/consensus_object_pools/blockchain_dag,
@@ -88,3 +89,13 @@ proc getEarliestInvalidBlockRoot*(
     curBlck = curBlck.parent
 
   curBlck.root
+
+func forkBlocksMatchHeads*(dag: ChainDAGRef): bool =
+  var expected: HashSet[Eth2Digest]
+  for head in dag.heads:
+    var cur = head
+    while cur != nil and not expected.containsOrIncl(cur.root):
+      cur = cur.parent
+  if expected.len != dag.forkBlocks.len:
+    return false
+  expected.allIt dag.containsForkBlock(it)


### PR DESCRIPTION
The --debug-invalidate-block-root flag allows users to prevent import of blocks that become asynchronously invalid via engine_forkchoiceUpdated. While we honor the flag during gossip validation to prevent importing blocks into fork choice optimistically (potentially getting stuck on an invalid justification), we currently don't apply it on initialization.

Update ChainDAGRef.init so that if we encounter a user invalidated block when loading the non-finalized portion of the chain, we instead reset the head to its parent block (latest valid head).