### PR TITLE
unconditionally use EIP-7917-based proposer lookahead when projecting next proposal actions

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1502,82 +1502,22 @@ proc maybeUpdateActionTrackerNextEpoch(
   let nextEpoch = currentSlot.epoch + 1
   if node.consensusManager[].actionTracker.needsUpdate(
       forkyState, nextEpoch):
-    template epochRefFallback() =
+    when typeof(forkyState).kind < ConsensusFork.Fulu:
       let epochRef =
         node.dag.getEpochRef(node.dag.head, nextEpoch, false).expect(
           "Getting head EpochRef should never fail")
       node.consensusManager[].actionTracker.updateActions(
         epochRef.shufflingRef, epochRef.beacon_proposers)
-
-    when forkyState is phase0.HashedBeaconState:
-      # The previous_epoch_participation-based logic requires Altair or newer
-      epochRefFallback()
     else:
       let
         shufflingRef = node.dag.getShufflingRef(node.dag.head, nextEpoch, false).valueOr:
-          # epochRefFallback() won't work in this case either
           return
-        # using the separate method of proposer indices calculation in Fulu
         nextEpochProposers = get_beacon_proposer_indices(
           forkyState.data, shufflingRef.shuffled_active_validator_indices,
           nextEpoch)
-        nextEpochFirstProposer = nextEpochProposers[0].valueOr:
-          # All proposers except the first can be more straightforwardly and
-          # efficiently (re)computed correctly once in that epoch.
-          epochRefFallback()
-          return
 
-      # Has to account for potential epoch transition TIMELY_SOURCE_FLAG_INDEX,
-      # TIMELY_TARGET_FLAG_INDEX, and inactivity penalties, resulting from spec
-      # functions get_flag_index_deltas() and get_inactivity_penalty_deltas().
-      #
-      # There are no penalties associated with TIMELY_HEAD_FLAG_INDEX, but a
-      # reward exists. effective_balance == MAX_EFFECTIVE_BALANCE.Gwei ensures
-      # if even so, then the effective balance cannot change as a result.
-      #
-      # It's not truly necessary to avoid all rewards and penalties, but only
-      # to bound them to ensure they won't unexpected alter effective balance
-      # during the upcoming epoch transition.
-      #
-      # During genesis epoch, the check for epoch participation is against
-      # current, not previous, epoch, and therefore there's a possibility of
-      # checking for if a validator has participated in an epoch before it will
-      # happen.
-      #
-      # Because process_rewards_and_penalties() in epoch processing happens
-      # before the current/previous participation swap, previous is correct
-      # even here, and consistent with what the epoch transition uses.
-      #
-      # Whilst slashing, proposal, and sync committee rewards and penalties do
-      # update the balances as they occur, they don't update effective_balance
-      # until the end of epoch, so detect via effective_balance_might_update.
-      #
-      # On EF mainnet epoch 233906, this matches 99.5% of active validators;
-      # with Holesky epoch 2041, 83% of active validators.
-      let
-        participation_flags =
-          forkyState.data.previous_epoch_participation[nextEpochFirstProposer]
-        effective_balance =
-          forkyState.data.validators[nextEpochFirstProposer].effective_balance
-
-      # Maximal potential accuracy primarily useful during the last slot of
-      # each epoch to prepare for a possible proposal the first slot of the
-      # next epoch. Otherwise, epochRefFallback is potentially very slow as
-      # it can induce a lengthy state replay.
-      if (not (currentSlot + 1).is_epoch) or
-         (participation_flags.has_flag(TIMELY_SOURCE_FLAG_INDEX) and
-          participation_flags.has_flag(TIMELY_TARGET_FLAG_INDEX) and
-          effective_balance == MAX_EFFECTIVE_BALANCE.Gwei and
-          forkyState.data.slot.epoch != GENESIS_EPOCH and
-          forkyState.data.inactivity_scores.item(
-            nextEpochFirstProposer) == 0 and
-          not effective_balance_might_update(
-            forkyState.data.balances.item(nextEpochFirstProposer),
-            effective_balance)):
-        node.consensusManager[].actionTracker.updateActions(
-          shufflingRef, nextEpochProposers)
-      else:
-        epochRefFallback()
+      node.consensusManager[].actionTracker.updateActions(
+        shufflingRef, nextEpochProposers)
 
 proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   ## Subscribe to subnets that we are providing stability for or aggregating

--- a/beacon_chain/spec/validator.nim
+++ b/beacon_chain/spec/validator.nim
@@ -562,8 +562,8 @@ func get_beacon_proposer_index*(
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.2/specs/fulu/beacon-chain.md#new-get_beacon_proposer_indices
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.9/specs/gloas/beacon-chain.md#modified-get_beacon_proposer_indices
 func get_beacon_proposer_indices*(
-    state: ForkyBeaconState, epoch: Epoch
-): seq[Opt[ValidatorIndex]] =
+    state: electra.BeaconState | fulu.BeaconState | gloas.BeaconState |
+           heze.BeaconState, epoch: Epoch): seq[Opt[ValidatorIndex]] =
   ## Return the proposer indices for the given `epoch`.
   let seed = get_seed(state, epoch, DOMAIN_BEACON_PROPOSER)
 


### PR DESCRIPTION
[EIP-7917](https://eips.ethereum.org/EIPS/eip-7917) removes the need for the pile of heuristics in favor of deterministic proposer lookahead. This makes pre-Fusaka gossip environments less optimized, but Fusaka and later gossip environments more optimized.

https://github.com/status-im/nimbus-eth2/blob/dfe31d71315af19bf78e9bf3ec85992119f3c3d8/beacon_chain/spec/validator.nim#L562-L610 already automatically routes Fulu and later states through this deterministic lookahead EIP-7917 pipeline, so the only change necessary is not to bail out prematurely based on criteria which don't matter anymore in Fulu.