### PR TITLE
fix validator bucket CI flakiness

### DIFF
--- a/tests/test_validator_bucket_sort.nim
+++ b/tests/test_validator_bucket_sort.nim
@@ -232,13 +232,21 @@ func findValidatorIndexBruteforce(
       return Opt.some validatorIndex
   Opt.none ValidatorIndex
 
+let hashedPubkeyItems = block:
+  var res: array[pubkeys.len, HashedValidatorPubKeyItem]
+  for i in 0 ..< pubkeys.len:
+    res[i] = HashedValidatorPubKeyItem(
+      key: pubkeys[i].get, root: hash_tree_root(pubkeys[i].get))
+  res
+
 suite "ValidatorPubKey bucket sort":
   setup:
     let
-      hashedPubkeyItems = mapIt(pubkeys, HashedValidatorPubKeyItem(
-        key: it.get, root: hash_tree_root(it.get)))
-      hashedPubkeys = mapIt(hashedPubkeyItems, HashedValidatorPubKey(
-        value: unsafeAddr it))
+      hashedPubkeys = block:
+        var res = newSeq[HashedValidatorPubKey](hashedPubkeyItems.len)
+        for i in 0 ..< hashedPubkeyItems.len:
+          res[i] = HashedValidatorPubKey(value: addr hashedPubkeyItems[i])
+        res
       validators = mapIt(hashedPubkeys, Validator(pubkeyData: it))
 
   test "one-shot construction":


### PR DESCRIPTION
```nim
iterator r[T](a: openArray[T]): T =
  for x in a: yield x
for m in r([1, 2, 3]): echo cast[uint](addr m)
```
is a variation of what was happening.