### PR TITLE
Use same file limits in light client as in BN/VC

### DIFF
--- a/beacon_chain/nimbus_light_client.nim
+++ b/beacon_chain/nimbus_light_client.nim
@@ -43,6 +43,8 @@ proc main() {.noinline, raises: [CatchableError].} =
     writePanicLine error # Logging not yet set up
     quit QuitFailure
 
+  setupFileLimits()
+
   notice "Launching light client",
     version = fullVersionStr, cmdParams = commandLineParams(), config
 


### PR DESCRIPTION
Light client was not raising its fd limit from system default, so that with too many peers, it could have trouble responding to port checks. Mirror the file limit setup to match the one from the BN/VC. The earlier #8411 should further help monitoring peer count.

Closes #8371