### PR TITLE
optimize is_valid_light_client_header default/zero comparisons by 15%

### DIFF
--- a/beacon_chain/spec/datatypes/capella.nim
+++ b/beacon_chain/spec/datatypes/capella.nim
@@ -691,7 +691,7 @@ func is_valid_light_client_header*(
   if epoch < cfg.CAPELLA_FORK_EPOCH:
     return
       header.execution == static(default(ExecutionPayloadHeader)) and
-      header.execution_branch == static(default(ExecutionBranch))
+      header.execution_branch.isZero
 
   is_valid_merkle_branch(
     get_lc_execution_root(header, cfg),

--- a/beacon_chain/spec/datatypes/deneb.nim
+++ b/beacon_chain/spec/datatypes/deneb.nim
@@ -691,7 +691,7 @@ func is_valid_light_client_header*(
   if epoch < cfg.CAPELLA_FORK_EPOCH:
     return
       header.execution == static(default(ExecutionPayloadHeader)) and
-      header.execution_branch == static(default(ExecutionBranch))
+      header.execution_branch.isZero
 
   is_valid_merkle_branch(
     get_lc_execution_root(header, cfg),

--- a/beacon_chain/spec/datatypes/electra.nim
+++ b/beacon_chain/spec/datatypes/electra.nim
@@ -738,7 +738,7 @@ func is_valid_light_client_header*(
   if epoch < cfg.CAPELLA_FORK_EPOCH:
     return
       header.execution == static(default(deneb.ExecutionPayloadHeader)) and
-      header.execution_branch == static(default(ExecutionBranch))
+      header.execution_branch.isZero
 
   is_valid_merkle_branch(
     get_lc_execution_root(header, cfg),

--- a/beacon_chain/spec/datatypes/gloas.nim
+++ b/beacon_chain/spec/datatypes/gloas.nim
@@ -1092,8 +1092,7 @@ func is_valid_light_client_header*(
       EXECUTION_BLOCK_HASH_GINDEX, header.beacon.body_root)
 
   # [Modified in Gloas:EIP7732]
-  header.execution_block_hash.isZero and
-  header.execution_branch == static(default(ExecutionBranch))
+  header.execution_block_hash.isZero and header.execution_branch.isZero
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.7/specs/gloas/light-client/fork.md#upgrading-light-client-data
 func upgrade_lc_header_to_gloas*(

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -152,6 +152,12 @@ func isZero*(x: Eth2Digest): bool =
     tmp2 = tmp2 or tmp
   tmp2 == 0
 
+func isZero*[N: static int](x: array[N, Eth2Digest]): bool =
+  var nonzero = false
+  staticFor i, 0 ..< N:
+    nonzero = nonzero or not x[i].isZero
+  not nonzero
+
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a
 

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -153,10 +153,11 @@ func isZero*(x: Eth2Digest): bool =
   tmp2 == 0
 
 func isZero*[N: static int](x: array[N, Eth2Digest]): bool =
-  var nonzero = false
+  static: doAssert N <= 32     # don't unroll too much
+  var nonzero = 0'u64
   staticFor i, 0 ..< N:
-    nonzero = nonzero or not x[i].isZero
-  not nonzero
+    nonzero = nonzero or uint64(not x[i].isZero)
+  nonzero == 0
 
 proc writeValue*(w: var JsonWriter, a: Eth2Digest) {.raises: [IOError].} =
   w.writeValue $a

--- a/beacon_chain/spec/digest.nim
+++ b/beacon_chain/spec/digest.nim
@@ -1,11 +1,11 @@
 # beacon_chain
-# Copyright (c) 2018-2024 Status Research & Development GmbH
+# Copyright (c) 2018-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 # Consensus hash function / digest
 #


### PR DESCRIPTION
Smaller change than
- #8779

It removes a few KiB worth of 768 static zeros and improves performance by 15% regardless of location of first nonzero entry:
```
Benchmark 1: ./bench_lcvh_old zero
  Time (mean ± σ):      6.073 s ±  0.170 s    [User: 6.052 s, System: 0.009 s]
  Range (min … max):    5.819 s …  6.283 s    10 runs
 
Benchmark 2: ./bench_lcvh_new zero
  Time (mean ± σ):      5.352 s ±  0.181 s    [User: 5.333 s, System: 0.009 s]
  Range (min … max):    5.115 s …  5.729 s    10 runs
 
Benchmark 3: ./bench_lcvh_old first
  Time (mean ± σ):      5.740 s ±  0.151 s    [User: 5.720 s, System: 0.011 s]
  Range (min … max):    5.508 s …  5.957 s    10 runs
 
Benchmark 4: ./bench_lcvh_new first
  Time (mean ± σ):      5.102 s ±  0.084 s    [User: 5.088 s, System: 0.006 s]
  Range (min … max):    4.991 s …  5.256 s    10 runs
 
Benchmark 5: ./bench_lcvh_old last
  Time (mean ± σ):      6.080 s ±  0.268 s    [User: 6.062 s, System: 0.009 s]
  Range (min … max):    5.821 s …  6.653 s    10 runs
 
Benchmark 6: ./bench_lcvh_new last
  Time (mean ± σ):      5.270 s ±  0.115 s    [User: 5.259 s, System: 0.004 s]
  Range (min … max):    5.121 s …  5.459 s    10 runs
```

Also slightly reduces overall binary sizes.