### PR TITLE
Feature: Use `Opt` instead of `Option` in Presto code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -159,7 +159,7 @@
 	path = vendor/nim-presto
 	url = https://github.com/status-im/nim-presto.git
 	ignore = untracked
-	branch = master
+	branch = feature/opt
 [submodule "vendor/nim-taskpools"]
 	path = vendor/nim-taskpools
 	url = https://github.com/status-im/nim-taskpools.git

--- a/beacon_chain/nimbus_signing_node.nim
+++ b/beacon_chain/nimbus_signing_node.nim
@@ -187,7 +187,7 @@ proc installApiHandlers*(node: SigningNodeRef) =
 
   router.api(MethodPost, "/api/v1/eth2/sign/{validator_key}") do (
     validator_key: ValidatorPubKey,
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let request =
       block:
         if contentBody.isNone():

--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -485,7 +485,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodPost, "/eth/v1/beacon/states/{state_id}/validators",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, contentBody: Option[ContentBody]) -> RestApiResponse:
+    state_id: StateIdent, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       (validatorIds, validatorsMask) =
         block:
@@ -600,7 +600,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodPost, "/eth/v1/beacon/states/{state_id}/validator_balances",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, contentBody: Option[ContentBody]) -> RestApiResponse:
+    state_id: StateIdent, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       validatorIds =
         block:
@@ -621,7 +621,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodPost, "/eth/v1/beacon/states/{state_id}/validator_identities",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, contentBody: Option[ContentBody]) -> RestApiResponse:
+    state_id: StateIdent, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       validatorIds =
         block:
@@ -642,8 +642,8 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodGet, "/eth/v1/beacon/states/{state_id}/committees",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, epoch: Option[Epoch], index: Option[CommitteeIndex],
-    slot: Option[Slot]) -> RestApiResponse:
+    state_id: StateIdent, epoch: Opt[Epoch], index: Opt[CommitteeIndex],
+    slot: Opt[Slot]) -> RestApiResponse:
     let
       sid = state_id.valueOr:
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
@@ -671,9 +671,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
             Http400, InvalidEpochValueError,
             "Requested epoch earlier than what committees can be computed for")
 
-        some(res)
+        Opt.some(res)
       else:
-        none[Epoch]()
+        Opt.none(Epoch)
     let vindex =
       if index.isSome():
         let rindex = index.get()
@@ -681,9 +681,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           return RestApiResponse.jsonError(Http400,
                                            InvalidCommitteeIndexValueError,
                                            $rindex.error)
-        some(rindex.get())
+        Opt.some(rindex.get())
       else:
-        none[CommitteeIndex]()
+        Opt.none(CommitteeIndex)
     let vslot =
       if slot.isSome():
         let rslot = slot.get()
@@ -708,9 +708,9 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
               Http400, InvalidEpochValueError,
               "Requested slot earlier than what committees can be computed for")
 
-        some(res)
+        Opt.some(res)
       else:
-        none[Slot]()
+        Opt.none(Slot)
 
     node.withStateForBlockSlotId(bslot):
       func getCommittee(slot: Slot,
@@ -719,7 +719,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         RestBeaconStatesCommittees(index: index, slot: slot,
                                    validators: validators)
 
-      func forSlot(slot: Slot, cindex: Option[CommitteeIndex],
+      func forSlot(slot: Slot, cindex: Opt[CommitteeIndex],
                    res: var seq[RestBeaconStatesCommittees]) =
         let committees_per_slot = get_committee_count_per_slot(
           state, slot.epoch, cache)
@@ -758,7 +758,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodGet, "/eth/v1/beacon/states/{state_id}/sync_committees",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, epoch: Option[Epoch]) -> RestApiResponse:
+    state_id: StateIdent, epoch: Opt[Epoch]) -> RestApiResponse:
     let
       sid = state_id.valueOr:
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
@@ -838,7 +838,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.metricsApi2(
     MethodGet, "/eth/v1/beacon/states/{state_id}/randao",
     {RestServerMetricsType.Status, Response}) do (
-    state_id: StateIdent, epoch: Option[Epoch]) -> RestApiResponse:
+    state_id: StateIdent, epoch: Opt[Epoch]) -> RestApiResponse:
     let
       sid = state_id.valueOr:
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
@@ -893,7 +893,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockHeaders
   router.api2(MethodGet, "/eth/v1/beacon/headers") do (
-    slot: Option[Slot], parent_root: Option[Eth2Digest]) -> RestApiResponse:
+    slot: Opt[Slot], parent_root: Opt[Eth2Digest]) -> RestApiResponse:
     # TODO (cheatfate): This call is incomplete, because structure
     # of database do not allow to query blocks by `parent_root`.
     let qslot =
