### PR TITLE
Support alternate spellings of Authorization scheme

### DIFF
--- a/AllTests-mainnet.md
+++ b/AllTests-mainnet.md
@@ -933,6 +933,8 @@ AllTests-mainnet
 ## ListKeys requests [Beacon Node] [Preset: mainnet]
 ```diff
 + Correct token provided [Beacon Node] [Preset: mainnet]                                     OK
++ Different Authorization Header spelling [Beacon Node] [Preset: mainnet]                    OK
++ Empty Authorization Token [Beacon Node] [Preset: mainnet]                                  OK
 + Invalid Authorization Header [Beacon Node] [Preset: mainnet]                               OK
 + Invalid Authorization Token [Beacon Node] [Preset: mainnet]                                OK
 + Missing Authorization header [Beacon Node] [Preset: mainnet]                               OK

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -11,7 +11,7 @@
 # please keep imports clear of `rest_utils` or any other module which imports
 # beacon node's specific networking code.
 
-import std/[strutils, tables]
+import std/tables
 import chronos, chronicles, confutils,
        results, stew/[base10, io2], blscurve, presto,
        nimcrypto/utils
@@ -86,9 +86,10 @@ func checkAuthorization*(
   let authorizations = request.headers.getList("authorization")
   if authorizations.len > 0:
     for authHeader in authorizations:
-      let parts = authHeader.split(' ', maxsplit = 1)
-      if parts.len == 2 and parts[0] == "Bearer":
-        if equalMemFull(parts[1], host.keymanagerToken):
+      let auth = getAuthorization(authHeader).valueOr:
+        return err invalidAuthorizationHeader
+      if auth.scheme == "bearer":
+        if equalMemFull(auth.credentials, host.keymanagerToken):
           return ok()
         else:
           return err incorrectToken
@@ -98,7 +99,7 @@ func checkAuthorization*(
 
 proc authErrorResponse(error: AuthorizationError): RestApiResponse =
   let status = case error:
-    of missingBearerScheme, noAuthorizationHeader:
+    of missingBearerScheme, invalidAuthorizationHeader, noAuthorizationHeader:
       Http401
     of incorrectToken:
       Http403

--- a/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
@@ -1,5 +1,5 @@
 # beacon_chain
-# Copyright (c) 2021-2024 Status Research & Development GmbH
+# Copyright (c) 2021-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).

--- a/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
+++ b/beacon_chain/spec/eth2_apis/rest_keymanager_types.nim
@@ -97,6 +97,7 @@ type
 
   AuthorizationError* = enum
     noAuthorizationHeader = "Missing Authorization Header"
+    invalidAuthorizationHeader = "Malformed Authorization Header"
     missingBearerScheme = "Bearer Authentication is not included in request"
     incorrectToken = "Authentication token is incorrect"
 

--- a/tests/test_keymanager_api.nim
+++ b/tests/test_keymanager_api.nim
@@ -812,6 +812,13 @@ proc runTests(keymanager: KeymanagerToTest) {.async.} =
 
       check filesystemKeys == apiKeys
 
+    asyncTest "Different Authorization Header spelling" & testFlavour:
+      let
+        response = await client.listKeysPlain(
+          extraHeaders = @[("Authorization", "BEARER  " & correctTokenValue)])
+
+      check response.status == 200
+
     asyncTest "Missing Authorization header" & testFlavour:
       let
         response = await client.listKeysPlain()
@@ -829,6 +836,16 @@ proc runTests(keymanager: KeymanagerToTest) {.async.} =
 
       check:
         response.status == 401
+        responseJson["message"].getStr() == InvalidAuthorizationError
+
+    asyncTest "Empty Authorization Token" & testFlavour:
+      let
+        response = await client.listKeysPlain(
+          extraHeaders = @[("Authorization", "Bearer")])
+        responseJson = Json.decode(response.data, JsonNode)
+
+      check:
+        response.status == 403
         responseJson["message"].getStr() == InvalidAuthorizationError
 
     asyncTest "Invalid Authorization Token" & testFlavour:


### PR DESCRIPTION
Authorization scheme ("Bearer") is case insensitive but we reject different spellings. Use the httputils helper in keymanager API.