### PR TITLE
enable P2P DSL macro to work in ARC/ORC

### DIFF
--- a/beacon_chain/networking/eth2_protocol_dsl.nim
+++ b/beacon_chain/networking/eth2_protocol_dsl.nim
@@ -8,9 +8,10 @@
 {.push raises: [].}
 
 import
-  std/[sequtils],
   results,
   stew/shims/macros, chronos, faststreams/outputs
+
+from std/sequtils import toSeq
 
 export chronos, results
 
@@ -184,7 +185,7 @@ proc createPeerState[Peer, ProtocolState](peer: Peer): RootRef =
   var res = new ProtocolState
   mixin initProtocolState
   initProtocolState(res, peer)
-  return cast[RootRef](res)
+  return RootRef(res)
 
 proc expectBlockWithProcs*(n: NimNode): seq[NimNode] =
   template helperName: auto = $n[0]
@@ -343,12 +344,12 @@ proc augmentUserHandler(p: P2PProtocol, userHandlerProc: NimNode) =
   if PeerStateType != nil:
     prelude.add quote do:
       template state(`peerVar`: `PeerType`): `PeerStateType` =
-        cast[`PeerStateType`](`getState`(`peerVar`, `protocolInfoVar`))
+        `PeerStateType`(`getState`(`peerVar`, `protocolInfoVar`))
 
   if NetworkStateType != nil:
     prelude.add quote do:
       template networkState(`peerVar`: `PeerType`): `NetworkStateType` =
-        cast[`NetworkStateType`](`getNetworkState`(`peerVar`.network, `protocolInfoVar`))
+        `NetworkStateType`(`getNetworkState`(`peerVar`.network, `protocolInfoVar`))
 
 proc addPreludeDefs*(userHandlerProc: NimNode, definitions: NimNode) =
   userHandlerProc.body[0].add definitions

--- a/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
+++ b/beacon_chain/spec/eth2_apis/eth2_rest_serialization.nim
@@ -259,7 +259,7 @@ func strictParse*[bits: static[int]](input: string,
 
 template withRestJsonWriter(w, typ, body: untyped): untyped =
   try:
-    var stream = memoryOutput()
+    let stream = memoryOutput()
     var w = JsonWriter[RestJson].init(stream)
     body
     stream.getOutput(typ)
@@ -535,7 +535,7 @@ proc sszResponseVersioned*[T: SomeForkedLightClientObject](
     entries: openArray[RestVersioned[T]]): RestApiResponse =
   let res =
     try:
-      var stream = memoryOutput()
+      let stream = memoryOutput()
       for e in entries:
         withForkyUpdate(e.data):
           when lcDataFork > LightClientDataFork.None:

--- a/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
+++ b/beacon_chain/spec/eth2_apis/rest_light_client_calls.nim
@@ -1,11 +1,11 @@
 # beacon_chain
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2026 Status Research & Development GmbH
 # Licensed and distributed under either of
 #   * MIT license (license terms in the root directory or at https://opensource.org/licenses/MIT).
 #   * Apache v2 license (license terms in the root directory or at https://www.apache.org/licenses/LICENSE-2.0).
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-{.push raises: [].}
+{.push raises: [], gcsafe.}
 
 import
   chronos,
@@ -13,7 +13,7 @@ import
   stew/endians2,
   presto/client,
   ../helpers,
-  "."/[rest_common, eth2_rest_serialization]
+  ./[rest_common, eth2_rest_serialization]
 
 func checkForkConsistency(
     obj: SomeForkedLightClientObject,
@@ -48,7 +48,7 @@ func decodeSszLightClientObject[T: SomeForkedLightClientObject](
   try:
     withLcDataFork(lcDataForkAtConsensusFork(consensusFork)):
       when lcDataFork > LightClientDataFork.None:
-        var obj = T.init(SSZ.decode(data, T.Forky(lcDataFork)))
+        let obj = T.init(SSZ.decode(data, T.Forky(lcDataFork)))
         obj.checkForkConsistency(cfg, consensusFork)
         obj
       else:
@@ -137,7 +137,7 @@ proc decodeSszLightClientObjects[S: seq[SomeForkedLightClientObject]](
       withLcDataFork(lcDataForkAtConsensusFork(consensusFork)):
         when lcDataFork > LightClientDataFork.None:
           type T = typeof(res[0])
-          var obj = T.init(SSZ.decode(
+          let obj = T.init(SSZ.decode(
             data.toOpenArray(begin + contextLen, after - 1),
             T.Forky(lcDataFork)))
           obj.checkForkConsistency(cfg, consensusFork)

--- a/beacon_chain/spec/state_transition_block.nim
+++ b/beacon_chain/spec/state_transition_block.nim
@@ -816,13 +816,13 @@ proc process_operations(
   # It costs a full validator set scan to construct these values; only do so if
   # there will be some kind of exit.
   # TODO Electra doesn't use exit_queue_info, don't calculate
-  var
-    exit_queue_info =
-      if body.proposer_slashings.len + body.attester_slashings.len +
-          body.voluntary_exits.len > 0:
-        get_state_exit_queue_info(state)
-      else:
-        default(ExitQueueInfo)  # not used
+  var exit_queue_info =
+    if body.proposer_slashings.len + body.attester_slashings.len +
+        body.voluntary_exits.len > 0:
+      get_state_exit_queue_info(state)
+    else:
+      default(ExitQueueInfo)  # not used
+  let
     bsv_use =
       when consensusFork in ConsensusFork.Electra .. ConsensusFork.Fulu:
         body.deposits.len + body.execution_requests.withdrawals.len +


### PR DESCRIPTION
Previously, it would fail to compile:
```
nimbus-eth2/beacon_chain/networking/eth2_protocol_dsl.nim(187, 10) Error: expression cannot be cast to 'RootRef'
```