### PR TITLE
adjust slot end/next-slot-preparation timings

### DIFF
--- a/beacon_chain/consensus_object_pools/attestation_pool.nim
+++ b/beacon_chain/consensus_object_pools/attestation_pool.nim
@@ -901,8 +901,7 @@ proc getBeaconHead*(
   # choice marked the slot's block full; the bid's `parent_block` must be on it.
   let
     isGloas =
-      pool.dag.cfg.consensusForkAtEpoch(
-        pool.dag.finalizedHead.slot.epoch) >= ConsensusFork.Gloas
+      pool.dag.finalizedHead.slot.epoch >= pool.dag.cfg.GLOAS_FORK_EPOCH
     finalizedExecutionBlockHash =
       if isGloas:
         pool.dag.loadExecutionAndParentBlockHash(pool.dag.finalizedHead.blck)

--- a/beacon_chain/consensus_object_pools/block_dag.nim
+++ b/beacon_chain/consensus_object_pools/block_dag.nim
@@ -88,7 +88,7 @@ func init*(
   # and later blocks are loaded as optimistic, which gets adjusted that first
   # `VALID` fcU from an EL plus markExecutionValid. Pre-merge blocks still get
   # marked as `VALID`.
-  if cfg.consensusForkAtEpoch(slot.epoch) >= ConsensusFork.Bellatrix:
+  if slot.epoch >= cfg.BELLATRIX_FORK_EPOCH:
     BlockRef.init(
       root, Opt.none Eth2Digest, Opt.none Eth2Digest,
       OptimisticStatus.notValidated, slot)

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -424,7 +424,7 @@ template validateBeaconBlockGloas(
   #
   # - [REJECT] The block's execution payload parent (defined by
   #   bid.parent_block_hash) passes all validation.
-  if dag.cfg.consensusForkAtEpoch(executionParent.slot.epoch()) >= ConsensusFork.Gloas:
+  if executionParent.slot.epoch() >= dag.cfg.GLOAS_FORK_EPOCH:
     # The executionParent exists in DAG, so we should check unviable envelope
     # and the database for the validation rules.
     if executionParent.root in envelopeQuarantine.unviable:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1350,8 +1350,7 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   # but more than SYNC_COMMITTEE_SUBNET_COUNT epochs from when the next sync
   # committee period begins, in which case `epochsToNextSyncPeriod` is none.
   if  epochsToSyncPeriod.isNone or
-      node.dag.cfg.consensusForkAtEpoch(epoch + epochsToSyncPeriod.get) <
-        ConsensusFork.Altair:
+      epoch + epochsToSyncPeriod.get < node.dag.cfg.ALTAIR_FORK_EPOCH:
     return subnets
 
   subnets + node.getNextSyncCommitteeSubnets(epoch)
@@ -1702,7 +1701,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
   # Do this after node.gossipState is updated to avoid adding immediately
   # unsubscribed subscriptions.
   for gossipEpoch in node.gossipState:
-    if node.dag.cfg.consensusForkAtEpoch(gossipEpoch) >= ConsensusFork.Fulu:
+    if gossipEpoch >= node.dag.cfg.FULU_FORK_EPOCH:
       node.updateDataColumnSidecarHandlers(gossipEpoch)
 
   node.doppelgangerChecked(slot.epoch)
@@ -1834,17 +1833,19 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # next slot
 
   let reconstructFut =
-    if node.dag.cfg.consensusForkAtEpoch(slot.epoch()) >= ConsensusFork.Fulu:
+    if slot.epoch() >= node.dag.cfg.FULU_FORK_EPOCH:
       reconstructDataColumns(node, slot)
     else:
       nil
 
   # By waiting until close before slot end, ensure that preparation for next
   # slot does not interfere with propagation of messages and with VC duties.
+  #
+  # This must be before the advanceOffset/advanceCutoff.
   let
-    endOffset = node.dag.timeParams.aggregateSlotOffset + nanos((
+    endOffset = node.dag.timeParams.payloadAttestationSlotOffset + nanos((
       node.dag.timeParams.SLOT_DURATION.nanoseconds -
-      node.dag.timeParams.aggregateSlotOffset.nanoseconds) div 2)
+      node.dag.timeParams.payloadAttestationSlotOffset.nanoseconds) div 6)
     endCutoff = node.beaconClock.fromNow(
       slot.start_beacon_time(node.dag.timeParams) + endOffset)
   if endCutoff.inFuture:
@@ -2001,19 +2002,21 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
   # When we're not behind schedule, we'll speculatively update the clearance
   # state in anticipation of receiving the next block - we do it after
   # logging slot end since the nextActionWaitTime can be short
+  #
+  # This must be after the endOffset/endCutoff.
   let
-    advanceOffset = node.dag.timeParams.aggregateSlotOffset + nanos((
+    advanceOffset = node.dag.timeParams.payloadAttestationSlotOffset + nanos((
       node.dag.timeParams.SLOT_DURATION.nanoseconds -
-      node.dag.timeParams.aggregateSlotOffset.nanoseconds) * 3 div 4)
+      node.dag.timeParams.payloadAttestationSlotOffset.nanoseconds) div 2)
     advanceCutoff = node.beaconClock.fromNow(
       slot.start_beacon_time(node.dag.timeParams) + advanceOffset)
 
   let proposalFcu =
     if advanceCutoff.inFuture:
-      # We wait until there's only a second left before the next slot begins, then
-      # we advance the clearance state to the next slot - this gives us a high
-      # probability of being prepared for the block that will arrive and the
-      # epoch processing that follows
+      # Wait until half-way through the slot's idle tail, and then advance the
+      # clearance state to the next slot - this gives us a high probability of
+      # being prepared for the block that will arrive and the epoch processing
+      # that follows
       await sleepAsync(advanceCutoff.offset)
       let
         nextSlot = slot + 1

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -9,13 +9,13 @@
 
 import std/[typetraits, sets, sequtils]
 import stew/base10, chronicles
-import ".."/[beacon_chain_db, beacon_node],
-       ".."/networking/eth2_network,
-       ".."/consensus_object_pools/[blockchain_dag, spec_cache,
-                                    attestation_pool, sync_committee_msg_pool],
-       ".."/validators/[beacon_validators, block_payloads],
-       ".."/spec/[beaconstate, forks, network, state_transition_block],
-       "."/[rest_utils, state_ttl_cache]
+import ../[beacon_chain_db, beacon_node],
+       ../networking/eth2_network,
+       ../consensus_object_pools/[blockchain_dag, spec_cache,
+                                  attestation_pool, sync_committee_msg_pool],
+       ../validators/[beacon_validators, block_payloads],
+       ../spec/[beaconstate, forks, network, state_transition_block],
+       ./[rest_utils, state_ttl_cache]
 
 export rest_utils
 
@@ -540,7 +540,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
               return RestApiResponse.jsonError(Http400,
                                                InvalidCommitteeIndexValueError,
                                                $res.error())
-            if node.dag.cfg.consensusForkAtEpoch(qslot.epoch) >= ConsensusFork.Electra:
+            if qslot.epoch >= node.dag.cfg.ELECTRA_FORK_EPOCH:
               0.CommitteeIndex
             else:
               res.get()

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -17,7 +17,7 @@ import
   eth/common/[eth_types, eth_types_rlp],
   eth/rlp, eth/trie/ordered_trie,
   # Internal
-  "."/[eth2_merkleization, forks, ssz_codec]
+  ./[eth2_merkleization, forks, ssz_codec]
 
 # TODO although eth2_merkleization already exports ssz_codec, *sometimes* code
 # fails to compile if the export is not done here also. Exporting rlp avoids a

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -18,8 +18,7 @@ import
   ./[beacon_chain_db, process_state]
 
 from presto import RestDecodingError
-from "."/beacon_clock import
-  BeaconClock, fromFloatSeconds, currentSlot, init
+from ./beacon_clock import BeaconClock, fromFloatSeconds, currentSlot, init
 
 const
   largeRequestsTimeout = 6.minutes  # Downloading large items such as states.
@@ -406,7 +405,7 @@ proc doTrustedNodeSync*(
 
     # For Gloas states and possibly beyond, we also need to
     # download the payload envelope for the head block.
-    if cfg.consensusForkAtEpoch(state[].slot.epoch) >= ConsensusFork.Gloas:
+    if state[].slot.epoch >= cfg.GLOAS_FORK_EPOCH:
       let blockRoot = withState(state[]):
         forkyState.latest_block_root()
       notice "Downloading execution payload envelope for checkpoint block",

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -317,7 +317,7 @@ proc createAndSendAttestation(node: BeaconNode,
                               {.async: (raises: [CancelledError]).} =
   let epoch = registered.data.slot.epoch
 
-  if node.dag.cfg.consensusForkAtEpoch(epoch) < ConsensusFork.Electra:
+  if epoch < node.dag.cfg.ELECTRA_FORK_EPOCH:
     warn "Routing of pre-electra attestations not supported",
       attestationData = shortLog(registered.data)
     return
@@ -418,8 +418,7 @@ proc proposeBlockAux(
           let
             parentId = state[].latest_block_id
             parentExecutionRequests =
-              if node.dag.cfg.consensusForkAtEpoch(parentId.slot.epoch()) >=
-                  ConsensusFork.Gloas:
+              if parentId.slot.epoch() >= node.dag.cfg.GLOAS_FORK_EPOCH:
                 # When proposal should extend the head payload, the envelope must
                 # exist or otherwise we shouldn't proceed.
                 let envelope = node.dag.db.getExecutionPayloadEnvelope(
@@ -824,7 +823,7 @@ proc sendAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     fork = node.dag.forkAtEpoch(slot.epoch)
     genesis_validators_root = node.dag.genesis_validators_root
     payloadIndex =
-      if node.dag.cfg.consensusForkAtEpoch(slot.epoch) < ConsensusFork.Gloas or
+      if slot.epoch < node.dag.cfg.GLOAS_FORK_EPOCH or
           attestationHead.blck.slot >= slot:
         0'u64
       else:
@@ -986,7 +985,7 @@ proc sendSyncCommitteeContributions(
         node, validator, subcommitteeIdx, head, slot)
 
 proc checkPayloadPresent(node: BeaconNode, blck: BlockRef): bool =
-  if node.dag.cfg.consensusForkAtEpoch(blck.slot.epoch) >= ConsensusFork.Gloas:
+  if blck.slot.epoch >= node.dag.cfg.GLOAS_FORK_EPOCH:
     node.dag.db.containsExecutionPayloadEnvelope(blck.root)
   else:
     true
@@ -1046,8 +1045,7 @@ proc sendPayloadAttestations(
     node: BeaconNode, head: BlockRef, slot: Slot) =
   ## Perform payload attestation duties for PTC members
 
-  let consensusFork = node.dag.cfg.consensusForkAtEpoch(slot.epoch)
-  if consensusFork < ConsensusFork.Gloas:
+  if slot.epoch < node.dag.cfg.GLOAS_FORK_EPOCH:
     return
 
   # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/gloas/validator.md#constructing-the-payloadattestationmessage
@@ -1092,7 +1090,7 @@ proc sendProposerPreferences(
     node: BeaconNode, head: BlockRef,
     slot: Slot) {.async: (raises: [CancelledError]).} =
 
-  if node.dag.cfg.consensusForkAtEpoch(slot.epoch) < ConsensusFork.Gloas:
+  if slot.epoch < node.dag.cfg.GLOAS_FORK_EPOCH:
     return
 
   if slot.is_epoch and slot.epoch > 0:
@@ -1202,7 +1200,7 @@ proc signAndSendAggregate(
     discard await node.router.routeSignedAggregateAndProof(
       msg, checkSignature = false)
 
-  if node.dag.cfg.consensusForkAtEpoch(slot.epoch) >= ConsensusFork.Electra:
+  if slot.epoch >= node.dag.cfg.ELECTRA_FORK_EPOCH:
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/validator.md#construct-aggregate
     # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/electra/validator.md#aggregateandproof
     var msg = electra.SignedAggregateAndProof(
@@ -1593,7 +1591,7 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   await node.sendProposerPreferences(head, slot)
 
 proc registerPTCDuties(node: BeaconNode, epoch: Epoch) =
-  if node.dag.cfg.consensusForkAtEpoch(epoch) < ConsensusFork.Gloas:
+  if epoch < node.dag.cfg.GLOAS_FORK_EPOCH:
     return
 
   let validatorIndices = block:


### PR DESCRIPTION
Currently, slot end happens 5/6 through a slot (in 6 and 12s slots respectively, 5s and 10s) and preparation for the next slot begins at 11/12 through the slot (in 6s/12s respectively, 5.5s and 11s).

This needs adjustment for two reasons:
- in Gloas, currently PTC-related deadlines now happen 3/4 through the slot, so those now define the relatively idle tail of a slot, and the "slot end" is redefined in terms of those; and
- 1s before the end of a slot has proven borderline too slow to avoid slot start delays in some circumstances, especially around epoch boundaries which involve storing beacon states.

This PR instead redefines them as, slot end is 19/24 through the slot (4.75s and 9.5s respectively for 6s/12s slots) and next slot preparation at 7/8 through a slot (resp 5.25s and 10.5s), for an additional half-second in the 12s case.

Those Gloas deadlines are defined regardless already regardless of whether the node is in Gloas, so they're safe to use regardless of the current fork.