### PR TITLE
Ensure sigsets are part of async env in batch validation

### DIFF
--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -136,8 +136,7 @@ type
 
   BatchTask = object
     ok: Atomic[bool]
-    setsPtr: ptr UncheckedArray[SignatureSet]
-    numSets: int
+    sigsets: seq[SignatureSet]
     secureRandomBytes: array[32, byte]
     taskpool: Taskpool
     cache: ptr BatchedBLSVerifierCache
@@ -210,11 +209,15 @@ proc complete(batchCrypto: var BatchCrypto, batch: var Batch, ok: bool) =
     reset(batchCrypto.counts)
 
 proc batchVerifyTask(task: ptr BatchTask) {.nimcall.} =
-  # Task suitable for running in taskpools - look, no GC!
+  # Task suitable for running in taskpools - the task[].sigsets payload is
+  # owned by the main thread; it is only read here, no refs are copied or
+  # destroyed
   let
     tp = task[].taskpool
+    setsPtr = makeUncheckedArray(baseAddr task[].sigsets)
+    numSets = task[].sigsets.len
     ok = tp.spawn batchVerify(
-      tp, task[].cache, task[].setsPtr, task[].numSets,
+      tp, task[].cache, setsPtr, numSets,
       addr task[].secureRandomBytes)
 
   task[].ok.store(sync ok)
@@ -247,18 +250,19 @@ proc batchVerifyAsync(
     verifier: ref BatchVerifier,
     signal: ThreadSignalPtr,
     batch: ref Batch): Future[bool] {.async: (raises: [CancelledError]).} =
-  let sigsets = batch[].multiSets.combineAll(verifier)
   var task = BatchTask(
-    setsPtr: makeUncheckedArray(baseAddr sigsets),
-    numSets: sigsets.len,
+    sigsets: batch[].multiSets.combineAll(verifier),
     taskpool: verifier[].taskpool,
     cache: addr verifier[].sigVerifCache,
     signal: signal,
   )
   verifier[].rng[].generate(task.secureRandomBytes)
 
-  # task will stay allocated in the async environment at least until the signal
-  # has fired at which point it's safe to release it
+  # The worker accesses `task` and the sigsets it owns until the signal has
+  # fired; being used across the `await` below is what makes the async
+  # environment keep `task` alive that long - locals used only before the
+  # `await` are implicitly freed on suspension and could be recycled while
+  # the worker is still reading it: https://github.com/nim-lang/Nim/pull/23787
   let taskPtr = addr task
   doAssert verifier[].taskpool.numThreads > 1,
     "Must have at least one separate thread or signal will never be fired"

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -138,10 +138,6 @@ type
     ok: Atomic[bool]
     setsPtr: ptr UncheckedArray[SignatureSet]
     numSets: int
-    sigsets: seq[SignatureSet]
-      # `setsPtr`'s backing store - owned by the thread that created the task;
-      # the worker must not access GC types and reads the payload through the
-      # `setsPtr`/`numSets` view instead
     secureRandomBytes: array[32, byte]
     taskpool: Taskpool
     cache: ptr BatchedBLSVerifierCache
@@ -251,20 +247,18 @@ proc batchVerifyAsync(
     verifier: ref BatchVerifier,
     signal: ThreadSignalPtr,
     batch: ref Batch): Future[bool] {.async: (raises: [CancelledError]).} =
+  let sigsets = batch[].multiSets.combineAll(verifier)
   var task = BatchTask(
-    sigsets: batch[].multiSets.combineAll(verifier),
+    setsPtr: makeUncheckedArray(baseAddr sigsets),
+    numSets: sigsets.len,
     taskpool: verifier[].taskpool,
     cache: addr verifier[].sigVerifCache,
     signal: signal,
   )
-  task.setsPtr = makeUncheckedArray(baseAddr task.sigsets)
-  task.numSets = task.sigsets.len
   verifier[].rng[].generate(task.secureRandomBytes)
 
