### PR TITLE
 update gossip validation for v1.7.0-alpha.13

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -516,6 +516,24 @@ func get_dependent_root*(
     return ZERO_HASH
   dependent.bid.root
 
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#is_valid_dependent_root
+func is_valid_dependent_root*(
+    dag: ChainDAGRef, root: Eth2Digest, epoch: Epoch): bool =
+  ## Check if the block with the given ``root`` is a possible dependent block
+  ## for the given ``epoch``, meaning that on some branch it is, or could
+  ## become, the latest block prior to the start of the epoch.
+  let
+    blck = dag.getBlockRef(root).valueOr:
+      return false
+    start_slot = epoch.start_slot()
+  if blck.slot >= start_slot:
+    return false
+  for key in dag.forkBlocks:
+    let candidate = key.blockRef()
+    if candidate.parent == blck and candidate.slot >= start_slot:
+      return true
+  dag.head.root == root
+
 type LRUCache[I: static[int], T] = block_pools_types.LRUCache[I, T]
 func nextTimestamp[I, T](cache: var LRUCache[I, T]): uint32 =
   if cache.timestamp == uint32.high:

--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -27,7 +27,7 @@ type
 
   SlotBids* = object
     highestBids*: Table[BidKey, gloas.SignedExecutionPayloadBid]
-    seenBuilders*: HashSet[tuple[builderIndex: uint64, key: BidKey]]
+    seenBuilders*: HashSet[(uint64, BidKey)]
 
   ExecutionPayloadBidPool* = object
     ## Pool for tracking execution payload bids received from builders.

--- a/beacon_chain/consensus_object_pools/execution_payload_pool.nim
+++ b/beacon_chain/consensus_object_pools/execution_payload_pool.nim
@@ -27,7 +27,7 @@ type
 
   SlotBids* = object
     highestBids*: Table[BidKey, gloas.SignedExecutionPayloadBid]
-    seenBuilders*: HashSet[uint64]
+    seenBuilders*: HashSet[tuple[builderIndex: uint64, key: BidKey]]
 
   ExecutionPayloadBidPool* = object
     ## Pool for tracking execution payload bids received from builders.
@@ -81,11 +81,12 @@ proc addBid*(
 
   let slotData = addr pool.slotBids.mgetOrPut(bid.slot, default(SlotBids))
 
-  if slotData.seenBuilders.containsOrIncl(bid.builder_index):
-    debug "Duplicate bid from builder, ignoring"
+  let key = (bid.parent_block_root, payloadAvailability)
+
+  if slotData.seenBuilders.containsOrIncl((bid.builder_index, key)):
+    debug "Duplicate bid from builder for this parent, ignoring"
     return
 
-  let key = (bid.parent_block_root, payloadAvailability)
   slotData.highestBids.withValue(key, currentBid):
     if bid.value <= currentBid.message.value:
       debug "Bid value not higher than current best",
@@ -98,15 +99,6 @@ proc addBid*(
     debug "First bid for this slot and parent"
 
   slotData.highestBids[key] = signedBid
-
-func getBidForSlotAndBuilder*(
-    pool: var ExecutionPayloadBidPool, slot: Slot,
-    builderIndex: uint64): Opt[gloas.SignedExecutionPayloadBid] =
-  pool.slotBids.withValue(slot, slotData):
-    for bid in slotData.highestBids.values:
-      if bid.message.builder_index == builderIndex:
-        return Opt.some(bid)
-  Opt.none(gloas.SignedExecutionPayloadBid)
 
 func getHighestBidForSlotAndParent*(
     pool: var ExecutionPayloadBidPool, slot: Slot,
@@ -139,10 +131,12 @@ proc getHighestBidForProposalState*(
   res
 
 func hasSeenBidFromBuilder*(
-    pool: var ExecutionPayloadBidPool, slot: Slot,
-    builderIndex: uint64): bool =
+    pool: var ExecutionPayloadBidPool, slot: Slot, builderIndex: uint64,
+    parentBlockRoot: Eth2Digest,
+    payloadAvailability: PayloadAvailability): bool =
   pool.slotBids.withValue(slot, slotData):
-    return builderIndex in slotData.seenBuilders
+    return (builderIndex, (parentBlockRoot, payloadAvailability)) in
+      slotData.seenBuilders
   false
 
 proc getPrevRandao*(

--- a/beacon_chain/fork_choice/fork_choice_epbs.nim
+++ b/beacon_chain/fork_choice/fork_choice_epbs.nim
@@ -14,7 +14,8 @@ import
 
 from ../spec/beaconstate import get_ptc
 from ../spec/datatypes/gloas import
-  PAYLOAD_TIMELY_THRESHOLD, DATA_AVAILABILITY_TIMELY_THRESHOLD
+  ExecutionPayloadBid, PAYLOAD_TIMELY_THRESHOLD,
+  DATA_AVAILABILITY_TIMELY_THRESHOLD
 
 func mgetPtcTally*(
     self: var ForkChoiceBackend, root: Eth2Digest,
@@ -97,6 +98,27 @@ proc should_build_on_full*(
   if head.slot == GENESIS_SLOT or head.slot.epoch < dag.cfg.GLOAS_FORK_EPOCH:
     return true
   self.backend.should_build_on_full(head.root, full, wallSlot)
+
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#is_bid_compatible_with_head
+proc is_bid_compatible_with_head*(
+    self: var ForkChoice, dag: ChainDAGRef,
+    bid: gloas.ExecutionPayloadBid): bool =
+  ## Check if ``bid`` is compatible with the head branch.
+  let
+    head = dag.head
+    (headBlockHash, headParentHash) = dag.loadExecutionAndParentBlockHash(head)
+    builds_on_parent_payload = headParentHash.isSome and
+      bid.parent_block_hash == headParentHash.unsafeGet
+
+  if not head.parent.isNil and bid.parent_block_root == head.parent.root:
+    return builds_on_parent_payload
+  if bid.parent_block_root != head.root:
+    return false
+  if self.should_build_on_full(
+      dag, head, dag.isPayloadStatusFull(head), bid.slot):
+    return headBlockHash.isSome and
+      bid.parent_block_hash == headBlockHash.unsafeGet
+  builds_on_parent_payload
 
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/fork-choice.md#modified-is_head_weak
 proc is_head_weak(

--- a/beacon_chain/gossip_processing/eth2_processor.nim
+++ b/beacon_chain/gossip_processing/eth2_processor.nim
@@ -919,7 +919,8 @@ proc processExecutionPayloadBid*(
     blockRoot = signedBid.message.parent_block_root
 
   let v = validateExecutionPayloadBid(
-    self.dag, self.executionPayloadBidPool, self.seenProposerPreferences,
+    self.dag, self.attestationPool.forkChoice,
+    self.executionPayloadBidPool, self.seenProposerPreferences,
     signedBid, wallTime)
   if v.isOk():
     debug "Execution payload bid validated"

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -2175,7 +2175,7 @@ proc validatePayloadAttestationMessage*(
 
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/p2p-interface.md#proposer_preferences
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#proposer_preferences
 proc validateProposerPreferences*(
     dag: ChainDAGRef,
     seen: var SeenProposerPreferences,
@@ -2202,8 +2202,26 @@ proc validateProposerPreferences*(
 
   # [IGNORE] The block with root preferences.dependent_root
   # has been seen (via gossip or non-gossip sources)
-  if dag.getBlockId(preferences.dependent_root).isNone:
+  let dependentRef = dag.getBlockRef(preferences.dependent_root).valueOr:
     return errIgnore("ProposerPreferences: dependent_root not seen")
+
+  if proposalEpoch < MIN_SEED_LOOKAHEAD:
+    return errIgnore("ProposerPreferences: proposal_slot before lookahead")
+  let lookaheadEpoch = proposalEpoch - MIN_SEED_LOOKAHEAD
+
+  # [REJECT] The slot of the block with root `preferences.dependent_root` is
+  # strictly less than `compute_start_slot_at_epoch(
+  # compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD)`
+  if not (dependentRef.slot < lookaheadEpoch.start_slot()):
+    return dag.checkedReject(
+      "ProposerPreferences: dependent_root not before lookahead epoch start")
+
+  # [IGNORE] `is_valid_dependent_root(store, preferences.dependent_root, epoch)`
+  # returns True, where `epoch` is
+  # `compute_epoch_at_slot(preferences.proposal_slot) - MIN_SEED_LOOKAHEAD`
+  if not dag.is_valid_dependent_root(
+      preferences.dependent_root, lookaheadEpoch):
+    return errIgnore("ProposerPreferences: invalid dependent_root")
 
   # [REJECT] is_valid_proposal_slot(state, preferences) returns True,
   # where state is the checkpoint state at the epoch
@@ -2212,8 +2230,6 @@ proc validateProposerPreferences*(
   #
   # Rather than replay that checkpoint state, compute the proposer from the
   # shuffling anchored at the referenced dependent_root block.
-  let dependentRef = dag.getBlockRef(preferences.dependent_root).valueOr:
-    return errIgnore("ProposerPreferences: dependent_root not in dag")
   let proposer = dag.getProposer(
       dependentRef, preferences.proposal_slot).valueOr:
     return errIgnore("ProposerPreferences: unable to compute proposer")

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1940,7 +1940,7 @@ proc validateLightClientOptimisticUpdate*(
   pool.latestForwardedOptimisticSlot = attested_slot
   ok()
 
-# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/p2p-interface.md#execution_payload_bid
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#execution_payload_bid
 proc validateExecutionPayloadBid*(
     dag: ChainDAGRef,
     executionPayloadBidPool: ref ExecutionPayloadBidPool,
@@ -1968,14 +1968,6 @@ proc validateExecutionPayloadBid*(
         return dag.checkedReject(
           "ExecutionPayloadBid: execution_payment is not zero")
 
-      # [IGNORE] This is the first signed bid seen with a valid signature from
-      # the given builder for this slot
-      let existingBid = executionPayloadBidPool[].getBidForSlotAndBuilder(
-        bid.slot, bid.builder_index)
-      if existingBid.isSome():
-        return errIgnore(
-          "ExecutionPayloadBid: already seen bid from this builder for this slot")
-
       # [IGNORE] bid.parent_block_hash is the block hash of a known execution
       # payload in fork choice
       let parentBlck = dag.getBlockRef(bid.parent_block_root).valueOr:
@@ -1996,6 +1988,17 @@ proc validateExecutionPayloadBid*(
             return errIgnore("ExecutionPayloadBid: parent block hash unknown")
         highestBid = executionPayloadBidPool[].getHighestBidForSlotAndParent(
           bid.slot, bid.parent_block_root, payloadAvailability)
+
+      # [IGNORE] this is the first signed bid seen with a valid signature from
+      # the given builder for the tuple
+      # `(bid.slot, bid.parent_block_hash, bid.parent_block_root)`
+      if executionPayloadBidPool[].hasSeenBidFromBuilder(
+          bid.slot, bid.builder_index, bid.parent_block_root,
+          payloadAvailability):
+        return errIgnore(
+          "ExecutionPayloadBid: already seen bid from this builder for this " &
+          "slot and parent")
+
       if highestBid.isSome() and highestBid.get().message.value > bid.value:
         return errIgnore(
           "ExecutionPayloadBid: not the highest value bid for this slot and parent")

--- a/beacon_chain/gossip_processing/gossip_validation.nim
+++ b/beacon_chain/gossip_processing/gossip_validation.nim
@@ -1943,6 +1943,7 @@ proc validateLightClientOptimisticUpdate*(
 # https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/p2p-interface.md#execution_payload_bid
 proc validateExecutionPayloadBid*(
     dag: ChainDAGRef,
+    forkChoice: var ForkChoice,
     executionPayloadBidPool: ref ExecutionPayloadBidPool,
     seenProposerPreferences: var SeenProposerPreferences,
     signed_execution_payload_bid: gloas.SignedExecutionPayloadBid,
@@ -1968,8 +1969,6 @@ proc validateExecutionPayloadBid*(
         return dag.checkedReject(
           "ExecutionPayloadBid: execution_payment is not zero")
 
-      # [IGNORE] bid.parent_block_hash is the block hash of a known execution
-      # payload in fork choice
       let parentBlck = dag.getBlockRef(bid.parent_block_root).valueOr:
         return errIgnore(
           "ExecutionPayloadBid: parent block root not found in fork choice")
@@ -2002,6 +2001,11 @@ proc validateExecutionPayloadBid*(
       if highestBid.isSome() and highestBid.get().message.value > bid.value:
         return errIgnore(
           "ExecutionPayloadBid: not the highest value bid for this slot and parent")
+
+      # [IGNORE] The bid is compatible with the current head branch, i.e.
+      # `is_bid_compatible_with_head(store, bid)` returns `True`.
+      if not forkChoice.is_bid_compatible_with_head(dag, bid):
+        return errIgnore("ExecutionPayloadBid: incompatible with head branch")
 
       # [IGNORE] bid.value is less or equal than the builder's excess balance
       if not can_builder_cover_bid(

--- a/tests/test_execution_payload_pool.nim
+++ b/tests/test_execution_payload_pool.nim
@@ -57,7 +57,8 @@ suite "Execution Payload Bid Pool":
     check:
       not pool.getHighestBidForSlotAndParent(
         1.Slot, blockRoot, PayloadAvailability.Timely).isSome()
-      not pool.hasSeenBidFromBuilder(1.Slot, 0)
+      not pool.hasSeenBidFromBuilder(
+        1.Slot, 0, blockRoot, PayloadAvailability.Timely)
 
   test "Add and retrieve highest bid":
     let bid = makeBid(10.Slot, 1, blockRoot, parentHash1, 100.Gwei)
@@ -77,7 +78,8 @@ suite "Execution Payload Bid Pool":
       bid2 = makeBid(10.Slot, 1, blockRoot, parentHash1, 200.Gwei)
 
     pool.addBid(bid1, PayloadAvailability.Timely, wallTime)
-    check pool.hasSeenBidFromBuilder(10.Slot, 1)
+    check pool.hasSeenBidFromBuilder(
+      10.Slot, 1, blockRoot, PayloadAvailability.Timely)
 
     pool.addBid(bid2, PayloadAvailability.Timely, wallTime)
 
@@ -141,9 +143,12 @@ suite "Execution Payload Bid Pool":
       PayloadAvailability.Timely, wallTime)
 
     check:
-      pool.hasSeenBidFromBuilder(10.Slot, 1)
-      pool.hasSeenBidFromBuilder(10.Slot, 2)
-      pool.hasSeenBidFromBuilder(10.Slot, 3)
+      pool.hasSeenBidFromBuilder(
+        10.Slot, 1, blockRoot, PayloadAvailability.Timely)
+      pool.hasSeenBidFromBuilder(
+        10.Slot, 2, blockRoot, PayloadAvailability.Timely)
+      pool.hasSeenBidFromBuilder(
+        10.Slot, 3, blockRoot, PayloadAvailability.Timely)
 
     check pool.slotBids.len == 1
 

--- a/tests/test_gossip_validation.nim
+++ b/tests/test_gossip_validation.nim
@@ -27,7 +27,8 @@ import
 
 from std/sequtils import count, toSeq
 from ./testbcutil import addHeadBlock
-from ../beacon_chain/spec/beaconstate import dependent_root, latest_block_root
+from ../beacon_chain/spec/beaconstate import
+  get_proposer_dependent_root, latest_block_root
 
 proc pruneAtFinalization(dag: ChainDAGRef, attPool: AttestationPool) =
   if dag.needStateCachesAndForkChoicePruning():
@@ -500,34 +501,17 @@ suite "Proposer preferences validation " & preset():
         validatorMonitor, {})
     var seen: SeenProposerPreferences
 
-    # Pick an upcoming slot and its scheduled proposer from the head state's
-    # proposer_lookahead.
-    var
-      proposer_slot: Slot
-      proposer_index: uint64
-      dependent_root: Eth2Digest
-      proposerFound = false
-      wrongValidator: uint64
-    withState(dag.headState):
-      when consensusFork >= ConsensusFork.Gloas:
-        let startSlot = forkyState.data.get_current_epoch().start_slot()
-        for offset in 1'u64 ..< forkyState.data.proposer_lookahead.lenu64:
-          let slot = startSlot + offset
-          if slot > forkyState.data.slot:
-            proposer_slot = slot
-            proposer_index = forkyState.data.proposer_lookahead.item(offset)
-            dependent_root = forkyState.dependent_root(slot.epoch)
-            proposerFound = true
-            break
-        # wrongValidator just needs to differ from the scheduled proposer at
-        # proposer_slot; that is the only slot the proposer check looks at.
-        wrongValidator = proposer_index + 1
-        if forkyState.data.proposer_lookahead.item(
-            proposer_slot - startSlot) == wrongValidator:
-          wrongValidator += 1
-    check proposerFound
-
     let
+      proposer_slot =
+        (GENESIS_EPOCH + MIN_SEED_LOOKAHEAD + 1).start_slot() + 1
+      proposer_index =
+        uint64 dag.getProposer(dag.head, proposer_slot).expect("proposer")
+      dependent_root = dag.head.root
+      # wrongValidator just needs to differ from the scheduled proposer at
+      # proposer_slot; that is the only slot the proposer check looks at.
+      wrongValidator =
+        if proposer_index == 0: 1'u64 else: proposer_index - 1
+
       prefs = ProposerPreferences(
         dependent_root: dependent_root,
         proposal_slot: proposer_slot,
@@ -536,7 +520,8 @@ suite "Proposer preferences validation " & preset():
         target_gas_limit: 30_000_000)
       signed = signProposerPreferences(
         dag, prefs, MockPrivKeys[proposer_index.ValidatorIndex])
-      wallTime = dag.head.slot.start_beacon_time(dag.cfg.timeParams)
+      wallTime = proposer_slot.epoch.start_slot().start_beacon_time(
+        dag.cfg.timeParams)
 
   test "validateProposerPreferences - happy case":
     check:


### PR DESCRIPTION
Note: `is_bid_compatible_with_head` in execution payload bid validation is  checked after the pool lookups rather than in the spec ordering, so cheaper checks drop duplicate and non-competitive bids first before `should_build_on_full` scans the PTC vote arrays since both are `[IGNORE]`s