### PR TITLE
consolidate web3signer remote block signing encode/decode tests

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -1117,10 +1117,7 @@ AllTests-mainnet
 + remote signing example AGGREGATE_AND_PROOF_V2 (ELECTRA)                                    OK
 + remote signing example AGGREGATION_SLOT                                                    OK
 + remote signing example ATTESTATION                                                         OK
-+ remote signing example BLOCK_V2 (BELLATRIX)                                                OK
-+ remote signing example BLOCK_V2 (CAPELLA)                                                  OK
-+ remote signing example BLOCK_V2 (DENEB)                                                    OK
-+ remote signing example BLOCK_V2 (ELECTRA)                                                  OK
++ remote signing example BLOCK_V2 (FULU)                                                     OK
 + remote signing example DEPOSIT                                                             OK
 + remote signing example RANDAO_REVEAL                                                       OK
 + remote signing example SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF                               OK

--- a/tests/test_files/web3signer.examples.json
+++ b/tests/test_files/web3signer.examples.json
@@ -1,5 +1,5 @@
 {
-  "BLOCK_V2 (ELECTRA)": {
+  "BLOCK_V2 (FULU)": {
     "value": {
       "type": "BLOCK_V2",
       "signingRoot": "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc",
@@ -12,85 +12,13 @@
         "genesis_validators_root": "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
       },
       "beacon_block": {
-        "version": "ELECTRA",
+        "version": "FULU",
         "block_header": {
           "slot": "0",
           "proposer_index": "4666673844721362956",
           "parent_root": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
           "state_root": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
           "body_root": "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
-        }
-      }
-    }
-  },
-  "BLOCK_V2 (DENEB)": {
-    "value": {
-      "type": "BLOCK_V2",
-      "signingRoot": "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc",
-      "fork_info": {
-        "fork": {
-          "previous_version": "0x00000001",
-          "current_version": "0x00000001",
-          "epoch": "1"
-        },
-        "genesis_validators_root": "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
-      },
-      "beacon_block": {
-        "version": "DENEB",
-        "block_header": {
-          "slot": "0",
-          "proposer_index": "4666673844721362956",
-          "parent_root": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
-          "state_root": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
-          "body_root": "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
-        }
-      }
-    }
-  },
-  "BLOCK_V2 (CAPELLA)": {
-    "value": {
-      "type": "BLOCK_V2",
-      "signingRoot": "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc",
-      "fork_info": {
-        "fork": {
-          "previous_version": "0x00000001",
-          "current_version": "0x00000001",
-          "epoch": "1"
-        },
-        "genesis_validators_root": "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
-      },
-      "beacon_block": {
-        "version": "CAPELLA",
-        "block_header": {
-          "slot": "0",
-          "proposer_index": "4666673844721362956",
-          "parent_root": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
-          "state_root": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
-          "body_root": "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
-        }
-      }
-    }
-  },
-  "BLOCK_V2 (BELLATRIX)": {
-    "value": {
-      "type": "BLOCK_V2",
-      "signingRoot": "0x26d0ee0b6c2261cd6010112a024de4f3d2e1e9844d11d60b057fac344c745464",
-      "fork_info": {
-        "fork": {
-          "previous_version": "0x00000001",
-          "current_version": "0x00000001",
-          "epoch": "1"
-        },
-        "genesis_validators_root": "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
-      },
-      "beacon_block": {
-        "version": "BELLATRIX",
-        "block_header": {
-          "slot": "0",
-          "proposer_index": "4666673844721362956",
-          "parent_root": "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef",
-          "state_root": "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e",
-          "body_root": "0xe74b0fc13f19ae2077403afa03fdc155484f22d05d93eb084473951bb3a8d1ae"
         }
       }
     }


### PR DESCRIPTION
All of these forks were/are identical, because they're only block headers since Bellatrix. Only keep one of them.