### PR TITLE
Derive should_extend_payload from fork choice instead of stored headPayload

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -933,6 +933,11 @@ proc getBeaconHead*(
     safeExecutionBlockHash: safeExecutionBlockHash,
     finalizedExecutionBlockHash: finalizedExecutionBlockHash)
 
+func shouldExtendPayload*(pool: var AttestationPool, head: BlockRef): bool =
+  head.slot == GENESIS_SLOT or
+  head.slot.epoch < pool.dag.cfg.GLOAS_FORK_EPOCH or
+  pool.forkChoice.should_extend_payload(head.root)
+
 proc willSelectNewHead*(
     pool: var AttestationPool,
     headBlock: BlockRef, wallTime: BeaconTime): Opt[void] =

--- a/beacon_chain/consensus_object_pools/block_pools_types.nim
+++ b/beacon_chain/consensus_object_pools/block_pools_types.nim
@@ -163,19 +163,6 @@ type
       ## The most recently known head, as chosen by fork choice; might be
       ## optimistic
 
-    headPayload*: BlockRef
-      ## The known payload head that is chosen by fork choice. It will be used
-      ## on the next block proposal for building payload on either the current
-      ## head (parent) or the parent of the current head (grandparent).
-      ##
-      ## Used only since Gloas. Always read values from the head instead of
-      ## headPayload. It is for deriving the should_extend_payload status.
-      ##
-      ## In the usual scenarios it should point to either`dag.head` or
-      ## `dag.head.parent`. It would be nil at the beginning of Gloas fork,
-      ## either Gloas genesis or upgrading from pre-Gloas. It would also be nil
-      ## if it is in a different fork from the head at node startup.
-
     backfill*: BeaconBlockSummary
       ## The backfill points to the oldest block with an unbroken ancestry from
       ## dag.tail - when backfilling, we'll move backwards in time starting

--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2536,23 +2536,6 @@ proc executionParent*(
     cur = cur.parent
   Opt.none(BlockRef)
 
-func shouldExtendPayload*(
-    dag: ChainDAGRef, head: BlockRef): bool =
-  ## A helper function for getting the status of whether or not to build/extend
-  ## on the head payload, as the payload selected by fork choice is stored in
-  ## DAG.
-  ##
-  ## Related fork choice helpers
-  ## https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/fork-choice.md#new-should_build_on_full
-  ## https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/fork-choice.md#new-should_extend_payload
-  (
-    # For either genesis or pre-Gloas block, we should always build on them.
-    head.slot == GENESIS_SLOT or
-    head.slot.epoch < dag.cfg.GLOAS_FORK_EPOCH or
-    # The usual path since Gloas
-    head == dag.headPayload
-  )
-
 from std/packedsets import PackedSet, incl, items
 
 func getBlsToExecutionChangeStatuses(
@@ -2813,28 +2796,6 @@ proc updateHead*(
       let data = FinalizationInfoObject.init(
         dag.finalizedHead.blck.root, stateRoot, dag.finalizedHead.slot.epoch)
       dag.onFinHappened(dag, data)
-
-proc updateHeadExecutionPayload*(
-    dag: ChainDAGRef, headPayload: BlockRef,
-    signedEnvelope: gloas.SignedExecutionPayloadEnvelope) =
-  ## Update the execution payload of the head block since Gloas, which should
-  ## usually be invoked after the call of updateHead().
-
-  logScope:
-    blockRoot = shortLog(signedEnvelope.message.beacon_block_root)
-    builderIdx = signedEnvelope.message.builder_index
-    slot = signedEnvelope.slot
-    head = shortLog(dag.head)
-    headPayload = shortLog(headPayload)
-
-  # Check with the head. When it is not related to the current head, it should
-  # be outdated and so ignoring it.
-  if not (headPayload == dag.head or headPayload == dag.head.parent):
-    warn "Head payload may be outdated or incorrect fork"
-    return
-
-  dag.headPayload = headPayload
-  debugGloasComment("update finalized head here?")
 
 proc isInitialized*(T: type ChainDAGRef, db: BeaconChainDB): Result[void, cstring] =
   ## Lightweight check to see if it is likely that the given database has been

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -345,7 +345,7 @@ proc prepareNextSlot*(
         beaconHead = self.attestationPool[].getBeaconHead(head)
         executionHead =
           when consensusFork >= ConsensusFork.Gloas:
-            if dag.shouldExtendPayload(head):
+            if self.attestationPool[].shouldExtendPayload(head):
               proposalExecutionHead(forkyState.data)
             else:
               dag.loadExecutionAndParentBlockHash(head).parentHash.valueOr:

--- a/beacon_chain/gossip_processing/block_processor.nim
+++ b/beacon_chain/gossip_processing/block_processor.nim
@@ -1005,10 +1005,6 @@ proc storePayload(
   let previousExecutionValid = dag.head.optimisticStatus == OptimisticStatus.valid
 
   debugGloasComment("deadline")
-  debugGloasComment("should be decided by Fork Choice")
-  # TODO To be removed - Temporary call without import.
-  if blck.slot() >= dag.head.slot():
-    blockchain_dag.updateHeadExecutionPayload(dag, blck, signedEnvelope)
 
   if optimisticStatusRes.isSome():
     await self.consensusManager.updateExecutionHead(

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1532,7 +1532,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
     node.updateValidators(forkyState.data.validators.asSeq())
 
   let newHead = await handleProposal(
-    node, head, node.dag.shouldExtendPayload(head), slot)
+    node, head, node.attestationPool[].shouldExtendPayload(head), slot)
   head = newHead
 
   # The latest point in time when we'll be sending out attestations


### PR DESCRIPTION
Replace #8481's `dag.headPayload` proposer mechanism with the fork-choice `should_extend_payload`. 
Depends on #8572