### PR TITLE
optimize SyncCommittee default/zero comparisons

### DIFF
--- a/beacon_chain/spec/crypto.nim
+++ b/beacon_chain/spec/crypto.nim
@@ -33,6 +33,7 @@ from std/sequtils import mapIt
 from std/tables import Table, withValue, `[]=`
 
 from nimcrypto/utils import burnMem
+from stew/staticfor import staticFor
 
 export results, blscurve, rand, json_serialization
 
@@ -409,6 +410,15 @@ func fromHex*(T: type BlsCurveType, hexStr: string): BlsResult[T] {.inline.} =
 
 func `==`*(a, b: ValidatorPubKey | ValidatorSig): bool =
   equalMem(unsafeAddr a.blob[0], unsafeAddr b.blob[0], sizeof(a.blob))
+
+func isZero*(x: ValidatorPubKey): bool =
+  var tmp {.noinit.}: uint64
+  var tmp2 = 0'u64
+  static: doAssert sizeof(x.blob) mod sizeof(tmp) == 0
+  staticFor i, 0 ..< sizeof(x.blob) div sizeof(tmp):
+    copyMem(addr tmp, addr x.blob[i * sizeof(tmp)], sizeof(tmp))
+    tmp2 = tmp2 or tmp
+  tmp2 == 0
 
 func `==`*(a, b: ValidatorPrivKey): bool {.error: "Secret keys should stay secret".}
 

--- a/beacon_chain/spec/datatypes/altair.nim
+++ b/beacon_chain/spec/datatypes/altair.nim
@@ -24,6 +24,7 @@ import
 
 export base, sets
 
+from std/sequtils import allIt
 from ssz_serialization/proofs import GeneralizedIndex, get_generalized_index
 export proofs.GeneralizedIndex
 
@@ -404,6 +405,9 @@ type
 chronicles.formatIt BeaconBlock: it.shortLog
 chronicles.formatIt SyncSubcommitteeIndex: uint8(it)
 
+func isZero*(v: SyncCommittee): bool =
+  allIt(v.pubkeys.data, it.isZero) and v.aggregate_pubkey.isZero
+
 template asList*(epochFlags: EpochParticipationFlags): untyped =
   List[ParticipationFlags, Limit VALIDATOR_REGISTRY_LIMIT] epochFlags
 template asList*(epochFlags: var EpochParticipationFlags): untyped =
@@ -687,7 +691,7 @@ func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     has_next_sync_committee:
-      v.next_sync_committee != static(default(typeof(v.next_sync_committee))),
+      not v.next_sync_committee.isZero,
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -759,7 +759,7 @@ func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     has_next_sync_committee:
-      v.next_sync_committee != static(default(typeof(v.next_sync_committee))),
+      not v.next_sync_committee.isZero,
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -780,7 +780,7 @@ func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     has_next_sync_committee:
-      v.next_sync_committee != static(default(typeof(v.next_sync_committee))),
+      not v.next_sync_committee.isZero,
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -29,7 +29,7 @@ from stew/bitops2 import log2trunc
 from stew/byteutils import to0xHex
 from ./altair import
   EpochParticipationFlags, InactivityScores, SyncAggregate, SyncCommittee,
-  TrustedSyncAggregate, num_active_participants
+  TrustedSyncAggregate, isZero, num_active_participants
 from ./capella import
   ExecutionBranch, HistoricalSummary, SignedBLSToExecutionChange,
   SignedBLSToExecutionChangeList, Withdrawal, EXECUTION_PAYLOAD_GINDEX
@@ -843,7 +843,7 @@ func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     has_next_sync_committee:
-      v.next_sync_committee != static(default(typeof(v.next_sync_committee))),
+      not v.next_sync_committee.isZero,
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/datatypes/gloas.nim
+++ b/beacon_chain/spec/datatypes/gloas.nim
@@ -28,7 +28,7 @@ import
 
 from ./altair import
   ParticipationFlags, SyncAggregate, SyncCommittee, TrustedSyncAggregate,
