### PR TITLE
Check validator registration to match latest params

### DIFF
--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1288,6 +1288,16 @@ proc getValidatorRegistration(
   else:
     ok(PendingValidatorRegistration(registration: registration, future: sigfut))
 
+proc isConsistent(
+    vc: ValidatorClientRef,
+    validatorRegistration: SignedValidatorRegistrationV1,
+    validator: AttachedValidator,
+    epoch: Epoch): bool =
+  validatorRegistration.message.fee_recipient ==
+    vc.getFeeRecipient(validator, epoch) and
+  validatorRegistration.message.gas_limit ==
+    vc.getGasLimit(validator)
+
 proc prepareRegistrationList*(
     vc: ValidatorClientRef,
     timestamp: Time,
@@ -1309,6 +1319,7 @@ proc prepareRegistrationList*(
     gasLimit = 0
     cached = 0
     timed = 0
+    stale = 0
 
   for validator in vc.attachedValidators[].items():
     let res = vc.getValidatorRegistration(validator, timestamp, genesis_fork_version)
@@ -1341,8 +1352,14 @@ proc prepareRegistrationList*(
       if sres.isOk():
         var reg = messages[index]
         reg.signature = sres.get()
+        let
+          validator = validators[index]
+          currentSlot = vc.beaconClock.toSlot(timestamp).slot
+        if not vc.isConsistent(reg, validator, currentSlot.epoch()):
+          inc(stale)
+          continue
         registrations.add(reg)
-        validators[index].externalBuilderRegistration = Opt.some(reg)
+        validator.externalBuilderRegistration = Opt.some(reg)
         inc(succeed)
       else:
         inc(bad)
@@ -1352,7 +1369,7 @@ proc prepareRegistrationList*(
   debug "Validator registrations prepared", total = total, succeed = succeed,
         cached = cached, bad = bad, errors = errors,
         index_missing = indexMissing, fee_missing = feeMissing,
-        incorrect_time = timed
+        incorrect_time = timed, stale
 
   registrations
 

--- a/beacon_chain/validator_client/common.nim
+++ b/beacon_chain/validator_client/common.nim
@@ -1369,7 +1369,7 @@ proc prepareRegistrationList*(
   debug "Validator registrations prepared", total = total, succeed = succeed,
         cached = cached, bad = bad, errors = errors,
         index_missing = indexMissing, fee_missing = feeMissing,
-        incorrect_time = timed, stale
+        incorrect_time = timed, stale = stale
 
   registrations
 

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1291,7 +1291,7 @@ proc getValidatorRegistration(
   if validator.index.isNone:
     # The validator index will be missing when the validator was not
     # activated for duties yet. We can safely skip the registration then.
-    return
+    return err("Validator not yet activated")
 
   let
     feeRecipient = node.getFeeRecipient(validator.pubkey, validator.index, epoch)
@@ -1314,6 +1314,16 @@ proc getValidatorRegistration(
     )
 
   ok validatorRegistration
+
+proc isConsistent(
+    node: BeaconNode,
+    validatorRegistration: SignedValidatorRegistrationV1,
+    validator: AttachedValidator,
+    epoch: Epoch): bool =
+  validatorRegistration.message.fee_recipient ==
+    node.getFeeRecipient(validator.pubkey, validator.index, epoch) and
+  validatorRegistration.message.gas_limit ==
+    node.getGasLimit(validator.pubkey)
 
 proc registerValidatorsPerBuilder(
     node: BeaconNode, payloadBuilderAddress: string, epoch: Epoch,
@@ -1412,22 +1422,18 @@ proc registerValidatorsPerBuilder(
       addValidatorRegistration validator.externalBuilderRegistration.get
     else:
       let validatorRegistration =
-        await node.getValidatorRegistration(validator, epoch)
-      if validatorRegistration.isErr:
-        error "registerValidators: validatorRegistration failed",
-                validatorRegistration
+          (await node.getValidatorRegistration(validator, epoch)).valueOr:
+        error "registerValidators: validatorRegistration failed", reason = error
         continue
 
-      # Time passed during await; REST keymanager API might have removed it
-      if key notin node.attachedValidators[].validators:
+      # Time passed during await; REST keymanager API might change / remove it
+      node.attachedValidators[].validators.withValue(key, validator):
+        if not node.isConsistent(validatorRegistration, validator[], epoch):
+          continue
+        validator[].externalBuilderRegistration.ok validatorRegistration
+        addValidatorRegistration validatorRegistration
+      do:
         continue
-      let validator = try:
-        node.attachedValidators[].validators[key]
-      except KeyError:
-        raiseAssert "just checked"
-
-      validator.externalBuilderRegistration = Opt.some validatorRegistration.get
-      addValidatorRegistration validatorRegistration.get
 
   if validatorRegistrations == emptyNestedSeq:
     return


### PR DESCRIPTION
We check for the situation where validator is removed via keymanager while being registered (async), but we don't handle case where settings are updated via keymanager for fee recipient and/or gas limit. Treat these same / don't save to validator.externalBuilderRegistration.