@@ -960,13 +960,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
       )
 
   router.api(MethodPost, "/eth/v1/beacon/blocks") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlockV2
   router.api(MethodPost, "/eth/v2/beacon/blocks") do (
-    broadcast_validation: Option[BroadcastValidationType],
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    broadcast_validation: Opt[BroadcastValidationType],
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let res =
       block:
         let
@@ -1090,13 +1090,13 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         respondSszOrJson(toSignedBlindedBeaconBlock(forkyBlck), consensusFork)
 
   router.api(MethodPost, "/eth/v1/beacon/blinded_blocks") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/publishBlindedBlockV2
   router.api(MethodPost, "/eth/v2/beacon/blinded_blocks") do (
-    broadcast_validation: Option[BroadcastValidationType],
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    broadcast_validation: Opt[BroadcastValidationType],
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     if contentBody.isNone():
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
 
@@ -1240,14 +1240,14 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         consensusFork, node.hasRestAllowedOrigin)
 
   router.api2(MethodGet, "/eth/v1/beacon/pool/attestations") do (
-    slot: Option[Slot],
-    committee_index: Option[CommitteeIndex]) -> RestApiResponse:
+    slot: Opt[Slot],
+    committee_index: Opt[CommitteeIndex]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttestationsV2
   router.api2(MethodGet, "/eth/v2/beacon/pool/attestations") do (
-    slot: Option[Slot],
-    committee_index: Option[CommitteeIndex]) -> RestApiResponse:
+    slot: Opt[Slot],
+    committee_index: Opt[CommitteeIndex]) -> RestApiResponse:
     let vindex =
       if committee_index.isSome():
         let rindex = committee_index.get().valueOr:
@@ -1290,12 +1290,12 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
           node.hasRestAllowedOrigin)
 
   router.api2(MethodPost, "/eth/v1/beacon/pool/attestations") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttestationsV2
   router.api2(MethodPost, "/eth/v2/beacon/pool/attestations") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     let
       headerVersion = request.headers.getString("eth-consensus-version")
@@ -1356,7 +1356,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   router.api(MethodPost, "/eth/v1/beacon/pool/attester_slashings") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getPoolAttesterSlashingsV2
@@ -1383,7 +1383,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttesterSlashingsV2
   router.api(MethodPost, "/eth/v2/beacon/pool/attester_slashings") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     let
       headerVersion = request.headers.getString("eth-consensus-version")
@@ -1424,7 +1424,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolProposerSlashings
   router.api(MethodPost, "/eth/v1/beacon/pool/proposer_slashings") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let slashing =
       block:
         if contentBody.isNone():
@@ -1453,7 +1453,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolBLSToExecutionChange
   # https://github.com/ethereum/beacon-APIs/blob/86850001845df9163da5ae9605dbf15cd318d5d0/apis/beacon/pool/bls_to_execution_changes.yaml
   router.api2(MethodPost, "/eth/v1/beacon/pool/bls_to_execution_changes") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     if node.currentSlot().epoch() < node.dag.cfg.CAPELLA_FORK_EPOCH:
       return RestApiResponse.jsonError(Http400,
                                        InvalidBlsToExecutionChangeObjectError,
@@ -1488,7 +1488,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolSyncCommitteeSignatures
   router.api(MethodPost, "/eth/v1/beacon/pool/sync_committees") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let messages =
       block:
         if contentBody.isNone():
@@ -1524,7 +1524,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolVoluntaryExit
   router.api(MethodPost, "/eth/v1/beacon/pool/voluntary_exits") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let exit =
       block:
         if contentBody.isNone():
@@ -1619,7 +1619,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishExecutionPayloadBid
   router.api(MethodPost, "/eth/v1/beacon/execution_payload_bids") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     let
       headerVersion = request.headers.getString("eth-consensus-version")
@@ -1650,7 +1650,7 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/publishExecutionPayloadEnvelope
   # https://github.com/ethereum/beacon-APIs/blob/e46367867f207237ecb4839b333431144a08899b/apis/beacon/execution_payload/envelope_post.yaml
   router.api(MethodPost, "/eth/v1/beacon/execution_payload_envelopes") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     if contentBody.isNone():
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)

