### PR TITLE
Allow PAYLOAD_DUE_BPS anywhere after AGGREGATE_DUE_BPS_GLOAS

### DIFF
--- a/beacon_chain/spec/presets.nim
+++ b/beacon_chain/spec/presets.nim
@@ -1271,10 +1271,10 @@ proc readRuntimeConfig*(
       cfg.timeParams.AGGREGATE_DUE_BPS_GLOAS)
     checkParsedValue(
       "PAYLOAD_DUE_BPS", cfg.timeParams.PAYLOAD_DUE_BPS,
-      cfg.timeParams.PAYLOAD_ATTESTATION_DUE_BPS)
+      cfg.timeParams.AGGREGATE_DUE_BPS_GLOAS ..< MAX_BPS, `in`)
     checkParsedValue(
       "PAYLOAD_ATTESTATION_DUE_BPS", cfg.timeParams.PAYLOAD_ATTESTATION_DUE_BPS,
-      cfg.timeParams.AGGREGATE_DUE_BPS_GLOAS ..< MAX_BPS, `in`)
+      cfg.timeParams.PAYLOAD_DUE_BPS ..< MAX_BPS, `in`)
     checkParsedValue(
       "INCLUSION_LIST_DUE_BPS", cfg.timeParams.INCLUSION_LIST_DUE_BPS,
       0'u16 ..< MAX_BPS, `in`)

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -1589,15 +1589,6 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
   sendAttestations(node, head, slot)
   sendSyncCommitteeMessages(node, head, slot)
 
-  let payloadAttestationCutOff = node.beaconClock.fromNow(
-    slot.payload_attestation_deadline(node.dag.timeParams))
-  if payloadAttestationCutOff.inFuture:
-    debug "Waiting to send payload attestations",
-      payloadAttestationCutOff = shortLog(payloadAttestationCutOff.offset)
-    await sleepAsync(payloadAttestationCutOff.offset)
-
-  sendPayloadAttestations(node, head, slot)
-
   updateValidatorMetrics(node) # the important stuff is done, update the vanity numbers
 
   # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.2/specs/phase0/validator.md#broadcast-aggregate
@@ -1616,6 +1607,15 @@ proc handleValidatorDuties*(node: BeaconNode, lastSlot, slot: Slot) {.async: (ra
 
   sendAggregatedAttestations(node, head, slot)
   sendSyncCommitteeContributions(node, head, slot)
+
+  let payloadAttestationCutOff = node.beaconClock.fromNow(
+    slot.payload_attestation_deadline(node.dag.timeParams))
+  if payloadAttestationCutOff.inFuture:
+    debug "Waiting to send payload attestations",
+      payloadAttestationCutOff = shortLog(payloadAttestationCutOff.offset)
+    await sleepAsync(payloadAttestationCutOff.offset)
+
+  sendPayloadAttestations(node, head, slot)
 
   await node.sendProposerPreferences(head, slot)
 


### PR DESCRIPTION
PAYLOAD_ATTESTATION_DUE_BPS and PAYLOAD_DUE_BPS do not necessarily have to match, allow payload attestations anywhere after aggregates.