### PR TITLE
bucket seen preferences by epoch mod (MIN_SEED_LOOKAHEAD + 2)

### DIFF
--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -145,8 +145,7 @@ type
     lightClientPool: ref LightClientPool
     executionPayloadBidPool*: ref ExecutionPayloadBidPool
     payloadAttestationPool*: ref PayloadAttestationPool
-    seenProposerPreferences*:
-      array[2, array[SLOTS_PER_EPOCH, Table[Eth2Digest, ProposerPreferences]]]
+    seenProposerPreferences*: SeenProposerPreferences
 
     doppelgangerDetection*: DoppelgangerProtection
 

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1855,7 +1855,7 @@ proc validateLightClientOptimisticUpdate*(
   pool.latestForwardedOptimisticSlot = attested_slot
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md#execution_payload_bid
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/p2p-interface.md#execution_payload_bid
 proc validateExecutionPayloadBid*(
     dag: ChainDAGRef,
     executionPayloadBidPool: ref ExecutionPayloadBidPool,
@@ -1954,10 +1954,10 @@ proc validateExecutionPayloadBid*(
           dag.cfg.get_blob_parameters(bid.slot.epoch()).MAX_BLOBS_PER_BLOCK):
         return dag.checkedReject("ExecutionPayloadBid: invalid kzg commitments")
 
-      # [REJECT] `bid.fee_recipient` matches the `fee_recipient` from the
+      # [IGNORE] `bid.fee_recipient` matches the `fee_recipient` from the
       # proposer's `SignedProposerPreferences` associated with `bid.slot`.
       if not (bid.fee_recipient == seenPref.fee_recipient):
-        return dag.checkedReject("ExecutionPayloadBid: fee recipient mismatch")
+        return errIgnore("ExecutionPayloadBid: fee recipient mismatch")
 
       # Extra check to prevent unincludable bids from purging legitimate ones
       # from the execution payload pool
@@ -2079,7 +2079,7 @@ proc validatePayloadAttestationMessage*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/p2p-interface.md#proposer_preferences
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/p2p-interface.md#proposer_preferences
 proc validateProposerPreferences*(
     dag: ChainDAGRef,
     seen: var SeenProposerPreferences,

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -51,6 +51,10 @@ declareCounter beacon_contributions_dropped_queue_full,
 type
   ValidationError* = (ValidationResult, cstring)
 
+  SeenProposerPreferences* =
+    array[MIN_SEED_LOOKAHEAD + 2,
+      array[SLOTS_PER_EPOCH, Table[Eth2Digest, ProposerPreferences]]]
+
 template errIgnore*(msg: cstring): untyped =
   err((ValidationResult.Ignore, msg))
 template errReject*(msg: cstring): untyped =
@@ -1855,8 +1859,7 @@ proc validateLightClientOptimisticUpdate*(
 proc validateExecutionPayloadBid*(
     dag: ChainDAGRef,
     executionPayloadBidPool: ref ExecutionPayloadBidPool,
-    seenProposerPreferences:
-      var array[2, array[SLOTS_PER_EPOCH, Table[Eth2Digest, ProposerPreferences]]],
+    seenProposerPreferences: var SeenProposerPreferences,
     signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
     wallTime: BeaconTime): Result[PayloadAvailability, ValidationError] =
   template bid: untyped = signed_execution_payload_bid.message
@@ -1920,7 +1923,7 @@ proc validateExecutionPayloadBid*(
 
       let bidDependentRoot = dag.get_dependent_root(parentBlck.bid, bid.slot)
       let
-        seenBucket = uint64(bid.slot.epoch()) mod 2
+        seenBucket = uint64(bid.slot.epoch()) mod (MIN_SEED_LOOKAHEAD + 2)
         seenKey = uint64(bid.slot) mod SLOTS_PER_EPOCH
       var seenPref: ProposerPreferences
       seenProposerPreferences[seenBucket][seenKey].withValue(
@@ -2079,7 +2082,7 @@ proc validatePayloadAttestationMessage*(
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.10/specs/gloas/p2p-interface.md#proposer_preferences
 proc validateProposerPreferences*(
     dag: ChainDAGRef,
-    seen: var array[2, array[SLOTS_PER_EPOCH, Table[Eth2Digest, ProposerPreferences]]],
+    seen: var SeenProposerPreferences,
     signed_preferences: SignedProposerPreferences,
     wallTime: BeaconTime): Result[void, ValidationError] =
   template preferences: untyped = signed_preferences.message
@@ -2126,7 +2129,7 @@ proc validateProposerPreferences*(
   # for the tuple (preferences.dependent_root, preferences.proposal_slot,
   # preferences.validator_index).
   let
-    bucket = proposalEpoch.uint64 mod 2
+    bucket = proposalEpoch.uint64 mod (MIN_SEED_LOOKAHEAD + 2)
     slotInEpoch = preferences.proposal_slot.uint64 mod SLOTS_PER_EPOCH
   if preferences.dependent_root in seen[bucket][slotInEpoch]:
     return errIgnore("ProposerPreferences: already seen")

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1798,7 +1798,8 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
 
     if slot.epoch > 0:
       let justEnded = slot.epoch - Epoch(1)
-      node.processor.seenProposerPreferences[justEnded.uint64 mod 2].reset()
+      node.processor.seenProposerPreferences[
+        justEnded.uint64 mod (MIN_SEED_LOOKAHEAD + 2)].reset()
 
   # Update upcoming actions - we do this every slot in case a reorg happens
   let head = node.dag.head

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -500,8 +500,7 @@ suite "Proposer preferences validation " & preset():
       dag = ChainDAGRef.init(
         cfg, cfg.makeTestDB(SLOTS_PER_EPOCH * 3),
         validatorMonitor, {})
-    var seen: array[2, array[
-      SLOTS_PER_EPOCH, Table[Eth2Digest, ProposerPreferences]]]
+    var seen: SeenProposerPreferences
 
     # Pick an upcoming slot and its scheduled proposer from the head state's
     # proposer_lookahead.


### PR DESCRIPTION
The seen proposer-preferences cache used only 2 epoch buckets (mod 2), where three consecutive epochs should stay distinct. the cache needs room for 3 epochs worth of prefss at once: the one being wiped (`E-1`, current: `E`, and next: `E+1`). With only 2 buckets, the `E-1` and the `E+1` share one bucket , so wiping `E-1` also wipes `E+1` preferences