--- a/beacon_chain/rpc/rest_key_management_api.nim
+++ b/beacon_chain/rpc/rest_key_management_api.nim
@@ -149,7 +149,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
 
   # https://ethereum.github.io/keymanager-APIs/#/Keymanager/ImportKeystores
   router.api2(MethodPost, "/eth/v1/keystores") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -219,7 +219,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
 
   # https://ethereum.github.io/keymanager-APIs/#/Keymanager/DeleteKeys
   router.api2(MethodDelete, "/eth/v1/keystores") do (
-      contentBody: Option[ContentBody]) -> RestApiResponse:
+      contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -301,7 +301,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
 
   # https://ethereum.github.io/keymanager-APIs/#/Remote%20Key%20Manager/ImportRemoteKeys
   router.api2(MethodPost, "/eth/v1/remotekeys") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -332,7 +332,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
 
   # https://ethereum.github.io/keymanager-APIs/#/Remote%20Key%20Manager/DeleteRemoteKeys
   router.api2(MethodDelete, "/eth/v1/remotekeys") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -381,7 +381,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
   # https://ethereum.github.io/keymanager-APIs/#/Fee%20Recipient/SetFeeRecipient
   router.api2(MethodPost, "/eth/v1/validator/{pubkey}/feerecipient") do (
               pubkey: ValidatorPubKey,
-              contentBody: Option[ContentBody]) -> RestApiResponse:
+              contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -455,7 +455,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
   # https://ethereum.github.io/keymanager-APIs/#/Gas%20Limit/setGasLimit
   router.api2(MethodPost, "/eth/v1/validator/{pubkey}/gas_limit") do (
               pubkey: ValidatorPubKey,
-              contentBody: Option[ContentBody]) -> RestApiResponse:
+              contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -515,7 +515,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
   # TODO: These URLs will be changed once we submit a proposal for
   #       /eth/v2/remotekeys that supports distributed keys.
   router.api2(MethodPost, "/eth/v1/remotekeys/distributed") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -543,7 +543,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
     RestApiResponse.jsonResponsePlain(response)
 
   router.api2(MethodDelete, "/eth/v1/remotekeys/distributed") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error
@@ -564,8 +564,8 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
 
   # https://ethereum.github.io/keymanager-APIs/?urls.primaryName=dev#/Voluntary%20Exit/signVoluntaryExit
   router.api2(MethodPost, "/eth/v1/validator/{pubkey}/voluntary_exit") do (
-    pubkey: ValidatorPubKey, epoch: Option[Epoch],
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    pubkey: ValidatorPubKey, epoch: Opt[Epoch],
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
@@ -648,7 +648,7 @@ proc installKeymanagerHandlers*(router: var RestRouter, host: KeymanagerHost) =
   # https://ethereum.github.io/keymanager-APIs/?urls.primaryName=dev#/Graffiti/setGraffiti
   router.api2(MethodPost, "/eth/v1/validator/{pubkey}/graffiti") do (
               pubkey: ValidatorPubKey,
-              contentBody: Option[ContentBody]) -> RestApiResponse:
+              contentBody: Opt[ContentBody]) -> RestApiResponse:
     let authStatus = checkAuthorization(request, host)
     if authStatus.isErr():
       return authErrorResponse authStatus.error

