### PR TITLE
Offload gossip KZG verifications to taskpool

### DIFF
--- a/beacon_chain/gossip_processing/batch_validation.nim
+++ b/beacon_chain/gossip_processing/batch_validation.nim
@@ -13,7 +13,7 @@ import
   metrics,
   # Status
   chronicles, chronos, chronos/threadsync,
-  ../spec/signatures_batch,
+  ../spec/[peerdas_helpers, signatures_batch],
   ../consensus_object_pools/[blockchain_dag, spec_cache]
 
 export signatures_batch, blockchain_dag
@@ -79,6 +79,9 @@ const
   InflightVerifications = 2
     ## Maximum number of concurrent in-flight verifications
 
+  InflightKzgVerifications = 2
+    ## Maximum number of concurrent in-flight KZG verifications
+
 type
   BatchResult* {.pure.} = enum
     Invalid # Invalid by default
@@ -122,6 +125,9 @@ type
       ## Each batch verification reqires a separate verifier
     verifier: int
 
+    kzgSignals: AsyncQueue[ThreadSignalPtr]
+      ## Pending KZG verifications, InflightKzgVerifications verifiers
+
     pruneTime: Moment ## last time we had to prune something
 
     counts: tuple[signatures, batches, aggregates: int64]
@@ -141,6 +147,15 @@ type
     secureRandomBytes: array[32, byte]
     taskpool: Taskpool
     cache: ptr BatchedBLSVerifierCache
