### PR TITLE
Syncing v3p3 (quarantines).

### DIFF
--- a/beacon_chain/consensus_object_pools/block_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/block_quarantine.nim
@@ -9,12 +9,16 @@
 
 import
   chronicles,
+  chronos,
   minilru,
   std/tables,
   ./quarantine_types,
   ../spec/[block_id, forks, presets]
 
 export tables, minilru, forks, quarantine_types
+
+from std/sequtils import toSeq, mapIt
+from std/strutils import join
 
 const
   MaxOrphans = int(SLOTS_PER_EPOCH * 3)
@@ -89,22 +93,41 @@ type
       ## so as to skip expensive cryptographic verification if the same block root
       ## and signature combination arrives multiple times over gossip
 
+    missingEvent*: AsyncEvent
+      ## This asynchronous event is triggered when a new orphaned block is added
+      ## to or removed from quarantine.
+
+    sidecarlessEvent*: AsyncEvent
+      ## This asynchronous event is triggered when a new block without sidecars
+      ## is added to or removed from quarantine.
+
     cfg*: RuntimeConfig
 
 func init*(T: type Quarantine, cfg: RuntimeConfig): T =
+  let missingEvent = newAsyncEvent()
   T(
     cfg: cfg,
     orphans: OrphanLru.init(MaxOrphans),
     sidecarless: SidecarlessLru.init(MaxSidecarless),
     unviable: UnviableLru.init(MaxUnviables),
     latest_sidecar_signatures: RecentSidecarSignatureLru.init(MaxRecentSidecarSignatures),
-    missing: MissingTable.init(),
+    missing: MissingTable.init(missingEvent),
+    missingEvent: missingEvent,
+    sidecarlessEvent: newAsyncEvent()
   )
 
-func checkMissing*(quarantine: var Quarantine, max: int): seq[FetchRecord] =
+proc checkMissing*(quarantine: var Quarantine, max: int): seq[FetchRecord] =
   ## Return a list of blocks that we should try to resolve from other client -
   ## to be called periodically but not too often (once per slot?)
   quarantine.missing.checkMissing(max)
+
+func checkOrphan*(quarantine: var Quarantine, root: Eth2Digest): bool =
+  ## Returns ``true`` if block with root ``root`` exists in ``orphans`` table.
+  ## Note: This procedure has O(n) complexity!
+  for k, v in quarantine.orphans.mpairs():
+      if v.root == root:
+        return true
+  false
 
 proc addMissing*(quarantine: var Quarantine, root: Eth2Digest): Result[void, UnviableKind] =
   ## Schedule the download a given block or its ancestor, if we're keeping
