### PR TITLE
Avoid duplicate fcU sending

### DIFF
--- a/beacon_chain/beacon_node.nim
+++ b/beacon_chain/beacon_node.nim
@@ -86,8 +86,7 @@ type
     config*: BeaconNodeConf
     attachedValidators*: ref ValidatorPool
     lightBlockProcessor*: LightBlockProcessor
-    lightClientFcuFut*: Future[(PayloadExecutionStatus, Opt[Hash32])]
-      .Raising([CancelledError])
+    lightClientFcuFut*: Future[void].Raising([CancelledError])
     lightClient*: LightClient
     dag*: ChainDAGRef
     list*: ChainListRef

--- a/beacon_chain/beacon_node_light_client.nim
+++ b/beacon_chain/beacon_node_light_client.nim
@@ -8,7 +8,7 @@
 {.push raises: [], gcsafe.}
 
 import
-  chronicles, web3/engine_api_types,
+  chronicles,
   ./beacon_node
 
 logScope: topics = "beacnde"
@@ -72,19 +72,17 @@ proc initLightClient*(
     proc onOptimisticHeader(
         lightClient: LightClient,
         optimisticHeader: ForkedLightClientHeader) =
-      if node.lightClientFcuFut != nil:
-        return
       withForkyHeader(optimisticHeader):
         when lcDataFork > LightClientDataFork.None:
-          let bid = forkyHeader.beacon.toBlockId()
+          let
+            wallSlot = node.currentSlot
+            bid = forkyHeader.beacon.toBlockId()
           logScope:
             opt = bid
             dag = node.dag.head.bid
-            wallSlot = node.currentSlot
+            wallSlot
           when lcDataFork >= LightClientDataFork.Capella:
-            let
-              consensusFork = node.dag.cfg.consensusForkAtEpoch(bid.slot.epoch)
-              blockHash = forkyHeader.execution_block_hash
+            let blockHash = forkyHeader.execution_block_hash
 
             # Retain light client head for other `forkchoiceUpdated` callers.
             # May temporarily block `forkchoiceUpdated` calls, e.g., Geth:
@@ -94,23 +92,18 @@ proc initLightClient*(
             # the situation recovers
             debug "New LC optimistic header"
             node.consensusManager[].setLightClientHead(bid, blockHash)
-            if not node.consensusManager[]
-                .shouldSyncViaLightClient(node.currentSlot):
+            if not node.consensusManager[].shouldSyncViaLightClient(wallSlot):
+              return
+            if node.lightClientFcuFut != nil:
               return
 
             # engine_forkchoiceUpdated
             let beaconHead = node.attestationPool[].getBeaconHead(nil)
-            withConsensusFork(consensusFork):
-              when lcDataForkAtConsensusFork(consensusFork) == lcDataFork:
-                let state = ForkchoiceStateV1.init(
-                  blockHash, beaconHead.safeExecutionBlockHash,
-                  beaconHead.finalizedExecutionBlockHash,
-                )
-                node.lightClientFcuFut = node.elManager.forkchoiceUpdated(
-                  state, payloadAttributes = Opt.none consensusFork.PayloadAttributes
-                )
-                node.lightClientFcuFut.addCallback do(future: pointer):
-                  node.lightClientFcuFut = nil
+            node.lightClientFcuFut = node.consensusManager
+              .updateLightClientExecutionHead(
+                beaconHead, wallSlot, sleepAsync(FORKCHOICEUPDATED_TIMEOUT))
+            node.lightClientFcuFut.addCallback do(future: pointer):
+              node.lightClientFcuFut = nil
           else:
             # The execution block hash is only available from Capella onward
             info "Ignoring new LC optimistic header until Capella"
@@ -118,7 +111,8 @@ proc initLightClient*(
     proc onFinalizedHeader(
         lightClient: LightClient,
         finalizedHeader: ForkedLightClientHeader) =
-      if not node.consensusManager[].shouldSyncViaLightClient(node.currentSlot):
+      let wallSlot = node.currentSlot
+      if not node.consensusManager[].shouldSyncViaLightClient(wallSlot):
         return
 
       node.eventBus.optFinHeaderUpdateQueue.emit(finalizedHeader)

--- a/beacon_chain/consensus_object_pools/consensus_manager.nim
+++ b/beacon_chain/consensus_object_pools/consensus_manager.nim
@@ -24,6 +24,11 @@ from ../validators/action_tracker import ActionTracker, getNextProposalSlot
 logScope: topics = "cman"
 
 type
+  ForkchoiceUpdate = object
+    wallSlot: Slot
+    state: ForkchoiceStateV1
+    status: PayloadExecutionStatus
+
   ConsensusManager* = object
     expectedSlot: Slot
     expectedBlockReceived: Future[bool].Raising([CancelledError])
@@ -60,6 +65,7 @@ type
 
     forkchoiceInflight: bool
       ## True when there's an async `forkchoiceUpdated` in flight
+    latestFcu: ForkchoiceUpdate
 
 # Initialization
 # ------------------------------------------------------------------------------
@@ -430,29 +436,86 @@ proc prepareNextSlot*(
 
 proc forkchoiceUpdated*(
     self: ref ConsensusManager,
-    slot: Slot,
+    headSlot: Slot,
     headBlockHash, safeBlockHash, finalizedBlockHash: Eth2Digest,
+    wallSlot: Slot,
     deadline: DeadlineFuture,
     retry: bool,
 ): Future[PayloadExecutionStatus] {.async: (raises: [CancelledError]).} =
-  ## Call non-proposer version of forkchoiceUpdated using the given slot to
-  ## select the correct PayloadAttributes version
+  ## Call non-proposer version of forkchoiceUpdated using the given head slot
+  ## to select the correct PayloadAttributes version.
+  ##
+  ## Results are cached for duplicate requests during the same wall slot
 
-  withConsensusFork(self[].dag.cfg.consensusForkAtEpoch(slot.epoch)):
+  withConsensusFork(self[].dag.cfg.consensusForkAtEpoch(headSlot.epoch)):
     when consensusFork >= ConsensusFork.Bellatrix:
       if headBlockHash.isZero:
         # Merge not yet activated
         PayloadExecutionStatus.valid
       else:
-        let
-          state = ForkchoiceStateV1.init(
-            headBlockHash, safeBlockHash, finalizedBlockHash)
-          (status, _) = await self.elManager.forkchoiceUpdated(
-            state, Opt.none consensusFork.PayloadAttributes, deadline, retry
-          )
+        let state = ForkchoiceStateV1.init(
+          headBlockHash, safeBlockHash, finalizedBlockHash)
+        if wallSlot == self.latestFcu.wallSlot and
+            state == self.latestFcu.state:
+          debug "Skipping fcU, state unchanged this slot",
+            headBlockHash, wallSlot
+          return self.latestFcu.status
+
+        let (status, _) = await self.elManager.forkchoiceUpdated(
+          state, Opt.none consensusFork.PayloadAttributes, deadline, retry)
+        self.latestFcu = ForkchoiceUpdate(
+          wallSlot: wallSlot, state: state, status: status)
         status
     else:
       PayloadExecutionStatus.valid
+
+proc lightClientForkchoiceUpdated(
+    self: ref ConsensusManager,
+    head: BeaconHead,
+    wallSlot: Slot,
+    deadline: DeadlineFuture,
+): Future[bool] {.async: (raises: [CancelledError]).} =
+  ## Send forkchoiceUpdated to the client, return false iff the
+  ## light client head was invalid and true otherwise
+
+  let
+    # No point retrying for light client sync since there will be a new attempt
+    # "soon". However, we call even if the light client head hasn't changed
+    # since the last slot since the finalized / safe blocks might have changed
+    lightClientHead = self.lightClientHead  # Mutable during `await`
+    status = await self.forkchoiceUpdated(
+      lightClientHead.bid.slot, lightClientHead.execution_block_hash,
+      head.safeExecutionBlockHash, head.finalizedExecutionBlockHash,
+      wallSlot, deadline, retry = false)
+
+  self.lightClientHeadStatus = status.to(OptimisticStatus)
+
+  case self.lightClientHeadStatus
+  of OptimisticStatus.valid, OptimisticStatus.notValidated:
+    true
+  of OptimisticStatus.invalidated:
+    warn "Light client execution payload invalid - " &
+      "the execution client or the light client data is faulty",
+      payloadExecutionStatus = status,
+      lightClientBlockHash = lightClientHead.execution_block_hash
+    false
+
+proc updateLightClientExecutionHead*(
+    self: ref ConsensusManager,
+    head: BeaconHead,
+    wallSlot: Slot,
+    deadline: DeadlineFuture) {.async: (raises: [CancelledError]).} =
+  ## Report the light client head to the execution client,
+  ## unless another `forkchoiceUpdated` is already in flight
+
+  if self.forkchoiceInflight:
+    return
+
+  self.forkchoiceInflight = true
+  defer:
+    self.forkchoiceInflight = false
+
+  discard await self.lightClientForkchoiceUpdated(head, wallSlot, deadline)
 
 proc forkchoiceUpdated(
     self: ref ConsensusManager,
@@ -465,25 +528,7 @@ proc forkchoiceUpdated(
   ## and true otherwise
 
   if self[].shouldSyncViaLightClient(wallSlot):
-    # No point retrying for light client sync since there will be a new attempt
-    # "soon". However, we call even if the light client head hasn't changed
-    # since the last slot since the finalized / safe blocks might have changed
-    let status = await self.forkchoiceUpdated(
-      self.lightClientHead.bid.slot, self.lightClientHead.execution_block_hash,
-      head.safeExecutionBlockHash, head.finalizedExecutionBlockHash,
-      deadline, retry = false)
-
-    self.lightClientHeadStatus = status.to(OptimisticStatus)
-
-    case self.lightClientHeadStatus
-    of OptimisticStatus.valid, OptimisticStatus.notValidated:
-      true
-    of OptimisticStatus.invalidated:
-      warn "Light client execution payload invalid - " &
-        "the execution client or the light client data is faulty",
-        payloadExecutionStatus = status,
-        lightClientBlockHash = self.lightClientHead.execution_block_hash
-      false
+    await self.lightClientForkchoiceUpdated(head, wallSlot, deadline)
   else:
     let
       headExecutionBlockHash = self.dag.loadExecutionBlockHash(head.blck).valueOr:
@@ -501,8 +546,7 @@ proc forkchoiceUpdated(
         return true
       status = await self.forkchoiceUpdated(
         head.blck.slot, headExecutionBlockHash, head.safeExecutionBlockHash,
-        head.finalizedExecutionBlockHash, deadline, retry,
-      )
+        head.finalizedExecutionBlockHash, wallSlot, deadline, retry)
 
     case status.to(OptimisticStatus)
     of OptimisticStatus.valid:


### PR DESCRIPTION
While light client is significantly ahead, its head overrides the head from forward sync when interacting with the ELs. That forward sync still triggers fcU periodically, though, which all get overridden with the same head information, leading to exact duplicates being sent.

This is changed to only send one duplicate per slot (still needed as the EL may be restarted or replaced in-between fcU calls). Also fix a race when switching over from the LC head to the forward sync head, where two fcU could be in flight simultaneously.

Closes #8041