-  # task is used across the await below, so it stays allocated in the async
-  # environment at least until the signal has fired, keeping the payload
-  # behind setsPtr alive as well - locals used only before the await are
-  # already freed on suspension: https://github.com/nim-lang/Nim/issues/26041
+  # task will stay allocated in the async environment at least until the signal
+  # has fired at which point it's safe to release it
   let taskPtr = addr task
   doAssert verifier[].taskpool.numThreads > 1,
     "Must have at least one separate thread or signal will never be fired"
@@ -274,6 +268,11 @@ proc batchVerifyAsync(
   except AsyncError as exc:
     warn "Batch verification verification failed - report bug", err = exc.msg
     return false
+
+  # `sigsets` must be used after the `await` or it is freed on suspension
+  # while the worker still reads it through `task.setsPtr`:
+  # https://github.com/nim-lang/Nim/issues/26041
+  discard sigsets
 
   task.ok.load()
 

--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -136,7 +136,12 @@ type
 
   BatchTask = object
     ok: Atomic[bool]
+    setsPtr: ptr UncheckedArray[SignatureSet]
+    numSets: int
     sigsets: seq[SignatureSet]
+      # `setsPtr`'s backing store - owned by the thread that created the task;
+      # the worker must not access GC types and reads the payload through the
+      # `setsPtr`/`numSets` view instead
     secureRandomBytes: array[32, byte]
     taskpool: Taskpool
     cache: ptr BatchedBLSVerifierCache
@@ -209,15 +214,11 @@ proc complete(batchCrypto: var BatchCrypto, batch: var Batch, ok: bool) =
     reset(batchCrypto.counts)
 
 proc batchVerifyTask(task: ptr BatchTask) {.nimcall.} =
-  # Task suitable for running in taskpools - the task[].sigsets payload is
-  # owned by the main thread; it is only read here, no refs are copied or
-  # destroyed
+  # Task suitable for running in taskpools - look, no GC!
   let
     tp = task[].taskpool
-    setsPtr = makeUncheckedArray(baseAddr task[].sigsets)
-    numSets = task[].sigsets.len
     ok = tp.spawn batchVerify(
-      tp, task[].cache, setsPtr, numSets,
+      tp, task[].cache, task[].setsPtr, task[].numSets,
       addr task[].secureRandomBytes)
 
   task[].ok.store(sync ok)
@@ -256,13 +257,14 @@ proc batchVerifyAsync(
     cache: addr verifier[].sigVerifCache,
     signal: signal,
   )
+  task.setsPtr = makeUncheckedArray(baseAddr task.sigsets)
+  task.numSets = task.sigsets.len
   verifier[].rng[].generate(task.secureRandomBytes)
 
-  # The worker accesses `task` and the sigsets it owns until the signal has
-  # fired; being used across the `await` below is what makes the async
-  # environment keep `task` alive that long - locals used only before the
-  # `await` are implicitly freed on suspension and could be recycled while
-  # the worker is still reading it: https://github.com/nim-lang/Nim/pull/23787
+  # task is used across the await below, so it stays allocated in the async
+  # environment at least until the signal has fired, keeping the payload
+  # behind setsPtr alive as well - locals used only before the await are
+  # already freed on suspension: https://github.com/nim-lang/Nim/issues/26041
   let taskPtr = addr task
   doAssert verifier[].taskpool.numThreads > 1,
     "Must have at least one separate thread or signal will never be fired"


### PR DESCRIPTION
(Patch was generated by Fable)

Since https://github.com/nim-lang/Nim/pull/23787:

> we lift only those locals that appear in more than one state

Therefore, the `let sigsets = batch[].multiSets.combineAll(verifier)` variable is only present in the stack, as it is not used anymore after the `await signal.wait()` further down.

To fix that, either we have to directly take an `addr` (or via template) but because we only do `baseAddr sigsets` it doesn't extend lifetime as that's just a regular `func` in stew.

Moving the section that converts the seq to unchecked array into the task fixes this, as the `task` is still used after the `await`.

Impact here is that some batch verifies may end up reporting a wrong result, and then fallback to the individual sig check. But we use refc so it's not deterministically hit.

https://github.com/nim-lang/Nim/issues/26041