### PR TITLE
rm now-unnecessary Nim bug workarounds

### DIFF
--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -118,7 +118,7 @@ func maxSidecars(maxSidecarsPerBlock: uint64): int =
   # blobs may arrive before an orphan is tagged `blobless`
   3 * int(SLOTS_PER_EPOCH) * int(maxSidecarsPerBlock)
 
-func enoughColumns*(q: SomeColumnQuarantine, count: int): bool =
+func enoughColumns(q: SomeColumnQuarantine, count: int): bool =
   if count >= NUMBER_OF_COLUMNS div 2:
     return true
   if count == len(q.custodyMap):

--- a/beacon_chain/consensus_object_pools/partial_column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/partial_column_quarantine.nim
@@ -12,16 +12,15 @@ import
   minilru, results,
   kzg4844/[kzg, kzg_abi],
   ssz_serialization/bitseqs,
-  ../spec/[digest, forks, helpers, presets]
+  ../spec/[datatypes/base, digest, presets]
 
 # Spec references:
 # - Fulu: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/fulu/partial-columns/p2p-interface.md
 # - Gloas: https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.8/specs/gloas/partial-columns/p2p-interface.md
 
-from ../spec/datatypes/fulu import
-  ColumnIndex, DataColumn
-
 from ../spec/datatypes/deneb import KzgCommitments, KzgProofs
+from ../spec/datatypes/fulu import ColumnIndex, DataColumn
+from ../spec/datatypes/gloas import PartialDataColumnGroupID
 
 export results
 
@@ -29,7 +28,7 @@ const
   MaxPartialHeaders* = 3 * int(SLOTS_PER_EPOCH)
     ## Maximum number of validated headers (Fulu) or group IDs (Gloas) to
     ## cache.
-  MaxPartialEntries* = 3 * int(SLOTS_PER_EPOCH) * NUMBER_OF_COLUMNS
+  MaxPartialEntries = 3 * int(SLOTS_PER_EPOCH) * NUMBER_OF_COLUMNS
     ## Maximum number of (block_id, column_index) entries to cache.
 
 type
@@ -82,7 +81,7 @@ type
   # Type class matching any fork's partial sidecar. Both variants share
   # the same cell-bearing fields (cells_present_bitmap, partial_column,
   # kzg_proofs) per spec.
-  AnyPartialDataColumnSidecar =
+  SomePartialDataColumnSidecar =
     fulu.PartialDataColumnSidecar | gloas.PartialDataColumnSidecar
 
 func hash*(gid: gloas.PartialDataColumnGroupID): Hash =
