### PR TITLE
tune scoring params for Gloas topics

### DIFF
--- a/beacon_chain/networking/topic_params.nim
+++ b/beacon_chain/networking/topic_params.nim
@@ -377,8 +377,9 @@ func getBlsToExecutionChangeTopicParams*(timeParams: TimeParams): TopicParams =
     Opt.none(MeshMessageInfo))
 
 func getExecutionPayloadBidTopicParams*(timeParams: TimeParams): TopicParams =
+  let messageRate = 5.0'f64
   timeParams.topicParams(
-    ExecutionPayloadBidWeight, 1.0'f64, timeParams.epochsDuration(20),
+    ExecutionPayloadBidWeight, messageRate, timeParams.epochsDuration(20),
     Opt.none(MeshMessageInfo))
 
 func getPayloadAttestationTopicParams*(timeParams: TimeParams): TopicParams =

--- a/beacon_chain/networking/topic_params.nim
+++ b/beacon_chain/networking/topic_params.nim
@@ -377,7 +377,7 @@ func getBlsToExecutionChangeTopicParams*(timeParams: TimeParams): TopicParams =
     Opt.none(MeshMessageInfo))
 
 func getExecutionPayloadBidTopicParams*(timeParams: TimeParams): TopicParams =
-  let messageRate = 5.0'f64
+  const messageRate = 5.0'f64
   timeParams.topicParams(
     ExecutionPayloadBidWeight, messageRate, timeParams.epochsDuration(20),
     Opt.none(MeshMessageInfo))

--- a/beacon_chain/networking/topic_params.nim
+++ b/beacon_chain/networking/topic_params.nim
@@ -66,6 +66,15 @@ const
   ## `BlsToExecutionChangeWeight` specifies the scoring weight that we apply to
   ## our bls to execution topic.
   BlsToExecutionChangeWeight = 0.05'f64
+  ## `ExecutionPayloadBidWeight` specifies the scoring weight that we apply to
+  ## our execution payload bid topic.
+  ExecutionPayloadBidWeight = 0.05'f64
+  ## `PayloadAttestationWeight` specifies the scoring weight that we apply to
+  ## our payload attestation topic.
+  PayloadAttestationWeight = 0.5'f64
+  ## `ProposerPreferencesWeight` specifies the scoring weight that we apply to
+  ## our proposer preferences topic.
+  ProposerPreferencesWeight = 0.05'f64
   ## `MaxInMeshScore` describes the max score a peer can attain from being in
   ## the mesh.
   MaxInMeshScore = 10'f64
@@ -365,6 +374,22 @@ func getBlsToExecutionChangeTopicParams*(timeParams: TimeParams): TopicParams =
   let messageRate = 1.0'f64 / 5.0'f64 / float64(SLOTS_PER_EPOCH)
   timeParams.topicParams(
     BlsToExecutionChangeWeight, messageRate, timeParams.epochsDuration(100),
+    Opt.none(MeshMessageInfo))
+
+func getExecutionPayloadBidTopicParams*(timeParams: TimeParams): TopicParams =
+  timeParams.topicParams(
+    ExecutionPayloadBidWeight, 1.0'f64, timeParams.epochsDuration(20),
+    Opt.none(MeshMessageInfo))
+
+func getPayloadAttestationTopicParams*(timeParams: TimeParams): TopicParams =
+  timeParams.topicParams(
+    PayloadAttestationWeight, float64(PTC_SIZE), timeParams.epochsDuration(1),
+    Opt.none(MeshMessageInfo))
+
+func getProposerPreferencesTopicParams*(timeParams: TimeParams): TopicParams =
+  let messageRate = 0.5'f64
+  timeParams.topicParams(
+    ProposerPreferencesWeight, messageRate, timeParams.epochsDuration(100),
     Opt.none(MeshMessageInfo))
 
 func basicParams*(): TopicParams = TopicParams.init()

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1394,13 +1394,15 @@ proc addCapellaMessageHandlers(
 proc addGloasMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
   node.addCapellaMessageHandlers(forkDigest, slot)
-  debugGloasComment "default gossipsub config"
   node.network.subscribe(
-    getExecutionPayloadBidTopic(forkDigest), basicParams())
+    getExecutionPayloadBidTopic(forkDigest),
+    getExecutionPayloadBidTopicParams(node.dag.timeParams))
   node.network.subscribe(
-    getPayloadAttestationMessageTopic(forkDigest), basicParams())
+    getPayloadAttestationMessageTopic(forkDigest),
+    getPayloadAttestationTopicParams(node.dag.timeParams))
   node.network.subscribe(
-    getProposerPreferencesTopic(forkDigest), basicParams())
+    getProposerPreferencesTopic(forkDigest),
+    getProposerPreferencesTopicParams(node.dag.timeParams))
 
 proc removeAltairMessageHandlers(node: BeaconNode, forkDigest: ForkDigest) =
   node.removePhase0MessageHandlers(forkDigest)


### PR DESCRIPTION
Weights and rates are set by analogy to existing topics.

For weights, `payload_attestation` uses `0.5`, the same as `BeaconBlockWeight/AggregateWeight`, since PTC votes are consensus-critical, while bid and prefs use `0.05`, matching the minor announcement topics `VoluntaryExit/Slashing/BlsToExecutionChange`. 

 For rates (messages per slot), payload_attestation follows the same theoretical-max convention as SyncContribution, and prefs is set to 0.5. For bid, [the gossip layer only forwards a bid if it beats the highest one already seen for that slot](https://github.com/status-im/nimbus-eth2/blob/c0748e292da2a5eddeafc9ef0e8111cf473bd33e/beacon_chain/gossip_processing/gossip_validation.nim#L1897) , so only a handful should actually propagate per slot regardless of builder count; so a small constant (5.0) is used to reflect that.

Decay windows are matched to each topic's frequency, copied from the closest existing topic: `payload_attestation` uses 1 epoch (high-rate, like `AggregateProof`), bid uses 20 epochs (moderate, like `BeaconBlock`), and prefs uses 100 epochs (rare, like the slashing/exit topics).