### PR TITLE
RPC chunks with stricter DOS limits where possible

### DIFF
--- a/beacon_chain/networking/eth2_network.nim
+++ b/beacon_chain/networking/eth2_network.nim
@@ -219,6 +219,7 @@ type
     SizePrefixOverflow
     InvalidContextBytes
     ResponseChunkOverflow
+    ExtraBytes
 
     UnknownError
 
@@ -940,6 +941,28 @@ proc readChunkPayload*(conn: Connection, peer: Peer,
   except SerializationError:
     neterr InvalidSszBytes
 
+proc readRequest(
+    conn: Connection, peer: Peer, MsgType: type
+): Future[NetRes[MsgType]] {.async: (raises: [CancelledError]).} =
+  let msg = ? await readChunkPayload(conn, peer, MsgType)
+
+  # A reader MUST consider the following cases as invalid input:
+  # - Any remaining bytes, after having read the n SSZ bytes.
+  #   An EOF is expected if more bytes are read than required.
+  # - [...]
+  # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/phase0/p2p-interface.md#ssz-snappy-encoding-strategy
+  var extraByte: byte
+  try:
+    await conn.readExactly(addr extraByte, 1)
+    neterr ExtraBytes
+  except LPStreamEOFError:  #, LPStreamIncompleteError: nim-lang/Nim#25903
+    ok msg
+  except LPStreamIncompleteError:
+    ok msg
+  except LPStreamError as exc:
+    debug "Unexpected error reading extra bytes after payload", exc = exc.msg
+    neterr BrokenConnection
+
 proc readResponseChunk(
     conn: Connection, peer: Peer, MsgType: typedesc):
     Future[NetRes[MsgType]] {.async: (raises: [CancelledError]).} =
@@ -979,7 +1002,7 @@ proc readResponseChunk(
   of Success:
     discard
 
-  return await readChunkPayload(conn, peer, MsgType)
+  await readChunkPayload(conn, peer, MsgType)
 
 proc readResponse(
     conn: Connection, peer: Peer,
@@ -1250,7 +1273,7 @@ proc handleIncomingStream(network: Eth2Node,
           let deadline = sleepAsync RESP_TIMEOUT_DUR
 
           awaitWithTimeout(
-            readChunkPayload(conn, peer, MsgRec), deadline):
+            readRequest(conn, peer, MsgRec), deadline):
               # Timeout, e.g., cancellation due to fulfillment by different peer.
               # Treat this similarly to `UnexpectedEOF`, `PotentiallyExpectedEOF`.
               nbc_reqresp_messages_failed.inc(1, [shortProtocolId(protocolId)])
@@ -1322,6 +1345,9 @@ proc handleIncomingStream(network: Eth2Node,
 
         of ResponseChunkOverflow:
           (InvalidRequest, errorMsgLit "Too many chunks in response")
+
+        of ExtraBytes:
+          (InvalidRequest, errorMsgLit "Extra bytes after payload")
 
         of UnknownError:
           (InvalidRequest, errorMsgLit "Unknown error while processing request")


### PR DESCRIPTION
Extra bytes beyond the `n` SSZ bytes in a Req/Resp request are required to invalidate the prior request:

- https://github.com/ethereum/consensus-specs/pull/1606

Should be fine on all of Mplex, Yamux and Quic, i.e., the protocol requires the sender to explicitly half-close their end of the stream, so we can always read the EOF explicitly on the reading end.

If there's a disconnect between the end of the request or the EOF, the regular 10 second read timeout would eventually hit.

Impact is potentially a tiny higher latency before requests are answered as we wait for 1 more signal that may or may not be combined with the last request byte.

Closes #8435