### PR TITLE
Skip zero ports when building peer dial addresses

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -1364,7 +1364,7 @@ func toPeerAddr*(r: enr.TypedRecord,
   for proto in peerAddrProto:
     case proto
     of PeerAddrProto.TCP:
-      if r.ip.isSome and r.tcp.isSome:
+      if r.ip.isSome and r.tcp.isSome and r.tcp.get != 0:
         let ip = IpAddress(
           family: IpAddressFamily.IPv4,
           address_v4: r.ip.get)
@@ -1374,9 +1374,9 @@ func toPeerAddr*(r: enr.TypedRecord,
         let ip = IpAddress(
           family: IpAddressFamily.IPv6,
           address_v6: r.ip6.get)
-        if r.tcp6.isSome:
+        if r.tcp6.isSome and r.tcp6.get != 0:
           addrs.add tcpEndPoint(ip, Port r.tcp6.get)
-        elif r.tcp.isSome:
+        elif r.tcp.isSome and r.tcp.get != 0:
           addrs.add tcpEndPoint(ip, Port r.tcp.get)
         else:
           discard
@@ -1400,7 +1400,7 @@ func toPeerAddr*(r: enr.TypedRecord,
           discard
 
     of PeerAddrProto.QUIC:
-      if r.ip.isSome and r.quic.isSome:
+      if r.ip.isSome and r.quic.isSome and r.quic.get != 0:
         let ip = IpAddress(
             family: IpAddressFamily.IPv4,
             address_v4: r.ip.get)
@@ -1410,9 +1410,9 @@ func toPeerAddr*(r: enr.TypedRecord,
         let ip = IpAddress(
           family: IpAddressFamily.IPv6,
           address_v6: r.ip6.get)
-        if r.quic6.isSome:
+        if r.quic6.isSome and r.quic6.get != 0:
           addrs.add quicEndPoint(ip, Port r.quic6.get)
-        elif r.quic.isSome:
+        elif r.quic.isSome and r.quic.get != 0:
           addrs.add quicEndPoint(ip, Port r.quic.get)
         else:
           discard

--- a/tests/test_discovery.nim
+++ b/tests/test_discovery.nim
@@ -479,3 +479,21 @@ suite "Discovery fork ID":
       not isCompatibleForkId(bellatrixForkId, altairForkId)
       not isCompatibleForkId(bellatrixForkId, altairBellatrixForkId)
       isCompatibleForkId(bellatrixForkId, bellatrixForkId)
+
+suite "toPeerAddr port handling":
+  test "Skips zero tcp/quic ports":
+    let
+      rng = HmacDrbgContext.new()
+      pk = keys.PrivateKey.random(rng[])
+      ip = IpAddress(family: IpAddressFamily.IPv4, address_v4: [127'u8, 0, 0, 1])
+      zeroTcp = enr.Record.init(1'u64, pk, Opt.some(ip),
+        tcpPort = Opt.some(Port(0)), udpPort = Opt.some(Port(9000))).get()
+      goodTcp = enr.Record.init(2'u64, pk, Opt.some(ip),
+        tcpPort = Opt.some(Port(9000)), udpPort = Opt.some(Port(9000))).get()
+      zeroQuic = enr.Record.init(3'u64, pk, Opt.some(ip),
+        quicPort = Opt.some(Port(0))).get()
+
+    check:
+      TypedRecord.fromRecord(zeroTcp).toPeerAddr([PeerAddrProto.TCP]).isErr()
+      TypedRecord.fromRecord(goodTcp).toPeerAddr([PeerAddrProto.TCP]).isOk()
+      TypedRecord.fromRecord(zeroQuic).toPeerAddr([PeerAddrProto.QUIC]).isErr()


### PR DESCRIPTION
`toPeerAddr` builds dial multiaddrs from a peer's ENR. For a record advertising a `tcp`/`tcp6`/`quic`/`quic6` port of `0`, it produced an undialable `/ip4/x/tcp/0` (or `/udp/0` for QUIC) address and handed it to `switch.connect`, wasting a dial attempt (and, for static peers, retried).

Treat a zero port as absent for the TCP and QUIC dial transports, matching how the reference clients skip such records (e.g. go-ethereum's dialer returns `errNoPort`). The UDP branch is unchanged since it is not used for dialing.

Found during a cross-client discv5 audit; the same fix landed in Erigon's caplin sentinel (erigontech/erigon#22271).

Test added in `tests/test_discovery.nim`; it fails before the change (a `tcp=0` / `quic=0` record yields a dial address) and passes after.
