### PR TITLE
consider execution payment in builder bids selection

### DIFF
--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -661,6 +661,11 @@ type
         defaultValue: ""
         name: "payload-builder-url" .}: string
 
+      payloadBuilderMaxExecutionPayment* {.
+        desc: "Maximum execution payment to trust when comparing builder bids"
+        defaultValue: 0
+        name: "payload-builder-max-execution-payment" .}: uint64
+
       # Flag name and semantics borrowed from Prysm
       # https://github.com/prysmaticlabs/prysm/pull/12227/files
       localBlockValueBoost* {.

--- a/beacon_chain/conf.nim
+++ b/beacon_chain/conf.nim
@@ -661,11 +661,6 @@ type
         defaultValue: ""
         name: "payload-builder-url" .}: string
 
-      payloadBuilderMaxExecutionPayment* {.
-        desc: "Maximum execution payment to trust when comparing builder bids"
-        defaultValue: 0
-        name: "payload-builder-max-execution-payment" .}: uint64
-
       # Flag name and semantics borrowed from Prysm
       # https://github.com/prysmaticlabs/prysm/pull/12227/files
       localBlockValueBoost* {.

--- a/beacon_chain/spec/forks.nim
+++ b/beacon_chain/spec/forks.nim
@@ -212,6 +212,10 @@ type
   ForkySignedBuilderBid* =
     fulu_mev.SignedBuilderBid
 
+  ForkySignedExecutionPayloadBid* =
+    gloas.SignedExecutionPayloadBid |
+    heze.SignedExecutionPayloadBid
+
   ForkyBlockContents* =
     deneb.BlockContents |
     electra.BlockContents |

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -643,12 +643,7 @@ proc proposeBlockAux(
 
     let
       bestBuilderBid =
-        if poolBid.isSome and builderApiBid.isSome:
-          if builderApiBid.get().message.value > poolBid.get().message.value:
-            builderApiBid
-          else:
-            poolBid
-        elif builderApiBid.isSome:
+        if effectiveBidValue(builderApiBid) > effectiveBidValue(poolBid):
           builderApiBid
         else:
           poolBid
@@ -656,7 +651,7 @@ proc proposeBlockAux(
         bestBuilderBid.isSome and
         builderBetterBid(
           localBlockValueBoost,
-          bestBuilderBid.get().message.value.uint64.u256 * GWEI_TO_WEI.u256,
+          effectiveBidValue(bestBuilderBid).uint64.u256 * GWEI_TO_WEI.u256,
           engineBid[].eps.blockValue)
       selectedBuilderBid =
         if useBuilderBid:

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -642,16 +642,18 @@ proc proposeBlockAux(
         await builderApiBidFut
 
     let
-      bestBuilderBid =
-        if effectiveBidValue(builderApiBid) > effectiveBidValue(poolBid):
-          builderApiBid
+      builderApiBidValue = effectiveBidValue(builderApiBid)
+      poolBidValue = effectiveBidValue(poolBid)
+      (bestBuilderBid, bestBidValue) =
+        if poolBid.isNone or builderApiBidValue > poolBidValue:
+          (builderApiBid, builderApiBidValue)
         else:
-          poolBid
+          (poolBid, poolBidValue)
       useBuilderBid =
         bestBuilderBid.isSome and
         builderBetterBid(
           localBlockValueBoost,
-          effectiveBidValue(bestBuilderBid).uint64.u256 * GWEI_TO_WEI.u256,
+          bestBidValue.uint64.u256 * GWEI_TO_WEI.u256,
           engineBid[].eps.blockValue)
       selectedBuilderBid =
         if useBuilderBid:
@@ -659,6 +661,7 @@ proc proposeBlockAux(
             slot,
             builderIndex = bestBuilderBid.get().message.builder_index,
             bidValue = bestBuilderBid.get().message.value,
+            executionPayment = bestBuilderBid.get().message.execution_payment,
             engineValue = engineBid[].eps.blockValue,
             localBlockValueBoost
           bestBuilderBid

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -140,6 +140,15 @@ func builderBetterBid*(
   of BoostFactorKind.Builder:
     builderBetterBid(boostFactor.value64, builderValue, engineValue)
 
+func effectiveBidValue*(bid: Opt[ForkySignedExecutionPayloadBid]): Gwei =
+  if bid.isNone:
+    return 0.Gwei
+  template msg: untyped = bid.get().message
+  if msg.value > Gwei(high(uint64)) - msg.execution_payment:
+    msg.value
+  else:
+    msg.value + msg.execution_payment
+
 template validateRequestType(request_type_and_payload, prev_type): untyped =
   ## Shared EIP-7685 framing checks: minimum length and strictly ascending,
   ## non-duplicated request types.

--- a/beacon_chain/validators/block_payloads.nim
+++ b/beacon_chain/validators/block_payloads.nim
@@ -144,7 +144,7 @@ func effectiveBidValue*(bid: Opt[ForkySignedExecutionPayloadBid]): Gwei =
   if bid.isNone:
     return 0.Gwei
   template msg: untyped = bid.get().message
-  if msg.value > Gwei(high(uint64)) - msg.execution_payment:
+  if (msg.value > Gwei(high(uint64)) - msg.execution_payment):
     msg.value
   else:
     msg.value + msg.execution_payment


### PR DESCRIPTION
ranks builder bids by the proposer's total take, (value + execution_payment), at two decision points: pool bid vs builder-API bid, and best bid vs local engine payload . 
execution payment is not enforced anywhere, it's credited at face value for bids from the configured `--payload-builder-url`, extending the same trust as per mev-boost....configuring the endpoint is the trust decision here