### PR TITLE
derive attestation index from payload status

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2659,6 +2659,27 @@ func isPayloadStatusFull*(dag: ChainDAGRef, head: BlockRef): bool =
   ## https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.12/specs/gloas/fork-choice.md#new-should_build_on_full
   head == dag.headPayload
 
+# https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.13/specs/gloas/validator.md#attestation
+func attestationDataIndex*(
+    dag: ChainDAGRef, blck: BlockRef, slot: Slot): CommitteeIndex =
+  if slot.epoch < dag.cfg.GLOAS_FORK_EPOCH or blck.slot >= slot:
+    return 0.CommitteeIndex
+
+  let payloadPresent =
+    if blck == dag.head:
+      # If nothing extends the head yet, fork choice holds the verdict
+      dag.isPayloadStatusFull(blck)
+    else:
+      # Else a descendant already recorded whether it extended this payload
+      withState(dag.headState):
+        when consensusFork >= ConsensusFork.Gloas:
+          forkyState.data.execution_payload_availability[
+            blck.slot mod SLOTS_PER_HISTORICAL_ROOT]
+        else:
+          false
+
+  if payloadPresent: 1.CommitteeIndex else: 0.CommitteeIndex
+
 from std/packedsets import PackedSet, incl, items
 
 func getBlsToExecutionChangeStatuses(

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -540,10 +540,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
               return RestApiResponse.jsonError(Http400,
                                                InvalidCommitteeIndexValueError,
                                                $res.error())
-            if qslot.epoch >= node.dag.cfg.ELECTRA_FORK_EPOCH:
-              0.CommitteeIndex
-            else:
-              res.get()
+            res.get()
         let qhead =
           block:
             let res = node.getSyncedHead(qslot)
@@ -562,9 +559,16 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
                   Http503, BeaconNodeInSyncError)
               qbs.blck
 
-        let epochRef = node.dag.getEpochRef(qhead, qslot.epoch, true).valueOr:
-          return RestApiResponse.jsonError(Http400, PrunedStateError, $error)
-        makeAttestationData(epochRef, qhead.atSlot(qslot), qindex)
+        let
+          epochRef = node.dag.getEpochRef(qhead, qslot.epoch, true).valueOr:
+            return RestApiResponse.jsonError(Http400, PrunedStateError, $error)
+          attestationHead = qhead.atSlot(qslot)
+        makeAttestationData(
+          epochRef, attestationHead,
+          if qslot.epoch >= node.dag.cfg.ELECTRA_FORK_EPOCH:
+            node.dag.attestationDataIndex(attestationHead.blck, qslot)
+          else:
+            qindex)
     RestApiResponse.jsonResponse(adata)
 
   router.api2(MethodGet, "/eth/v1/validator/aggregate_attestation") do (

--- a/beacon_chain/rpc/rest_validator_api.nim
+++ b/beacon_chain/rpc/rest_validator_api.nim
@@ -500,7 +500,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
         return RestApiResponse.jsonError(
           Http500, "Unsupported fork for block production: " & $consensusFork)
 
-  # https://ethereum.github.io/beacon-APIs/#/Validator/produceAttestationData
+  # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/validator/attestation_data.yaml
   router.api2(MethodGet, "/eth/v1/validator/attestation_data") do (
     slot: Option[Slot],
     committee_index: Option[CommitteeIndex]) -> RestApiResponse:
@@ -530,17 +530,6 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
             Http400, InvalidSlotValueError,
             "Slot cannot be more than an epoch in the past")
 
-        let qindex =
-          block:
-            if committee_index.isNone():
-              return RestApiResponse.jsonError(Http400,
-                                               MissingCommitteeIndexValueError)
-            let res = committee_index.get()
-            if res.isErr():
-              return RestApiResponse.jsonError(Http400,
-                                               InvalidCommitteeIndexValueError,
-                                               $res.error())
-            res.get()
         let qhead =
           block:
             let res = node.getSyncedHead(qslot)
@@ -565,10 +554,7 @@ proc installValidatorApiHandlers*(router: var RestRouter, node: BeaconNode) =
           attestationHead = qhead.atSlot(qslot)
         makeAttestationData(
           epochRef, attestationHead,
-          if qslot.epoch >= node.dag.cfg.ELECTRA_FORK_EPOCH:
-            node.dag.attestationDataIndex(attestationHead.blck, qslot)
-          else:
-            qindex)
+          node.dag.attestationDataIndex(attestationHead.blck, qslot))
     RestApiResponse.jsonResponse(adata)
 
   router.api2(MethodGet, "/eth/v1/validator/aggregate_attestation") do (

--- a/beacon_chain/validators/beacon_validators.nim
+++ b/beacon_chain/validators/beacon_validators.nim
@@ -876,20 +876,9 @@ proc sendAttestations(node: BeaconNode, head: BlockRef, slot: Slot) =
     committees_per_slot = get_committee_count_per_slot(epochRef.shufflingRef)
     fork = node.dag.forkAtEpoch(slot.epoch)
     genesis_validators_root = node.dag.genesis_validators_root
-    payloadIndex =
-      if slot.epoch < node.dag.cfg.GLOAS_FORK_EPOCH or
-          attestationHead.blck.slot >= slot:
-        0'u64
-      else:
-        withState(node.dag.headState):
-          when consensusFork >= ConsensusFork.Gloas:
-            if forkyState.data.execution_payload_availability[
-                attestationHead.blck.slot mod SLOTS_PER_HISTORICAL_ROOT]:
-              1'u64
-            else: 0'u64
-          else: 0'u64
     data = makeAttestationData(
-      epochRef, attestationHead, CommitteeIndex(payloadIndex))
+      epochRef, attestationHead,
+      node.dag.attestationDataIndex(attestationHead.blck, slot))
     # TODO signing_root is recomputed in produceAndSignAttestation/signAttestation just after
     signingRoot =
       compute_attestation_signing_root(fork, genesis_validators_root, data)


### PR DESCRIPTION
attestationData.index was derived from `state.execution_payload_availability`, but the bit for a slot is written by `apply_parent_execution_payload` while processing that slot's child block. If the slot has no child block yet, the bit is unset (i.e  stays `0` until some block at a later slot is applied) regardless of whether the payload was applied, so the index will be always 0.