### PR TITLE
 add gloas builder-API execution-payload-bid client

### DIFF
--- a/beacon_chain/spec/mev/rest_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_mev_calls.nim
@@ -47,6 +47,35 @@ proc getHeader*(
     restAcceptType = "application/octet-stream,application/json;q=0.5",
   )
 
+proc getExecutionPayloadBidPlain*(
+    slot: Slot,
+    parent_hash: Eth2Digest,
+    parent_root: Eth2Digest,
+    proposer_pubkey: ValidatorPubKey
+): RestPlainResponse {.
+  rest, endpoint:
+    "/eth/v1/builder/execution_payload_bid/{slot}/{parent_hash}/{parent_root}/{proposer_pubkey}",
+  meth: MethodPost, connection: {Dedicated, Close}.}
+  ## https://github.com/ethereum/builder-specs/blob/78a5546d9d8253beabf7db8baf988a58abdec87f/apis/builder/execution_payload_bid.yaml
+
+proc getExecutionPayloadBid*(
+    client: RestClientRef,
+    slot: Slot,
+    parent_hash: Eth2Digest,
+    parent_root: Eth2Digest,
+    proposer_pubkey: ValidatorPubKey
+): Future[RestPlainResponse] {.
+  async: (raises: [CancelledError, RestEncodingError, RestDnsResolveError,
+                   RestCommunicationError], raw: true).} =
+  debugGloasComment""
+  # The `SignedRequestAuthV1` request body is optional to send; a builder MAY
+  # still refuse unauthenticated requests (401). We send none for now. Request
+  # the SSZ (octet-stream) encoding of the bare `SignedExecutionPayloadBid`.
+  client.getExecutionPayloadBidPlain(
+    slot, parent_hash, parent_root, proposer_pubkey,
+    restAcceptType = "application/octet-stream",
+  )
+
 proc submitBlindedBlockV2Plain*(
     body: fulu_mev.SignedBlindedBeaconBlock
 ): RestPlainResponse {.

--- a/beacon_chain/spec/mev/rest_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_mev_calls.nim
@@ -69,7 +69,7 @@ proc getExecutionPayloadBid*(
                    RestCommunicationError], raw: true).} =
   debugGloasComment""
   # The `SignedRequestAuthV1` request body is optional to send; a builder MAY
-  # still refuse unauthenticated requests (401). None sentt for now.
+  # still refuse unauthenticated requests (401). None sent for now.
   client.getExecutionPayloadBidPlain(
     slot, parent_hash, parent_root, proposer_pubkey,
     restAcceptType = "application/octet-stream",

--- a/beacon_chain/spec/mev/rest_mev_calls.nim
+++ b/beacon_chain/spec/mev/rest_mev_calls.nim
@@ -69,8 +69,7 @@ proc getExecutionPayloadBid*(
                    RestCommunicationError], raw: true).} =
   debugGloasComment""
   # The `SignedRequestAuthV1` request body is optional to send; a builder MAY