@@ -231,7 +230,7 @@ func hasCellReceived*[K, H](
 
 # --- Cell ingestion and assembly ---
 
-func addCells*[K, H; S: AnyPartialDataColumnSidecar](
+func addCells*[K, H; S: SomePartialDataColumnSidecar](
     quarantine: var PartialColumnQuarantine[K, H],
     blockId: K,
     columnIndex: ColumnIndex,

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -710,11 +710,8 @@ func is_eligible_for_activation*(
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/beacon-chain.md#is_valid_indexed_attestation
 proc is_valid_indexed_attestation*(
     state: ForkyBeaconState,
-    # phase0.SomeIndexedAttestation | electra.SomeIndexedAttestation:
-    # https://github.com/nim-lang/Nim/issues/18095
     indexed_attestation:
-      phase0.IndexedAttestation | phase0.TrustedIndexedAttestation |
-      electra.IndexedAttestation | electra.TrustedIndexedAttestation,
+      phase0.SomeIndexedAttestation | electra.SomeIndexedAttestation,
     flags: UpdateFlags): Result[void, cstring] =
   ## Check if ``indexed_attestation`` is not empty, has sorted and unique
   ## indices and has a valid aggregate signature.

--- a/beacon_chain/spec/forks_light_client.nim
+++ b/beacon_chain/spec/forks_light_client.nim
@@ -190,57 +190,37 @@ type
       gloasData*: gloas.LightClientStore
 
 template kind*(
-    # `SomeLightClientObject`: https://github.com/nim-lang/Nim/issues/18095
     x: typedesc[
+      altair.SomeLightClientObject |
       altair.LightClientHeader |
-      altair.LightClientBootstrap |
-      altair.LightClientUpdate |
-      altair.LightClientFinalityUpdate |
-      altair.LightClientOptimisticUpdate |
       altair.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Altair
 
 template kind*(
-    # `SomeLightClientObject`: https://github.com/nim-lang/Nim/issues/18095
     x: typedesc[
+      capella.SomeLightClientObject |
       capella.LightClientHeader |
-      capella.LightClientBootstrap |
-      capella.LightClientUpdate |
-      capella.LightClientFinalityUpdate |
-      capella.LightClientOptimisticUpdate |
       capella.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Capella
 
 template kind*(
-    # `SomeLightClientObject`: https://github.com/nim-lang/Nim/issues/18095
     x: typedesc[
+      deneb.SomeLightClientObject |
       deneb.LightClientHeader |
-      deneb.LightClientBootstrap |
-      deneb.LightClientUpdate |
-      deneb.LightClientFinalityUpdate |
-      deneb.LightClientOptimisticUpdate |
       deneb.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Deneb
 
 template kind*(
-    # `SomeLightClientObject`: https://github.com/nim-lang/Nim/issues/18095
     x: typedesc[
+      electra.SomeLightClientObject |
       electra.LightClientHeader |
-      electra.LightClientBootstrap |
-      electra.LightClientUpdate |
-      electra.LightClientFinalityUpdate |
-      electra.LightClientOptimisticUpdate |
       electra.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Electra
 
 template kind*(
-    # `SomeLightClientObject`: https://github.com/nim-lang/Nim/issues/18095
     x: typedesc[
+      gloas.SomeLightClientObject |
       gloas.LightClientHeader |
-      gloas.LightClientBootstrap |
-      gloas.LightClientUpdate |
-      gloas.LightClientFinalityUpdate |
-      gloas.LightClientOptimisticUpdate |
       gloas.LightClientStore]): LightClientDataFork =
   LightClientDataFork.Gloas
 

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -237,11 +237,8 @@ func is_slashable_attestation_data(
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/phase0/beacon-chain.md#attester-slashings
 proc check_attester_slashing*(
     state: ForkyBeaconState,
-    # phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing:
-    # https://github.com/nim-lang/Nim/issues/18095
     attester_slashing:
-      phase0.AttesterSlashing | phase0.TrustedAttesterSlashing |
-      electra.AttesterSlashing | electra.TrustedAttesterSlashing,
+      phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing,
     flags: UpdateFlags): Result[seq[ValidatorIndex], cstring] =
   let
     attestation_1 = attester_slashing.attestation_1
@@ -275,11 +272,8 @@ proc check_attester_slashing*(
 
 proc check_attester_slashing*(
     state: var ForkedHashedBeaconState,
-    # phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing:
-    # https://github.com/nim-lang/Nim/issues/18095
     attester_slashing:
-      phase0.AttesterSlashing | phase0.TrustedAttesterSlashing |
-      electra.AttesterSlashing | electra.TrustedAttesterSlashing,
+      phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing,
     flags: UpdateFlags): Result[seq[ValidatorIndex], cstring] =
   withState(state):
     check_attester_slashing(forkyState.data, attester_slashing, flags)
@@ -288,11 +282,8 @@ proc check_attester_slashing*(
 proc process_attester_slashing*(
     cfg: RuntimeConfig,
     state: var ForkyBeaconState,
-    # phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing:
-    # https://github.com/nim-lang/Nim/issues/18095
     attester_slashing:
-      phase0.AttesterSlashing | phase0.TrustedAttesterSlashing |
-      electra.AttesterSlashing | electra.TrustedAttesterSlashing,
+      phase0.SomeAttesterSlashing | electra.SomeAttesterSlashing,
     flags: UpdateFlags,
     exit_queue_info: ExitQueueInfo, cache: var StateCache
     ): Result[(Gwei, ExitQueueInfo), cstring] =
@@ -992,16 +983,10 @@ proc process_execution_payload*(
 
   ok()
 
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-# copy of datatypes/deneb.nim
-type SomeDenebBeaconBlockBody =
-  deneb.BeaconBlockBody | deneb.SigVerifiedBeaconBlockBody |
-  deneb.TrustedBeaconBlockBody
-
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#process_execution_payload
 proc process_execution_payload*(
     cfg: RuntimeConfig, state: var deneb.BeaconState,
-    body: SomeDenebBeaconBlockBody,
+    body: deneb.SomeBeaconBlockBody,
     notify_new_payload: deneb.ExecutePayload): Result[void, cstring] =
   template payload: auto = body.execution_payload
 
@@ -1033,16 +1018,10 @@ proc process_execution_payload*(
 
   ok()
 
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-# copy of datatypes/electra.nim
-type SomeElectraBeaconBlockBody =
-  electra.BeaconBlockBody | electra.SigVerifiedBeaconBlockBody |
-  electra.TrustedBeaconBlockBody
-
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.3/specs/electra/beacon-chain.md#modified-process_execution_payload
 proc process_execution_payload*(
     cfg: RuntimeConfig, state: var electra.BeaconState,
-    body: SomeElectraBeaconBlockBody | electra_mev.SigVerifiedBlindedBeaconBlockBody,
+    body: electra.SomeBeaconBlockBody | electra_mev.SigVerifiedBlindedBeaconBlockBody,
     notify_new_payload: deneb.ExecutePayload): Result[void, cstring] =
   template payload: auto = body.payload
 
@@ -1078,16 +1057,10 @@ proc process_execution_payload*(
 
   ok()
 
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-# copy of datatypes/fulu.nim
-type SomeFuluBeaconBlockBody =
-  fulu.BeaconBlockBody | fulu.SigVerifiedBeaconBlockBody |
-  fulu.TrustedBeaconBlockBody
-
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.0/specs/fulu/beacon-chain.md#modified-process_execution_payload
 proc process_execution_payload*(
     cfg: RuntimeConfig, state: var fulu.BeaconState,
-    body: SomeFuluBeaconBlockBody | fulu_mev.SigVerifiedBlindedBeaconBlockBody,
+    body: fulu.SomeBeaconBlockBody | fulu_mev.SigVerifiedBlindedBeaconBlockBody,
     notify_new_payload: deneb.ExecutePayload): Result[void, cstring] =
   template payload: auto = body.payload()
 
@@ -1560,13 +1533,9 @@ proc validate_blobs*(
 
   ok()
 
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-# copy of datatypes/phase0.nim
-type SomePhase0Block =
-  phase0.BeaconBlock | phase0.SigVerifiedBeaconBlock | phase0.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var phase0.BeaconState, blck: SomePhase0Block, flags: UpdateFlags,
+    state: var phase0.BeaconState, blck: phase0.SomeBeaconBlock, flags: UpdateFlags,
     cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1579,13 +1548,9 @@ proc process_block*(
   ok(? process_operations(cfg, state, blck.body, 0.Gwei, flags, cache))
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.4/specs/altair/beacon-chain.md#block-processing
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-# copy of datatypes/altair.nim
-type SomeAltairBlock =
-  altair.BeaconBlock | altair.SigVerifiedBeaconBlock | altair.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var altair.BeaconState, blck: SomeAltairBlock, flags: UpdateFlags,
+    state: var altair.BeaconState, blck: altair.SomeBeaconBlock, flags: UpdateFlags,
     cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1608,12 +1573,9 @@ proc process_block*(
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.8/specs/bellatrix/beacon-chain.md#block-processing
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-type SomeBellatrixBlock =
-  bellatrix.BeaconBlock | bellatrix.SigVerifiedBeaconBlock | bellatrix.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var bellatrix.BeaconState, blck: SomeBellatrixBlock,
+    state: var bellatrix.BeaconState, blck: bellatrix.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1639,12 +1601,9 @@ proc process_block*(
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/capella/beacon-chain.md#block-processing
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-type SomeCapellaBlock =
-  capella.BeaconBlock | capella.SigVerifiedBeaconBlock | capella.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var capella.BeaconState, blck: SomeCapellaBlock,
+    state: var capella.BeaconState, blck: capella.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1676,12 +1635,9 @@ proc process_block*(
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/deneb/beacon-chain.md#block-processing
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-type SomeDenebBlock =
-  deneb.BeaconBlock | deneb.SigVerifiedBeaconBlock | deneb.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var deneb.BeaconState, blck: SomeDenebBlock,
+    state: var deneb.BeaconState, blck: deneb.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1711,13 +1667,9 @@ proc process_block*(
   ok(operations_rewards)
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-alpha.1/specs/electra/beacon-chain.md#block-processing
-# TODO workaround for https://github.com/nim-lang/Nim/issues/18095
-type SomeElectraBlock =
-  electra.BeaconBlock | electra.SigVerifiedBeaconBlock | electra.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var electra.BeaconState,
-    blck: SomeElectraBlock,
+    state: var electra.BeaconState, blck: electra.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1746,12 +1698,9 @@ proc process_block*(
 
   ok(operations_rewards)
 
-type SomeFuluBlock =
-  fulu.BeaconBlock | fulu.SigVerifiedBeaconBlock | fulu.TrustedBeaconBlock
 proc process_block*(
-    cfg: RuntimeConfig,
-    state: var fulu.BeaconState,
-    blck: SomeFuluBlock | fulu_mev.SigVerifiedBlindedBeaconBlock,
+    cfg: RuntimeConfig, state: var fulu.BeaconState,
+    blck: fulu.SomeBeaconBlock | fulu_mev.SigVerifiedBlindedBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1850,12 +1799,9 @@ proc verify_execution_payload_envelope*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.5/specs/gloas/beacon-chain.md#block-processing
 debugGloasComment "readd gloas_mev block and, well the rest too"
-type SomeGloasBlock =
-  gloas.BeaconBlock | gloas.SigVerifiedBeaconBlock | gloas.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var gloas.BeaconState,
-    blck: SomeGloasBlock,
+    state: var gloas.BeaconState, blck: gloas.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when
@@ -1880,12 +1826,9 @@ proc process_block*(
 
   ok(operations_rewards)
 
-type SomeHezeBlock =
-  heze.BeaconBlock | heze.SigVerifiedBeaconBlock | heze.TrustedBeaconBlock
 proc process_block*(
     cfg: RuntimeConfig,
-    state: var heze.BeaconState,
-    blck: SomeHezeBlock,
+    state: var heze.BeaconState, blck: heze.SomeBeaconBlock,
     flags: UpdateFlags, cache: var StateCache): Result[BlockRewards, cstring] =
   ## When there's a new block, we need to verify that the block is sane and
   ## update the state accordingly - the state is left in an unknown state when


### PR DESCRIPTION
- https://github.com/nim-lang/Nim/issues/18095

has been fixed in Nim 2.2.10, which `nimbus-eth2` uses.