### PR TITLE
use let in place of var in ncli/{ncli_testnet,resttest}

### DIFF
--- a/ncli/ncli_testnet.nim
+++ b/ncli/ncli_testnet.nim
@@ -425,7 +425,7 @@ proc doCreateTestnet*(config: CliConfig,
       quit 1
 
   template createAndSaveState(): Eth2Digest =
-    var initialState =
+    let initialState =
       initGenesisState(cfg, eth1Hash, startTime, deposits, {skipBlsValidation})
     withState(initialState[]):
       # https://github.com/ethereum/eth2.0-pm/tree/6e41fcf383ebeb5125938850d8e9b4e9888389b4/interop/mocked_start#create-genesis-state

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -1,11 +1,11 @@
 # beacon_chain
-# Copyright (c) 2021-2025 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   std/[strutils, os, options, uri, json, tables],

--- a/ncli/resttest.nim
+++ b/ncli/resttest.nim
@@ -761,7 +761,7 @@ proc validateHeaders(resp: HttpResponseHeader, expect: HeadersExpect): bool =
     true
 
 proc jsonBody(body: openArray[byte]): Result[JsonNode, cstring] =
-  var sbody = cast[string](@body)
+  let sbody = cast[string](@body)
   let res =
     try:
       parseJson(sbody)
@@ -1049,10 +1049,10 @@ proc workerLoop(address: TransportAddress, uri: Uri, worker: int,
 proc startTests(conf: RestTesterConf, uri: Uri,
                 rules: seq[JsonNode]): Future[int] {.async.} =
   var workers = newSeq[Future[void]](conf.connectionsCount)
-  var inputQueue = newAsyncQueue[TestCase](len(rules))
-  var outputQueue = newAsyncQueue[TestCaseResult](conf.connectionsCount)
+  let inputQueue = newAsyncQueue[TestCase](len(rules))
+  let outputQueue = newAsyncQueue[TestCaseResult](conf.connectionsCount)
   var results = newSeq[TestResult](len(rules))
-  var restarts = 0
+  let restarts = 0
 
   let address =
     block:
@@ -1178,5 +1178,5 @@ proc run(conf: RestTesterConf): int =
 
 when isMainModule:
   echo RestTesterHeader
-  var conf = RestTesterConf.load(version = RestTesterVersion)
+  let conf = RestTesterConf.load(version = RestTesterVersion)
   quit run(conf)


### PR DESCRIPTION
No semantic changes, no `beacon_chain/` changes, no production code affected.