+    signal: ThreadSignalPtr
+
+  KzgTask = object
+    ok: Atomic[bool]
+    commitmentsPtr: ptr UncheckedArray[KzgCommitment]
+    cellIndicesPtr: ptr UncheckedArray[CellIndex]
+    cellsPtr: ptr UncheckedArray[KzgCell]
+    proofsPtr: ptr UncheckedArray[KzgProof]
+    numCells: int
     signal: ThreadSignalPtr
 
 proc new*(
@@ -163,6 +178,20 @@ proc new*(
             discard res.verifiers[j].signal.close()
           return err(sig.error())
     )
+
+  res.kzgSignals = newAsyncQueue[ThreadSignalPtr](
+    maxsize = InflightKzgVerifications)
+  for _ in 0..<InflightKzgVerifications:
+    let sig = ThreadSignalPtr.new().valueOr:
+      for j in 0..<res.verifiers.len:
+        discard res.verifiers[j].signal.close()
+      for j in 0..<res.kzgSignals.len:
+        discard res.kzgSignals[j].close()
+      return err(error)
+    try:
+      res.kzgSignals.addLastNoWait(sig)
+    except AsyncQueueFullError:
+      raiseAssert "Unreachable, maxsize items are added"
 
   ok res
 
@@ -227,6 +256,22 @@ proc spawnBatchVerifyTask(tp: Taskpool, task: ptr BatchTask) =
   # Workaround: Ensure that `tp.spawn` is not used within an `{.async.}` proc
   # Possibly related to: https://github.com/nim-lang/Nim/issues/22305
   tp.spawn batchVerifyTask(task)
+
+proc kzgProofsTask(task: ptr KzgTask) {.nimcall.} =
+  # Task suitable for running in taskpools - look, no GC!
+  let ok = verifyCellKzgProofBatch(
+    task[].commitmentsPtr.toOpenArray(0, task[].numCells - 1),
+    task[].cellIndicesPtr.toOpenArray(0, task[].numCells - 1),
+    task[].cellsPtr.toOpenArray(0, task[].numCells - 1),
+    task[].proofsPtr.toOpenArray(0, task[].numCells - 1)).get(false)
+
+  task[].ok.store(ok)
+
+  discard task[].signal.fireSync()
+
+proc spawnKzgTask(tp: Taskpool, task: ptr KzgTask) =
+  # Keep `tp.spawn` out of `{.async.}` procs - see `spawnBatchVerifyTask`
+  tp.spawn kzgProofsTask(task)
 
 func combine(
     multiSet: MultiSignatureSet,
@@ -604,3 +649,87 @@ proc schedulePayloadAttestationCheck*(
         fork, genesis_validators_root, msg, pubkey, sig)
 
   ok((fut, sig))
+
+func toBatchResult(valid: bool): BatchResult =
+  if valid:
+    BatchResult.Valid
+  else:
+    BatchResult.Invalid
+
+proc scheduleKzgCheck(
+    batchCrypto: ref BatchCrypto,
+    commitments: seq[KzgCommitment], cellIndices: seq[CellIndex],
+    cells: seq[KzgCell], proofs: seq[KzgProof]):
+    Future[BatchResult] {.async: (raises: [CancelledError]).} =
+  ## Verify the KZG proofs of a data column on the task pool
+  if batchCrypto.taskpool.numThreads <= 1:
+    return toBatchResult verifyCellKzgProofBatch(
+      commitments, cellIndices, cells, proofs).get(false)
+
+  let
+    created = Moment.now()
+    signal = await batchCrypto.kzgSignals.popFirst()
+  defer:
+    try:
+      batchCrypto[].kzgSignals.addLastNoWait(signal)
+    except AsyncQueueFullError:
+      raiseAssert "Unreachable, pops and adds are balanced"
+
+  let
+    startTick = Moment.now()
+    slotDuration = batchCrypto.timeParams.SLOT_DURATION
+
+  # If the hardware is too slow to keep up or an event caused a temporary
+  # buildup of column checks, the check will be dropped so as to recover and
+  # not cause even further buildup - this puts an (elastic) upper bound
+  # on the amount of queued-up work
+  if created + slotDuration < startTick:
+    if batchCrypto[].pruneTime + slotDuration < startTick:
+      notice "Column check queue pruned, skipping data column validation"
+      batchCrypto[].pruneTime = startTick
+
+    return BatchResult.Timeout
+
+  var task = KzgTask(
+    commitmentsPtr: makeUncheckedArray(baseAddr commitments),
+    cellIndicesPtr: makeUncheckedArray(baseAddr cellIndices),
+    cellsPtr: makeUncheckedArray(baseAddr cells),
+    proofsPtr: makeUncheckedArray(baseAddr proofs),
+    numCells: cells.len,
+    signal: signal)
+
+  # task will stay allocated in the async environment at least until the signal
+  # has fired at which point it's safe to release it
+  let taskPtr = addr task
+  batchCrypto[].taskpool.spawnKzgTask(taskPtr)
+  try:
+    await signal.wait()
+  except AsyncError as exc:
+    warn "Column KZG proof verification failed - report bug", err = exc.msg
+    return BatchResult.Invalid
+
+  toBatchResult(task.ok.load())
+
+proc scheduleDataColumnSidecarCheck*(
+    batchCrypto: ref BatchCrypto,
+    data_column_sidecar: ref fulu.DataColumnSidecar): FutureBatchResult =
+  ## Schedule KZG proof verification of a fulu data column sidecar
+  batchCrypto.scheduleKzgCheck(
+    data_column_sidecar[].kzg_commitments.asSeq,
+    repeat(CellIndex(data_column_sidecar[].index),
+      data_column_sidecar[].column.len),
+    data_column_sidecar[].column.asSeq,
+    data_column_sidecar[].kzg_proofs.asSeq)
+
+proc scheduleDataColumnSidecarCheck*(
+    batchCrypto: ref BatchCrypto,
+    data_column_sidecar: ref gloas.DataColumnSidecar,
+    kzg_commitments: seq[KzgCommitment]): FutureBatchResult =
+  ## Schedule KZG proof verification of a gloas data column sidecar against the
+  ## commitments carried by the execution payload bid
+  batchCrypto.scheduleKzgCheck(
+    kzg_commitments,
+    repeat(CellIndex(data_column_sidecar[].index),
+      data_column_sidecar[].column.len),
+    data_column_sidecar[].column.asSeq,
+    data_column_sidecar[].kzg_proofs.asSeq)

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -366,9 +366,10 @@ proc processExecutionPayloadEnvelope*(
   ok()
 
 proc processDataColumnSidecar*(
-    self: var Eth2Processor, src: MsgSource,
+    self: ref Eth2Processor, src: MsgSource,
     dataColumnSidecar: ref fulu.DataColumnSidecar,
-    subnet_id: uint64): ValidationRes =
+    subnet_id: uint64
+): Future[ValidationRes] {.async: (raises: [CancelledError]).} =
   template block_header: untyped =
     dataColumnSidecar[].signed_block_header.message
 
@@ -391,9 +392,9 @@ proc processDataColumnSidecar*(
 
   let
     validationStart = Moment.now()
-    v =
-      self.dag.validateDataColumnSidecar(self.quarantine, self.fuluColumnQuarantine,
-                                         dataColumnSidecar, wallTime, subnet_id)
+    v = await self.dag.validateDataColumnSidecar(
+      self.batchCrypto, self.quarantine, self.fuluColumnQuarantine,
+      dataColumnSidecar, wallTime, subnet_id)
 
   data_column_sidecar_validation_duration.observe(
     (Moment.now() - validationStart).toFloatSeconds())
@@ -431,9 +432,10 @@ proc processDataColumnSidecar*(
   v
 
 proc processDataColumnSidecar*(
-    self: var Eth2Processor, src: MsgSource,
+    self: ref Eth2Processor, src: MsgSource,
     dataColumnSidecar: ref gloas.DataColumnSidecar,
-    subnet_id: uint64): ValidationRes =
+    subnet_id: uint64
+): Future[ValidationRes] {.async: (raises: [CancelledError]).} =
   let
     wallTime = self.getCurrentBeaconTime()
     (afterGenesis, wallSlot) = wallTime.toSlot(self.dag.timeParams)
@@ -448,9 +450,9 @@ proc processDataColumnSidecar*(
 
   debug "Data column received"
 
-  let v = self.dag.validateDataColumnSidecar(
-    self.quarantine, self.gloasColumnQuarantine, self.executionPayloadBidPool,
-    dataColumnSidecar, wallTime, subnet_id)
+  let v = await self.dag.validateDataColumnSidecar(
+    self.batchCrypto, self.quarantine, self.gloasColumnQuarantine,
+    self.executionPayloadBidPool, dataColumnSidecar, wallTime, subnet_id)
 
   if v.isErr():
     # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md#modified-data_column_sidecar_subnet_id

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -45,6 +45,9 @@ declareCounter beacon_sync_messages_dropped_queue_full,
 declareCounter beacon_contributions_dropped_queue_full,
   "Number of sync committee contributions dropped because queue is full"
 
+declareCounter beacon_data_column_sidecars_dropped_queue_full,
+  "Number of data column sidecars dropped because queue is full"
+
 # This result is a little messy in that it returns Result.ok for
 # ValidationResult.Accept and an err for the others - this helps transport
 # an error message to callers but could arguably be done in an cleaner way.
@@ -226,15 +229,6 @@ func check_data_column_sidecar_inclusion_proof(
     data_column_sidecar: ref fulu.DataColumnSidecar):
     Result[void, ValidationError] =
   let res = data_column_sidecar[].verify_data_column_sidecar_inclusion_proof()
-  if res.isErr:
-    return errReject(res.error)
-
-  ok()
-
-proc check_data_column_sidecar_kzg_proofs(
-    data_column_sidecar: ref fulu.DataColumnSidecar):
-    Result[void, ValidationError] =
-  let res = data_column_sidecar[].verify_data_column_sidecar_kzg_proofs()
   if res.isErr:
     return errReject(res.error)
 
@@ -505,11 +499,13 @@ template validateBeaconBlockGloas(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.6.0-alpha.3/specs/fulu/p2p-interface.md#data_column_sidecar_subnet_id
 proc validateDataColumnSidecar*(
-    dag: ChainDAGRef, quarantine: ref Quarantine,
+    dag: ChainDAGRef,
+    batchCrypto: ref BatchCrypto,
+    quarantine: ref Quarantine,
     fuluColumnQuarantine: ref FuluColumnQuarantine,
     data_column_sidecar: ref fulu.DataColumnSidecar,
-    wallTime: BeaconTime, subnet_id: uint64):
-    Result[void, ValidationError] =
+    wallTime: BeaconTime, subnet_id: uint64
+): Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
 
   # If the header is invalid, so is the block that shares its block_root ->
   # we can mark those blocks invalid without further processing
@@ -617,10 +613,20 @@ proc validateDataColumnSidecar*(
 
   # [REJECT] The sidecar's column data is valid as
   # verified by `verify_data_column_kzg_proofs(sidecar)`
-  block:
-    let r = check_data_column_sidecar_kzg_proofs(data_column_sidecar)
-    if r.isErr:
-      return dag.checkedReject(r.error)
+  case await batchCrypto.scheduleDataColumnSidecarCheck(data_column_sidecar)
+  of BatchResult.Invalid:
+    return dag.checkedReject("DataColumnSidecar: validation failed")
+  of BatchResult.Timeout:
+    beacon_data_column_sidecars_dropped_queue_full.inc()
+    return errIgnore("DataColumnSidecar: timeout checking KZG proofs")
+  of BatchResult.Valid:
+    discard # keep going only in this case
+
+  # The KZG proof check yielded - re-check that no other copy of this sidecar
+  # was verified and stored in the meantime
+  if fuluColumnQuarantine[].hasVerifiedSidecar(
+      block_root, data_column_sidecar[].index):
+    return errIgnore("DataColumnSidecar: already have valid data column")
 
   # Send notification about new data column sidecar via callback
   let onDataColumnSidecarCallback =
@@ -645,12 +651,14 @@ proc validateDataColumnSidecar*(
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/specs/gloas/p2p-interface.md#modified-data_column_sidecar_subnet_id
 proc validateDataColumnSidecar*(
-    dag: ChainDAGRef, quarantine: ref Quarantine,
+    dag: ChainDAGRef,
+    batchCrypto: ref BatchCrypto,
+    quarantine: ref Quarantine,
     gloasColumnQuarantine: ref GloasColumnQuarantine,
     executionPayloadBidPool: ref ExecutionPayloadBidPool,
     data_column_sidecar: ref gloas.DataColumnSidecar,
-    wallTime: BeaconTime, subnet_id: uint64):
-    Result[void, ValidationError] =
+    wallTime: BeaconTime, subnet_id: uint64
+): Future[Result[void, ValidationError]] {.async: (raises: [CancelledError]).} =
 
   template blockRoot(): auto = data_column_sidecar[].beacon_block_root
 
@@ -701,11 +709,15 @@ proc validateDataColumnSidecar*(
 
   # [REJECT] The sidecar's column data is valid as verified by
   # `verify_data_column_sidecar_kzg_proofs(sidecar, bid.blob_kzg_commitments)`.
-  block:
-    let v = verify_data_column_sidecar_kzg_proofs(
-      data_column_sidecar[], bid.blob_kzg_commitments)
-    if v.isErr:
-      return dag.checkedReject(v.error)
+  case await batchCrypto.scheduleDataColumnSidecarCheck(
+      data_column_sidecar, bid.blob_kzg_commitments.asSeq)
+  of BatchResult.Invalid:
+    return dag.checkedReject("DataColumnSidecar: validation failed")
+  of BatchResult.Timeout:
+    beacon_data_column_sidecars_dropped_queue_full.inc()
+    return errIgnore("DataColumnSidecar: timeout checking KZG proofs")
+  of BatchResult.Valid:
+    discard # keep going only in this case
 
   # [IGNORE] The sidecar is the first sidecar for the tuple
   # `(sidecar.beacon_block_root, sidecar.index)` with valid kzg proof.

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -2389,26 +2389,28 @@ proc installMessageValidators(node: BeaconNode) =
           for it in 0'u64..<node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
             closureScope:
               let subnet_id = it
-              node.network.addValidator(
+              node.network.addAsyncValidator(
                 getDataColumnSidecarTopic(digest, subnet_id), proc (
                   dataColumnSidecar: gloas.DataColumnSidecar,
                   src: PeerId
-                ): ValidationResult =
-                  toValidationResult(
-                    node.processor[].processDataColumnSidecar(
+                ): Future[ValidationResult] {.
+                    async: (raises: [CancelledError]).} =
+                  return toValidationResult(
+                    await node.processor.processDataColumnSidecar(
                       MsgSource.gossip, newClone(dataColumnSidecar),
                       subnet_id)))
         elif consensusFork == ConsensusFork.Fulu:
           for it in 0'u64..<node.dag.cfg.NUMBER_OF_CUSTODY_GROUPS:
             closureScope:
               let subnet_id = it
-              node.network.addValidator(
+              node.network.addAsyncValidator(
                 getDataColumnSidecarTopic(digest, subnet_id), proc (
                   dataColumnSidecar: fulu.DataColumnSidecar,
                   src: PeerId
-                ): ValidationResult =
-                  toValidationResult(
-                    node.processor[].processDataColumnSidecar(
+                ): Future[ValidationResult] {.
+                    async: (raises: [CancelledError]).} =
+                  return toValidationResult(
+                    await node.processor.processDataColumnSidecar(
                       MsgSource.gossip, newClone(dataColumnSidecar),
                       subnet_id)))
 


### PR DESCRIPTION
While processing KZG isn't as heavy as BLS, the timing of KZG gossip overlaps with attestation duties (Fulu) / payload attestations (Gloas). As soon as we received enough columns, the head event is sent to the VC but remaining data columns are still streaming in, potentially slowing down the submission of attestations, e.g., this should help with #7981.

As we already have the infrastructure for offloading the cryptographic verification work for other gossip topics, it's straightforward to just reuse the same machinery for KZG proofs. It's a bit simpler than BLS as we don't batch across columns, but follows the same flow.