### PR TITLE
fix Gloas withdrawals predictions; quarantine Gloas columns arriving before block

### DIFF
--- a/beacon_chain/consensus_object_pools/column_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/column_quarantine.nim
@@ -356,13 +356,11 @@ proc put*[
           if isEmpty(node[].value.sidecars[index]):
             inc(res)
         res
+  if newSidecarsCount > 0:
+    q.ensureSidecarsFits(newSidecarsCount).isOkOr:
+      return
 
-  if newSidecarsCount == 0:
-    return
-
-  q.ensureSidecarsFits(newSidecarsCount).isOkOr:
-    return
-
+  var upgradedSidecars = false
   for sidecar in sidecars:
     let index = q.getIndex(sidecar.index)
     if index < 0: continue
@@ -377,6 +375,20 @@ proc put*[
           proposer_index: sidecar[].proposer_index(),
           verified: verified,
           data: sidecar)
+    elif verified and isLoaded(node[].value.sidecars[index]) and
+        not node[].value.sidecars[index].verified:
+      node[].value.sidecars[index] =
+        SidecarHolder[A](
+          kind: SidecarHolderKind.Loaded,
+          slot: sidecar[].slot(),
+          index: uint64(sidecar[].index),
+          proposer_index: sidecar[].proposer_index(),
+          verified: true,
+          data: sidecar)
+      upgradedSidecars = true
+
+  if newSidecarsCount == 0 and not upgradedSidecars:
+    return
 
   q.memSidecarsCount += newSidecarsCount
   blob_quarantine_memory_slots_occupied.set(
@@ -508,6 +520,18 @@ func hasSidecar*(
     index: ColumnIndex
 ): bool =
   hasSidecarImpl(blockRoot, index)
+
+func hasVerifiedSidecar*(
+    quarantine: SomeColumnQuarantine,
+    blockRoot: Eth2Digest,
+    index: ColumnIndex
+): bool =
+  let node = quarantine.roots.getOrDefault(blockRoot)
+  if isNil(node):
+    return false
+  let idx = quarantine.getIndex(index)
+  (idx != -1) and not node[].value.sidecars[idx].isEmpty() and
+    node[].value.sidecars[idx].verified
 
 func hasSidecars*(
     quarantine: SomeColumnQuarantine,

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -282,6 +282,19 @@ proc getFeeRecipient*(
 proc getGasLimit*(self: ConsensusManager, pubkey: ValidatorPubKey): uint64 =
   getGasLimit(self.validatorsDir, self.defaultGasLimit, pubkey)
 
+func pendingBuilderPayment(
+    state: gloas.BeaconState | heze.BeaconState
+): Opt[BuilderPendingWithdrawal] =
+  ## The `BuilderPendingPayment` from `process_execution_payload_bid`
+  template bid: untyped = state.latest_execution_payload_bid
+  if bid.value > 0.Gwei:
+    Opt.some(BuilderPendingWithdrawal(
+      fee_recipient: bid.fee_recipient,
+      amount: bid.value,
+      builder_index: bid.builder_index))
+  else:
+    Opt.none(BuilderPendingWithdrawal)
+
 proc prepareNextSlot*(
     self: ref ConsensusManager, proposalSlot: Slot, deadline: DeadlineFuture
 ) {.async: (raises: [CancelledError]).} =
@@ -332,6 +345,8 @@ proc prepareNextSlot*(
   withState(dag.clearanceState):
     when consensusFork >= ConsensusFork.Electra:
       debug "Sending proposal fcU", proposalSlot, validatorIndex, nextProposer
+      when consensusFork >= ConsensusFork.Gloas:
+        let shouldExtend = dag.shouldExtendPayload(head)
       let
         timestamp = dag.timeParams
           .compute_timestamp_at_slot(forkyState.data, proposalSlot)
@@ -345,7 +360,7 @@ proc prepareNextSlot*(
         beaconHead = self.attestationPool[].getBeaconHead(head)
         executionHead =
           when consensusFork >= ConsensusFork.Gloas:
-            if dag.shouldExtendPayload(head):
+            if shouldExtend:
               proposalExecutionHead(forkyState.data)
             else:
               dag.loadExecutionAndParentBlockHash(head).parentHash.valueOr:
@@ -358,6 +373,19 @@ proc prepareNextSlot*(
         return
 
       let
+        withdrawals =
+          when consensusFork >= ConsensusFork.Gloas:
+            if shouldExtend:
+              get_expected_withdrawals(
+                forkyState.data, pendingBuilderPayment(forkyState.data)
+              ).withdrawals
+            else:
+              # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/validator.md#executionpayload
+              # if should_build_on_full(store, head): ...
+              # else: withdrawals = state.payload_expected_withdrawals
+              forkyState.data.payload_expected_withdrawals.asSeq
+          else:
+            get_expected_withdrawals(forkyState.data)
         state = ForkchoiceStateV1.init(
           executionHead, beaconHead.safeExecutionBlockHash,
           beaconHead.finalizedExecutionBlockHash,
@@ -365,14 +393,12 @@ proc prepareNextSlot*(
         attributes =
           when consensusFork >= ConsensusFork.Gloas:
             PayloadAttributesV4.init(timestamp, prevRandao, feeRecipient,
-              get_expected_withdrawals(forkyState.data).withdrawals,
-              beaconHead.blck.bid.root, proposalSlot,
+              withdrawals, beaconHead.blck.bid.root, proposalSlot,
               self[].getGasLimit(nextProposer))
           else:
             # https://github.com/ethereum/execution-apis/blob/v1.0.0-beta.4/src/engine/cancun.md#payloadattributesv3
             PayloadAttributesV3.init(timestamp, prevRandao, feeRecipient,
-              get_expected_withdrawals(forkyState.data),
-              beaconHead.blck.bid.root)
+              withdrawals, beaconHead.blck.bid.root)
 
         (status, _) = await self.elManager.forkchoiceUpdated(
           state, Opt.some(attributes), deadline, false
@@ -393,7 +419,7 @@ proc prepareNextSlot*(
                 timestamp: timestamp,
                 prev_randao: prevRandao,
                 suggested_fee_recipient: feeRecipient,
-                withdrawals: get_expected_withdrawals(forkyState.data).withdrawals,
+                withdrawals: withdrawals,
                 parent_beacon_block_root: beaconHead.blck.bid.root,
                 slot_number: uint64(proposalSlot),
                 target_gas_limit: self[].getGasLimit(nextProposer)))))

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -440,13 +440,21 @@ proc processDataColumnSidecar*(
     notice "Data column before genesis"
     return errIgnore("Data column before genesis")
 
-  debug "Data column received (Gloas - quarantine not implemented)"
+  debug "Data column received"
 
   let v = self.dag.validateDataColumnSidecar(
     self.quarantine, self.gloasColumnQuarantine, self.executionPayloadBidPool,
     dataColumnSidecar, wallTime, subnet_id)
 
   if v.isErr():
+    # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md#modified-data_column_sidecar_subnet_id
+    # "If not yet seen, a client SHOULD queue the sidecar for deferred
+    # validation and possible processing once the block is received or
+    # retrieved."
+    if v.error[0] == ValidationResult.Ignore:
+      self.gloasColumnQuarantine[].put(
+        dataColumnSidecar[].beacon_block_root, dataColumnSidecar,
+        verified = false)
     debug "Dropping data column", error = v.error()
     data_column_sidecars_dropped.inc(1, [$v.error[0]])
     return v

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -594,7 +594,7 @@ proc validateDataColumnSidecar*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/p2p-interface.md#data_column_sidecar_subnet_id
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md#modified-data_column_sidecar_subnet_id
 proc validateDataColumnSidecar*(
     dag: ChainDAGRef, quarantine: ref Quarantine,
     gloasColumnQuarantine: ref GloasColumnQuarantine,
@@ -605,8 +605,16 @@ proc validateDataColumnSidecar*(
 
   template blockRoot(): auto = data_column_sidecar[].beacon_block_root
 
+  # [REJECT] The sidecar is for the correct subnet -- i.e.
+  # `compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id`.
+  #
+  # Keep before block-seen [IGNORE] so the [REJECT] occurs properly
+  if not (compute_subnet_for_data_column_sidecar(data_column_sidecar[].index) ==
+      subnet_id):
+    return dag.checkedReject("DataColumnSidecar: not for correct subnet")
+
   # [IGNORE] A valid block for the sidecar's `slot` has been seen (via gossip or
-  # non-gossip sources). If not yet seen, a client MUST queue the sidecar for
+  # non-gossip sources). If not yet seen, a client SHOULD queue the sidecar for
   # deferred validation and possible processing once the block is received or
   # retrieved.
   let blck =
@@ -642,12 +650,6 @@ proc validateDataColumnSidecar*(
     if v.isErr:
       return dag.checkedReject(v.error)
 
-  # [REJECT] The sidecar is for the correct subnet -- i.e.
-  # `compute_subnet_for_data_column_sidecar(sidecar.index) == subnet_id`.
-  if not (compute_subnet_for_data_column_sidecar(data_column_sidecar[].index) ==
-      subnet_id):
-    return dag.checkedReject("DataColumnSidecar: not for correct subnet")
-
   # [REJECT] The sidecar's column data is valid as verified by
   # `verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments)`.
   block:
@@ -658,7 +660,9 @@ proc validateDataColumnSidecar*(
 
   # [IGNORE] The sidecar is the first sidecar for the tuple
   # `(sidecar.beacon_block_root, sidecar.index)` with valid kzg proof.
-  if gloasColumnQuarantine[].hasSidecar(
+  # An unverified sidecar at the same index (queued before its block was
+  # seen) does not count: this one has a valid kzg proof and supersedes it.
+  if gloasColumnQuarantine[].hasVerifiedSidecar(
       blockRoot, data_column_sidecar[].index):
     return errIgnore("DataColumnSidecar: already have valid data column")
 

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -2017,7 +2017,7 @@ func get_expected_withdrawals*(
     state: gloas.BeaconState | heze.BeaconState,
     extra_builder_payment = Opt.none(BuilderPendingWithdrawal)):
     ExpectedWithdrawals =
-  ## Get builder withdrawals
+  # Get builder withdrawals
   # `extra_builder_payment` gets proposal withdrawals from pre-proposal states
   let (builder_withdrawals, builder_withdrawal_index,
        processed_builder_withdrawals_count) =

--- a/beacon_chain/spec/beaconstate.nim
+++ b/beacon_chain/spec/beaconstate.nim
@@ -1799,7 +1799,8 @@ func is_builder_index*(validator_index: uint64): bool =
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.2/specs/gloas/beacon-chain.md#new-get_builder_withdrawals
 func get_builder_withdrawals(
     state: gloas.BeaconState | heze.BeaconState,
-    withdrawal_index: WithdrawalIndex, prior_withdrawals: seq[Withdrawal]):
+    withdrawal_index: WithdrawalIndex, prior_withdrawals: seq[Withdrawal],
+    extra_pending = Opt.none(BuilderPendingWithdrawal)):
     (seq[Withdrawal], WithdrawalIndex, uint64) =
   const withdrawals_limit = MAX_WITHDRAWALS_PER_PAYLOAD - 1
 
@@ -1813,8 +1814,8 @@ func get_builder_withdrawals(
     withdrawals: seq[Withdrawal]
   for withdrawal in state.builder_pending_withdrawals:
     let
-      all_withdrawals = prior_withdrawals & withdrawals
-      has_reached_limit = len(all_withdrawals) == withdrawals_limit
+      all_withdrawals_len = len(prior_withdrawals) + len(withdrawals)
+      has_reached_limit = all_withdrawals_len >= withdrawals_limit
     if has_reached_limit:
       break
 
@@ -1826,6 +1827,21 @@ func get_builder_withdrawals(
       amount: withdrawal.amount))
     withdrawal_index += WithdrawalIndex(1)
     processed_count += 1
+
+  # A pending withdrawal used to predict the next proposal's withdrawals after
+  # parent bid's builder payment's applied by `apply_parent_execution_payload`
+  # before `get_expected_withdrawals` runs in the state transition.
+  extra_pending.isErrOr:
+    if value.amount > 0.Gwei and
+        len(prior_withdrawals) + len(withdrawals) < withdrawals_limit:
+      withdrawals.add(Withdrawal(
+        index: withdrawal_index,
+        validator_index:
+          convert_builder_index_to_validator_index(value.builder_index),
+        address: value.fee_recipient,
+        amount: value.amount))
+      inc withdrawal_index
+      inc processed_count
 
   (withdrawals, withdrawal_index, processed_count)
 
@@ -1998,12 +2014,15 @@ func get_validators_sweep_withdrawals(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.1/specs/gloas/beacon-chain.md#modified-get_expected_withdrawals
 func get_expected_withdrawals*(
-    state: gloas.BeaconState | heze.BeaconState): ExpectedWithdrawals =
-  # [New in Gloas:EIP7732]
-  # Get builder withdrawals
+    state: gloas.BeaconState | heze.BeaconState,
+    extra_builder_payment = Opt.none(BuilderPendingWithdrawal)):
+    ExpectedWithdrawals =
+  ## Get builder withdrawals
+  # `extra_builder_payment` gets proposal withdrawals from pre-proposal states
   let (builder_withdrawals, builder_withdrawal_index,
        processed_builder_withdrawals_count) =
-    get_builder_withdrawals(state, state.next_withdrawal_index, @[])
+    get_builder_withdrawals(
+      state, state.next_withdrawal_index, @[], extra_builder_payment)
   var withdrawals = builder_withdrawals
 
   # Get partial withdrawals

--- a/beacon_chain/validators/slashing_protection_v2.nim
+++ b/beacon_chain/validators/slashing_protection_v2.nim
@@ -1161,7 +1161,7 @@ template withContext*(dbParam: SlashingProtectionDB_v2, body: untyped): untyped 
   var
     commit = false
     res: Result[typeof(body), string]
-    beginRes = db.backend.exec("BEGIN TRANSACTION;")
+  let beginRes = db.backend.exec("BEGIN TRANSACTION;")
   if beginRes.isErr(): # always lovely handling errors in templates
     res.err(beginRes.error())
   else:

--- a/ncli/ncli_db.nim
+++ b/ncli/ncli_db.nim
@@ -242,19 +242,19 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
     dag = withTimerRet(timers[tInit]):
       ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
 
-  var
+  let
     (start, ends) = dag.getSlotRange(conf.benchSlot, conf.benchSlots)
     blockRefs = dag.getBlockRange(max(start, Slot 1), ends)
-    blocks: (
-      seq[phase0.TrustedSignedBeaconBlock],
-      seq[altair.TrustedSignedBeaconBlock],
-      seq[bellatrix.TrustedSignedBeaconBlock],
-      seq[capella.TrustedSignedBeaconBlock],
-      seq[deneb.TrustedSignedBeaconBlock],
-      seq[electra.TrustedSignedBeaconBlock],
-      seq[fulu.TrustedSignedBeaconBlock],
-      seq[gloas.TrustedSignedBeaconBlock],
-      seq[heze.TrustedSignedBeaconBlock])
+  var blocks: (
+    seq[phase0.TrustedSignedBeaconBlock],
+    seq[altair.TrustedSignedBeaconBlock],
+    seq[bellatrix.TrustedSignedBeaconBlock],
+    seq[capella.TrustedSignedBeaconBlock],
+    seq[deneb.TrustedSignedBeaconBlock],
+    seq[electra.TrustedSignedBeaconBlock],
+    seq[fulu.TrustedSignedBeaconBlock],
+    seq[gloas.TrustedSignedBeaconBlock],
+    seq[heze.TrustedSignedBeaconBlock])
 
   echo "Loaded head slot ", dag.head.slot,
     " selected ", blockRefs.len, " blocks"
@@ -296,18 +296,18 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
   let stateData = newClone(dag.headState)
 
   var
-    cache = StateCache()
-    info = ForkedEpochInfo()
-    loadedState = (
-      (ref phase0.HashedBeaconState)(),
-      (ref altair.HashedBeaconState)(),
-      (ref bellatrix.HashedBeaconState)(),
-      (ref capella.HashedBeaconState)(),
-      (ref deneb.HashedBeaconState)(),
-      (ref electra.HashedBeaconState)(),
-      (ref fulu.HashedBeaconState)(),
-      (ref gloas.HashedBeaconState)(),
-      (ref heze.HashedBeaconState)())
+    cache: StateCache
+    info: ForkedEpochInfo
+  let loadedState = (
+    (ref phase0.HashedBeaconState)(),
+    (ref altair.HashedBeaconState)(),
+    (ref bellatrix.HashedBeaconState)(),
+    (ref capella.HashedBeaconState)(),
+    (ref deneb.HashedBeaconState)(),
+    (ref electra.HashedBeaconState)(),
+    (ref fulu.HashedBeaconState)(),
+    (ref gloas.HashedBeaconState)(),
+    (ref heze.HashedBeaconState)())
 
   withTimer(timers[tLoadState]):
     doAssert dag.updateState(
@@ -325,7 +325,7 @@ proc cmdBench(conf: DbConf, cfg: RuntimeConfig) =
             dag.cfg, stateData[], stateData[].slot + 1, cache,
             info, {}).expect("Slot processing can't fail with correct inputs")
 
-      var start = Moment.now()
+      let start = Moment.now()
       withTimer(timers[tApplyBlock]):
         if conf.resetCache:
           cache = StateCache()
@@ -764,14 +764,12 @@ proc cmdValidatorPerf(conf: DbConf, cfg: RuntimeConfig) =
   let
     validatorMonitor = newClone(ValidatorMonitor.init(cfg))
     dag = ChainDAGRef.init(cfg, db, validatorMonitor, {}, conf.eraDir)
-
-  var
     (start, ends) = dag.getSlotRange(conf.perfSlot, conf.perfSlots)
     blockRefs = dag.getBlockRange(start, ends)
-    perfs = newSeq[ValidatorPerformance](
-      dag.headState.validators.len())
-    cache = StateCache()
-    info = ForkedEpochInfo()
+  var
+    perfs = newSeq[ValidatorPerformance](dag.headState.validators.len())
+    cache: StateCache
+    info: ForkedEpochInfo
     blck: phase0.TrustedSignedBeaconBlock
 
   doAssert blockRefs.len() > 0, "Must select at least one block"
@@ -1159,7 +1157,7 @@ proc cmdValidatorDb(conf: DbConf, cfg: RuntimeConfig) =
 
       if nextSlot.is_epoch:
         withState(tmpState[]):
-          var stateData = newClone(forkyState.data)
+          let stateData = newClone(forkyState.data)
           rewardsAndPenalties.collectEpochRewardsAndPenalties(
             stateData[], cache, cfg, flags)
 
@@ -1217,7 +1215,7 @@ when isMainModule:
   when defined(posix):
     c_signal(SIGTERM, exitOnSigterm)
 
-  var
+  let
     conf = DbConf.load()
     cfg = getRuntimeConfig(conf.eth2Network)
 


### PR DESCRIPTION
Whereas in Fulu, the columns refer [primarily to the parent block](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/fulu/p2p-interface.md#new-data_column_sidecar_subnet_id):
```python
    # [IGNORE] The sidecar's block's parent has been seen
    # (MAY be queued for processing once the parent block is retrieved)
    if block_header.parent_root not in store.blocks:
        raise GossipIgnore("sidecar's parent has not been seen")

    # [REJECT] The sidecar's block's parent passes validation
    if block_header.parent_root not in store.block_states:
        raise GossipReject("sidecar's parent failed validation")
```

In Gloas they [refer to the current block](https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md), which means Gloas contains block/column races in a way Fulu doesn't.

Therefore, can't only use `ACCEPTED` columns in Gloas without dropping some. The column quarantine already had this `verified` vs not-`verified` structure, anticipating this distinction.

Been running this for a couple hours on `glamsterdam-devnet-6`. The column quarantine has caught 17 blocks arriving after some columns, which would have been previously dropped, and now are accounted for.

Also been comparing each predicted withdrawal with actual withdrawal and they've all matched.