### PR TITLE
rm old --rpc warning messages

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -686,7 +686,7 @@ type
         name: "debug-bandwidth-estimate" .}: Option[Natural]
 
       rpcEnabled* {.
-        obsolete: "Superceded by REST API as of v1.7.0"
+        hidden
         name: "rpc" .}: Option[bool]
 
       rpcPort* {.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2676,9 +2676,6 @@ proc doRunBeaconNode(
 
   createPidFile(config.dataDir.string / "beacon_node.pid")
 
-  if config.rpcEnabled.isSome:
-    warn "Nimbus's JSON-RPC server has been removed. This includes the --rpc, --rpc-port, and --rpc-address configuration options. https://nimbus.guide/rest-api.html shows how to enable and configure the REST Beacon API server which replaces it."
-
   # Trusted setup is needed for Cancun+ blocks and is shared between threads,
   # so it needs to be initalized from the main thread before anything else tries
   # to use it


### PR DESCRIPTION
This conflicts with the `--rpc` flag of `nimbus-eth1`'s unified client and creates spurious warnings.