--- a/beacon_chain/rpc/rest_light_client_api.nim
+++ b/beacon_chain/rpc/rest_light_client_api.nim
@@ -54,7 +54,7 @@ proc installLightClientApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/getLightClientUpdatesByRange
   router.api2(MethodGet,
               "/eth/v1/beacon/light_client/updates") do (
-    start_period: Option[SyncCommitteePeriod], count: Option[uint64]
+    start_period: Opt[SyncCommitteePeriod], count: Opt[uint64]
     ) -> RestApiResponse:
     doAssert node.dag.lcDataStore.serve
     let contentType =

--- a/beacon_chain/rpc/rest_nimbus_api.nim
+++ b/beacon_chain/rpc/rest_nimbus_api.nim
@@ -205,14 +205,14 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonResponse((peers: res))
 
   router.api2(MethodPost, "/nimbus/v1/graffiti") do (
-      contentBody: Option[ContentBody]) -> RestApiResponse:
+      contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalNimbusGraffiti)
 
   router.api2(MethodGet, "/nimbus/v1/graffiti") do () -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalNimbusGraffiti)
 
   router.api2(MethodPost, "/nimbus/v1/chronicles/settings") do (
-    log_level: Option[string]) -> RestApiResponse:
+    log_level: Opt[string]) -> RestApiResponse:
     if log_level.isSome():
       let level =
         block:
@@ -330,7 +330,7 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonResponse(res)
 
   router.api2(MethodPost, "/nimbus/v1/validator/activity/{epoch}") do (
-    epoch: Epoch, contentBody: Option[ContentBody]) -> RestApiResponse:
+    epoch: Epoch, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let indexList =
       block:
         if contentBody.isNone():
@@ -455,7 +455,7 @@ proc installNimbusApiHandlers*(router: var RestRouter, node: BeaconNode) =
     )
 
   router.api2(MethodPost, "/nimbus/v1/timesync") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       timestamp2 = getTimestamp()
       timestamp1 =

--- a/beacon_chain/rpc/rest_rewards_api.nim
+++ b/beacon_chain/rpc/rest_rewards_api.nim
@@ -119,7 +119,7 @@ proc installRewardsApiHandlers*(router: var RestRouter, node: BeaconNode) =
   router.api2(
     MethodPost, "/eth/v1/beacon/rewards/sync_committee/{block_id}") do (
       block_id: BlockIdent,
-      contentBody: Option[ContentBody]) -> RestApiResponse:
+      contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       idents =
         block:

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -24,7 +24,7 @@ logScope: topics = "rest_validatorapi"
 proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/getAttesterDuties
   router.api2(MethodPost, "/eth/v1/validator/duties/attester/{epoch}") do (
-    epoch: Epoch, contentBody: Option[ContentBody]) -> RestApiResponse:
+    epoch: Epoch, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let indexList =
       block:
         if contentBody.isNone():
@@ -163,7 +163,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/getSyncCommitteeDuties
   router.api2(MethodPost, "/eth/v1/validator/duties/sync/{epoch}") do (
-    epoch: Epoch, contentBody: Option[ContentBody]) -> RestApiResponse:
+    epoch: Epoch, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let indexList =
       block:
         if contentBody.isNone():
