### PR TITLE
Persist all chain DAG heads in database

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -40,6 +40,7 @@ AllTests-mainnet
 + batch put data columns [Preset: mainnet]                                                   OK
 + empty database [Preset: mainnet]                                                           OK
 + find ancestors [Preset: mainnet]                                                           OK
++ head blocks roundtrip [Preset: mainnet]                                                    OK
 + sanity check altair and cross-fork getState rollback [Preset: mainnet]                     OK
 + sanity check altair blocks [Preset: mainnet]                                               OK
 + sanity check altair states [Preset: mainnet]                                               OK
@@ -143,6 +144,7 @@ AllTests-mainnet
 + Gloas reverse order blocks with missing parent [Preset: mainnet]                           OK
 + Invalidate block root [Preset: mainnet]                                                    OK
 + Invalidate existing block root [Preset: mainnet]                                           OK
++ Multiple heads [Preset: mainnet]                                                           OK
 + Process Deneb block without blob sidecars [Preset: mainnet]                                OK
 + Process Fulu block with data column sidecars [Preset: mainnet]                             OK
 + Process Fulu block without data column sidecars [Preset: mainnet]                          OK
@@ -1224,6 +1226,7 @@ AllTests-mainnet
 ```
 ## Starting states
 ```diff
++ Checkpoint with missed epoch start slot                                                    OK
 + Starting state without block                                                               OK
 ```
 ## State history
@@ -1318,6 +1321,7 @@ AllTests-mainnet
 ```
 ## chain DAG finalization tests [Preset: mainnet]
 ```diff
++ discard unloadable and duplicate heads on init [Preset: mainnet]                           OK
 + init with gaps [Preset: mainnet]                                                           OK
 + orphaned epoch block [Preset: mainnet]                                                     OK
 + prune heads on finalization [Preset: mainnet]                                              OK

--- a/beacon_chain/beacon_chain_db.nim
+++ b/beacon_chain/beacon_chain_db.nim
@@ -209,6 +209,8 @@ type
       ## for future deposits, beyond the `finalized` branch from EIP-4881.
       ## Those extra hashes may be set to ZERO_HASH when importing from a
       ## compressed EIP-4881 `DepositTreeSnapshot`.
+    kHeadBlocks
+      ## List of pointers to all head blocks in the fork choice. v26.7.0+
 
   BeaconBlockSummary* = object
     ## Cache of beacon block summaries - during startup when we construct the
@@ -1090,6 +1092,10 @@ proc delStateDiff*(db: BeaconChainDB, root: Eth2Digest) =
 proc putHeadBlock*(db: BeaconChainDB, key: Eth2Digest) =
   db.keyValues.putRaw(subkey(kHeadBlock), key)
 
+proc putHeadBlocks*(db: BeaconChainDB, keys: seq[Eth2Digest]) =
+  doAssert keys.len > 0
+  db.keyValues.putSSZ(subkey(kHeadBlocks), keys)
+
 proc putTailBlock*(db: BeaconChainDB, key: Eth2Digest) =
   db.keyValues.putRaw(subkey(kTailBlock), key)
 
@@ -1401,6 +1407,10 @@ proc getHeadBlock(db: BeaconChainDBV0): Opt[Eth2Digest] =
 proc getHeadBlock*(db: BeaconChainDB): Opt[Eth2Digest] =
   db.keyValues.getRaw(subkey(kHeadBlock), Eth2Digest) or
     db.v0.getHeadBlock()
+
+proc getHeadBlocks*(db: BeaconChainDB): seq[Eth2Digest] =
+  if db.keyValues.getSSZ(subkey(kHeadBlocks), result) != GetResult.found:
+    result.reset()
 
 proc getTailBlock(db: BeaconChainDBV0): Opt[Eth2Digest] =
   db.backend.getRaw(subkey(kTailBlock), Eth2Digest)

--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -145,7 +145,7 @@ proc loadHead(
   var
     blocks: seq[BlockRef]
     cur = head
-  while cur != dag.finalizedHead.blck:
+  while cur != nil and cur.root notin forkChoice.backend:
     blocks.add cur
     cur = cur.parent
 
@@ -211,12 +211,16 @@ proc init*(
     finalizedEpochRef, dag.finalizedHead.blck, currentSlot, wallTime)
 
   # Feed fork choice with unfinalized history
-  info "Initializing fork choice", head = dag.head
+  info "Initializing fork choice", head = dag.head, heads = dag.heads
 
   var shallow: HashSet[BlockRef]
   shallow.collectShallowAncestors(dag.head)
-  
+  for additionalHead in dag.heads:
+    shallow.collectShallowAncestors(additionalHead)
+
   forkChoice.loadHead(dag, dag.head, shallow)
+  for additionalHead in dag.heads:
+    forkChoice.loadHead(dag, additionalHead, shallow)
 
   info "Fork choice initialized",
     justified = shortLog(dag.headState.current_justified_checkpoint),

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -72,6 +72,9 @@ proc putBlock*(
     dag: ChainDAGRef, signedBlock: ForkyTrustedSignedBeaconBlock) =
   dag.db.putBlock(signedBlock)
 
+proc didUpdateHeads(dag: ChainDAGRef) =
+  dag.db.putHeadBlocks(dag.heads.mapIt(it.bid.root))
+
 proc updateState*(
     dag: ChainDAGRef, state: var ForkedHashedBeaconState, bsi: BlockSlotId,
     save: bool, cache: var StateCache,
@@ -1133,7 +1136,7 @@ proc applyBlock(
 proc genesis_validators_root*(dag: ChainDAGRef): Eth2Digest =
   dag.headState.genesis_validators_root
 
-proc registerHead*(dag: ChainDAGRef, headRef: BlockRef) =
+proc registerHead*(dag: ChainDAGRef, headRef: BlockRef, persistToDb = true) =
   var foundHead: bool
   for head in dag.heads.mitems():
     if head.isAncestorOf(headRef):
@@ -1142,12 +1145,14 @@ proc registerHead*(dag: ChainDAGRef, headRef: BlockRef) =
       break
   if not foundHead:
     dag.heads.add(headRef)
+  if persistToDb:
+    dag.didUpdateHeads()
 
 proc loadHead(
     dag: ChainDAGRef, headRoot: Eth2Digest, finalizedSlot: Slot,
     invalidBlockRoots: openArray[Eth2Digest]): Result[BlockRef, string] =
   template tmpState: var ForkedHashedBeaconState =
-    dag.headState
+    (if dag.head == nil: addr dag.headState else: addr dag.clearanceState)[]
 
   let head = dag.db.getBlockId(headRoot).valueOr:
     return err "head block id, database corrupt?"
@@ -1161,10 +1166,17 @@ proc loadHead(
     foundHeadState = false
     headBlocks: seq[BlockRef]
 
-  # Load head -> finalized, or all summaries in case the finalized block table
-  # hasn't been written yet
+  # Load head -> first known BlockRef (if exists), or finalized (initial head),
+  # or all summaries in case the finalized block table hasn't been written yet
   var isInvalid = false
   for blck in dag.db.getAncestorSummaries(headRoot):
+    let baseRef = dag.getBlockRef(blck.root).valueOr(nil)
+    if baseRef != nil:
+      if headRef == nil:
+        return ok baseRef
+      link(baseRef, curRef)
+      break
+
     let newRef = BlockRef.init(dag.cfg, blck.root, blck.summary.slot)
 
     if headRef == nil:
@@ -1177,11 +1189,16 @@ proc loadHead(
 
     dag.forkBlocks.incl(KeyedBlockRef.init(curRef))
 
+    let isFinalized = dag.head != nil and curRef.slot <= finalizedSlot
     isInvalid = curRef.slot > finalizedSlot and curRef.root in invalidBlockRoots
-    if isInvalid:
+    if isFinalized or isInvalid:
       while headRef != nil:
         dag.forkBlocks.excl(KeyedBlockRef.init(headRef))
         headRef = headRef.parent
+      if dag.isFinalized(curRef.bid):
+        return ok dag.finalizedHead.blck
+      if isFinalized:
+        return err "Head block orphaned"
       foundHeadState = false
       headBlocks.reset()
       continue
@@ -1200,9 +1217,13 @@ proc loadHead(
           headBlocks.add curRef
         else:
           if headBlocks.len > 0:
-            fatal "Missing a block to create head state, database corrupt?",
-              curRef = shortLog(curRef)
-            quit 1
+            if dag.head == nil:
+              fatal "Missing a block to create head state, database corrupt?",
+                curRef = shortLog(curRef)
+              quit 1
+            for blockRef in headBlocks:
+              dag.forkBlocks.excl(KeyedBlockRef.init(blockRef))
+            headBlocks.reset()
           # Without the block data we can't form a state for this root, so
           # we'll need to move the head back
           headRef = nil
@@ -1220,19 +1241,32 @@ proc loadHead(
   if headRef == nil:
     headRef = curRef
 
+  var cache: StateCache
   if not foundHeadState:
-    if not dag.getStateByParent(curRef.bid, tmpState):
-      fatal "Could not load head state, database corrupt?",
-        head = shortLog(head), tail = shortLog(dag.tail)
-      quit 1
+    foundHeadState =
+      if dag.getStateByParent(curRef.bid, tmpState):
+        true
+      elif dag.head == nil:
+        false  # DAG states not yet initialized -> updateState unavailable
+      elif (let bsi = curRef.atSlot.parent.toBlockSlotId(); bsi.isSome):
+        assign(tmpState, dag.headState)
+        dag.updateState(tmpState, bsi.unsafeGet, false, cache, dag.updateFlags)
+      else:
+        false
+    if not foundHeadState:
+      if dag.head == nil:
+        fatal "Could not load head state, database corrupt?",
+          head = shortLog(head), tail = shortLog(dag.tail)
+        quit 1
+      for blockRef in headBlocks:
+        dag.forkBlocks.excl(KeyedBlockRef.init(blockRef))
+      return err "Could not load head state, database corrupt?"
 
-  # EpochRef needs an epoch boundary state
-  assign(dag.epochRefState, tmpState)
+  if dag.head == nil:
+    # EpochRef needs an epoch boundary state
+    assign(dag.epochRefState, tmpState)
 
-  var
-    cache: StateCache
-    info: ForkedEpochInfo
-
+  var info: ForkedEpochInfo
   for i in countdown(headBlocks.high, 0):
     dag.applyBlock(
         tmpState, headBlocks[i].bid, cache, info, dag.updateFlags).isOkOr:
@@ -1242,7 +1276,7 @@ proc loadHead(
       dag.forkBlocks.excl(KeyedBlockRef.init(headRef))
       return err "head blocks should apply"
 
-  dag.registerHead(headRef)
+  dag.registerHead(headRef, persistToDb = false)
   ok headRef
 
 proc updateFinalizedBlocks(dag: ChainDAGRef, withAncestors = false) =
@@ -1373,7 +1407,7 @@ proc init*(
   dag.head = dag.loadHead(headRoot, finalizedSlot, invalidBlockRoots).valueOr:
     fatal "Error while loading head from database", reason = error, headRoot
     quit 1
-  let hasOrphans = dag.head.root != headRoot
+  var hasOrphans = dag.head.root != headRoot
 
   let summariesTick = Moment.now()
 
@@ -1481,15 +1515,30 @@ proc init*(
 
   let finalizedTick = Moment.now()
 
+  for additionalHeadRoot in db.getHeadBlocks():
+    let headRef = dag.loadHead(
+        additionalHeadRoot, finalizedSlot, invalidBlockRoots).valueOr:
+      info "Skipped loading head from database",
+        reason = error, headRoot = additionalHeadRoot
+      hasOrphans = true
+      continue
+    hasOrphans = hasOrphans or (headRef.root != additionalHeadRoot)
+
   assign(dag.clearanceState, dag.headState)
 
   if hasOrphans and not dag.db.db.readOnly:
     db.withManyWrites:
       var orphans: HashSet[BlockId]
       orphans.collectOrphanedAncestors(dag, headRoot)
+      for additionalHeadRoot in db.getHeadBlocks():
+        orphans.collectOrphanedAncestors(dag, additionalHeadRoot)
       for bid in orphans:
         dag.pruneBlockId(bid)
       dag.db.putHeadBlock(dag.head.root)
+      dag.didUpdateHeads()
+
+  let additionalHeadsTick = Moment.now()
+
   if dag.backfill.slot > GENESIS_SLOT:  # Try frontfill from era files
     let backfillSlot = dag.backfill.slot - 1
     dag.frontfillBlocks = newSeqOfCap[Eth2Digest](backfillSlot.int)
@@ -1577,7 +1626,8 @@ proc init*(
     loadDur = loadTick - startTick,
     summariesDur = summariesTick - loadTick,
     finalizedDur = finalizedTick - summariesTick,
-    frontfillDur = frontfillTick - finalizedTick,
+    additionalHeadsDur = additionalHeadsTick - finalizedTick,
+    frontfillDur = frontfillTick - additionalHeadsTick,
     keysDur = Moment.now() - frontfillTick
 
   dag.initLightClientDataCache()
@@ -2185,6 +2235,8 @@ proc pruneBlocksDAG(dag: ChainDAGRef) =
       cur = cur.parentOrSlot
 
     dag.heads.del(n)
+  if dag.heads.len != hlen:
+    dag.didUpdateHeads()
 
   debug "Pruned the blockchain DAG",
     currentCandidateHeads = dag.heads.len,
@@ -2854,6 +2906,7 @@ proc preInit*(
       db.putBlock(blck)
       db.putGenesisBlock(blck.root)
       db.putHeadBlock(blck.root)
+      db.putHeadBlocks(@[blck.root])
       db.putTailBlock(blck.root)
 
       notice "Database initialized from genesis",
@@ -2867,6 +2920,7 @@ proc preInit*(
         parent_root: forkyState.data.latest_block_header.parent_root
       ))
       db.putHeadBlock(blockRoot)
+      db.putHeadBlocks(@[blockRoot])
       db.putTailBlock(blockRoot)
 
       if db.getGenesisBlock().isSome():

--- a/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag_light_client.nim
@@ -744,7 +744,6 @@ proc initLightClientDataForPeriod(
     dag.lcDataStore.db.sealPeriod(period)
   ok()
 
-
 proc loadHead(dag: ChainDAGRef, head: BlockRef): Opt[void] =
   ## Initialize light client data for a given head's non-finalized blocks.
   let tailSlot = dag.lcDataStore.cache.tailSlot
@@ -777,6 +776,8 @@ proc loadHead(dag: ChainDAGRef, head: BlockRef): Opt[void] =
     bid = head.bid
   while bid.slot > tailSlot:
     blocks.add bid
+    if bid in dag.lcDataStore.cache.data:
+      break
     bid = dag.existingParent(bid).valueOr:
       dag.handleUnexpectedLightClientError(bid.slot)
       result.err()
@@ -786,7 +787,12 @@ proc loadHead(dag: ChainDAGRef, head: BlockRef): Opt[void] =
 
   # Process blocks (reuses `dag.clearanceState`)
   var cache: StateCache
-  for i in countdown(blocks.high, 0):
+  let startIndex =
+    if blocks[^1] in dag.lcDataStore.cache.data:
+      blocks.high - 1
+    else:
+      blocks.high
+  for i in countdown(startIndex, 0):
     bid = blocks[i]
     if not dag.updateExistingState(
         dag.clearanceState, bid.atSlot(), save = false, cache):
@@ -850,8 +856,13 @@ proc initLightClientDataCache*(dag: ChainDAGRef) =
       # Block availability, needed for `LightClientHeader.execution_branch`
       dag.backfill.slot))
 
-  dag.lcDataStore.cache.tailSlot = max(dag.head.slot, targetTailSlot)
-  if dag.head.slot < dag.lcDataStore.cache.tailSlot:
+  var maxHeadSlot = dag.head.slot
+  for additionalHead in dag.heads:
+    if additionalHead.slot > maxHeadSlot:
+      maxHeadSlot = additionalHead.slot
+
+  dag.lcDataStore.cache.tailSlot = max(maxHeadSlot, targetTailSlot)
+  if maxHeadSlot < dag.lcDataStore.cache.tailSlot:
     return
 
   # Import light client data for finalized period through finalized head
@@ -876,6 +887,9 @@ proc initLightClientDataCache*(dag: ChainDAGRef) =
   # Import non-finalized light client data (reuses `dag.clearanceState`)
   if dag.loadHead(dag.head).isErr:
     res.err()
+  for additionalHead in dag.heads:
+    if dag.loadHead(additionalHead).isErr:
+      res.err()
 
   # Import initial `LightClientBootstrap`
   if dag.finalizedHead.slot >= dag.lcDataStore.cache.tailSlot:

--- a/tests/test_beacon_chain_db.nim
+++ b/tests/test_beacon_chain_db.nim
@@ -141,6 +141,33 @@ suite "Beacon chain DB" & preset():
       db.getStateRef(ConsensusFork.Phase0, ZERO_HASH).isNil
       db.getBlock(ZERO_HASH, phase0.TrustedSignedBeaconBlock).isNone
 
+  test "head blocks roundtrip" & preset():
+    let db = BeaconChainDB.new("", cfg, inMemory = true)
+    var a, b, c: Eth2Digest
+    a.data[0] = 1
+    b.data[0] = 2
+    c.data[0] = 3
+
+    check:
+      db.getHeadBlock().isNone
+      db.getHeadBlocks().len == 0
+
+    db.putHeadBlock(a)
+    db.putHeadBlocks(@[a, b])
+    check:
+      db.getHeadBlock() == Opt.some(a)
+      db.getHeadBlocks() == @[a, b]
+
+    db.putHeadBlock(c)
+    check:
+      db.getHeadBlock() == Opt.some(c)
+      db.getHeadBlocks() == @[a, b]
+
+    db.putHeadBlocks(@[c])
+    check:
+      db.getHeadBlock() == Opt.some(c)
+      db.getHeadBlocks() == @[c]
+
   template doBlockTest(consensusFork: static ConsensusFork): untyped =
     block:
       let db = BeaconChainDB.new(

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -167,6 +167,70 @@ suite "Block processor" & preset():
       dag2.heads[0].root == b2.root
       dag2.forkBlocksMatchHeads()
 
+  asyncTest "Multiple heads" & preset():
+    var
+      cache2: StateCache
+      cache3: StateCache
+    let
+      processor = BlockProcessor.new(
+        false, "", "", batchVerifier, consensusManager, validatorMonitor,
+        dataColumnQuarantine, gloasColumnQuarantine, envelopeQuarantine,
+        getTimeFn)
+
+      # 0 <- 1a <- 2aa
+      #         <- 2ab
+      #   <- 1b <- 2ba
+      #         <- 2bb
+      s2ba = assignClone(state[])
+      b1a = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      s2ab = assignClone(state[])
+      b2aa = addTestBlock(
+        state[], cache, graffiti = "aa".graffiti, cfg = cfg).bellatrixData
+      b2ab = addTestBlock(
+        s2ab[], cache3, graffiti = "ab".graffiti, cfg = cfg).bellatrixData
+      b1b = addTestBlock(
+        s2ba[], cache2, graffiti = "b".graffiti, cfg = cfg).bellatrixData
+      s2bb = assignClone(s2ba[])
+      b2ba = addTestBlock(
+        s2ba[], cache2, graffiti = "ba".graffiti, cfg = cfg).bellatrixData
+      b2bb = addTestBlock(
+        s2bb[], cache3, graffiti = "bb".graffiti, cfg = cfg).bellatrixData
+    check:
+      (await processor.addBlock(MsgSource.gossip, b1a, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2aa, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2ab, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b1b, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2ba, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2bb, noSidecars)).isOk
+      dag.heads.len == 4
+    dag.updateHead(dag.getBlockRef(b2ab.root).get(), quarantine[], [])
+
+    let
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
+      dag2 = ChainDAGRef.init(cfg, db, validatorMonitor2, {})
+    check:
+      dag2.head.root == b2ab.root
+      dag2.heads.mapIt(it.bid).toHashSet == dag.heads.mapIt(it.bid).toHashSet
+      dag2.forkBlocksMatchHeads()
+
+    let
+      quarantine2 = newClone(Quarantine.init(cfg))
+      pool2 = newClone(AttestationPool.init(dag2, quarantine2))
+    check pool2[].forkChoiceMatchesHeads()
+
+    for importMode in LightClientDataImportMode:
+      let
+        validatorMonitor3 = newClone(ValidatorMonitor.init(cfg))
+        dag3 = ChainDAGRef.init(
+          cfg, db, validatorMonitor3, {},
+          lcDataConfig = LightClientDataConfig(
+            serve: true, importMode: importMode))
+      check:
+        dag3.head.root == b2ab.root
+        dag3.heads.len == 4
+        dag3.forkBlocksMatchHeads()
+        dag3.lcDataMatchesHeads()
+
   asyncTest "Invalidate block root" & preset():
     let
       b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
@@ -203,30 +267,53 @@ suite "Block processor" & preset():
         not dag.containsForkBlock(b2.root)
 
   asyncTest "Invalidate existing block root" & preset():
+    var
+      cache2: StateCache
+      cache3: StateCache
     let
       processor = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager, validatorMonitor,
         dataColumnQuarantine, gloasColumnQuarantine, envelopeQuarantine,
         getTimeFn)
 
-      b1 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
-      b2 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
-      b3 = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      # 0 <- 1a <- 2a <- 3a
+      #   <- 1b <- 2ba
+      #         <- 2bb
+      s2ba = assignClone(state[])
+      b1a = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b2a = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b3a = addTestBlock(state[], cache, cfg = cfg).bellatrixData
+      b1b = addTestBlock(
+        s2ba[], cache2, graffiti = "b".graffiti, cfg = cfg).bellatrixData
+      s2bb = assignClone(s2ba[])
+      b2ba = addTestBlock(
+        s2ba[], cache2, graffiti = "ba".graffiti, cfg = cfg).bellatrixData
+      b2bb = addTestBlock(
+        s2bb[], cache3, graffiti = "bb".graffiti, cfg = cfg).bellatrixData
     check:
-      (await processor.addBlock(MsgSource.gossip, b1, noSidecars)).isOk
-      (await processor.addBlock(MsgSource.gossip, b2, noSidecars)).isOk
-      (await processor.addBlock(MsgSource.gossip, b3, noSidecars)).isOk
-    dag.updateHead(dag.getBlockRef(b3.root).get(), quarantine[], [])
+      (await processor.addBlock(MsgSource.gossip, b1a, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2a, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b3a, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b1b, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2ba, noSidecars)).isOk
+      (await processor.addBlock(MsgSource.gossip, b2bb, noSidecars)).isOk
+      dag.heads.len == 3
+    dag.updateHead(dag.getBlockRef(b3a.root).get(), quarantine[], [])
 
     let
       validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
       dag2 = ChainDAGRef.init(
-        cfg, db, validatorMonitor2, {}, invalidBlockRoots = @[b2.root])
+        cfg, db, validatorMonitor2, {},
+        invalidBlockRoots = @[b2a.root, b2bb.root])
     check:
-      dag2.getBlockRef(b1.root).isSome
-      dag2.getBlockRef(b2.root).isNone
-      dag2.getBlockRef(b3.root).isNone
-      dag2.head == dag2.getBlockRef(b1.root).get
+      dag2.head.root == b1a.root
+      dag2.heads.toHashSet == toHashSet [
+        dag2.getBlockRef(b1a.root).expect("Valid"),
+        dag2.getBlockRef(b2ba.root).expect("Valid")]
+      dag2.getForkedBlock(b1b.root).isSome
+      dag2.getForkedBlock(b2a.root).isNone
+      dag2.getForkedBlock(b3a.root).isNone
+      dag2.getForkedBlock(b2bb.root).isNone
       dag2.forkBlocksMatchHeads()
 
   asyncTest "Process a block from each fork (without blobs)" & preset():
@@ -582,15 +669,18 @@ suite "Block processor" & preset():
         newClone(ColumnQuarantine()), newClone(GloasColumnQuarantine()),
         newClone(EnvelopeQuarantine()), getTimeFn2)
 
+    check:
+      dag2.head.root == b1.root
+      dag2.heads.len == 1
+      dag2.heads[0].root == b3.root
+      dag2.forkBlocksMatchHeads()
+      attestationPool2[].forkChoiceMatchesHeads()
+
     # updateState should replay through b1-b3 from
     # disk, calling applyExecutionPayloadEnvelope for each
     let res4 = await processor2.addBlock(
       MsgSource.gossip, b4, noSidecars)
-
-    # TODO: Currently fails because applyExecutionPayloadEnvelope
-    # returns an error for missing envelopes during replay.
-    # Per spec, absent envelopes are valid and state should progress.
-    check res4.isErr
+    check res4.isOk
 
 # Clean up KZG trusted setup at the end of all tests
 doAssert kzg.freeTrustedSetup().isOk

--- a/tests/test_blockchain_dag.nim
+++ b/tests/test_blockchain_dag.nim
@@ -472,6 +472,8 @@ suite "chain DAG finalization tests" & preset():
 
     check:
       dag.heads.len() == 1
+      dag.forkBlocksMatchHeads()
+      db.getHeadBlocks() == dag.heads.mapIt(it.root)
       dag.getBlockIdAtSlot(0.Slot).get().bid.slot == 0.Slot
       dag.getBlockIdAtSlot(2.Slot).get() ==
         BlockSlotId.init(dag.getBlockIdAtSlot(1.Slot).get().bid, 2.Slot)
@@ -588,6 +590,7 @@ suite "chain DAG finalization tests" & preset():
       dag2.finalizedHead.blck.root == dag.finalizedHead.blck.root
       dag2.finalizedHead.slot == dag.finalizedHead.slot
       dag2.headState.root == dag.headState.root
+      dag2.forkBlocksMatchHeads()
 
     # No canonical block data should be pruned by the removal of the fork
     for i in Slot(0)..dag2.head.slot:
@@ -597,6 +600,28 @@ suite "chain DAG finalization tests" & preset():
 
     # The unviable block should have been pruned however
     check: dag2.getForkedBlock(lateBlock.root).isNone
+
+  test "discard unloadable and duplicate heads on init" & preset():
+    let blck = makeTestBlock(dag.headState, cache).phase0Data
+    block:
+      let added = dag.addHeadBlock(verifier, blck, nilPhase0Callback)
+      check: added.isOk()
+      dag.updateHead(added[], quarantine, [])
+
+    # Add separate head to database, but don't store block data
+    let
+      headRoot = dag.head.root
+      staleState = assignClone(dag.headState)
+      staleRoot = makeTestBlock(staleState[], cache).phase0Data.root
+    db.putHeadBlocks(@[headRoot, staleRoot, headRoot])  # Also add duplicate
+
+    let
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
+    check:
+      dag2.heads.mapIt(it.bid.root) == @[headRoot]
+      db.getHeadBlocks() == @[headRoot]
+      dag2.forkBlocksMatchHeads()
 
   test "orphaned epoch block" & preset():
     let prestate = (ref ForkedHashedBeaconState)(kind: ConsensusFork.Phase0)
@@ -632,8 +657,10 @@ suite "chain DAG finalization tests" & preset():
       dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
 
     # check that we can apply the block after the orphaning
-    let added2 = dag2.addHeadBlock(verifier, blck, nilPhase0Callback)
-    check: added2.isOk()
+    check:
+      dag2.getBlockRef(blck.root).isSome
+      dag2.addHeadBlock(verifier, blck, nilPhase0Callback) ==
+        AddHeadRes.err VerifierError.Duplicate
 
   test "init with gaps" & preset():
     for blck in makeTestBlocks(
@@ -688,7 +715,10 @@ suite "chain DAG finalization tests" & preset():
       dag2.headState.root == dag.headState.root
 
   test "shutdown during finalization" & preset():
-    var testPassed: bool
+    var
+      testPassed: bool
+      forkRoot: Eth2Digest
+      firstCanonicalRoot: Eth2Digest
 
     # Configure a hook that is called during finalization while the
     # database has been partially written, to test behaviour if the
@@ -709,15 +739,36 @@ suite "chain DAG finalization tests" & preset():
 
         # If the beacon node were to exit _now_, this is what the DB looks like.
         # Validate that we can initialize a new DAG from this database.
-        let validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
-        discard ChainDAGRef.init(cfg, db, validatorMonitor2, {})
+        let
+          validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
+          dag2 = ChainDAGRef.init(cfg, db, validatorMonitor2, {})
+        if dag2.finalizedHead.slot > GENESIS_SLOT:
+          # Orphans and pre-finalized should lose their BlockRef
+          doAssert dag2.heads.len == 1
+          doAssert dag2.getBlockRef(forkRoot).isNone
+          doAssert dag2.getForkedBlock(forkRoot).isNone
+          doAssert dag2.getBlockRef(firstCanonicalRoot).isNone
+          doAssert dag2.forkBlocksMatchHeads()
         testPassed = true
     dag.setHeadCb(onHeadChanged)
+
+    # Add an extra block that will be orphaned and purged on finality
+    block:
+      var cache: StateCache
+      let
+        tmpState = assignClone(dag.headState)
+        forkBlock = addTestBlock(
+          tmpState[], cache, graffiti = "fork".graffiti).phase0Data
+        added = dag.addHeadBlock(verifier, forkBlock, nilPhase0Callback)
+      check: added.isOk()
+      forkRoot = forkBlock.root
 
     for blck in makeTestBlocks(
         dag.headState, cache, int(SLOTS_PER_EPOCH * 4), attested = true):
       let added = dag.addHeadBlock(verifier, blck.phase0Data, nilPhase0Callback)
       check: added.isOk
+      if firstCanonicalRoot.isZero:
+        firstCanonicalRoot = added[].root
       dag.updateHead(added[], quarantine, [])
       dag.pruneAtFinalization()
 
@@ -1216,6 +1267,52 @@ suite "Starting states":
 
     check:
       dag.getFinalizedEpochRef() != nil
+
+  test "Checkpoint with missed epoch start slot":
+    var
+      cache: StateCache
+      info: ForkedEpochInfo
+    while tailState[].slot.uint64 + 1 < SLOTS_PER_EPOCH:
+      discard addTestBlock(tailState[], cache)
+
+    # The epoch start slot is missed, state checkpoint not stored at block slot
+    check cfg.process_slots(
+      tailState[], Slot(SLOTS_PER_EPOCH), cache, info, {}).isOk()
+
+    ChainDAGRef.preInit(db, tailState[])
+
+    let
+      rng = HmacDrbgContext.new()
+      taskpool = Taskpool.new()
+      validatorMonitor = newClone(ValidatorMonitor.init(cfg))
+      dag = init(ChainDAGRef, cfg, db, validatorMonitor, {})
+    var verifier = BatchVerifier.init(rng, taskpool)
+
+    # Create two heads on top of the checkpoint
+    let
+      forkState = assignClone(tailState[])
+      b1 = addTestBlock(tailState[], cache).phase0Data
+    block:
+      let added = dag.addHeadBlock(verifier, b1, nilPhase0Callback)
+      check: added.isOk()
+      dag.updateHead(added[], quarantine[], [])
+    var cache2: StateCache
+    let bFork = addTestBlock(
+      forkState[], cache2, graffiti = "fork".graffiti).phase0Data
+    block:
+      let added = dag.addHeadBlock(verifier, bFork, nilPhase0Callback)
+      check: added.isOk()
+    check dag.heads.len == 2
+
+    # Reload: `bFork` builds on the tail, whose state is not stored at its own
+    # slot - the head must be reconstructed, not dropped
+    let
+      validatorMonitor2 = newClone(ValidatorMonitor.init(cfg))
+      dag2 = init(ChainDAGRef, cfg, db, validatorMonitor2, {})
+    check:
+      dag2.head.root == b1.root
+      dag2.heads.mapIt(it.bid).toHashSet == dag.heads.mapIt(it.bid).toHashSet
+      dag2.forkBlocksMatchHeads()
 
 suite "Latest valid hash" & preset():
   setup:

--- a/tests/testblockutil.nim
+++ b/tests/testblockutil.nim
@@ -39,6 +39,9 @@ const
   MockPrivKeys* = MockPrivKeysT()
   MockPubKeys* = MockPubKeysT()
 
+template graffiti*(input: string): GraffitiBytes =
+  GraffitiBytes.init(input)
+
 type
   BlobsBundle* = object
     # TODO the fulu BlobsBundle uses an ugly hack to get deneb compatibility

--- a/tests/testdbutil.nim
+++ b/tests/testdbutil.nim
@@ -11,7 +11,7 @@ import
   std/sequtils,
   chronicles,
   ../beacon_chain/beacon_chain_db,
-  ../beacon_chain/consensus_object_pools/blockchain_dag,
+  ../beacon_chain/consensus_object_pools/[attestation_pool, blockchain_dag],
   ../beacon_chain/spec/[forks, state_transition],
   eth/db/[kvstore, kvstore_sqlite3],
   ./[testblockutil, teststateutil]
@@ -90,12 +90,29 @@ proc getEarliestInvalidBlockRoot*(
 
   curBlck.root
 
-func forkBlocksMatchHeads*(dag: ChainDAGRef): bool =
-  var expected: HashSet[Eth2Digest]
+func allExpectedBlockIds(
+    dag: ChainDAGRef, minSlot = GENESIS_SLOT): HashSet[BlockId] =
   for head in dag.heads:
     var cur = head
-    while cur != nil and not expected.containsOrIncl(cur.root):
+    while cur != nil and cur.slot >= minSlot and
+        not result.containsOrIncl(cur.bid):
       cur = cur.parent
-  if expected.len != dag.forkBlocks.len:
-    return false
-  expected.allIt dag.containsForkBlock(it)
+
+func forkBlocksMatchHeads*(dag: ChainDAGRef): bool =
+  let expected = dag.allExpectedBlockIds
+  expected.len == dag.forkBlocks.len and
+  expected.allIt(dag.containsForkBlock(it.root))
+
+func forkChoiceMatchesHeads*(pool: AttestationPool): bool =
+  let expected = pool.dag.allExpectedBlockIds
+  expected.len == pool.forkChoice.backend.proto_array.indices.len and
+  expected.allIt(it.root in pool.forkChoice.backend)
+
+func lcDataMatchesHeads*(dag: ChainDAGRef): bool =
+  let expected =
+    if dag.lcDataStore.importMode != LightClientDataImportMode.None:
+      dag.allExpectedBlockIds(minSlot = dag.lcDataStore.cache.tailSlot)
+    else:
+      HashSet[BlockId]()
+  expected.len == dag.lcDataStore.cache.data.len and
+  expected.allIt(it in dag.lcDataStore.cache.data)


### PR DESCRIPTION
Avoid having to re-discover additional branches on each restart, helping with non-finality scenarios and reducing spurious extra block data being left in the database.

As Nimbus supports arbitrary up/downgrading, have to be careful to also process stale entries in the database that may appear in an upgrade -> downgrade -> upgrade again scenario.