### PR TITLE
Add --force-resync option

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -362,8 +362,8 @@ type
 
       forceResync* {.
         hidden
-        desc: "Delete the existing beacon chain database and sync from scratch"
-        name: "debug-force-resync" .}: bool
+        desc: "Delete the existing beacon chain database and resync from scratch"
+        name: "force-resync" .}: bool
 
       externalBeaconApiUrl* {.
         desc: "External beacon API to use for syncing (on empty database)"
@@ -918,8 +918,8 @@ type
 
       forceResyncTNS* {.
         hidden
-        desc: "Delete the existing beacon chain database and sync from scratch"
-        name: "debug-force-resync" .}: bool
+        desc: "Delete the existing beacon chain database and resync from scratch"
+        name: "force-resync" .}: bool
 
       backfillBlocks* {.
         desc: "Backfill blocks directly from REST server instead of fetching via API"

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -360,6 +360,11 @@ type
         desc: "Weak subjectivity checkpoint in the format block_root:epoch_number"
         name: "weak-subjectivity-checkpoint" .}: Option[Checkpoint]
 
+      forceResync* {.
+        hidden
+        desc: "Delete the existing beacon chain database and sync from scratch"
+        name: "debug-force-resync" .}: bool
+
       externalBeaconApiUrl* {.
         desc: "External beacon API to use for syncing (on empty database)"
         name: "external-beacon-api-url" .}: Option[string]
@@ -910,6 +915,11 @@ type
       lcTrustedBlockRoot* {.
         desc: "Recent trusted finalized block root to initialize light client from"
         name: "trusted-block-root" .}: Option[Eth2Digest]
+
+      forceResyncTNS* {.
+        hidden
+        desc: "Delete the existing beacon chain database and sync from scratch"
+        name: "debug-force-resync" .}: bool
 
       backfillBlocks* {.
         desc: "Backfill blocks directly from REST server instead of fetching via API"

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -149,11 +149,24 @@ proc fetchCheckpointState(
   else:
     Opt.some default(ref ForkedHashedBeaconState)
 
+proc clearDatabase(databaseDir: string): Opt[void] =
+  notice "Deleting existing database, `--debug-force-resync` was requested",
+    databaseDir
+  try:
+    removeDir(databaseDir, checkDir = false)
+    ok()
+  except OSError as exc:
+    error "Failed to delete existing database",
+      path = databaseDir, err = exc.msg
+    return err()
+
 proc setupDatabase(
     config: BeaconNodeConf, metadata: Eth2NetworkMetadata
 ): Future[Opt[BeaconChainDB]] {.async: (raises: [CancelledError]).} =
   # Open the database and initialize it with genesis/checkpoint if it wasn't
   # setup before - fails if the data sources we use are broken
+  if config.forceResync:
+    ? clearDatabase(config.databaseDir)
   let db = BeaconChainDB.new(
     config.databaseDir, metadata.cfg, inMemory = false,
     lightClientDataImportBackfill = config.lightClientDataImportBackfill)
@@ -2816,12 +2829,15 @@ proc handleStartUpCmd(config: var BeaconNodeConf) {.raises: [CatchableError].} =
   of BNStartUpCmd.web3: doWeb3Cmd(config, rng[])
   of BNStartUpCmd.slashingdb: doSlashingInterchange(config)
   of BNStartUpCmd.trustedNodeSync:
+    let metadata = loadEth2Network(config)
+
     if config.blockId.isSome():
       error "--blockId option has been removed - use --state-id instead!"
       quit 1
 
+    if config.forceResyncTNS and clearDatabase(config.databaseDir).isErr:
+      quit 1
     let
-      metadata = loadEth2Network(config)
       db = BeaconChainDB.new(
         config.databaseDir, metadata.cfg, inMemory = false)
       genesisState = (waitFor fetchGenesisState(metadata, config.eraDir)).valueOr:

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -150,7 +150,7 @@ proc fetchCheckpointState(
     Opt.some default(ref ForkedHashedBeaconState)
 
 proc clearDatabase(databaseDir: string): Opt[void] =
-  notice "Deleting existing database, `--debug-force-resync` was requested",
+  notice "Deleting existing database, `--force-resync` was requested",
     databaseDir
   try:
     removeDir(databaseDir, checkDir = false)


### PR DESCRIPTION
To aid with certain devops setups, provide a way to clear the sync DB via an extra startup option, while still preserving slashing protection and validator information. Option can be supplied to both trusted node sync and the regular startup command.

Closes #7913