### PR TITLE
Fix slowlogs.py default threshold handling

### DIFF
--- a/scripts/slowlogs.py
+++ b/scripts/slowlogs.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 THRESHOLD = 0.75
 
-if len(sys.argv) > 0:
+if len(sys.argv) > 1:
     THRESHOLD = float(sys.argv[1])
 
 last = None


### PR DESCRIPTION

## Summary

Fix `scripts/slowlogs.py` so it can run without an explicit threshold argument.

The script defines a default threshold of `0.75`, but it previously checked `len(sys.argv) > 0` before reading `sys.argv[1]`. Since `sys.argv` always contains the script name, running the script without arguments raised an `IndexError` instead of using the default threshold.

## Changes

- Use the default threshold when no CLI argument is provided
- Preserve the existing custom threshold behavior

## Testing

- Verified default threshold behavior with sample log input
- Verified custom threshold behavior with `python3 scripts/slowlogs.py 0.25`