### PR TITLE
Drop unused debug-enable-reconstruction flag

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -238,12 +238,6 @@ type
       desc: "Backward compatible partial data column sidecar support",
       name: "debug-partial-columns" .}: bool
 
-    debugEnableReconstruction* {.
-      hidden
-      defaultValue: false,
-      desc: "Enables column reconstruction for the currently running beacon node"
-      name: "debug-enable-reconstruction" .}: bool
-
     slashingDbKind* {.
       hidden
       defaultValue: SlashingDbKind.v2


### PR DESCRIPTION
Flag isn't used anywhere in code, and it's a "debug-" flag so can be removed at any time without warning.