### PR TITLE
replace deprecated actions/cache@v4 with actions/cache@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows'
         id: windows-mingw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: external/mingw-${{ matrix.target.cpu }}
           key: 'mingw-llvm-17-${{ matrix.target.cpu }}'
@@ -174,7 +174,7 @@ jobs:
       - name: Restore prebuilt Nim from cache
         if: matrix.branch == null
         id: nim-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: NimBinCache
           key: 'nim-${{ matrix.target.os }}-${{ matrix.target.cpu }}-${{ steps.versions.outputs.nimbus_build_system }}'

--- a/beacon_chain/trusted_node_sync.nim
+++ b/beacon_chain/trusted_node_sync.nim
@@ -262,7 +262,7 @@ proc fetchCheckpointState*(
   syncTarget: TrustedNodeSyncTarget,
   genesisState: ref ForkedHashedBeaconState,
 ): Future[ref ForkedHashedBeaconState] {.async: (raises: [CancelledError]).} =
-  var
+  let
     client = createNewRestClient(restUrl).valueOr:
       error "Cannot connect to server", url = restUrl, reason = error
       quit 1


### PR DESCRIPTION
Triggers
> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/