@@ -313,31 +313,31 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonError(Http404, StateNotFoundError)
 
   router.api2(MethodGet, "/eth/v1/validator/blocks/{slot}") do (
-    slot: Slot, randao_reveal: Option[ValidatorSig],
-    graffiti: Option[GraffitiBytes]) -> RestApiResponse:
+    slot: Slot, randao_reveal: Opt[ValidatorSig],
+    graffiti: Opt[GraffitiBytes]) -> RestApiResponse:
     RestApiResponse.jsonError(
       Http410, DeprecatedRemovalValidatorBlocksV1)
 
   router.api(MethodGet, "/eth/v2/validator/blocks/{slot}") do (
-      slot: Slot, randao_reveal: Option[ValidatorSig],
-      graffiti: Option[GraffitiBytes],
-      skip_randao_verification: Option[string]) -> RestApiResponse:
+      slot: Slot, randao_reveal: Opt[ValidatorSig],
+      graffiti: Opt[GraffitiBytes],
+      skip_randao_verification: Opt[string]) -> RestApiResponse:
     RestApiResponse.jsonError(
       Http410, DeprecatedRemovalValidatorBlocksV2)
 
   router.api(MethodGet, "/eth/v1/validator/blinded_blocks/{slot}") do (
-      slot: Slot, randao_reveal: Option[ValidatorSig],
-      graffiti: Option[GraffitiBytes],
-      skip_randao_verification: Option[string]) -> RestApiResponse:
+      slot: Slot, randao_reveal: Opt[ValidatorSig],
+      graffiti: Opt[GraffitiBytes],
+      skip_randao_verification: Opt[string]) -> RestApiResponse:
     RestApiResponse.jsonError(
       Http410, DeprecatedRemovalProduceBlindedBlockV1)
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceBlockV3
   router.api(MethodGet, "/eth/v3/validator/blocks/{slot}") do (
-      slot: Slot, randao_reveal: Option[ValidatorSig],
-      graffiti: Option[GraffitiBytes],
-      skip_randao_verification: Option[string],
-      builder_boost_factor: Option[uint64]) -> RestApiResponse:
+      slot: Slot, randao_reveal: Opt[ValidatorSig],
+      graffiti: Opt[GraffitiBytes],
+      skip_randao_verification: Opt[string],
+      builder_boost_factor: Opt[uint64]) -> RestApiResponse:
     let
       contentType = preferredContentType(jsonMediaType, sszMediaType).valueOr:
         return RestApiResponse.jsonError(Http406, ContentNotAcceptableError)
@@ -502,8 +502,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceAttestationData
   router.api2(MethodGet, "/eth/v1/validator/attestation_data") do (
-    slot: Option[Slot],
-    committee_index: Option[CommitteeIndex]) -> RestApiResponse:
+    slot: Opt[Slot],
+    committee_index: Opt[CommitteeIndex]) -> RestApiResponse:
     let adata =
       block:
         let qslot =
@@ -568,15 +568,15 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonResponse(adata)
 
   router.api2(MethodGet, "/eth/v1/validator/aggregate_attestation") do (
-    attestation_data_root: Option[Eth2Digest],
-    slot: Option[Slot]) -> RestApiResponse:
+    attestation_data_root: Opt[Eth2Digest],
+    slot: Opt[Slot]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/getAggregatedAttestationV2
   router.api2(MethodGet, "/eth/v2/validator/aggregate_attestation") do (
-    attestation_data_root: Option[Eth2Digest],
-    committee_index: Option[CommitteeIndex],
-    slot: Option[Slot]) -> RestApiResponse:
+    attestation_data_root: Opt[Eth2Digest],
+    committee_index: Opt[CommitteeIndex],
+    slot: Opt[Slot]) -> RestApiResponse:
 
     let qslot =
       block:
@@ -633,12 +633,12 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
     RestApiResponse.jsonResponsePlain(forked, qfork, node.hasRestAllowedOrigin)
 
   router.api2(MethodPost, "/eth/v1/validator/aggregate_and_proofs") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     RestApiResponse.jsonError(Http410, DeprecatedRemovalElectra)
 
   # https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Validator/publishAggregateAndProofsV2
   router.api2(MethodPost, "/eth/v2/validator/aggregate_and_proofs") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     if contentBody.isNone():
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
@@ -683,7 +683,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/prepareBeaconCommitteeSubnet
   router.api2(MethodPost,
               "/eth/v1/validator/beacon_committee_subscriptions") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let requests =
       block:
         if contentBody.isNone():
@@ -760,7 +760,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/prepareSyncCommitteeSubnets
   router.api2(MethodPost,
               "/eth/v1/validator/sync_committee_subscriptions") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let subscriptions =
       block:
         var res: seq[RestSyncCommitteeSubscription]
