### PR TITLE
Emit head event also when there was a reorg

### DIFF
--- a/beacon_chain/consensus_object_pools/blockchain_dag.nim
+++ b/beacon_chain/consensus_object_pools/blockchain_dag.nim
@@ -2868,6 +2868,33 @@ proc updateHead*(
   # Update light client data
   dag.processHeadChangeForLightClient()
 
+  # `head` events are then only required when a new block is imported
+  # or when a reorg changes the head block
+  # https://github.com/ethereum/beacon-APIs/pull/117
+  if not(isNil(dag.onHeadChanged)):
+    let
+      depRoot = withState(dag.headState): forkyState.proposer_dependent_root
+      prevDepRoot = withState(dag.headState):
+        forkyState.attester_dependent_root
+      # TODO (cheatfate): Proper implementation required
+      data = HeadChangeInfoObject.init(dag.head.slot, dag.head.root,
+                                       dag.headState.root,
+                                       epochTransition, prevDepRoot,
+                                       depRoot)
+    dag.onHeadChanged(data)
+
+  if not isNil(dag.onHeadV2Changed):
+    # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/eventstream/index.yaml#L62-L66
+    let
+      headEpoch = dag.head.slot.epoch()
+      curEpochDepRoot = dag.getEpochDepRoot(headEpoch, 1)
+      nextEpochDepRoot = dag.getEpochDepRoot(headEpoch, 0)
+
+    dag.onHeadV2Changed(HeadV2ChangeInfoObject.init(
+      dag.headState.kind, dag.head.slot, dag.head.root,
+      dag.headState.root, epochTransition, curEpochDepRoot,
+      nextEpochDepRoot))
+
   let (isAncestor, ancestorDepth) = lastHead.getDepth(newHead)
   if not(isAncestor):
     notice "Updated head block with chain reorg",
@@ -2897,30 +2924,6 @@ proc updateHead*(
       justified = shortLog(dag.headState.current_justified_checkpoint),
       finalized = shortLog(dag.headState.finalized_checkpoint),
       optStatus = newHead.optimisticStatus
-
-    if not(isNil(dag.onHeadChanged)):
-      let
-        depRoot = withState(dag.headState): forkyState.proposer_dependent_root
-        prevDepRoot = withState(dag.headState):
-          forkyState.attester_dependent_root
-        # TODO (cheatfate): Proper implementation required
-        data = HeadChangeInfoObject.init(dag.head.slot, dag.head.root,
-                                         dag.headState.root,
-                                         epochTransition, prevDepRoot,
-                                         depRoot)
-      dag.onHeadChanged(data)
-
-    if not isNil(dag.onHeadV2Changed):
-      # https://github.com/ethereum/beacon-APIs/blob/v5.0.0-alpha.2/apis/eventstream/index.yaml#L62-L66
-      let
-        headEpoch = dag.head.slot.epoch()
-        curEpochDepRoot = dag.getEpochDepRoot(headEpoch, 1)
-        nextEpochDepRoot = dag.getEpochDepRoot(headEpoch, 0)
-
-      dag.onHeadV2Changed(HeadV2ChangeInfoObject.init(
-        dag.headState.kind, dag.head.slot, dag.head.root,
-        dag.headState.root, epochTransition, curEpochDepRoot,
-        nextEpochDepRoot))
 
   withState(dag.headState):
     # Every time the head changes, the "canonical" view of balances and other


### PR DESCRIPTION
Spec is a bit vague but https://github.com/ethereum/beacon-APIs/pull/117 description clarifies that the head event should also be sent for reorg. This way, VCs subscribed only to 'head' can detect reorgs more quickly.