### PR TITLE
fix: validate preferences against dependent_root shuffling, not head …

### DIFF
--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2058,7 +2058,7 @@ proc validatePayloadAttestationMessage*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/p2p-interface.md#proposer_preferences
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/p2p-interface.md#proposer_preferences
 proc validateProposerPreferences*(
     dag: ChainDAGRef,
     seen: var array[2, array[SLOTS_PER_EPOCH, Opt[ProposerPreferences]]],
@@ -2092,18 +2092,17 @@ proc validateProposerPreferences*(
   # where state is the checkpoint state at the epoch
   # compute_epoch_at_slot(preferences.proposal_slot) - 1
   # and the root preferences.dependent_root.
-  # Spec requires the checkpoint state at dependent_root; we approximate
-  # with head state which should have the same proposer_lookahead when synced.
-  withState(dag.headState):
-    when consensusFork >= ConsensusFork.Gloas:
-      if not is_valid_proposal_slot(
-          forkyState.data, preferences.proposal_slot,
-          preferences.validator_index):
-        return dag.checkedReject(
-          "ProposerPreferences: not the proposer for proposal_slot")
-    else:
-      return errIgnore(
-        "ProposerPreferences: head state not yet at Gloas fork")
+  #
+  # Rather than replay that checkpoint state, compute the proposer from the
+  # shuffling anchored at the referenced dependent_root block.
+  let dependentRef = dag.getBlockRef(preferences.dependent_root).valueOr:
+    return errIgnore("ProposerPreferences: dependent_root not in dag")
+  let proposer = dag.getProposer(
+      dependentRef, preferences.proposal_slot).valueOr:
+    return errIgnore("ProposerPreferences: unable to compute proposer")
+  if proposer.uint64 != preferences.validator_index:
+    return dag.checkedReject(
+      "ProposerPreferences: not the proposer for proposal_slot")
 
   # [IGNORE] The signed_proposer_preferences is the first valid message seen
   # for the tuple (preferences.dependent_root, preferences.proposal_slot,

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -609,18 +609,6 @@ func get_beacon_proposer_indices*(
     # function does not require shuffled indices post Fulu
     get_beacon_proposer_indices(state, epoch)
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/p2p-interface.md#proposer_preferences
-func is_valid_proposal_slot*(
-    state: gloas.BeaconState | heze.BeaconState,
-    slot: Slot, validator_index: uint64): bool =
-  ## Check if the validator is the proposer for the given slot within the
-  ## proposer lookahead.
-  let start_slot = state.get_current_epoch().start_slot()
-  if slot < start_slot or
-      slot - start_slot >= state.proposer_lookahead.lenu64:
-    return false
-  state.proposer_lookahead.item(slot - start_slot) == validator_index
-
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/validator.md#broadcasting-signedproposerpreferences
 # The signature of this function diverges from the spec to avoid
 # passing the full beacon state through an inline iterator which

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -521,7 +521,7 @@ suite "Proposer preferences validation " & preset():
             proposerFound = true
             break
         # wrongValidator just needs to differ from the scheduled proposer at
-        # proposerSlot; other slots don't matter for is_valid_proposal_slot.
+        # proposer_slot; that is the only slot the proposer check looks at.
         wrongValidator = proposer_index + 1
         if forkyState.data.proposer_lookahead.item(
             proposer_slot - startSlot) == wrongValidator:


### PR DESCRIPTION
Compute the proposer from the shuffling anchored at `preferences.dependent_root` and compare to `preferences.validator_index`. Matches both the send side `get_upcoming_proposal_slots`, which reads the frozen `proposer_lookahead` and the spec's `is_valid_proposal_slot`