-  # still refuse unauthenticated requests (401). We send none for now. Request
-  # the SSZ (octet-stream) encoding of the bare `SignedExecutionPayloadBid`.
+  # still refuse unauthenticated requests (401). None sentt for now.
   client.getExecutionPayloadBidPlain(
     slot, parent_hash, parent_root, proposer_pubkey,
     restAcceptType = "application/octet-stream",

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -475,7 +475,10 @@ proc proposeBlockAux(
     if not payloadBuilderClient.isNil:
       builderApiBidFut = node.getBuilderExecutionPayloadBid(
         fork, payloadBuilderClient, state, slot,
-        proposalExecutionHead(state[].forky(fork).data),
+        if shouldExtendPayload:
+          proposalExecutionHead(state[].forky(fork).data)
+        else:
+          state[].forky(fork).data.latest_execution_payload_bid.parent_block_hash,
         state[].forky(fork).data.get_block_root_at_slot(slot - 1),
         validator.pubkey)
 

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -465,6 +465,20 @@ proc proposeBlockAux(
       else:
         default(fork.ExecutionRequests)
 
+  # Start the builder-API execution-payload-bid request now so it
+  # runs concurrently with the local execution payload build below
+  var builderApiBidFut: Future[Opt[gloas.SignedExecutionPayloadBid]]
+  when fork >= ConsensusFork.Gloas:
+    let payloadBuilderClient =
+      node.getPayloadBuilderClient(validator_index.distinctBase).valueOr(nil)
+    if not payloadBuilderClient.isNil:
+      builderApiBidFut = node.getBuilderExecutionPayloadBid(
+        fork, payloadBuilderClient, state, slot,
+        proposalExecutionHead(state[].forky(fork).data),
+        state[].forky(fork).data.get_block_root_at_slot(slot - 1),
+        validator.pubkey)
+
+  let
     engineBid =
       when fork == ConsensusFork.Heze:
         debugHezeComment "stub: heze block proposals"
@@ -599,6 +613,8 @@ proc proposeBlockAux(
         static: raiseAssert "Unsupported fork " & $fork
 
   if engineBid.isNone():
+    if not builderApiBidFut.isNil and not builderApiBidFut.finished:
+      await builderApiBidFut.cancelAndWait()
     beacon_block_production_errors.inc()
     return head
 
@@ -614,21 +630,39 @@ proc proposeBlockAux(
           Opt.none gloas.SignedExecutionPayloadBid
       localBlockValueBoost =
         BoostFactor.init(node.config.localBlockValueBoost)
-      usePoolBid =
-        poolBid.isSome and
+
+    let builderApiBid =
+      if builderApiBidFut.isNil:
+        Opt.none(gloas.SignedExecutionPayloadBid)
+      else:
+        await builderApiBidFut
+
+    let
+      bestBuilderBid =
+        if poolBid.isSome and builderApiBid.isSome:
+          if builderApiBid.get().message.value > poolBid.get().message.value:
+            builderApiBid
+          else:
+            poolBid
+        elif builderApiBid.isSome:
+          builderApiBid
+        else:
+          poolBid
+      useBuilderBid =
+        bestBuilderBid.isSome and
         builderBetterBid(
           localBlockValueBoost,
-          poolBid.get().message.value.uint64.u256 * GWEI_TO_WEI.u256,
+          bestBuilderBid.get().message.value.uint64.u256 * GWEI_TO_WEI.u256,
           engineBid[].eps.blockValue)
       selectedBuilderBid =
-        if usePoolBid:
-          info "Using builder bid from pool",
+        if useBuilderBid:
+          info "Using builder bid",
             slot,
-            builderIndex = poolBid.get().message.builder_index,
-            bidValue = poolBid.get().message.value,
+            builderIndex = bestBuilderBid.get().message.builder_index,
+            bidValue = bestBuilderBid.get().message.value,
             engineValue = engineBid[].eps.blockValue,
             localBlockValueBoost
-          Opt.some(poolBid.get())
+          bestBuilderBid
         else:
           Opt.none(gloas.SignedExecutionPayloadBid)
 

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -466,8 +466,9 @@ proc proposeBlockAux(
         default(fork.ExecutionRequests)
 
   # Start the builder-API execution-payload-bid request now so it
-  # runs concurrently with the local execution payload build below
-  var builderApiBidFut: Future[Opt[gloas.SignedExecutionPayloadBid]]
+  # runs concurrently with the local execution payload build below.
+  var builderApiBidFut:
+    Future[Opt[gloas.SignedExecutionPayloadBid]].Raising([CancelledError])
   when fork >= ConsensusFork.Gloas:
     let payloadBuilderClient =
       node.getPayloadBuilderClient(validator_index.distinctBase).valueOr(nil)

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -462,6 +462,39 @@ proc getSignedBuilderBid(
     )
   ok res.data
 
+# https://github.com/ethereum/builder-specs/blob/78a5546d9d8253beabf7db8baf988a58abdec87f/apis/builder/execution_payload_bid.yaml
+proc getExecutionPayloadBidFromBuilder*(
+    payloadBuilderClient: RestClientRef,
+    slot: Slot,
+    parent_hash: Eth2Digest,
+    parent_root: Eth2Digest,
+    proposer_pubkey: ValidatorPubKey,
+): Future[Result[gloas.SignedExecutionPayloadBid, string]] {.
+    async: (raises: [CancelledError]).} =
+  info "Requesting execution payload bid",
+    slot, parent_hash = shortLog(parent_hash), pubkey = shortLog(proposer_pubkey)
+
+  let response =
+    try:
+      await payloadBuilderClient.getExecutionPayloadBid(
+        slot, parent_hash, parent_root, proposer_pubkey)
+    except RestDecodingError as exc:
+      return err("getExecutionPayloadBid REST decoding error: " & exc.msg)
+    except RestError as exc:
+      return err("getExecutionPayloadBid REST error: " & exc.msg)
+
+  if response.status == 204:
+    return err("builder has no execution payload bid available")
+  if response.status != 200:
+    return err("getExecutionPayloadBid: HTTP error " & $response.status)
+
+  let bid =
+    try:
+      SSZ.decode(response.data, gloas.SignedExecutionPayloadBid)
+    except CatchableError as exc:
+      return err("getExecutionPayloadBid SSZ decode error: " & exc.msg)
+  ok(bid)
+
 proc getBuilderBid(
     node: BeaconNode,
     consensusFork: static ConsensusFork,

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -495,6 +495,36 @@ proc getExecutionPayloadBidFromBuilder*(
       return err("getExecutionPayloadBid SSZ decode error: " & exc.msg)
   ok(bid)
 
+proc getBuilderExecutionPayloadBid*(
+    node: BeaconNode,
+    consensusFork: static ConsensusFork,
+    payloadBuilderClient: RestClientRef,
+    proposalState: ref ForkedHashedBeaconState,
+    slot: Slot,
+    parent_block_hash: Eth2Digest,
+    parent_block_root: Eth2Digest,
+    proposer_pubkey: ValidatorPubKey,
+): Future[Opt[gloas.SignedExecutionPayloadBid]] {.
+    async: (raises: [CancelledError]).} =
+  let
+    bidRes = awaitWithTimeout(
+      getExecutionPayloadBidFromBuilder(
+        payloadBuilderClient, slot, parent_block_hash, parent_block_root,
+        proposer_pubkey),
+      BUILDER_PROPOSAL_DELAY_TOLERANCE):
+        return Opt.none(gloas.SignedExecutionPayloadBid)
+
+    signedBid = bidRes.valueOr:
+      debug "No builder-API execution payload bid", slot, err = error
+      return Opt.none(gloas.SignedExecutionPayloadBid)
+
+  node.dag.cfg.can_process_execution_payload_bid(
+      proposalState[].forky(consensusFork).data, signedBid, slot).isOkOr:
+    notice "Discarding invalid builder-API bid", slot, err = error
+    return Opt.none(gloas.SignedExecutionPayloadBid)
+
+  Opt.some(signedBid)
+
 proc getBuilderBid(
     node: BeaconNode,
     consensusFork: static ConsensusFork,


### PR DESCRIPTION
 https://github.com/ethereum/builder-specs/blob/main/apis/builder/execution_payload_bid.yaml

When `--payload-builder-url` is set, the node requests a bid from that builder in parallel with the engine build. The better of the gossip and builder-API bids is compared against the engine payload's value