### PR TITLE
Only subscribe to each column topic once

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1367,14 +1367,22 @@ func getSyncCommitteeSubnets(node: BeaconNode, epoch: Epoch): SyncnetBits =
   subnets + node.getNextSyncCommitteeSubnets(epoch)
 
 proc updateDataColumnSidecarHandlers(node: BeaconNode, gossipEpoch: Epoch) =
-  let forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
-  var custody: seq[CustodyIndex]
+  let
+    forkDigest = node.dag.forkDigests[].atEpoch(gossipEpoch, node.dag.cfg)
+    prevSubnets = move(node.lastColumnCustodyIndices)
+  template subscribeSubnets: var seq[CustodyIndex] =
+    node.lastColumnCustodyIndices
 
   for i in node.validatorCustody.custodyGroups():
-    let topic = getDataColumnSidecarTopic(forkDigest, i)
-    node.network.subscribe(topic, basicParams())
-    custody.add(i)
-  node.lastColumnCustodyIndices = custody
+    if i notin prevSubnets:
+      let topic = getDataColumnSidecarTopic(forkDigest, i)
+      node.network.subscribe(topic, basicParams())
+      subscribeSubnets.add(i)
+
+  for i in prevSubnets:
+    if i notin subscribeSubnets:
+      let topic = getDataColumnSidecarTopic(forkDigest, i)
+      node.network.unsubscribe(topic)
 
 proc addAltairMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
@@ -1405,9 +1413,17 @@ proc addCapellaMessageHandlers(
     getBlsToExecutionChangeTopic(forkDigest),
     getBlsToExecutionChangeTopicParams(node.dag.timeParams))
 
-proc addGloasMessageHandlers(
+proc addFuluMessageHandlers(
     node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
   node.addCapellaMessageHandlers(forkDigest, slot)
+
+  for i in node.lastColumnCustodyIndices:
+    let topic = getDataColumnSidecarTopic(forkDigest, i)
+    node.network.subscribe(topic, basicParams())
+
+proc addGloasMessageHandlers(
+    node: BeaconNode, forkDigest: ForkDigest, slot: Slot) =
+  node.addFuluMessageHandlers(forkDigest, slot)
   node.network.subscribe(
     getExecutionPayloadBidTopic(forkDigest),
     getExecutionPayloadBidTopicParams(node.dag.timeParams))
@@ -1637,7 +1653,7 @@ proc updateGossipStatus(node: BeaconNode, slot: Slot) {.async.} =
     addCapellaMessageHandlers,
     addCapellaMessageHandlers,  # deneb (capella handlers, different forkDigest)
     addCapellaMessageHandlers,  # electra (capella handlers, different forkDigest)
-    addCapellaMessageHandlers, # no blobs; updateDataColumnSidecarHandlers for rest
+    addFuluMessageHandlers,
     addGloasMessageHandlers,
     addGloasMessageHandlers  # heze (gloas handlers)
   ]


### PR DESCRIPTION
Rather than adding duplicate subscription per slot, only subscribe to data column topic when custody extends or new fork starts.