@@ -799,8 +799,8 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/produceSyncCommitteeContribution
   router.api2(MethodGet,
               "/eth/v1/validator/sync_committee_contribution") do (
-    slot: Option[Slot], subcommittee_index: Option[SyncSubCommitteeIndex],
-    beacon_block_root: Option[Eth2Digest]) -> RestApiResponse:
+    slot: Opt[Slot], subcommittee_index: Opt[SyncSubCommitteeIndex],
+    beacon_block_root: Opt[Eth2Digest]) -> RestApiResponse:
     let qslot = block:
       if slot.isNone():
         return RestApiResponse.jsonError(Http400, MissingSlotValueError)
@@ -863,7 +863,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/Validator/publishContributionAndProofs
   router.api2(MethodPost,
               "/eth/v1/validator/contribution_and_proofs") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let proofs =
       block:
         if contentBody.isNone():
@@ -910,7 +910,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://ethereum.github.io/beacon-APIs/#/ValidatorRequiredApi/prepareBeaconProposer
   router.api2(MethodPost,
               "/eth/v1/validator/prepare_beacon_proposer") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       body =
         block:
@@ -945,7 +945,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://github.com/ethereum/beacon-APIs/blob/v2.3.0/apis/validator/register_validator.yaml
   router.api2(MethodPost,
               "/eth/v1/validator/register_validator") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     if contentBody.isNone():
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
     let
@@ -967,7 +967,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
   # https://github.com/ethereum/beacon-APIs/blob/31140d7d11fa0bf9aa0017c67c54ab5b1809bede/apis/validator/proposer_preferences.yaml
   router.api2(MethodPost,
               "/eth/v1/validator/submit_proposer_preferences") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     if contentBody.isNone():
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
     let
@@ -991,7 +991,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://ethereum.github.io/beacon-APIs/#/Validator/getLiveness
   router.api2(MethodPost, "/eth/v1/validator/liveness/{epoch}") do (
-    epoch: Epoch, contentBody: Option[ContentBody]) -> RestApiResponse:
+    epoch: Epoch, contentBody: Opt[ContentBody]) -> RestApiResponse:
     let
       qepoch =
         block:
@@ -1060,7 +1060,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://github.com/ethereum/beacon-APIs/blob/f087fbf2764e657578a6c29bdf0261b36ee8db1e/apis/validator/beacon_committee_selections.yaml
   router.api2(MethodPost, "/eth/v1/validator/beacon_committee_selections") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     # "Consensus clients need not support this endpoint and may return a 501."
     # https://github.com/ethereum/beacon-APIs/pull/224: "This endpoint need not
     # be implemented on the CL side. Once a validator client is aware of it and
@@ -1071,7 +1071,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
 
   # https://github.com/ethereum/beacon-APIs/blob/f087fbf2764e657578a6c29bdf0261b36ee8db1e/apis/validator/sync_committee_selections.yaml
   router.api2(MethodPost, "/eth/v1/validator/sync_committee_selections") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
     # "Consensus clients need not support this endpoint and may return a 501."
     # https://github.com/ethereum/beacon-APIs/pull/224: "This endpoint need not
     # be implemented on the CL side. Once a validator client is aware of it and

--- a/tests/test_mev_calls.nim
+++ b/tests/test_mev_calls.nim
@@ -143,7 +143,7 @@ proc sszResponseSignedBuilderBid*(
 
 proc setupEngineAPI*(router: var RestRouter, node: TestNodeRef) =
   router.api2(MethodPost, "/eth/v1/builder/validators") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     if contentBody.isNone:
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)
@@ -193,7 +193,7 @@ proc setupEngineAPI*(router: var RestRouter, node: TestNodeRef) =
       RestApiResponse.jsonError(Http500, "Unsupported slot number")
 
   router.api2(MethodPost, "/eth/v2/builder/blinded_blocks") do (
-    contentBody: Option[ContentBody]) -> RestApiResponse:
+    contentBody: Opt[ContentBody]) -> RestApiResponse:
 
     if contentBody.isNone:
       return RestApiResponse.jsonError(Http400, EmptyRequestBodyError)


### PR DESCRIPTION
Per @arnetheduck's request in https://github.com/status-im/nim-presto/issues/87, Presto allows to use `Opt` along with `Option` to denote optional params: https://github.com/status-im/nim-presto/pull/99

This PR utilizes this new ability, replacing `Option` with `Opt` where Presto is used.