### PR TITLE
Avoid calling postStateValidators with empty list

### DIFF
--- a/beacon_chain/validator_client/duties_service.nim
+++ b/beacon_chain/validator_client/duties_service.nim
@@ -63,16 +63,23 @@ proc pollForValidatorIndices*(
         res
     start = Moment.now()
     validators =
-      try:
-        await vc.postValidators(
-          validatorIdents, vc.getMode()[FnKind.getValidators])
-      except ValidatorApiError as exc:
-        warn "Unable to get head state's validator information",
-              reason = exc.getFailureReason()
-        return
-      except CancelledError as exc:
-        debug "Validator's indices processing was interrupted"
-        raise exc
+      if len(validatorIdents) == 0:
+        # If the supplied list is empty (i.e. the value is []) [...]
+        # then all validators will be returned.
+        # https://ethereum.github.io/beacon-APIs/#/Beacon/postStateValidators
+        # -> Request body -> Schema -> ids -> Expand all
+        @[]
+      else:
+        try:
+          await vc.postValidators(
+            validatorIdents, vc.getMode()[FnKind.getValidators])
+        except ValidatorApiError as exc:
+          warn "Unable to get head state's validator information",
+                reason = exc.getFailureReason()
+          return
+        except CancelledError as exc:
+          debug "Validator's indices processing was interrupted"
+          raise exc
 
   var
     missing: seq[string]


### PR DESCRIPTION
In the POST version for getting validators, they made it so that passing an empty list returns ALL validators. This is different from the GET version where omitting the list is handled differently from empty list.

If we don't have any validator idents of interest, don't send request. Regression from #8822.