@@ -140,12 +163,13 @@ proc addMissing*(quarantine: var Quarantine, root: Eth2Digest): Result[void, Unv
 
   ok()
 
-func remove*(quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =
+proc remove*(quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =
   quarantine.orphans.del((signedBlock.root, signedBlock.signature))
-  quarantine.sidecarless.del(signedBlock.root)
   quarantine.missing.del(signedBlock.root)
+  if quarantine.sidecarless.pop(signedBlock.root).isSome():
+    quarantine.sidecarlessEvent.fire()
 
-func startProcessing*(quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =
+proc startProcessing*(quarantine: var Quarantine, signedBlock: ForkySignedBeaconBlock) =
   quarantine.remove(signedBlock)
   quarantine.processing = signedBlock.root
 
@@ -208,7 +232,7 @@ func removeUnviableSidecarlessTree(
 
     toRemove.setLen(0)
 
-func addUnviable*(quarantine: var Quarantine, root: Eth2Digest, kind: UnviableKind): UnviableKind =
+proc addUnviable*(quarantine: var Quarantine, root: Eth2Digest, kind: UnviableKind): UnviableKind =
   # Unviable - don't try to download again!
   quarantine.missing.del(root)
 
@@ -228,7 +252,7 @@ func addUnviable*(quarantine: var Quarantine, root: Eth2Digest, kind: UnviableKi
   quarantine.unviable.put(root, kind)
   kind
 
-func cleanupOrphans(quarantine: var Quarantine, finalizedSlot: Slot) =
+proc cleanupOrphans(quarantine: var Quarantine, finalizedSlot: Slot) =
   var toDel: seq[(Eth2Digest, ValidatorSig)]
 
   for k, v in quarantine.orphans:
@@ -239,7 +263,7 @@ func cleanupOrphans(quarantine: var Quarantine, finalizedSlot: Slot) =
     discard quarantine.addUnviable(k[0], UnviableKind.UnviableFork)
     quarantine.orphans.del k
 
-func cleanupSidecarless(quarantine: var Quarantine, finalizedSlot: Slot) =
+proc cleanupSidecarless(quarantine: var Quarantine, finalizedSlot: Slot) =
   var toDel: seq[Eth2Digest]
 
   for k, v in quarantine.sidecarless:
@@ -250,31 +274,17 @@ func cleanupSidecarless(quarantine: var Quarantine, finalizedSlot: Slot) =
     discard quarantine.addUnviable(k, UnviableKind.UnviableFork)
     quarantine.sidecarless.del k
 
-func clearAfterReorg*(quarantine: var Quarantine) =
+  if len(toDel) > 0:
+    quarantine.sidecarlessEvent.fire()
+
+proc clearAfterReorg*(quarantine: var Quarantine) =
   ## Clear missing and orphans to start with a fresh slate in case of a reorg
   ## Unviables remain unviable and are not cleared.
   quarantine.missing.resetItems()
   quarantine.orphans.reset()
 
-func pruneAfterFinalization*(
-    quarantine: var Quarantine, epoch: Epoch, needsBackfill: bool
-) =
-  let
-    startEpoch =
-      if needsBackfill:
-        # Because Quarantine could be used as temporary storage for blocks which
-        # do not have sidecars yet, we should not prune blocks which are behind
-        # `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` epoch. Otherwise we will not
-        # be able to backfill these blocks properly.
-        if epoch < quarantine.cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS:
-          Epoch(0)
-        else:
-          epoch - quarantine.cfg.MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS
-      else:
-        epoch
-    slot = startEpoch.start_slot()
-
-  quarantine.cleanupSidecarless(slot)
+proc pruneAfterFinalization*(quarantine: var Quarantine, epoch: Epoch) =
+  quarantine.cleanupSidecarless(epoch.start_slot())
 
 # Typically, blocks will arrive in mostly topological order, with some
 # out-of-order block pairs. Therefore, it is unhelpful to use either a
@@ -322,7 +332,8 @@ proc addOrphan*(
   ):
     if evicted:
       # When an orphan gets evicted, also evict the sidecars
-      quarantine.sidecarless.del key[0]
+      if quarantine.sidecarless.pop(key[0]).isSome():
+        quarantine.sidecarlessEvent.fire()
 
   ok()
 
@@ -335,6 +346,33 @@ iterator pop*(quarantine: var Quarantine, root: Eth2Digest): ForkedSignedBeaconB
       quarantine.orphans.del k
 
   for k, v in quarantine.orphans.mpairs():
+    if v.parent_root == root:
+      toRemove.add(k)
+      yield v
+
+iterator peek*(
+    quarantine: var Quarantine,
+    root: Eth2Digest
+): ForkedSignedBeaconBlock =
+  # Peek orphans whose root is the block identified by `root`.
+  for k, v in quarantine.orphans.mpairs():
+    if v.root == root:
+      yield v
+
+iterator popSidecarlessBlocks*(
+    quarantine: var Quarantine,
+    root: Eth2Digest
+): ForkedSignedBeaconBlock =
+  # Pop sidecarless blocks whose parent is the block identified by `root`
+
+  var toRemove: seq[Eth2Digest]
+  defer: # Run even if iterator is not carried to termination
+    for k in toRemove:
+      quarantine.sidecarless.del k
+    if len(toRemove) > 0:
+      quarantine.sidecarlessEvent.fire()
+
+  for k, v in quarantine.sidecarless.mpairs():
     if v.parent_root == root:
       toRemove.add(k)
       yield v
@@ -356,6 +394,7 @@ proc addSidecarless(
     signedBlock.root, ForkedSignedBeaconBlock.init(signedBlock)
   )
   quarantine.missing.del(signedBlock.root)
+  quarantine.sidecarlessEvent.fire()
   true
 
 proc addSidecarless*(
@@ -379,17 +418,23 @@ func popSidecarless*(
 ): Opt[ForkedSignedBeaconBlock] =
   quarantine.sidecarless.pop(root)
 
-func removeSidecarless*(
+proc removeSidecarless*(
     quarantine: var Quarantine, root: Eth2Digest
 ): bool =
   ## Remove the sidecarless entry for ``root`` if present.
   ## Returns true if an entry existed and was removed.
-  if not quarantine.sidecarless.contains(root):
-    return false
-  quarantine.sidecarless.del(root)
-  true
+  if quarantine.sidecarless.pop(root).isSome():
+    quarantine.sidecarlessEvent.fire()
+    true
+  else:
+    false
 
 func getSidecarless*(
+    quarantine: var Quarantine, root: Eth2Digest
+): Opt[ForkedSignedBeaconBlock] =
+  quarantine.sidecarless.peek(root)
+
+func peekSidecarless*(
     quarantine: var Quarantine, root: Eth2Digest
 ): Opt[ForkedSignedBeaconBlock] =
   quarantine.sidecarless.peek(root)
@@ -397,3 +442,87 @@ func getSidecarless*(
 iterator peekSidecarless*(quarantine: Quarantine): ForkedSignedBeaconBlock =
   for k, v in quarantine.sidecarless.pairs():
     yield v
+
+func debugSidecarlessJsonDump*(q: var Quarantine): string =
+  var
+    res: seq[BlockId]
+    minBlockSlot = FAR_FUTURE_SLOT
+    maxBlockSlot = GENESIS_SLOT
+
+  for k, v in q.sidecarless.mpairs():
+    let
+      slot = v.slot()
+      bid = BlockId(root: k, slot: slot)
+    if slot < minBlockSlot:
+      minBlockSlot = slot
+    if slot > maxBlockSlot:
+      maxBlockSlot = slot
+    res.add(bid)
+
+  let
+    sminBlockSlot =
+      if len(q.sidecarless) == 0:
+        "not available"
+      else:
+        $minBlockSlot
+    smaxBlockSlot =
+      if len(q.sidecarless) == 0:
+        "not available"
+      else:
+        $maxBlockSlot
+
+  "{\"count\":" & $len(q.sidecarless) &
+    ",\"max_sidecarless_items\":" & $MaxSidecarless &
+    ",\"min_block_slot\":\"" & sminBlockSlot & "\"" &
+    ",\"max_block_slot\":\"" & smaxBlockSlot & "\"" &
+    ",\"items\":[" &
+    res.mapIt("\"" & shortLog(it) & "\"").join(",") & "]}"
+
+func debugOrphansJsonDump*(q: var Quarantine): string =
+  var
+    res: seq[BlockId]
+    minBlockSlot = FAR_FUTURE_SLOT
+    maxBlockSlot = GENESIS_SLOT
+
+  for k, v in q.orphans.mpairs():
+    let
+      slot = v.slot()
+      bid = BlockId(root: k[0], slot: slot)
+    if slot < minBlockSlot:
+      minBlockSlot = slot
+    if slot > maxBlockSlot:
+      maxBlockSlot = slot
+    res.add(bid)
+
+  let
+    sminBlockSlot =
+      if len(q.orphans) == 0:
+        "not available"
+      else:
+        $minBlockSlot
+    smaxBlockSlot =
+      if len(q.orphans) == 0:
+        "not available"
+      else:
+        $maxBlockSlot
+
+  "{\"count\":" & $len(q.orphans) &
+    ",\"max_orphans_items\":" & $MaxOrphans &
+    ",\"min_block_slot\":\"" & sminBlockSlot & "\"" &
+    ",\"max_block_slot\":\"" & smaxBlockSlot & "\"" &
+    ",\"items\":[" &
+    res.mapIt("\"" & shortLog(it) & "\"").join(",") & "]}"
+
+func debugMissingJsonDump*(q: Quarantine): string =
+  let res =
+    q.missing.items.keys().toSeq().mapIt("\"" & shortLog(it) & "\"").join(",")
+  "{\"count\":" & $len(q.missing.items) &
+    ",\"max_missing_items\":" & $q.missing.maxCapacity &
+    ",\"items\":[" & res & "]}"
+
+func debugUnviablesJsonDump*(q: var Quarantine): string =
+  let res =
+    q.unviable.keys().toSeq().mapIt("\"" & shortLog(it) & "\"").join(",")
+  "{\"count\":" & $len(q.unviable) &
+    ",\"max_unviable_items\":" & $MaxUnviables &
+    ",\"items\":[" & res & "]}"

--- a/beacon_chain/consensus_object_pools/envelope_quarantine.nim
+++ b/beacon_chain/consensus_object_pools/envelope_quarantine.nim
@@ -9,11 +9,14 @@
 
 import
   std/tables,
-  minilru,
+  minilru, chronos,
   ./quarantine_types,
   ../spec/[digest, forks]
 
 export tables, minilru, forks, quarantine_types
+
+from std/sequtils import toSeq, mapIt
+from std/strutils import join
 
 const
   MaxOrphans = int(SLOTS_PER_EPOCH * 3)
@@ -40,17 +43,24 @@ type
     unviable*: UnviableLru
       ## List of block roots whose canonical envelopes are unviable.
 
-func init*(T: typedesc[EnvelopeQuarantine]): T =
+    missingEvent*: AsyncEvent
+      ## This asynchronous event is triggered when a new orphaned block is added
+      ## to the quarantine.
+
+proc init*(T: typedesc[EnvelopeQuarantine]): T =
+  let missingEvent = newAsyncEvent()
   T(
     orphans: OrphanLru.init(MaxOrphans),
     unviable: UnviableLru.init(MaxUnviables),
-    missing: MissingTable.init(),
+    missing: MissingTable.init(missingEvent),
+    missingEvent: missingEvent
   )
 
-func addMissing*(self: var EnvelopeQuarantine, root: Eth2Digest) =
+proc addMissing*(self: var EnvelopeQuarantine, root: Eth2Digest) =
   self.missing.add(root)
+  self.missingEvent.fire()
 
-func checkMissing*(self: var EnvelopeQuarantine, max: int): seq[FetchRecord] =
+proc checkMissing*(self: var EnvelopeQuarantine, max: int): seq[FetchRecord] =
   self.missing.checkMissing(max)
 
 func cleanupOrphans(self: var EnvelopeQuarantine, finalizedSlot: Slot) =
@@ -94,7 +104,7 @@ func delOrphan*(self: var EnvelopeQuarantine, blck: gloas.SignedBeaconBlock) =
   for k in toDel:
     self.orphans.del k
 
-func remove*(self: var EnvelopeQuarantine, root: Eth2Digest) =
+proc remove*(self: var EnvelopeQuarantine, root: Eth2Digest) =
   var toDel: seq[(Eth2Digest, uint64)]
   for k, _ in self.orphans:
     if k[0] == root:
@@ -103,6 +113,50 @@ func remove*(self: var EnvelopeQuarantine, root: Eth2Digest) =
     self.orphans.del k
   self.missing.del(root)
 
-func addUnviable*(self: var EnvelopeQuarantine, root: Eth2Digest) =
+proc addUnviable*(self: var EnvelopeQuarantine, root: Eth2Digest) =
   self.remove(root)
   self.unviable.put(root, ())
+
+func jsonLog*(envelope: gloas.SignedExecutionPayloadEnvelope): string =
+  $envelope.message.payload.slot_number & "@" &
+    shortLog(envelope.message.beacon_block_root) & ">" &
+    shortLog(envelope.message.parent_beacon_block_root)
+
+func debugMissingJsonDump*(q: EnvelopeQuarantine): string =
+  let res =
+    q.missing.items.keys().toSeq().mapIt("\"" & shortLog(it) & "\"").join(",")
+  "{\"count\":" & $len(q.missing.items) & ",\"items\":[" & res & "]}"
+
+func debugUnviablesJsonDump*(q: EnvelopeQuarantine): string =
+  let res =
+    q.unviable.keys().toSeq().mapIt("\"" & shortLog(it) & "\"").join(",")
+  "{\"count\":" & $len(q.unviable) & ",\"items\":[" & res & "]}"
+
+func debugOrphansJsonDump*(q: EnvelopeQuarantine): string =
+  var
+    res: seq[string]
+    minBlockSlot = FAR_FUTURE_SLOT
+    maxBlockSlot = GENESIS_SLOT
+
+  for value in q.orphans.values():
+    let slot = value.message.payload.slot_number
+    if slot < minBlockSlot:
+      minBlockSlot = slot
+    if slot > maxBlockSlot:
+      maxBlockSlot = slot
+    res.add("\"" & jsonLog(value) & "\"")
+
+  let
+    sminBlockSlot = if len(q.orphans) == 0: "not available" else: $minBlockSlot
+    smaxBlockSlot = if len(q.orphans) == 0: "not available" else: $maxBlockSlot
+
+  "{\"count\":" & $len(q.orphans) &
+    ",\"max_orphans_items\":" & $MaxOrphans &
+    ",\"min_block_slot\":\"" & sminBlockSlot & "\"" &
+    ",\"max_block_slot\":\"" & smaxBlockSlot & "\"" &
+    ",\"items\":[" & res.join(",") & "]}"
+
+func debugJsonDump*(q: EnvelopeQuarantine): string =
+  "{\"orphans\":" & q.debugOrphansJsonDump() &
+    ",\"missing\":" & q.debugMissingJsonDump() &
+    ",\"unviable\":" & q.debugUnviablesJsonDump() & "}"

--- a/beacon_chain/consensus_object_pools/quarantine_types.nim
+++ b/beacon_chain/consensus_object_pools/quarantine_types.nim
@@ -10,6 +10,7 @@
 import
   std/tables,
   stew/bitops2,
+  chronos,
   ../spec/digest
 
 type
@@ -26,15 +27,30 @@ type
       ## Max capacity of missing items
     maxRetries*: int
       ## Exponential backoff, double interval between each attempt
+    event*: AsyncEvent
+      ## Event that will be set when the number of elements changes
 
 func init*(
     T: type MissingTable,
     maxCapacity: int = 1024,
-    maxRetries: int = 8,
+    maxRetries: int = 8
 ): T =
   T(
     maxCapacity: maxCapacity,
     maxRetries: 1 shl (maxRetries - 1),
+    event: nil
+  )
+
+func init*(
+    T: type MissingTable,
+    event: AsyncEvent,
+    maxCapacity: int = 1024,
+    maxRetries: int = 8
+): T =
+  T(
+    maxCapacity: maxCapacity,
+    maxRetries: 1 shl (maxRetries - 1),
+    event: event
   )
 
 func len*(self: MissingTable): int =
@@ -43,12 +59,14 @@ func len*(self: MissingTable): int =
 func isFull*(self: MissingTable): bool =
   self.len() >= self.maxCapacity
 
-func add*(self: var MissingTable, root: Eth2Digest) =
+proc add*(self: var MissingTable, root: Eth2Digest) =
   if self.isFull():
     return
-  discard self.items.hasKeyOrPut(root, MissingItem())
+  if self.items.hasKeyOrPut(root, MissingItem()):
+    if not(isNil(self.event)):
+      self.event.fire()
 
-func checkMissing*(self: var MissingTable, max: int): seq[FetchRecord] =
+proc checkMissing*(self: var MissingTable, max: int): seq[FetchRecord] =
   # Remove items that have reached max retries
   var done: seq[Eth2Digest]
   for k, v in self.items.mpairs():
@@ -56,6 +74,9 @@ func checkMissing*(self: var MissingTable, max: int): seq[FetchRecord] =
       done.add(k)
   for k in done:
     self.items.del(k)
+
+  if (len(done) > 0) and not(isNil(self.event)):
+    self.event.fire()
 
   # Get items
   for k, v in self.items.mpairs():
@@ -65,11 +86,17 @@ func checkMissing*(self: var MissingTable, max: int): seq[FetchRecord] =
       if result.len() >= max:
         break
 
-func del*(self: var MissingTable, root: Eth2Digest) =
-  self.items.del(root)
+proc del*(self: var MissingTable, root: Eth2Digest) =
+  var value: MissingItem
+  if self.items.pop(root, value):
+    if not(isNil(self.event)):
+      self.event.fire()
 
-func resetItems*(self: var MissingTable) =
+proc resetItems*(self: var MissingTable) =
+  let length = len(self.items)
   self.items.reset()
+  if (length > 0) and not(isNil(self.event)):
+    self.event.fire()
 
 func contains*(self: MissingTable, root: Eth2Digest): bool =
   root in self.items

--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1790,7 +1790,7 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
     node.processor.gloasColumnQuarantine[].pruneAfterFinalization(
       node.dag.finalizedHead.slot.epoch(), backfillSlot)
     node.processor.quarantine[].pruneAfterFinalization(
-      node.dag.finalizedHead.slot.epoch(), node.dag.needsBackfill())
+      node.dag.finalizedHead.slot.epoch())
 
   # Delay part of pruning until latency critical duties are done.
   # The other part of pruning, `pruneBlocksDAG`, is done eagerly.

--- a/tests/test_block_processor.nim
+++ b/tests/test_block_processor.nim
@@ -668,7 +668,7 @@ suite "Block processor" & preset():
       processor2 = BlockProcessor.new(
         false, "", "", batchVerifier, consensusManager2, validatorMonitor2,
         newClone(FuluColumnQuarantine()), newClone(GloasColumnQuarantine()),
-        newClone(EnvelopeQuarantine()), getTimeFn2)
+        newClone(EnvelopeQuarantine.init()), getTimeFn2)
 
     check:
       dag2.head.root == b1.root


### PR DESCRIPTION
Add `onChange` asynchronous events to `block`, `sidecarless` and `envelope` quarantines.
Add `debugJsonDump()` for `block`, `sidecarless` and `envelope` quarantines.
Fix `block` quarantine pruning procedure to ignore backfill process.