### PR TITLE
enable QUIC by default

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -318,7 +318,7 @@ type
       quicEnabled* {.
         hidden
         desc: "Enable QUIC transport"
-        defaultValue: false
+        defaultValue: true
         name: "debug-quic" .}: bool
 
       quicPort* {.
@@ -848,7 +848,7 @@ type
         quicExtEnabled* {.
           hidden
           desc: "Enable QUIC transport"
-          defaultValue: false
+          defaultValue: true
           name: "debug-quic" .}: bool
 
         quicPortExt* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -322,7 +322,6 @@ type
         name: "debug-quic" .}: bool
 
       quicPort* {.
-        hidden
         desc: "Listening UDP port for Ethereum LibP2P traffic over QUIC"
         defaultValue: defaultEth2QuicPort
         defaultValueDesc: $defaultEth2QuicPortDesc
@@ -852,7 +851,6 @@ type
           name: "debug-quic" .}: bool
 
         quicPortExt* {.
-          hidden
           desc: "External QUIC port"
           defaultValue: defaultEth2QuicPort
           name: "quic-port" .}: Port

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -72,7 +72,7 @@ type LightClientConf* = object
   quicEnabled* {.
     hidden
     desc: "Enable QUIC transport"
-    defaultValue: false
+    defaultValue: true
     name: "debug-quic" .}: bool
 
   quicPort* {.

--- a/beacon_chain/conf_light_client.nim
+++ b/beacon_chain/conf_light_client.nim
@@ -76,7 +76,6 @@ type LightClientConf* = object
     name: "debug-quic" .}: bool
 
   quicPort* {.
-    hidden
     desc: "Listening UDP port for Ethereum LibP2P traffic over QUIC"
     defaultValue: defaultEth2QuicPort
     defaultValueDesc: $defaultEth2QuicPortDesc

--- a/docs/the_nimbus_book/src/options.md
+++ b/docs/the_nimbus_book/src/options.md
@@ -61,6 +61,7 @@ The following options are available:
      --bootstrap-file          Specifies a line-delimited file of bootstrap Ethereum network addresses.
      --listen-address          Listening address for the Ethereum LibP2P and Discovery v5 traffic [=*].
      --tcp-port                Listening TCP port for Ethereum LibP2P traffic [=9000].
+     --quic-port               Listening UDP port for Ethereum LibP2P traffic over QUIC [=9001].
      --udp-port                Listening UDP port for node discovery [=9000].
      --max-peers               The target number of peers to connect to [=160].
      --hard-max-peers          The maximum number of peers to connect to. Defaults to maxPeers * 1.5.


### PR DESCRIPTION
Previous attempt failed due to:
- https://github.com/vacp2p/nim-libp2p/issues/2817

This has since been fixed by:
- https://github.com/vacp2p/nim-lsquic/pull/99 / #8759

So try again.