### PR TITLE
reduce max stack usage while building tests

### DIFF
--- a/tests/test_peerdas_helpers.nim
+++ b/tests/test_peerdas_helpers.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2018-2026 Status Research & Development GmbH
+# Copyright (c) 2024-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
@@ -15,7 +15,7 @@ import
   kzg4844/[kzg_abi, kzg],
   ./consensus_spec/[os_ops, fixtures_utils],
   ../beacon_chain/spec/[helpers, peerdas_helpers],
-  ../beacon_chain/spec/datatypes/[fulu, gloas, deneb]
+  ../beacon_chain/spec/datatypes/[deneb, fulu, gloas]
 
 from std/strutils import rsplit
 
@@ -29,9 +29,9 @@ block:
 # such that BLS modulus does not overflow
 const MAX_TOP_BYTE = 114
 
-proc createSampleKzgBlobs(n: int, seed: int): seq[KzgBlob] =
+func createSampleKzgBlobs(n: int, seed: int): seq[KzgBlob] =
   var
-    blobs: seq[KzgBlob] = @[]
+    blobs: seq[KzgBlob]
     # Initialize the PRNG with the given seed
     rng = initRand(seed)
   for blobIndex in 0..<n:
@@ -67,10 +67,11 @@ proc buildSidecarsFromBlobs(blobs: seq[KzgBlob]): BuiltSidecars =
     commitmentsSeq = newSeqOfCap[KzgCommitment](blobs.len)
 
   for i, blob in blobs:
-    let cp = computeCellsAndKzgProofs(blob).valueOr:
-      raiseAssert "computeCellsAndKzgProofs failed"
-    allCells[i] = cp.cells
-    allProofs[i] = cp.proofs
+    let cp = computeCellsAndKzgProofs(blob)
+    doAssert cp.isOk, "computeCellsAndKzgProofs failed"
+    cp.isErrOr:
+      allCells[i] = value.cells
+      allProofs[i] = value.proofs
     let c = blobToKzgCommitment(blob).valueOr:
       raiseAssert "blobToKzgCommitment failed"
     commitmentsSeq.add(c)


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/actions/runs/27313403727/job/80688534935 failed with:
```
/github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/vendor/nimbus-build-system/vendor/Nim/lib/system/iterators_1.nim: In function ‘_ZN20test_peerdas_helpers22buildSidecarsFromBlobsE3seqIN7kzg_abi7KzgBlobEE’:
/github-runner/github-runner-node-02/workspace/nimbus-eth2/nimbus-eth2/tests/test_peerdas_helpers.nim:61:15: error: stack usage might be 936528 bytes [-Werror=stack-usage=]
   61 | proc buildSidecarsFromBlobs(blobs: seq[KzgBlob]): BuiltSidecars =
      |               ^
lto1: some warnings being treated as errors
```

Using `isErrOr` rather than `valueOr` reduces stack usage and removes some pointless copies, to stay under the limit.