### PR TITLE
Pre-heat shuffling cache for next next epoch at last slot in epoch

### DIFF
--- a/beacon_chain/nimbus_beacon_node.nim
+++ b/beacon_chain/nimbus_beacon_node.nim
@@ -1861,6 +1861,12 @@ proc onSlotEnd(node: BeaconNode, slot: Slot) {.async.} =
       # checked by maybeUpdateActionTrackerNextEpoch.
       node.maybeUpdateActionTrackerNextEpoch(forkyState, slot)
 
+    # Pre-heat the shuffling cache for upcoming attestation duties, to avoid
+    # having to compute them when REST API is requested at next epoch start.
+    if (slot + 1).is_epoch:
+      discard node.dag.getShufflingRef(
+        head, slot.epoch + 2, preFinalized = false)
+
   let
     nextAttestationSlot =
       node.consensusManager[].actionTracker.getNextAttestationSlot(slot)


### PR DESCRIPTION
VC requests duties for epoch n+1 at start of epoch n, the attester dependent root is dictated by the last root at end of epoch n-1. We can pre-heat the cache at end of epoch n-1 so that the start of epoch n that fulfills the duties request handler has less work to do.