### PR TITLE
Support recent stateRoot in more beacon-APIs

### DIFF
--- a/beacon_chain/rpc/rest_beacon_api.nim
+++ b/beacon_chain/rpc/rest_beacon_api.nim
@@ -212,10 +212,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                          $error)
 
@@ -238,10 +234,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -271,10 +263,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                          $error)
 
@@ -471,10 +459,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(
           Http404, StateNotFoundError, $error)
       validatorIds =
@@ -523,10 +507,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError, $error)
     getValidators(node, bslot, validatorsMask, validatorIds)
 
@@ -543,10 +523,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidValidatorIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -607,10 +583,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError, $error)
       validatorIds =
         block:
@@ -642,10 +614,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError, $error)
     getBalances(node, bslot, validatorIds)
 
@@ -667,10 +635,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError, $error)
     getValidatorIdentities(node, bslot, validatorIds)
 
@@ -685,10 +649,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -804,10 +764,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -888,10 +844,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -1761,10 +1713,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                          $error)
 
@@ -1792,10 +1740,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 
@@ -1823,10 +1767,6 @@ proc installBeaconApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(Http400, InvalidStateIdValueError,
                                          $error)
       bslot = node.getBlockSlotId(sid).valueOr:
-        if sid.kind == StateQueryKind.Root:
-          # TODO (cheatfate): Its impossible to retrieve state by `state_root`
-          # in current version of database.
-          return RestApiResponse.jsonError(Http500, NoImplementationError)
         return RestApiResponse.jsonError(Http404, StateNotFoundError,
                                           $error)
 

--- a/ncli/resttest-rules.json
+++ b/ncli/resttest-rules.json
@@ -146,11 +146,11 @@
       "url": "/eth/v1/beacon/states/0x0000000000000000000000000000000000000000000000000000000000000000/root",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {
@@ -159,11 +159,11 @@
       "url": "/eth/v1/beacon/states/0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/root",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {
@@ -304,11 +304,11 @@
       "url": "/eth/v1/beacon/states/0x0000000000000000000000000000000000000000000000000000000000000000/fork",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {
@@ -317,11 +317,11 @@
       "url": "/eth/v1/beacon/states/0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/fork",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {
@@ -466,11 +466,11 @@
       "url": "/eth/v1/beacon/states/0x0000000000000000000000000000000000000000000000000000000000000000/finality_checkpoints",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {
@@ -479,11 +479,11 @@
       "url": "/eth/v1/beacon/states/0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF/finality_checkpoints",
       "headers": {"Accept": "application/json"}
     },
-    "comment": "Hexadecimal state root tests (TODO (cheatfate))",
+    "comment": "Hexadecimal state root tests",
     "response": {
-      "status": {"operator": "equals", "value": "500"},
+      "status": {"operator": "equals", "value": "404"},
       "headers": [{"key": "Content-Type", "value": "application/json", "operator": "equals"}],
-      "body": [{"operator": "jstructcmpns", "value": {"code": 500, "message": ""}}]
+      "body": [{"operator": "jstructcmpns", "value": {"code": 404, "message": ""}}]
     }
   },
   {


### PR DESCRIPTION
Nimbus db doesn't support looking up historical states by state_root, but recent state roots are available in the BeaconState already in RAM, and getBlockSlotId actually supports looking them up.

Allow querying by recent state roots (8192, based on head BeaconState) and fix error code which should be 404 if not found instead of 500. The functionality is available, just not exposed.

We still can't provide these APIs for historical states, but they are available by slot. Further, only canonical states according to fork choice are available by state_root.

Closes #7832