### PR TITLE
Fix trailing commas in resttest-rules.json

### DIFF
--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -3318,7 +3318,7 @@
     },
     "response": {
       "status": {"operator": "equals", "value": "410"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}]
     }
   },
   {
@@ -3767,7 +3767,7 @@
     },
     "response": {
       "status": {"operator": "equals", "value": "410"},
-      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
+      "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}]
     }
   },
   {
@@ -4792,7 +4792,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks",
+      "url": "/eth/v2/beacon/blocks"
     },
     "response": {
       "status": {"operator": "equals", "value": "400"},
@@ -4809,7 +4809,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks?broadcast_validation=gossip",
+      "url": "/eth/v2/beacon/blocks?broadcast_validation=gossip"
     },
     "response": {
       "status": {"operator": "equals", "value": "400"},
@@ -4826,7 +4826,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks?broadcast_validation=test",
+      "url": "/eth/v2/beacon/blocks?broadcast_validation=test"
     },
     "response": {
       "status": {"operator": "equals", "value": "400"},
@@ -4843,7 +4843,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks?broadcast_validation=",
+      "url": "/eth/v2/beacon/blocks?broadcast_validation="
     },
     "response": {
       "status": {"operator": "equals", "value": "400"},
@@ -4860,7 +4860,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks?broadcast_validation=consensus",
+      "url": "/eth/v2/beacon/blocks?broadcast_validation=consensus"
     },
     "comment": "TODO: This should be replaced when `consensus` become supported",
     "response": {
@@ -4878,7 +4878,7 @@
         "Content-Type": "application/json",
         "Eth-Consensus-Version": "capella"
       },
-      "url": "/eth/v2/beacon/blocks?broadcast_validation=consensus_and_equivocation",
+      "url": "/eth/v2/beacon/blocks?broadcast_validation=consensus_and_equivocation"
     },
     "comment": "TODO: This should be replaced when `consensus_and_equivocation` become supported",
     "response": {


### PR DESCRIPTION
JSON does not allow trailing comma after last object field. Fix format.