-  SyncnetBits, num_active_participants
+  SyncnetBits, isZero, num_active_participants
 from ./capella import
   ExecutionBranch, HistoricalSummary,
   SignedBLSToExecutionChange, Withdrawal, EXECUTION_PAYLOAD_GINDEX
@@ -1207,7 +1207,7 @@ func shortLog*(v: LightClientUpdate): auto =
   (
     attested: shortLog(v.attested_header),
     has_next_sync_committee:
-      v.next_sync_committee != static(default(typeof(v.next_sync_committee))),
+      not v.next_sync_committee.isZero,
     finalized: shortLog(v.finalized_header),
     num_active_participants: v.sync_aggregate.num_active_participants,
     signature_slot: v.signature_slot

--- a/beacon_chain/spec/helpers.nim
+++ b/beacon_chain/spec/helpers.nim
@@ -264,8 +264,7 @@ template is_finality_update*(update: SomeForkyLightClientUpdate): bool =
 
 # https://github.com/ethereum/consensus-specs/blob/v1.5.0-beta.0/specs/altair/light-client/sync-protocol.md#is_next_sync_committee_known
 template is_next_sync_committee_known*(store: ForkyLightClientStore): bool =
-  store.next_sync_committee !=
-    static(default(typeof(store.next_sync_committee)))
+  not store.next_sync_committee.isZero
 
 # https://github.com/ethereum/consensus-specs/blob/v1.4.0-beta.5/specs/altair/light-client/sync-protocol.md#get_safety_threshold
 func get_safety_threshold*(store: ForkyLightClientStore): uint64 =

--- a/beacon_chain/spec/state_transition_epoch.nim
+++ b/beacon_chain/spec/state_transition_epoch.nim
@@ -409,9 +409,8 @@ proc compute_unrealized_finality*(
   info.process_attestations(state, cache)
   template balances(): auto = info.balances
 
-  var finalityState = state.toFinalityState()
   let jfRes = weigh_justification_and_finalization(
-    finalityState, balances.current_epoch,
+    state.toFinalityState(), balances.current_epoch,
     balances.previous_epoch_target_attesters,
     balances.current_epoch_target_attesters)
   FinalityCheckpoints(
@@ -454,9 +453,8 @@ proc compute_unrealized_finality*(
       justified: state.current_justified_checkpoint,
       finalized: state.finalized_checkpoint), balances)
 
-  var finalityState = state.toFinalityState()
   let jfRes = weigh_justification_and_finalization(
-    finalityState, balances.current_epoch,
+    state.toFinalityState(), balances.current_epoch,
     balances.previous_epoch[TIMELY_TARGET_FLAG_INDEX],
     balances.current_epoch_TIMELY_TARGET)
   (FinalityCheckpoints(
@@ -1397,7 +1395,7 @@ func process_builder_pending_payments*(
 
   for index in 0 ..< min(
       state.builder_pending_payments.len, SLOTS_PER_EPOCH.int):
-    var payment = state.builder_pending_payments.mitem(index)
+    let payment = state.builder_pending_payments.mitem(index)
     if payment.weight.distinctBase >= quorum:
       if not state.builder_pending_withdrawals.add(payment.withdrawal):
         return err("process_builder_pending_payments: couldn't add to builder_pending_withdrawals")


### PR DESCRIPTION
- fixes https://github.com/status-im/nimbus-eth2/issues/8728

Avoids the megabytes of zeros and is faster (each benchmark does 500k iterations, so it was ~420 ns/call before and now is ~275 ns/call):
```
$ hyperfine -N ./statusquo ./new
Benchmark 1: ./statusquo
  Time (mean ± σ):     212.8 ms ±  10.1 ms    [User: 211.5 ms, System: 0.9 ms]
  Range (min … max):   203.9 ms … 240.6 ms    14 runs
 
Benchmark 2: ./new
  Time (mean ± σ):     132.8 ms ±   5.5 ms    [User: 129.9 ms, System: 2.5 ms]
  Range (min … max):   124.9 ms … 152.8 ms    22 runs
 
Summary
  ./new ran
    1.60 ± 0.10 times faster than ./statusquo
```