### PR TITLE
Reject bids with invalid prev_randao during gossip validation

### DIFF
--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -130,9 +130,8 @@ proc getPrevRandao*(
     pool: ExecutionPayloadBidPool, slot: Slot,
     parentBid: BlockId): Opt[Eth2Digest] =
   for payloadAvailability in PayloadAvailability:
-    let bid = pool.getHighestBidForSlotAndParent(
-      slot, parentBid.root, payloadAvailability)
-    if bid.isSome:
-      return Opt.some bid.unsafeGet.message.prev_randao
+    pool.getHighestBidForSlotAndParent(
+        slot, parentBid.root, payloadAvailability).isErrOr:
+      return Opt.some value.message.prev_randao
 
   pool.dag.computeRandaoMix(parentBid)

--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -125,3 +125,14 @@ proc prune*(pool: var ExecutionPayloadBidPool, beforeSlot: Slot) =
       slotsToRemove.add(slot)
   for slot in slotsToRemove:
     pool.slotBids.del(slot)
+
+proc getPrevRandao*(
+    pool: ExecutionPayloadBidPool, slot: Slot,
+    parentBid: BlockId): Opt[Eth2Digest] =
+  for payloadAvailability in PayloadAvailability:
+    let bid = pool.getHighestBidForSlotAndParent(
+      slot, parentBid.root, payloadAvailability)
+    if bid.isSome:
+      return Opt.some bid.unsafeGet.message.prev_randao
+
+  pool.dag.computeRandaoMix(parentBid)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1939,6 +1939,18 @@ proc validateExecutionPayloadBid*(
       if not (bid.fee_recipient == seenPref.fee_recipient):
         return dag.checkedReject("ExecutionPayloadBid: fee recipient mismatch")
 
+      # Extra check to prevent unincludable bids from purging legitimate ones
+      # from the execution payload pool
+      # https://github.com/ethereum/consensus-specs/pull/5360
+      # [REJECT] bid.prev_randao is the correct RANDAO mix -- i.e.
+      # validate that bid.prev_randao ==
+      # get_randao_mix(parent_state, get_current_epoch(parent_state)).
+      let expectedPrevRandao = executionPayloadBidPool[]
+          .getPrevRandao(bid.slot, parentBlck.bid).valueOr:
+        return errIgnore("ExecutionPayloadBid: unknown RANDAO mix")
+      if not (bid.prev_randao == expectedPrevRandao):
+        return errReject("ExecutionPayloadBid: incorrect RANDAO mix")
+
       # [REJECT] signed_execution_payload_bid.signature is valid with respect
       # to the bid.builder_index
       let builderPubkey =


### PR DESCRIPTION
When someone sends us a bid with invalid prev_randao but high value, it kicks out the legitimate bid. The invalid one is also non-punishable as it fails subsequent state transition by peers.

Add an extra reject rule to filter out invalid prev_randao, there is only a single valid value for each parent block root, and we have efficient functionality in the blockchain_dag to obtain correct RANDAO without expensive state replays.

Also proposed for spec inclusion, but we'll need the rule regardless:

- https://github.com/ethereum/consensus-specs/pull/5360

Have moved this check to the end, because if the correct value has not yet been cached (i.e., no valid bid received), we may have to load the block from disk (once).